### PR TITLE
fix installation from npm3

### DIFF
--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -1,10 +1,23 @@
+var fs = require('fs');
 var path = require('path');
 
 var pathToRoot = path.join(__dirname, '../../');
+var pathToRootParent = path.join(__dirname, '../../../../');
 var pathToSrc = path.join(pathToRoot, 'src/');
 var pathToImageTest = path.join(pathToRoot, 'test/image');
 var pathToDist = path.join(pathToRoot, 'dist/');
 var pathToBuild = path.join(pathToRoot, 'build/');
+
+var pathToTopojsonSrc;
+
+// npm3 flattens modules, so they won't be accessible through the old nested npm2 paths
+// attempt a synchronous filestat check, and on error, use the npm3 path
+try {
+    pathToTopojsonSrc = path.join(pathToRoot, 'node_modules/sane-topojson/dist/');
+    fs.statSync(pathToTopojsonSrc);
+} catch (e) {
+    pathToTopojsonSrc = path.join(pathToRootParent, 'node_modules/sane-topojson/dist/');
+}
 
 module.exports = {
     pathToRoot: pathToRoot,
@@ -17,7 +30,7 @@ module.exports = {
     pathToPlotlyDistMin: path.join(pathToDist, 'plotly.min.js'),
     pathToPlotlyDistWithMeta: path.join(pathToDist, 'plotly-with-meta.js'),
 
-    pathToTopojsonSrc: path.join(pathToRoot, 'node_modules/sane-topojson/dist/'),
+    pathToTopojsonSrc: pathToTopojsonSrc,
     pathToTopojsonDist: path.join(pathToDist, 'topojson/'),
     pathToPlotlyGeoAssetsSrc: path.join(pathToSrc, 'assets/geo_assets.js'),
     pathToPlotlyGeoAssetsDist: path.join(pathToDist, 'plotly-geo-assets.js'),


### PR DESCRIPTION
npm3 will flatten node_modules, so the nested node_modules that is used
for copying the JSON over from Topojson will not be available in the
package's relative node_modules. This commit uses a synchronous check to
see if the path is valid and on failure with try to use the path
expected from npm3 installations.

Tested this fix on my repo using a git url: `"plotly.js": git://github.com/justinwoo/plotly.js.git#90e1c36ec12e431"`