### PR TITLE
Fix test-jasmine on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "jasmine-core": "^2.3.4",
     "jshint": "^2.8.0",
     "karma": "^0.13.15",
-    "karma-browserify": "^4.4.0",
+    "karma-browserify": "^4.4.1",
     "karma-chrome-launcher": "^0.2.1",
     "karma-coverage": "^0.5.3",
     "karma-firefox-launcher": "^0.1.6",

--- a/tasks/util/shortcut_paths.js
+++ b/tasks/util/shortcut_paths.js
@@ -22,7 +22,8 @@ module.exports = transformTools.makeRequireTransform('requireTransform',
         Object.keys(shortcutsConfig).forEach(function(k) {
             if(pathIn.indexOf(k) !== -1) {
                 var tail = pathIn.split(k)[1];
-                pathOut = 'require(\''+ shortcutsConfig[k] + tail + '\')';
+                var newPath = path.join(shortcutsConfig[k], tail).replace(/\\/g, '/');
+                pathOut = 'require(\''+ newPath + '\')';
             }
         });
 


### PR DESCRIPTION
Two issues were preventing `npm run test-jasmine` on windows:

1) karma-browserify had a bug (See nikku/karma-browserify#154, fixed by bumping to karma-browserify 4.4.1).
2) On windows (or cygwin) paths generated by the requireTransform browserify transform contain platform-specific file separators (fixed by converting file separators).