### PR TITLE
Use require.resolve to get path to topojson files

### DIFF
--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -15,7 +15,6 @@ var pathToTopojsonSrc = path.join(
 module.exports = {
     pathToRoot: pathToRoot,
     pathToSrc: pathToSrc,
-    pathToMocks: path.join(pathToRoot, 'test/image/mocks'),
 
     pathToPlotlySrc: path.join(pathToSrc, 'index.js'),
     pathToPlotlyBuild: path.join(pathToBuild, 'plotly.js'),

--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -1,25 +1,16 @@
-var fs = require('fs');
 var path = require('path');
 
 var pkg = require('../../package.json');
 
 var pathToRoot = path.join(__dirname, '../../');
-var pathToRootParent = path.join(__dirname, '../../../../');
 var pathToSrc = path.join(pathToRoot, 'src/');
 var pathToImageTest = path.join(pathToRoot, 'test/image');
 var pathToDist = path.join(pathToRoot, 'dist/');
 var pathToBuild = path.join(pathToRoot, 'build/');
 
-var pathToTopojsonSrc;
-
-// npm3 flattens modules, so they won't be accessible through the old nested npm2 paths
-// attempt a synchronous filestat check, and on error, use the npm3 path
-try {
-    pathToTopojsonSrc = path.join(pathToRoot, 'node_modules/sane-topojson/dist/');
-    fs.statSync(pathToTopojsonSrc);
-} catch (e) {
-    pathToTopojsonSrc = path.join(pathToRootParent, 'node_modules/sane-topojson/dist/');
-}
+var pathToTopojsonSrc = path.join(
+    path.dirname(require.resolve('sane-topojson')), 'dist/'
+);
 
 module.exports = {
     pathToRoot: pathToRoot,

--- a/tasks/util/shortcut_paths.js
+++ b/tasks/util/shortcut_paths.js
@@ -10,7 +10,7 @@ var constants = require('./constants');
 
 var shortcutsConfig = {
     '@src': constants.pathToSrc,
-    '@mocks': constants.pathToMocks
+    '@mocks': constants.pathToTestImageMocks
 };
 
 module.exports = transformTools.makeRequireTransform('requireTransform',


### PR DESCRIPTION
@justinwoo @mdtusz @bpostlethwaite 

I found a possibly cleaner way (you tell me :smile:) to find the path to the topojson files using node's [`require.resolve`](https://nodejs.org/api/globals.html#globals_require_resolve).

Supports both npm@2 and npm@3 .