### PR TITLE
Using docker compose

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,10 +12,10 @@ machine:
 
 dependencies:
   pre: 
-    - docker pull plotly/imageserver:1.0.0
+    - docker pull plotly/imageserver:latest
   post:
     - npm run cibuild
-    - docker run -d --name myimageserver -v $PWD:/var/www/streambed/image_server/plotly.js -p 9010:9010 plotly/imageserver:1.0.0; sleep 20
+    - docker run -d --name myimageserver -v $PWD:/var/www/streambed/image_server/plotly.js -p 9010:9010 plotly/imageserver:latest; sleep 20
 
 test:
   override:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+---
+# For installing docker-compose, please refer page
+# https://docs.docker.com/compose/install/
+# For using docker compose
+# 1. start docker container, like vagrant, go under folder
+#    contains docker-compose.yml file and run:
+#    $ docker-compose up -d
+# 2. stop the container
+#    $ docker-compose stop
+# 3. remove the container
+#    $ docker-compose rm -f
+
+
+dev:
+  container_name: imageserver
+  image: plotly/imageserver:1.0.0
+  volumes: 
+    - .:/var/www/streambed/image_server/plotly.js
+  ports:
+    - "9010:9010"
+    - "2022:22"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@
 
 
 dev:
-  container_name: imageserver
-  image: plotly/imageserver:1.0.0
+  container_name: imagetest
+  image: plotly/imageserver:latest
   volumes: 
     - .:/var/www/streambed/image_server/plotly.js
   ports:

--- a/test/image/README.md
+++ b/test/image/README.md
@@ -2,20 +2,22 @@
 
 Test plotly.js with the Plotly Image-Server docker container.
 
-### Run the container
 
+### Run the container with `docker compose`
+
+Plotly.js uses `docker-compose` to ease the creation/stopping/deletion of testing docker container,
+please refer [installing docker-compose](https://docs.docker.com/compose/install/) for installation.
 Inside your `plotly.js` directory, run
 
 ```bash
-docker run -d --name imagetest \
-    -v $PWD:/var/www/streambed/image_server/plotly.js \
-    -p 9010:9010 -p 2022:22 plotly/imageserver:[version]
+$ docker-compose up -d
 ```
 
-where `[version]` is the latest Plotly Image-Server docker container version
+In the `docker-compose.yml` file, `latest` is the latest Plotly Image-Server docker container version
 as listed on
 [hub.docker.com](https://hub.docker.com/r/plotly/imageserver/tags/) and
 `imagetest` is the name of the docker container.
+
 
 ### Run the tests
 
@@ -70,16 +72,20 @@ docker images
 docker ps -a
 ```
 
-### Stop container
+### Stop your testing container
+
+Inside your `plotly.js` directory, run
 
 ```bash
-docker stop [container_id]
+docker-compose stop
 ```
 
-### Remove container
+### Remove your testing container
+
+Inside your `plotly.js` directory, run
 
 ```bash
-docker rm [container_id]
+docker-compose rm -f
 ```
 
 For more comprehensive information about docker, please refer to [docker document](http://docs.docker.com/)

--- a/test/image/README.md
+++ b/test/image/README.md
@@ -14,8 +14,7 @@ $ docker-compose up -d
 ```
 
 In the `docker-compose.yml` file, `latest` is the latest Plotly Image-Server docker container version
-as listed on
-[hub.docker.com](https://hub.docker.com/r/plotly/imageserver/tags/) and
+as listed on [hub.docker.com](https://hub.docker.com/r/plotly/imageserver/tags/) and
 `imagetest` is the name of the docker container.
 
 


### PR DESCRIPTION
@etpinard  Using docker-compose to ease the creation/stopping/deletion of testing docker container. Please refer the `test/image/README.md` for detail information.  