### PR TITLE
Optimize by calling window.getComputedStyle once

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2517,7 +2517,8 @@ function calculateReservedMargins(margins) {
 
 function plotAutoSize(gd, aobj) {
     var fullLayout = gd._fullLayout,
-        context = gd._context;
+        context = gd._context
+        computedStyle;
 
     var newHeight, newWidth;
 
@@ -2548,8 +2549,9 @@ function plotAutoSize(gd, aobj) {
         // provide height and width for the container div,
         // specify size in layout, or take the defaults,
         // but don't enforce any ratio restrictions
-        newHeight = parseFloat(window.getComputedStyle(gd).height) || fullLayout.height;
-        newWidth = parseFloat(window.getComputedStyle(gd).width) || fullLayout.width;
+        computedStyle = window.getComputedStyle(gd);
+        newHeight = parseFloat(computedStyle.height) || fullLayout.height;
+        newWidth = parseFloat(computedStyle.width) || fullLayout.width;
     }
 
     if(Math.abs(fullLayout.width - newWidth) > 1 ||

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2517,7 +2517,7 @@ function calculateReservedMargins(margins) {
 
 function plotAutoSize(gd, aobj) {
     var fullLayout = gd._fullLayout,
-        context = gd._context
+        context = gd._context,
         computedStyle;
 
     var newHeight, newWidth;


### PR DESCRIPTION
Although called on a single element, getComputedStyle forces layout thrashing/reflow: https://gist.github.com/paulirish/5d52fb081b3570c81e3a