### PR TITLE
If gd provided is not in the DOM, then create a div with id = gd.

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -368,7 +368,7 @@ function getGraphDiv(gd) {
         gdElement = document.getElementById(gd);
 
         if(gdElement === null) {
-            div = d3.select("body").append("div").attr("id",gd);
+            div = d3.select("body").append("div").attr("id",gd).attr("class","js-plotly-plot");
             gdElement = div[0][0];
         }
 

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -368,7 +368,8 @@ function getGraphDiv(gd) {
         gdElement = document.getElementById(gd);
 
         if(gdElement === null) {
-            throw new Error('No DOM element with id \'' + gd + '\' exits on the page.');
+            div = d3.select("body").append("div").attr("id",gd);
+            gdElement = div[0][0];
         }
 
         return gdElement;


### PR DESCRIPTION
I am writing a(nother) wrapper for Julia/Juno that deals directly with plotly.js and this would allow me to create multiple charts on the fly without having the div already in the DOM.