### PR TITLE
Halt the 2D render loop when the canvas is removed.

### DIFF
--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -403,7 +403,7 @@ trace_id_loop:
 };
 
 proto.draw = function() {
-    if(this.stopped) return;
+    if(this.stopped || !document.body.contains(this.canvas)) return;
     requestAnimationFrame(this.redraw);
 
     var glplot = this.glplot,


### PR DESCRIPTION
This is a partial fix for [plotly.js#126](https://github.com/plotly/plotly.js/issues/126) that will stop the 2D GL render loop when its canvas is removed from `document.body`.

The advantage of this approach is that it works even if `purge` is never called, for example when using `Tabs.fresh()` in the test dashboard.  Any removal of the plot from the page at any level is enough to shut down the rendering.

A separate fix is still needed to address the same issue in 3D scenes.