### PR TITLE
Plotly.deleteTraces bug

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1498,8 +1498,13 @@ Plotly.deleteTraces = function deleteTraces (gd, indices) {
     // we want descending here so that splicing later doesn't affect indexing
     indices.sort().reverse();
     for (i = 0; i < indices.length; i += 1) {
-        deletedTrace = gd.data.splice(indices[i], 1)[0];
-        traces.push(deletedTrace);
+        if (gd.data.length > 1){
+            deletedTrace = gd.data.splice(indices[i], 1)[0];
+            traces.push(deletedTrace);
+        }else {
+            traces.push(gd.data[0]);
+            gd.data = [{ type: gd._fullData.type }];
+        }
     }
 
     Plotly.redraw(gd);


### PR DESCRIPTION
When `Plotly.deleteTraces` is called on a plot with only one trace, it calls `Plotly.plot` with an empty data array, rendering a blank canvas and for some reason leaving the trace that you wanted to delete. 

Recreation:

``` javascript
    Plotly.plot('graphDiv', [{ x: [1,2,3,4], y: [5,6,7,8] }], {});

    var graphDiv = document.getElementById('graphDiv');
    
    Plotly.deleteTrace(graphDiv, 0);
```

The fix is to check whether we are deleting the last trace of a data array, and if so, set `gd.data = [{ type: 'someType' }]` - the type is required to ensure that the correct axes/layout are redrawn for the type of data that previously existed. 

By pushing the last object onto `traces`, it means that multiple "empty actions" will build up if someone continuously deletes the last trace - if anyone has suggestions for a good way to avoid this, I'm all ears.

