### PR TITLE
idiomatically set zIndex when creating the Cartesian plot dragCover/coverSlip

### DIFF
--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -2060,7 +2060,7 @@ function coverSlip() {
     cStyle.right = 0;
     cStyle.top = 0;
     cStyle.bottom = 0;
-    cStyle['z-index'] = 999999999;
+    cStyle.zIndex = 999999999;
     cStyle.background = 'none';
 
     document.body.appendChild(cover);


### PR DESCRIPTION
At work, I develop on Firefox 31. I found that this browser does not support setting `z-index` via `style['z-index']`. However, it works correctly with `style.zIndex`.

[W3Schools](http://www.w3schools.com/jsref/prop_style_zindex.asp) (I know, I know...but I couldn't find a better reference for this) confirms that this is the expected, idiomatic behavior.

Firefox 38 seems to handle either approach correctly.