### PR TITLE
Pie chart slices support transparent rgba() colors

### DIFF
--- a/src/traces/pie/index.js
+++ b/src/traces/pie/index.js
@@ -152,7 +152,7 @@ pie.calc = function(gd, trace) {
 
         color = tinycolor(trace.marker.colors[i]);
         if(color.isValid()) {
-            color = Plotly.Color.tinyRGB(color);
+            color = Plotly.Color.addOpacity(color, color.getAlpha())
             if(!colorMap[label]) {
                 colorMap[label] = color;
             }


### PR DESCRIPTION
Plotly.js pie charts accept `rgba()` marker colors, but drop any opacity value present. This codepen and image demonstrate: http://codepen.io/tlrdstd/pen/adoKgp

![image](https://cloud.githubusercontent.com/assets/194300/11547905/8e7522de-9925-11e5-9a9d-04ab54bc05dc.png)

Running the same demo again with the attached change yields a chart with one transparent `rgba()` slice, one `rgba()` slice at 100% opacity, and an `rgb()` slice:

![image](https://cloud.githubusercontent.com/assets/194300/11547930/b960947e-9925-11e5-9963-357cb35ed609.png)
