### PR TITLE
s/exits/exists/ in gdElement existence check error message

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -369,7 +369,7 @@ function getGraphDiv(gd) {
         gdElement = document.getElementById(gd);
 
         if(gdElement === null) {
-            throw new Error('No DOM element with id \'' + gd + '\' exits on the page.');
+            throw new Error('No DOM element with id \'' + gd + '\' exists on the page.');
         }
 
         return gdElement;


### PR DESCRIPTION
Fixes a minor spelling typo (`exits` vs `exists`) in the gdElement existence check. Current error reads:

`No DOM element with id 'myDiv' exits on the page.`

New error reads:

`No DOM element with id 'myDiv' exists on the page.`