### PR TITLE
length-1 bins count as ascending in Plotly.Lib.findBin

### DIFF
--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -34,7 +34,7 @@ exports.findBin = function(val, bins, linelow) {
             c = 0,
             n,
             test;
-        if(bins[bins.length - 1] > bins[0]) {
+        if(bins[bins.length - 1] >= bins[0]) {
             test = linelow ? lessThan : lessOrEqual;
         } else {
             test = linelow ? greaterOrEqual : greaterThan;

--- a/test/jasmine/tests/search_test.js
+++ b/test/jasmine/tests/search_test.js
@@ -1,0 +1,37 @@
+var Plotly = require('@src/plotly');
+
+describe('Test search.js:', function() {
+    'use strict';
+
+    describe('findBin', function() {
+        it('should work on ascending arrays', function() {
+            expect(Plotly.Lib.findBin(-10000, [0, 1, 3])).toBe(-1);
+            expect(Plotly.Lib.findBin(0.5, [0, 1, 3])).toBe(0);
+            expect(Plotly.Lib.findBin(2, [0, 1, 3])).toBe(1);
+            expect(Plotly.Lib.findBin(10000, [0, 1, 3])).toBe(2);
+            // default: linelow falsey, so the line is in the higher bin
+            expect(Plotly.Lib.findBin(1, [0, 1, 3])).toBe(1);
+            // linelow truthy, so the line is in the lower bin
+            expect(Plotly.Lib.findBin(1, [0, 1, 3], true)).toBe(0);
+        });
+
+        it('should work on decending arrays', function() {
+            expect(Plotly.Lib.findBin(-10000, [3, 1, 0])).toBe(2);
+            expect(Plotly.Lib.findBin(0.5, [3, 1, 0])).toBe(1);
+            expect(Plotly.Lib.findBin(2, [3, 1, 0])).toBe(0);
+            expect(Plotly.Lib.findBin(10000, [3, 1, 0])).toBe(-1);
+
+            expect(Plotly.Lib.findBin(1, [3, 1, 0])).toBe(0);
+            expect(Plotly.Lib.findBin(1, [3, 1, 0], true)).toBe(1);
+        });
+
+        it('should treat a length-1 array as ascending', function() {
+            expect(Plotly.Lib.findBin(-1, [0])).toBe(-1);
+            expect(Plotly.Lib.findBin(1, [0])).toBe(0);
+
+            expect(Plotly.Lib.findBin(0, [0])).toBe(0);
+            expect(Plotly.Lib.findBin(0, [0], true)).toBe(-1);
+        });
+        // TODO: didn't test bins as objects {start, stop, size}
+    });
+});


### PR DESCRIPTION
@etpinard @chriddyp gotta love 1-character fixes! The test `it('should treat a length-1 array as ascending'` failed before the fix. fixes #38 