### PR TITLE
Remove dependencies on Plotly for Choropleth

### DIFF
--- a/src/traces/choropleth/index.js
+++ b/src/traces/choropleth/index.js
@@ -9,9 +9,9 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'choropleth', ['geo', 'noOpacity'], {
+Plots.register(exports, 'choropleth', ['geo', 'noOpacity'], {
     description: [
         'The data that describes the choropleth value-to-color mapping',
         'is set in `z`.',

--- a/src/traces/choropleth/plot.js
+++ b/src/traces/choropleth/plot.js
@@ -13,13 +13,16 @@ var Plotly = require('../../plotly');
 var d3 = require('d3');
 
 var Color = require('../../components/color');
+var Drawing = require('../../components/drawing');
+
+var getColorscale = require('../../components/colorscale/get_scale');
+var makeScaleFunction = require('../../components/colorscale/make_scale_function');
 var getTopojsonFeatures = require('../../lib/topojson_utils').getTopojsonFeatures;
 var locationToFeature = require('../../lib/geo_location_utils').locationToFeature;
 var arrayToCalcItem = require('../../lib/array_to_calc_item');
-var getColorscale = require('../../components/colorscale/get_scale');
-var makeScaleFunction = require('../../components/colorscale/make_scale_function');
 
 var constants = require('../../constants/geo_constants');
+var attributes = require('./attributes');
 
 var plotChoropleth = module.exports = {};
 
@@ -141,7 +144,7 @@ plotChoropleth.style = function(geo) {
                     d3.select(this)
                         .attr('fill', function(d) { return sclFunc(d.z); })
                         .call(Color.stroke, d.mlc || markerLine.color)
-                        .call(Plotly.Drawing.dashLine, '', d.mlw || markerLine.width);
+                        .call(Drawing.dashLine, '', d.mlw || markerLine.width);
                 });
         });
 };
@@ -157,7 +160,7 @@ function makeCleanHoverLabelsFunc(geo, trace) {
     }
 
     var hoverinfoParts = (hoverinfo === 'all') ?
-            Plotly.Choropleth.attributes.hoverinfo.flags :
+            attributes.hoverinfo.flags :
             hoverinfo.split('+');
 
     var hasName = (hoverinfoParts.indexOf('name') !== -1),

--- a/src/traces/scatter/attributes.js
+++ b/src/traces/scatter/attributes.js
@@ -6,8 +6,7 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
-var Plotly = require('../../plotly');
+var Drawing = require('../../components/drawing');
 
 var PTS_LINESONLY = 20;  // TODO put in constants/
 
@@ -166,7 +165,7 @@ module.exports = {
     marker: {
         symbol: {
             valType: 'enumerated',
-            values: Plotly.Drawing.symbolList,
+            values: Drawing.symbolList,
             dflt: 'circle',
             arrayOk: true,
             role: 'style',


### PR DESCRIPTION
Just removed a few references to `Plotly.___` where they cause circular dependency issues.