### PR TITLE
Added click event on pie charts.

### DIFF
--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -1276,7 +1276,7 @@ fx.click = function(gd,evt){
     if(gd._hoverdata && evt && evt.target) {
         gd.emit('plotly_click', {points: gd._hoverdata});
         // why do we get a double event without this???
-        evt.stopImmediatePropagation();
+        if(evt.stopImmediatePropagation) evt.stopImmediatePropagation();
     }
 };
 

--- a/src/traces/pie/index.js
+++ b/src/traces/pie/index.js
@@ -374,7 +374,7 @@ pie.plot = function(gd, cdpie) {
                 }
 
                 function handleClick (evt) {
-                    gd._hoverdata = pt;
+                    gd._hoverdata = [pt];
                     gd._hoverdata.trace = cd.trace;
                     Plotly.Fx.click(gd, { target: true });
                 }

--- a/src/traces/pie/index.js
+++ b/src/traces/pie/index.js
@@ -373,6 +373,12 @@ pie.plot = function(gd, cdpie) {
                     }
                 }
 
+                function handleClick (evt) {
+                    gd._hoverdata = pt;
+                    gd._hoverdata.trace = slices[0][0].__data__.trace;
+                    Plotly.Fx.click(gd, { target: true });
+                }
+
                 slicePath.enter().append('path')
                     .classed('surface', true)
                     .style({'pointer-events': 'all'});
@@ -381,7 +387,8 @@ pie.plot = function(gd, cdpie) {
 
                 sliceTop
                     .on('mouseover', handleMouseOver)
-                    .on('mouseout', handleMouseOut);
+                    .on('mouseout', handleMouseOut)
+                    .on('click', handleClick);
 
                 if(trace.pull) {
                     var pull = +(Array.isArray(trace.pull) ? trace.pull[pt.i] : trace.pull) || 0;

--- a/src/traces/pie/index.js
+++ b/src/traces/pie/index.js
@@ -375,7 +375,7 @@ pie.plot = function(gd, cdpie) {
 
                 function handleClick (evt) {
                     gd._hoverdata = pt;
-                    gd._hoverdata.trace = slices[0][0].__data__.trace;
+                    gd._hoverdata.trace = cd.trace;
                     Plotly.Fx.click(gd, { target: true });
                 }
 


### PR DESCRIPTION
From issue https://github.com/plotly/plotly.js/issues/105.

It seems like a bit of an ugly hack, but there doesn't appear to be a standardized method for the click event. 

The ugly part of adding `slices[0][0].__data__.trace` is because for some reason, only the first slice in the `each` loop - the largest slice - contains the trace data.

I'd prefer to make some changes before merging this in, but I'm open to suggestions. 