### PR TITLE
Added webpack field for entry point to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The open source javascript graphing library that powers plotly",
   "license": "MIT",
   "main": "./src/index.js",
+  "webpack": "./dist/plotly.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/plotly/plotly.js.git"


### PR DESCRIPTION
This won't break anything for people who have been using `require('plotly.js/dist/plotly.min.js')` because of how webpack resolves things. 