### PR TITLE
Bring back click events [fixes #173]

### DIFF
--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -2044,7 +2044,10 @@ fx.dragElement = function(options) {
 
         if(Math.abs(dx) < minDrag) dx = 0;
         if(Math.abs(dy) < minDrag) dy = 0;
-        if(dx||dy) gd._dragged = true;
+        if(dx||dy) {
+            gd._dragged = true;
+            fx.unhover(gd);
+        }
 
         if(options.moveFn) options.moveFn(dx, dy, gd._dragged);
 
@@ -2059,7 +2062,6 @@ fx.dragElement = function(options) {
 
         if(!gd._dragging) {
             gd._dragged = false;
-            fx.unhover(gd);
             return;
         }
         gd._dragging = false;

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -1403,7 +1403,6 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 clearSelect();
             }
             else if(dragModeNow === 'select' || dragModeNow === 'lasso') {
-                fx.unhover(gd); // we want a clear plot for dragging
                 prepSelect(e, startX, startY, dragOptions, dragModeNow);
             }
         }
@@ -2060,6 +2059,7 @@ fx.dragElement = function(options) {
 
         if(!gd._dragging) {
             gd._dragged = false;
+            fx.unhover(gd);
             return;
         }
         gd._dragging = false;

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -1377,7 +1377,6 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         yaxes: ya,
         doubleclick: doubleClick,
         prepFn: function(e, startX, startY) {
-            fx.unhover(gd); // we want a clear plot for dragging
             var dragModeNow = gd._fullLayout.dragmode;
             if(ns + ew === 'nsew') {
                 // main dragger handles all drag modes, and changes
@@ -1404,6 +1403,7 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 clearSelect();
             }
             else if(dragModeNow === 'select' || dragModeNow === 'lasso') {
+                fx.unhover(gd); // we want a clear plot for dragging
                 prepSelect(e, startX, startY, dragOptions, dragModeNow);
             }
         }


### PR DESCRIPTION
@alexcjohnson @mdtusz @cldougl 

The lasso PR (https://github.com/plotly/plotly.js/pull/154) added a `fx.unhover` call which clear the hover data when drag box motions are initiated, which had the side effect of clearing the hover data for the click event emitter.

This PR moves the `fx.unhover` call to the `onMove` dragBox handler, bringing back click event.

That said, this has the side effect of making all drag boxes (e.g. select box, zoom box, colorbar, annotations and legend) clear hover upon drag. 