### PR TITLE
WIP: Trace Module Functionality

### DIFF
--- a/src/components/legend/index.js
+++ b/src/components/legend/index.js
@@ -12,7 +12,7 @@
 var Plotly = require('../../plotly');
 var d3 = require('d3');
 
-var Pie = require('../../traces/pie');
+var styleOne = require('../../traces/pie/style_one');
 
 var legend = module.exports = {};
 
@@ -235,7 +235,7 @@ legend.pie = function(d) {
         .attr('transform', 'translate(20,0)');
     pts.exit().remove();
 
-    if(pts.size()) pts.call(Pie.styleOne, d[0], trace);
+    if(pts.size()) pts.call(styleOne, d[0], trace);
 };
 
 legend.style = function(s) {

--- a/src/components/legend/index.js
+++ b/src/components/legend/index.js
@@ -12,6 +12,8 @@
 var Plotly = require('../../plotly');
 var d3 = require('d3');
 
+var Pie = require('../../traces/pie');
+
 var legend = module.exports = {};
 
 legend.layoutAttributes = require('./attributes');
@@ -233,7 +235,7 @@ legend.pie = function(d) {
         .attr('transform', 'translate(20,0)');
     pts.exit().remove();
 
-    if(pts.size()) pts.call(Plotly.Pie.styleOne, d[0], trace);
+    if(pts.size()) pts.call(Pie.styleOne, d[0], trace);
 };
 
 legend.style = function(s) {

--- a/src/index.js
+++ b/src/index.js
@@ -45,3 +45,22 @@ exports.Queue = Plotly.Queue;
 
 // export d3 used in the bundle
 exports.d3 = require('d3');
+
+Plotly.register({
+    traces: {
+        bar: require('./traces/bar'),
+        box: require('./traces/box'),
+        heatmap: require('./traces/heatmap'),
+        histogram: require('./traces/histogram'),
+        histogram2d: require('./traces/histogram2d'),
+        histogram2dcontour: require('./traces/histogram2dcontour'),
+        pie: require('./traces/pie'),
+        contour: require('./traces/contour'),
+        scatter3d: require('./traces/scatter3d'),
+        surface: require('./traces/surface'),
+        mesh3d: require('./traces/mesh3d'),
+        scattergeo: require('./traces/scattergeo'),
+        choropleth: require('./traces/choropleth'),
+        scattergl: require('./traces/scattergl')
+    }
+});

--- a/src/index.js
+++ b/src/index.js
@@ -46,21 +46,19 @@ exports.Queue = Plotly.Queue;
 // export d3 used in the bundle
 exports.d3 = require('d3');
 
-Plotly.register({
-    traces: {
-        bar: require('./traces/bar'),
-        box: require('./traces/box'),
-        heatmap: require('./traces/heatmap'),
-        histogram: require('./traces/histogram'),
-        histogram2d: require('./traces/histogram2d'),
-        histogram2dcontour: require('./traces/histogram2dcontour'),
-        pie: require('./traces/pie'),
-        contour: require('./traces/contour'),
-        scatter3d: require('./traces/scatter3d'),
-        surface: require('./traces/surface'),
-        mesh3d: require('./traces/mesh3d'),
-        scattergeo: require('./traces/scattergeo'),
-        choropleth: require('./traces/choropleth'),
-        scattergl: require('./traces/scattergl')
-    }
-});
+Plotly.register([
+    require('./traces/bar'),
+    require('./traces/box'),
+    require('./traces/heatmap'),
+    require('./traces/histogram'),
+    require('./traces/histogram2d'),
+    require('./traces/histogram2dcontour'),
+    require('./traces/pie'),
+    require('./traces/contour'),
+    require('./traces/scatter3d'),
+    require('./traces/surface'),
+    require('./traces/mesh3d'),
+    require('./traces/scattergeo'),
+    require('./traces/choropleth'),
+    require('./traces/scattergl')
+]);

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -253,7 +253,7 @@ Plotly.plot = function(gd, data, layout, config) {
             modules = gd._modules;
 
         var i, j, cd, trace, uid, subplot, subplotInfo,
-            cdSubplot, cdError, cdModule, module;
+            cdSubplot, cdError, cdModule, _module;
 
         function getCdSubplot(calcdata, subplot) {
             var cdSubplot = [];
@@ -266,13 +266,13 @@ Plotly.plot = function(gd, data, layout, config) {
             return cdSubplot;
         }
 
-        function getCdModule(cdSubplot, module) {
+        function getCdModule(cdSubplot, _module) {
             var cdModule = [];
             var i, cd, trace;
             for (i = 0; i < cdSubplot.length; i++) {
                 cd = cdSubplot[i];
                 trace = cd[0].trace;
-                if (trace._module===module && trace.visible===true) cdModule.push(cd);
+                if (trace._module === _module && trace.visible === true) cdModule.push(cd);
             }
             return cdModule;
         }
@@ -311,12 +311,12 @@ Plotly.plot = function(gd, data, layout, config) {
             if(subplotInfo.plot) subplotInfo.plot.selectAll('g.trace').remove();
 
             for(j = 0; j < modules.length; j++) {
-                module = modules[j];
-                if(!module.plot) continue;
+                _module = modules[j];
+                if(!_module.plot) continue;
 
                 // plot all traces of this type on this subplot at once
-                cdModule = getCdModule(cdSubplot, module);
-                module.plot(gd, subplotInfo, cdModule);
+                cdModule = getCdModule(cdSubplot, _module);
+                _module.plot(gd, subplotInfo, cdModule);
                 Lib.markTime('done ' + (cdModule[0] && cdModule[0][0].trace.type));
 
                 // collect the traces that may have error bars

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1356,7 +1356,7 @@ Plotly.addTraces = function addTraces(gd, traces, newIndices) {
     // if the user didn't define newIndices, they just want the traces appended
     // i.e., we can simply redraw and be done
     if (typeof newIndices === 'undefined') {
-        var promise = Plotly.redraw(gd);
+        promise = Plotly.redraw(gd);
         if (Queue) Queue.add(gd, undoFunc, undoArgs, redoFunc, redoArgs);
         return promise;
     }
@@ -1382,7 +1382,7 @@ Plotly.addTraces = function addTraces(gd, traces, newIndices) {
     // this requires some extra work that moveTraces will do
     if (Queue) Queue.startSequence(gd);
     if (Queue) Queue.add(gd, undoFunc, undoArgs, redoFunc, redoArgs);
-    var promise = Plotly.moveTraces(gd, currentIndices, newIndices);
+    promise = Plotly.moveTraces(gd, currentIndices, newIndices);
     if (Queue) Queue.stopSequence(gd);
     return promise;
 };

--- a/src/plotly.js
+++ b/src/plotly.js
@@ -39,9 +39,6 @@ var Plots = exports.Plots = require('./plots/plots');
 var Cartesian = require('./plots/cartesian');
 Plots.registerSubplot(Cartesian);
 
-exports.Axes = require('./plots/cartesian/axes');
-exports.Fx = require('./plots/cartesian/graph_interact');
-
 var Geo = require('./plots/geo');
 Plots.registerSubplot(Geo);
 
@@ -49,9 +46,12 @@ var Gl3d = require('./plots/gl3d');
 Plots.registerSubplot(Gl3d);
 
 var Gl2d = require('./plots/gl2d');
-Plots.registerSubplot(Gl2d);
 
+Plots.registerSubplot(Gl2d);
+exports.Axes = require('./plots/cartesian/axes');
+exports.Fx = require('./plots/cartesian/graph_interact');
 exports.micropolar = require('./plots/polar/micropolar');
+
 
 // components
 exports.Color = require('./components/color');
@@ -65,22 +65,24 @@ exports.Titles = require('./components/titles');
 exports.Legend = require('./components/legend');
 exports.ModeBar = require('./components/modebar');
 
-// traces
-exports.Scatter = require('./traces/scatter');
-exports.Bar = require('./traces/bar');
-exports.Box = require('./traces/box');
-exports.Heatmap = require('./traces/heatmap');
-exports.Histogram = require('./traces/histogram');
-exports.Histogram2d = require('./traces/histogram2d');
-exports.Histogram2dContour = require('./traces/histogram2dcontour');
-exports.Pie = require('./traces/pie');
-exports.Contour = require('./traces/contour');
-exports.Scatter3D = require('./traces/scatter3d');
-exports.Surface = require('./traces/surface');
-exports.Mesh3D = require('./traces/mesh3d');
-exports.ScatterGeo = require('./traces/scattergeo');
-exports.Choropleth = require('./traces/choropleth');
-exports.ScatterGl = require('./traces/scattergl');
+// Traces are registered in index.js
+exports.register = function register(options) {
+    if(!options || options === {}){
+        throw new Error('You must pass a config object to Plotly.register.');
+    }
+
+    for(var trace in options.traces){
+        var newTrace = options.traces[trace];
+        Plots.register(newTrace, newTrace._type, newTrace._categories, newTrace._meta);
+    }
+};
+
+exports.register({
+    traces: [require('./traces/scatter')]
+});
+
+// Scatter is the only trace included by default
+exports.Scatter = Plots.getModule('scatter');
 
 // plot api
 require('./plot_api/plot_api');

--- a/src/plotly.js
+++ b/src/plotly.js
@@ -46,8 +46,8 @@ var Gl3d = require('./plots/gl3d');
 Plots.registerSubplot(Gl3d);
 
 var Gl2d = require('./plots/gl2d');
-
 Plots.registerSubplot(Gl2d);
+
 exports.Axes = require('./plots/cartesian/axes');
 exports.Fx = require('./plots/cartesian/graph_interact');
 exports.micropolar = require('./plots/polar/micropolar');
@@ -65,21 +65,27 @@ exports.Titles = require('./components/titles');
 exports.Legend = require('./components/legend');
 exports.ModeBar = require('./components/modebar');
 
-// Traces are registered in index.js
-exports.register = function register(options) {
-    if(!options || options === {}){
-        throw new Error('You must pass a config object to Plotly.register.');
+exports.register = function register(_modules) {
+    if(!_modules){
+        throw new Error('No argument passed to Plotly.register.');
+    } else if(_modules && !Array.isArray(_modules)){
+        _modules = [_modules];
     }
 
-    for(var trace in options.traces){
-        var newTrace = options.traces[trace];
-        Plots.register(newTrace, newTrace._type, newTrace._categories, newTrace._meta);
+
+    for(var i = 0; i < _modules.length; i++){
+        var newModule = _modules[i];
+
+        if(newModule && newModule.moduleType !== 'trace'){
+            throw new Error('Invalid module was attempted to be registered!');
+        } else {
+            Plots.register(newModule, newModule.name, newModule.categories, newModule.meta);
+        }
     }
 };
 
-exports.register({
-    traces: [require('./traces/scatter')]
-});
+
+exports.register(require('./traces/scatter'));
 
 // Scatter is the only trace included by default
 exports.Scatter = Plots.getModule('scatter');

--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -146,8 +146,10 @@ proto.onceTopojsonIsLoaded = function(geoData, geoLayout) {
         traceData[trace.type].push(trace);
     }
 
-    for(var traceType in traceData){
-        Plots.getModule(traceType).plot(this, traceData[traceType], geoLayout);
+    var traceKeys = Object.keys(traceData);
+    for(var j = 0; j < traceKeys.length; j++){
+        var traceKey = traceKeys[j];
+        Plots.getModule(traceKey).plot(this, traceData[traceKey], geoLayout);
     }
 
     this.render();

--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -14,13 +14,12 @@
 var Plotly = require('../../plotly');
 var d3 = require('d3');
 
+var Plots = require('../../plots/plots');
+
 var addProjectionsToD3 = require('./projections');
 var createGeoScale = require('./set_scale');
 var createGeoZoom = require('./zoom');
 var createGeoZoomReset = require('./zoom_reset');
-
-var plotScatterGeo = require('../../traces/scattergeo/plot');
-var plotChoropleth = require('../../traces/choropleth/plot');
 
 var constants = require('../../constants/geo_constants');
 var topojsonUtils = require('../../lib/topojson_utils');
@@ -136,21 +135,20 @@ proto.plot = function(geoData, fullLayout, promises) {
 };
 
 proto.onceTopojsonIsLoaded = function(geoData, geoLayout) {
-    var scattergeoData = [],
-        choroplethData = [];
+    var traceData = {};
 
     this.drawLayout(geoLayout);
 
     for(var i = 0; i < geoData.length; i++) {
         var trace = geoData[i];
-        var traceType = trace.type;
 
-        if(traceType === 'scattergeo') scattergeoData.push(trace);
-        else if(traceType === 'choropleth') choroplethData.push(trace);
+        traceData[trace.type] = traceData[trace.type] || [];
+        traceData[trace.type].push(trace);
     }
 
-    if(scattergeoData.length>0) plotScatterGeo.plot(this, scattergeoData);
-    if(choroplethData.length>0) plotChoropleth.plot(this, choroplethData, geoLayout);
+    for(var traceType in traceData){
+        Plots.getModule(traceType).plot(this, traceData[traceType], geoLayout);
+    }
 
     this.render();
 };

--- a/src/plots/geo/zoom_reset.js
+++ b/src/plots/geo/zoom_reset.js
@@ -9,8 +9,7 @@
 
 'use strict';
 
-var loneUnhover = require('../../plotly').Fx.loneUnhover;
-
+var Fx = require('../cartesian/graph_interact');
 
 function createGeoZoomReset(geo, geoLayout) {
     var projection = geo.projection,
@@ -23,7 +22,7 @@ function createGeoZoomReset(geo, geoLayout) {
         zoom.scale(projection.scale());
         zoom.translate(projection.translate());
 
-        loneUnhover(geo.hoverContainer);
+        Fx.loneUnhover(geo.hoverContainer);
 
         geo.render();
     };

--- a/src/plots/gl3d/index.js
+++ b/src/plots/gl3d/index.js
@@ -9,11 +9,9 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
-
 var Scene = require('./scene');
+var Plots = require('../plots');
 
-var plots = Plotly.Plots;
 var axesNames = ['xaxis', 'yaxis', 'zaxis'];
 
 
@@ -32,7 +30,7 @@ exports.supplyLayoutDefaults = require('./layout/defaults');
 exports.plot = function plotGl3d(gd) {
     var fullLayout = gd._fullLayout,
         fullData = gd._fullData,
-        sceneIds = plots.getSubplotIds(fullLayout, 'gl3d');
+        sceneIds = Plots.getSubplotIds(fullLayout, 'gl3d');
 
     fullLayout._paperdiv.style({
         width: fullLayout.width + 'px',
@@ -43,7 +41,7 @@ exports.plot = function plotGl3d(gd) {
 
     for(var i = 0; i < sceneIds.length; i++) {
         var sceneId = sceneIds[i],
-            fullSceneData = plots.getSubplotData(fullData, 'gl3d', sceneId),
+            fullSceneData = Plots.getSubplotData(fullData, 'gl3d', sceneId),
             scene = fullLayout[sceneId]._scene;  // ref. to corresp. Scene instance
 
         // If Scene is not instantiated, create one!
@@ -83,7 +81,7 @@ exports.initAxes = function(gd) {
     delete fullLayout.xaxis;
     delete fullLayout.yaxis;
 
-    var sceneIds = Plotly.Plots.getSubplotIds(fullLayout, 'gl3d');
+    var sceneIds = Plots.getSubplotIds(fullLayout, 'gl3d');
 
     for(var i = 0; i < sceneIds.length; ++i) {
         var sceneId = sceneIds[i];

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -416,7 +416,7 @@ plots.supplyDefaults = function(gd) {
         newData = gd.data || [],
         modules = gd._modules = [];
 
-    var i, trace, fullTrace, module, axList, ax;
+    var i, trace, fullTrace, _module, axList, ax;
 
 
     // first fill in what we can of layout without looking at data
@@ -441,14 +441,14 @@ plots.supplyDefaults = function(gd) {
         else if(plots.traceIs(fullTrace, 'gl2d')) newFullLayout._hasGL2D = true;
         else if('r' in fullTrace) newFullLayout._hasPolar = true;
 
-        module = fullTrace._module;
-        if (module && modules.indexOf(module)===-1) modules.push(module);
+        _module = fullTrace._module;
+        if (_module && modules.indexOf(_module)===-1) modules.push(_module);
     }
 
     // special cases that introduce interactions between traces
     for (i = 0; i < modules.length; i++) {
-        module = modules[i];
-        if (module.cleanData) module.cleanData(newFullData);
+        _module = modules[i];
+        if (_module.cleanData) _module.cleanData(newFullData);
     }
 
     if (oldFullData.length === newData.length) {
@@ -563,7 +563,7 @@ plots.supplyDataDefaults = function(traceIn, i, layout) {
     traceOut.index = i;
     var visible = coerce('visible'),
         scene,
-        module;
+        _module;
 
     coerce('type');
     coerce('uid');
@@ -577,14 +577,14 @@ plots.supplyDataDefaults = function(traceIn, i, layout) {
     // module-specific attributes --- note: we need to send a trace into
     // the 3D modules to have it removed from the webgl context.
     if(visible || scene) {
-        module = plots.getModule(traceOut);
-        traceOut._module = module;
+        _module = plots.getModule(traceOut);
+        traceOut._module = _module;
     }
 
     // gets overwritten in pie and geo
     if(visible) coerce('hoverinfo', (layout._dataLength === 1) ? 'x+y+z+text' : undefined);
 
-    if(module && visible) module.supplyDefaults(traceIn, traceOut, defaultColor, layout);
+    if(_module && visible) _module.supplyDefaults(traceIn, traceOut, defaultColor, layout);
 
     if(visible) {
         coerce('name', 'trace ' + i);

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -13,6 +13,8 @@ var Plotly = require('../plotly');
 var d3 = require('d3');
 var isNumeric = require('fast-isnumeric');
 
+var Lib = require('../lib');
+
 var plots = module.exports = {};
 
 var modules = plots.modules = {},
@@ -269,7 +271,7 @@ plots.resize = function(gd) {
 };
 
 
-// for use in Plotly.Lib.syncOrAsync, check if there are any
+// for use in Lib.syncOrAsync, check if there are any
 // pending promises in this plot and wait for them
 plots.previousPromises = function(gd) {
     if((gd._promises || []).length) {
@@ -524,7 +526,7 @@ function relinkPrivateKeys(toLayout, fromLayout) {
         else if (Array.isArray(fromLayout[k]) &&
                  Array.isArray(toLayout[k]) &&
                  fromLayout[k].length &&
-                 Plotly.Lib.isPlainObject(fromLayout[k][0])) {
+                 Lib.isPlainObject(fromLayout[k][0])) {
             if(fromLayout[k].length !== toLayout[k].length) {
                 // this should be handled elsewhere, it causes
                 // ambiguity if we try to deal with it here.
@@ -536,8 +538,8 @@ function relinkPrivateKeys(toLayout, fromLayout) {
                 relinkPrivateKeys(toLayout[k][j], fromLayout[k][j]);
             }
         }
-        else if (Plotly.Lib.isPlainObject(fromLayout[k]) &&
-                 Plotly.Lib.isPlainObject(toLayout[k])) {
+        else if (Lib.isPlainObject(fromLayout[k]) &&
+                 Lib.isPlainObject(toLayout[k])) {
             // recurse into objects, but only if they still exist
             relinkPrivateKeys(toLayout[k], fromLayout[k]);
             if (!Object.keys(toLayout[k]).length) delete toLayout[k];
@@ -550,12 +552,12 @@ plots.supplyDataDefaults = function(traceIn, i, layout) {
         defaultColor = Plotly.Color.defaults[i % Plotly.Color.defaults.length];
 
     function coerce(attr, dflt) {
-        return Plotly.Lib.coerce(traceIn, traceOut, plots.attributes, attr, dflt);
+        return Lib.coerce(traceIn, traceOut, plots.attributes, attr, dflt);
     }
 
     function coerceSubplotAttr(subplotType, subplotAttr) {
         if(!plots.traceIs(traceOut, subplotType)) return;
-        return Plotly.Lib.coerce(traceIn, traceOut,
+        return Lib.coerce(traceIn, traceOut,
             plots.subplotsRegistry[subplotType].attributes, subplotAttr);
     }
 
@@ -615,14 +617,14 @@ plots.supplyDataDefaults = function(traceIn, i, layout) {
 
 plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut) {
     function coerce(attr, dflt) {
-        return Plotly.Lib.coerce(layoutIn, layoutOut, plots.layoutAttributes, attr, dflt);
+        return Lib.coerce(layoutIn, layoutOut, plots.layoutAttributes, attr, dflt);
     }
 
-    var globalFont = Plotly.Lib.coerceFont(coerce, 'font');
+    var globalFont = Lib.coerceFont(coerce, 'font');
 
     coerce('title');
 
-    Plotly.Lib.coerceFont(coerce, 'titlefont', {
+    Lib.coerceFont(coerce, 'titlefont', {
         family: globalFont.family,
         size: Math.round(globalFont.size * 1.4),
         color: globalFont.color
@@ -928,7 +930,7 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults){
         if(typeof d === 'function') {
             return null;
         }
-        if(Plotly.Lib.isPlainObject(d)) {
+        if(Lib.isPlainObject(d)) {
             var o={}, v, src;
             for(v in d) {
                 // remove private elements and functions
@@ -951,7 +953,7 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults){
                     // in a trace, we will keep the data array.
                     src = d[v+'src'];
                     if(typeof src==='string' && src.indexOf(':')>0) {
-                        if(!Plotly.Lib.isPlainObject(d.stream)) {
+                        if(!Lib.isPlainObject(d.stream)) {
                             continue;
                         }
                     }
@@ -978,7 +980,7 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults){
         // convert native dates to date strings...
         // mostly for external users exporting to plotly
         if(d && d.getTime) {
-            return Plotly.Lib.ms2DateTime(d);
+            return Lib.ms2DateTime(d);
         }
 
         return d;

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -41,7 +41,8 @@ plots.fontWeight = 'normal';
  */
 plots.register = function(_module, thisType, categoriesIn, meta) {
     if(modules[thisType]) {
-        throw new Error('type ' + thisType + ' already registered');
+        console.warn('type ' + thisType + ' already registered');
+        return;
     }
 
     var categoryObj = {};

--- a/src/traces/bar/index.js
+++ b/src/traces/bar/index.js
@@ -9,21 +9,7 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Bar = {};
-
-Plots.register(Bar, 'bar',
-    ['cartesian', 'bar', 'oriented', 'markerColorscale', 'errorBarsOK', 'showLegend'], {
-        description: [
-            'The data visualized by the span of the bars is set in `y`',
-            'if `orientation` is set th *v* (the default)',
-            'and the labels are set in `x`.',
-
-            'By setting `orientation` to *h*, the roles are interchanged.'
-        ].join(' ')
-    }
-);
 
 Bar.attributes = require('./attributes');
 Bar.layoutAttributes = require('./layout_attributes');
@@ -36,5 +22,16 @@ Bar.arraysToCalcdata = require('./arrays_to_calcdata');
 Bar.plot = require('./plot');
 Bar.style = require('./style');
 Bar.hoverPoints = require('./hover');
+
+Bar._categories = ['cartesian', 'bar', 'oriented', 'markerColorscale', 'errorBarsOK', 'showLegend'];
+Bar._type = 'bar';
+Bar._meta = {
+    description: [
+        'The data visualized by the span of the bars is set in `y`',
+        'if `orientation` is set th *v* (the default)',
+        'and the labels are set in `x`.',
+        'By setting `orientation` to *h*, the roles are interchanged.'
+    ].join(' ')
+};
 
 module.exports = Bar;

--- a/src/traces/bar/index.js
+++ b/src/traces/bar/index.js
@@ -23,9 +23,10 @@ Bar.plot = require('./plot');
 Bar.style = require('./style');
 Bar.hoverPoints = require('./hover');
 
-Bar._categories = ['cartesian', 'bar', 'oriented', 'markerColorscale', 'errorBarsOK', 'showLegend'];
-Bar._type = 'bar';
-Bar._meta = {
+Bar.moduleType = 'trace';
+Bar.name = 'bar';
+Bar.categories = ['cartesian', 'bar', 'oriented', 'markerColorscale', 'errorBarsOK', 'showLegend'];
+Bar.meta = {
     description: [
         'The data visualized by the span of the bars is set in `y`',
         'if `orientation` is set th *v* (the default)',

--- a/src/traces/bar/index.js
+++ b/src/traces/bar/index.js
@@ -9,9 +9,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'bar',
+var Bar = {};
+
+Plots.register(Bar, 'bar',
     ['cartesian', 'bar', 'oriented', 'markerColorscale', 'errorBarsOK', 'showLegend'], {
         description: [
             'The data visualized by the span of the bars is set in `y`',
@@ -23,24 +25,16 @@ Plotly.Plots.register(exports, 'bar',
     }
 );
 
-exports.attributes = require('./attributes');
+Bar.attributes = require('./attributes');
+Bar.layoutAttributes = require('./layout_attributes');
+Bar.supplyDefaults = require('./defaults');
+Bar.supplyLayoutDefaults = require('./layout_defaults');
+Bar.calc = require('./calc');
+Bar.setPositions = require('./set_positions');
+Bar.colorbar = require('../scatter/colorbar');
+Bar.arraysToCalcdata = require('./arrays_to_calcdata');
+Bar.plot = require('./plot');
+Bar.style = require('./style');
+Bar.hoverPoints = require('./hover');
 
-exports.layoutAttributes = require('./layout_attributes');
-
-exports.supplyDefaults = require('./defaults');
-
-exports.supplyLayoutDefaults = require('./layout_defaults');
-
-exports.calc = require('./calc');
-
-exports.setPositions = require('./set_positions');
-
-exports.colorbar = require('../scatter/colorbar');
-
-exports.arraysToCalcdata = require('./arrays_to_calcdata');
-
-exports.plot = require('./plot');
-
-exports.style = require('./style');
-
-exports.hoverPoints = require('./hover');
+module.exports = Bar;

--- a/src/traces/box/index.js
+++ b/src/traces/box/index.js
@@ -8,9 +8,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'box',
+var Box = {};
+
+Plots.register(Box, 'box',
     ['cartesian', 'symbols', 'oriented', 'box', 'showLegend'], {
         description: [
             'In vertical (horizontal) box plots,',
@@ -29,12 +31,14 @@ Plotly.Plots.register(exports, 'box',
     }
 );
 
-exports.attributes = require('./attributes');
-exports.layoutAttributes = require('./layout_attributes');
-exports.supplyDefaults = require('./defaults');
-exports.supplyLayoutDefaults = require('./layout_defaults');
-exports.calc = require('./calc');
-exports.setPositions = require('./set_positions');
-exports.plot = require('./plot');
-exports.style = require('./style');
-exports.hoverPoints = require('./hover');
+Box.attributes = require('./attributes');
+Box.layoutAttributes = require('./layout_attributes');
+Box.supplyDefaults = require('./defaults');
+Box.supplyLayoutDefaults = require('./layout_defaults');
+Box.calc = require('./calc');
+Box.setPositions = require('./set_positions');
+Box.plot = require('./plot');
+Box.style = require('./style');
+Box.hoverPoints = require('./hover');
+
+module.exports = Box;

--- a/src/traces/box/index.js
+++ b/src/traces/box/index.js
@@ -8,28 +8,7 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Box = {};
-
-Plots.register(Box, 'box',
-    ['cartesian', 'symbols', 'oriented', 'box', 'showLegend'], {
-        description: [
-            'In vertical (horizontal) box plots,',
-            'statistics are computed using `y` (`x`) values.',
-            'By supplying an `x` (`y`) array, one box per distinct x (y) value',
-            'is drawn',
-            'If no `x` (`y`) {array} is provided, a single box is drawn.',
-            'That box position is then positioned with',
-            'with `name` or with `x0` (`y0`) if provided.',
-            'Each box spans from quartile 1 (Q1) to quartile 3 (Q3).',
-            'The second quartile (Q2) is marked by a line inside the box.',
-            'By default, the whiskers correspond to the box\' edges',
-            '+/- 1.5 times the interquartile range (IQR = Q3-Q1),',
-            'see *boxpoints* for other options.'
-        ].join(' ')
-    }
-);
 
 Box.attributes = require('./attributes');
 Box.layoutAttributes = require('./layout_attributes');
@@ -40,5 +19,24 @@ Box.setPositions = require('./set_positions');
 Box.plot = require('./plot');
 Box.style = require('./style');
 Box.hoverPoints = require('./hover');
+
+Box._type = 'box';
+Box._categories = ['cartesian', 'symbols', 'oriented', 'box', 'showLegend'];
+Box._meta = {
+    description: [
+        'In vertical (horizontal) box plots,',
+        'statistics are computed using `y` (`x`) values.',
+        'By supplying an `x` (`y`) array, one box per distinct x (y) value',
+        'is drawn',
+        'If no `x` (`y`) {array} is provided, a single box is drawn.',
+        'That box position is then positioned with',
+        'with `name` or with `x0` (`y0`) if provided.',
+        'Each box spans from quartile 1 (Q1) to quartile 3 (Q3).',
+        'The second quartile (Q2) is marked by a line inside the box.',
+        'By default, the whiskers correspond to the box\' edges',
+        '+/- 1.5 times the interquartile range (IQR = Q3-Q1),',
+        'see *boxpoints* for other options.'
+    ].join(' ')
+};
 
 module.exports = Box;

--- a/src/traces/box/index.js
+++ b/src/traces/box/index.js
@@ -20,9 +20,10 @@ Box.plot = require('./plot');
 Box.style = require('./style');
 Box.hoverPoints = require('./hover');
 
-Box._type = 'box';
-Box._categories = ['cartesian', 'symbols', 'oriented', 'box', 'showLegend'];
-Box._meta = {
+Box.moduleType = 'trace';
+Box.name = 'box';
+Box.categories = ['cartesian', 'symbols', 'oriented', 'box', 'showLegend'];
+Box.meta = {
     description: [
         'In vertical (horizontal) box plots,',
         'statistics are computed using `y` (`x`) values.',

--- a/src/traces/choropleth/index.js
+++ b/src/traces/choropleth/index.js
@@ -17,9 +17,10 @@ Choropleth.colorbar = require('../heatmap/colorbar');
 Choropleth.calc = require('../surface/calc');
 Choropleth.plot = require('./plot').plot;
 
-Choropleth._type = 'choropleth';
-Choropleth._categories = ['geo', 'noOpacity'];
-Choropleth._meta = {
+Choropleth.moduleType = 'trace';
+Choropleth.name = 'choropleth';
+Choropleth.categories = ['geo', 'noOpacity'];
+Choropleth.meta = {
     description: [
         'The data that describes the choropleth value-to-color mapping',
         'is set in `z`.',

--- a/src/traces/choropleth/index.js
+++ b/src/traces/choropleth/index.js
@@ -11,7 +11,9 @@
 
 var Plots = require('../../plots/plots');
 
-Plots.register(exports, 'choropleth', ['geo', 'noOpacity'], {
+var Choropleth = {};
+
+Plots.register(Choropleth, 'choropleth', ['geo', 'noOpacity'], {
     description: [
         'The data that describes the choropleth value-to-color mapping',
         'is set in `z`.',
@@ -20,10 +22,10 @@ Plots.register(exports, 'choropleth', ['geo', 'noOpacity'], {
     ].join(' ')
 });
 
-exports.attributes = require('./attributes');
+Choropleth.attributes = require('./attributes');
+Choropleth.supplyDefaults = require('./defaults');
+Choropleth.colorbar = require('../heatmap/colorbar');
+Choropleth.calc = require('../surface/calc');
+Choropleth.plot = require('./plot').plot;
 
-exports.supplyDefaults = require('./defaults');
-
-exports.colorbar = require('../heatmap/colorbar');
-
-exports.calc = require('../surface/calc');
+module.exports = Choropleth;

--- a/src/traces/choropleth/index.js
+++ b/src/traces/choropleth/index.js
@@ -9,23 +9,23 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Choropleth = {};
-
-Plots.register(Choropleth, 'choropleth', ['geo', 'noOpacity'], {
-    description: [
-        'The data that describes the choropleth value-to-color mapping',
-        'is set in `z`.',
-        'The geographic locations corresponding to each value in `z`',
-        'are set in `locations`.'
-    ].join(' ')
-});
 
 Choropleth.attributes = require('./attributes');
 Choropleth.supplyDefaults = require('./defaults');
 Choropleth.colorbar = require('../heatmap/colorbar');
 Choropleth.calc = require('../surface/calc');
 Choropleth.plot = require('./plot').plot;
+
+Choropleth._type = 'choropleth';
+Choropleth._categories = ['geo', 'noOpacity'];
+Choropleth._meta = {
+    description: [
+        'The data that describes the choropleth value-to-color mapping',
+        'is set in `z`.',
+        'The geographic locations corresponding to each value in `z`',
+        'are set in `locations`.'
+    ].join(' ')
+};
 
 module.exports = Choropleth;

--- a/src/traces/contour/index.js
+++ b/src/traces/contour/index.js
@@ -9,9 +9,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'contour',
+var Contour = {};
+
+Plots.register(Contour, 'contour',
     ['cartesian', '2dMap', 'contour'], {
         description: [
             'The data from which contour lines are computed is set in `z`.',
@@ -21,22 +23,22 @@ Plotly.Plots.register(exports, 'contour',
             'these N rows correspond to N y coordinates',
             '(set in `y` or auto-generated) and the M columns',
             'correspond to M x coordinates (set in `x` or auto-generated).',
-
             'By setting `transpose` to *true*, the above behavior is flipped.'
         ].join(' ')
-    }
-);
+    });
 
-exports.attributes = require('./attributes');
+Contour.attributes = require('./attributes');
 
-exports.supplyDefaults = require('./defaults');
+Contour.supplyDefaults = require('./defaults');
 
-exports.calc = require('./calc');
+Contour.calc = require('./calc');
 
-exports.plot = require('./plot');
+Contour.plot = require('./plot');
 
-exports.style = require('./style');
+Contour.style = require('./style');
 
-exports.colorbar = require('./colorbar');
+Contour.colorbar = require('./colorbar');
 
-exports.hoverPoints = require('./hover');
+Contour.hoverPoints = require('./hover');
+
+module.exports = Contour;

--- a/src/traces/contour/index.js
+++ b/src/traces/contour/index.js
@@ -19,9 +19,10 @@ Contour.style = require('./style');
 Contour.colorbar = require('./colorbar');
 Contour.hoverPoints = require('./hover');
 
-Contour._type = 'contour';
-Contour._categories = ['cartesian', '2dMap', 'contour'];
-Contour._meta = {
+Contour.moduleType = 'trace';
+Contour.name = 'contour';
+Contour.categories = ['cartesian', '2dMap', 'contour'];
+Contour.meta = {
     description: [
         'The data from which contour lines are computed is set in `z`.',
         'Data in `z` must be a {2D array} of numbers.',

--- a/src/traces/contour/index.js
+++ b/src/traces/contour/index.js
@@ -9,36 +9,29 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Contour = {};
 
-Plots.register(Contour, 'contour',
-    ['cartesian', '2dMap', 'contour'], {
-        description: [
-            'The data from which contour lines are computed is set in `z`.',
-            'Data in `z` must be a {2D array} of numbers.',
-
-            'Say that `z` has N rows and M columns, then by default,',
-            'these N rows correspond to N y coordinates',
-            '(set in `y` or auto-generated) and the M columns',
-            'correspond to M x coordinates (set in `x` or auto-generated).',
-            'By setting `transpose` to *true*, the above behavior is flipped.'
-        ].join(' ')
-    });
-
 Contour.attributes = require('./attributes');
-
 Contour.supplyDefaults = require('./defaults');
-
 Contour.calc = require('./calc');
-
 Contour.plot = require('./plot');
-
 Contour.style = require('./style');
-
 Contour.colorbar = require('./colorbar');
-
 Contour.hoverPoints = require('./hover');
+
+Contour._type = 'contour';
+Contour._categories = ['cartesian', '2dMap', 'contour'];
+Contour._meta = {
+    description: [
+        'The data from which contour lines are computed is set in `z`.',
+        'Data in `z` must be a {2D array} of numbers.',
+
+        'Say that `z` has N rows and M columns, then by default,',
+        'these N rows correspond to N y coordinates',
+        '(set in `y` or auto-generated) and the M columns',
+        'correspond to M x coordinates (set in `x` or auto-generated).',
+        'By setting `transpose` to *true*, the above behavior is flipped.'
+    ].join(' ')
+};
 
 module.exports = Contour;

--- a/src/traces/heatmap/index.js
+++ b/src/traces/heatmap/index.js
@@ -9,9 +9,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'heatmap', ['cartesian', '2dMap'], {
+var Heatmap = {};
+
+Plots.register(Heatmap, 'heatmap', ['cartesian', '2dMap'], {
     description: [
         'The data that describes the heatmap value-to-color mapping',
         'is set in `z`.',
@@ -38,16 +40,12 @@ Plotly.Plots.register(exports, 'heatmap', ['cartesian', '2dMap'], {
     ].join(' ')
 });
 
-exports.attributes = require('./attributes');
+Heatmap.attributes = require('./attributes');
+Heatmap.supplyDefaults = require('./defaults');
+Heatmap.calc = require('./calc');
+Heatmap.plot = require('./plot');
+Heatmap.colorbar = require('./colorbar');
+Heatmap.style = require('./style');
+Heatmap.hoverPoints = require('./hover');
 
-exports.supplyDefaults = require('./defaults');
-
-exports.calc = require('./calc');
-
-exports.plot = require('./plot');
-
-exports.colorbar = require('./colorbar');
-
-exports.style = require('./style');
-
-exports.hoverPoints = require('./hover');
+module.exports = Heatmap;

--- a/src/traces/heatmap/index.js
+++ b/src/traces/heatmap/index.js
@@ -9,11 +9,19 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Heatmap = {};
 
-Plots.register(Heatmap, 'heatmap', ['cartesian', '2dMap'], {
+Heatmap.attributes = require('./attributes');
+Heatmap.supplyDefaults = require('./defaults');
+Heatmap.calc = require('./calc');
+Heatmap.plot = require('./plot');
+Heatmap.colorbar = require('./colorbar');
+Heatmap.style = require('./style');
+Heatmap.hoverPoints = require('./hover');
+
+Heatmap._type = 'heatmap';
+Heatmap._categories = ['cartesian', '2dMap'];
+Heatmap._meta = {
     description: [
         'The data that describes the heatmap value-to-color mapping',
         'is set in `z`.',
@@ -38,14 +46,6 @@ Plots.register(Heatmap, 'heatmap', ['cartesian', '2dMap'], {
         'In the case where `z` is a 1D {array}, the x and y coordinates must be',
         'provided in `x` and `y` respectively to form data triplets.'
     ].join(' ')
-});
-
-Heatmap.attributes = require('./attributes');
-Heatmap.supplyDefaults = require('./defaults');
-Heatmap.calc = require('./calc');
-Heatmap.plot = require('./plot');
-Heatmap.colorbar = require('./colorbar');
-Heatmap.style = require('./style');
-Heatmap.hoverPoints = require('./hover');
+};
 
 module.exports = Heatmap;

--- a/src/traces/heatmap/index.js
+++ b/src/traces/heatmap/index.js
@@ -19,9 +19,10 @@ Heatmap.colorbar = require('./colorbar');
 Heatmap.style = require('./style');
 Heatmap.hoverPoints = require('./hover');
 
-Heatmap._type = 'heatmap';
-Heatmap._categories = ['cartesian', '2dMap'];
-Heatmap._meta = {
+Heatmap.moduleType = 'trace';
+Heatmap.name = 'heatmap';
+Heatmap.categories = ['cartesian', '2dMap'];
+Heatmap.meta = {
     description: [
         'The data that describes the heatmap value-to-color mapping',
         'is set in `z`.',

--- a/src/traces/histogram/index.js
+++ b/src/traces/histogram/index.js
@@ -36,9 +36,10 @@ Histogram.style = require('../bar/style');
 Histogram.colorbar = require('../scatter/colorbar');
 Histogram.hoverPoints = require('../bar/hover');
 
-Histogram._type = 'histogram';
-Histogram._categories = ['cartesian', 'bar', 'histogram', 'oriented', 'errorBarsOK', 'showLegend'];
-Histogram._meta = {
+Histogram.moduleType = 'trace';
+Histogram.name = 'histogram';
+Histogram.categories = ['cartesian', 'bar', 'histogram', 'oriented', 'errorBarsOK', 'showLegend'];
+Histogram.meta = {
     description: [
         'The sample data from which statistics are computed is set in `x`',
         'for vertically spanning histograms and',

--- a/src/traces/histogram/index.js
+++ b/src/traces/histogram/index.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
 /**
  * Histogram has its own attribute, defaults and calc steps,
@@ -24,35 +24,30 @@ var Plotly = require('../../plotly');
  * to allow quadrature combination of errors in summed histograms...
  */
 
-Plotly.Plots.register(exports, 'histogram',
+
+var Histogram = {};
+
+Plots.register(Histogram, 'histogram',
     ['cartesian', 'bar', 'histogram', 'oriented', 'errorBarsOK', 'showLegend'], {
         description: [
             'The sample data from which statistics are computed is set in `x`',
             'for vertically spanning histograms and',
             'in `y` for horizontally spanning histograms.',
-
             'Binning options are set `xbins` and `ybins` respectively',
             'if no aggregation data is provided.'
         ].join(' ')
     }
 );
 
-exports.attributes = require('./attributes');
+Histogram.attributes = require('./attributes');
+Histogram.layoutAttributes = require('../bar/layout_attributes');
+Histogram.supplyDefaults = require('./defaults');
+Histogram.supplyLayoutDefaults = require('../bar/layout_defaults');
+Histogram.calc = require('./calc');
+Histogram.setPositions = require('../bar/set_positions');
+Histogram.plot = require('../bar/plot');
+Histogram.style = require('../bar/style');
+Histogram.colorbar = require('../scatter/colorbar');
+Histogram.hoverPoints = require('../bar/hover');
 
-exports.layoutAttributes = require('../bar/layout_attributes');
-
-exports.supplyDefaults = require('./defaults');
-
-exports.supplyLayoutDefaults = require('../bar/layout_defaults');
-
-exports.calc = require('./calc');
-
-exports.setPositions = require('../bar/set_positions');
-
-exports.plot = require('../bar/plot');
-
-exports.style = require('../bar/style');
-
-exports.colorbar = require('../scatter/colorbar');
-
-exports.hoverPoints = require('../bar/hover');
+module.exports = Histogram;

--- a/src/traces/histogram/index.js
+++ b/src/traces/histogram/index.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 /**
  * Histogram has its own attribute, defaults and calc steps,
  * but uses bar's plot to display
@@ -27,18 +25,6 @@ var Plots = require('../../plots/plots');
 
 var Histogram = {};
 
-Plots.register(Histogram, 'histogram',
-    ['cartesian', 'bar', 'histogram', 'oriented', 'errorBarsOK', 'showLegend'], {
-        description: [
-            'The sample data from which statistics are computed is set in `x`',
-            'for vertically spanning histograms and',
-            'in `y` for horizontally spanning histograms.',
-            'Binning options are set `xbins` and `ybins` respectively',
-            'if no aggregation data is provided.'
-        ].join(' ')
-    }
-);
-
 Histogram.attributes = require('./attributes');
 Histogram.layoutAttributes = require('../bar/layout_attributes');
 Histogram.supplyDefaults = require('./defaults');
@@ -49,5 +35,17 @@ Histogram.plot = require('../bar/plot');
 Histogram.style = require('../bar/style');
 Histogram.colorbar = require('../scatter/colorbar');
 Histogram.hoverPoints = require('../bar/hover');
+
+Histogram._type = 'histogram';
+Histogram._categories = ['cartesian', 'bar', 'histogram', 'oriented', 'errorBarsOK', 'showLegend'];
+Histogram._meta = {
+    description: [
+        'The sample data from which statistics are computed is set in `x`',
+        'for vertically spanning histograms and',
+        'in `y` for horizontally spanning histograms.',
+        'Binning options are set `xbins` and `ybins` respectively',
+        'if no aggregation data is provided.'
+    ].join(' ')
+};
 
 module.exports = Histogram;

--- a/src/traces/histogram2d/index.js
+++ b/src/traces/histogram2d/index.js
@@ -19,9 +19,10 @@ Histogram2D.colorbar = require('../heatmap/colorbar');
 Histogram2D.style = require('../heatmap/style');
 Histogram2D.hoverPoints = require('../heatmap/hover');
 
-Histogram2D._type = 'histogram2d';
-Histogram2D._categories = ['cartesian', '2dMap', 'histogram'];
-Histogram2D._meta = {
+Histogram2D.moduleType = 'trace';
+Histogram2D.name = 'histogram2d';
+Histogram2D.categories = ['cartesian', '2dMap', 'histogram'];
+Histogram2D.meta = {
     hrName: 'histogram_2d',
     description: [
         'The sample data from which statistics are computed is set in `x`',

--- a/src/traces/histogram2d/index.js
+++ b/src/traces/histogram2d/index.js
@@ -9,23 +9,7 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Histogram2D = {};
-
-Plots.register(Histogram2D, 'histogram2d',
-    ['cartesian', '2dMap', 'histogram'], {
-        hrName: 'histogram_2d',
-        description: [
-            'The sample data from which statistics are computed is set in `x`',
-            'and `y` (where `x` and `y` represent marginal distributions,',
-            'binning is set in `xbins` and `ybins` in this case)',
-            'or `z` (where `z` represent the 2D distribution and binning set,',
-            'binning is set by `x` and `y` in this case).',
-            'The resulting distribution is visualized as a heatmap.'
-        ].join(' ')
-    }
-);
 
 Histogram2D.attributes = require('./attributes');
 Histogram2D.supplyDefaults = require('./defaults');
@@ -34,5 +18,19 @@ Histogram2D.plot = require('../heatmap/plot');
 Histogram2D.colorbar = require('../heatmap/colorbar');
 Histogram2D.style = require('../heatmap/style');
 Histogram2D.hoverPoints = require('../heatmap/hover');
+
+Histogram2D._type = 'histogram2d';
+Histogram2D._categories = ['cartesian', '2dMap', 'histogram'];
+Histogram2D._meta = {
+    hrName: 'histogram_2d',
+    description: [
+        'The sample data from which statistics are computed is set in `x`',
+        'and `y` (where `x` and `y` represent marginal distributions,',
+        'binning is set in `xbins` and `ybins` in this case)',
+        'or `z` (where `z` represent the 2D distribution and binning set,',
+        'binning is set by `x` and `y` in this case).',
+        'The resulting distribution is visualized as a heatmap.'
+    ].join(' ')
+};
 
 module.exports = Histogram2D;

--- a/src/traces/histogram2d/index.js
+++ b/src/traces/histogram2d/index.js
@@ -9,9 +9,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'histogram2d',
+var Histogram2D = {};
+
+Plots.register(Histogram2D, 'histogram2d',
     ['cartesian', '2dMap', 'histogram'], {
         hrName: 'histogram_2d',
         description: [
@@ -25,16 +27,12 @@ Plotly.Plots.register(exports, 'histogram2d',
     }
 );
 
-exports.attributes = require('./attributes');
+Histogram2D.attributes = require('./attributes');
+Histogram2D.supplyDefaults = require('./defaults');
+Histogram2D.calc = require('../heatmap/calc');
+Histogram2D.plot = require('../heatmap/plot');
+Histogram2D.colorbar = require('../heatmap/colorbar');
+Histogram2D.style = require('../heatmap/style');
+Histogram2D.hoverPoints = require('../heatmap/hover');
 
-exports.supplyDefaults = require('./defaults');
-
-exports.calc = require('../heatmap/calc');
-
-exports.plot = require('../heatmap/plot');
-
-exports.colorbar = require('../heatmap/colorbar');
-
-exports.style = require('../heatmap/style');
-
-exports.hoverPoints = require('../heatmap/hover');
+module.exports = Histogram2D;

--- a/src/traces/histogram2dcontour/index.js
+++ b/src/traces/histogram2dcontour/index.js
@@ -9,9 +9,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'histogram2dcontour',
+var Histogram2dContour = {};
+
+Plots.register(Histogram2dContour, 'histogram2dcontour',
     ['cartesian', '2dMap', 'contour', 'histogram'], {
         hrName: 'histogram_2d_contour',
         description: [
@@ -25,16 +27,12 @@ Plotly.Plots.register(exports, 'histogram2dcontour',
     }
 );
 
-exports.attributes = require('./attributes');
+Histogram2dContour.attributes = require('./attributes');
+Histogram2dContour.supplyDefaults = require('./defaults');
+Histogram2dContour.calc = require('../contour/calc');
+Histogram2dContour.plot = require('../contour/plot');
+Histogram2dContour.style = require('../contour/style');
+Histogram2dContour.colorbar = require('../contour/colorbar');
+Histogram2dContour.hoverPoints = require('../contour/hover');
 
-exports.supplyDefaults = require('./defaults');
-
-exports.calc = require('../contour/calc');
-
-exports.plot = require('../contour/plot');
-
-exports.style = require('../contour/style');
-
-exports.colorbar = require('../contour/colorbar');
-
-exports.hoverPoints = require('../contour/hover');
+module.exports = Histogram2dContour;

--- a/src/traces/histogram2dcontour/index.js
+++ b/src/traces/histogram2dcontour/index.js
@@ -19,9 +19,10 @@ Histogram2dContour.style = require('../contour/style');
 Histogram2dContour.colorbar = require('../contour/colorbar');
 Histogram2dContour.hoverPoints = require('../contour/hover');
 
-Histogram2dContour._type = 'histogram2dcontour';
-Histogram2dContour._categories = ['cartesian', '2dMap', 'contour', 'histogram'];
-Histogram2dContour._meta = {
+Histogram2dContour.moduleType = 'trace';
+Histogram2dContour.name = 'histogram2dcontour';
+Histogram2dContour.categories = ['cartesian', '2dMap', 'contour', 'histogram'];
+Histogram2dContour.meta = {
     hrName: 'histogram_2d_contour',
     description: [
         'The sample data from which statistics are computed is set in `x`',

--- a/src/traces/histogram2dcontour/index.js
+++ b/src/traces/histogram2dcontour/index.js
@@ -9,23 +9,7 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Histogram2dContour = {};
-
-Plots.register(Histogram2dContour, 'histogram2dcontour',
-    ['cartesian', '2dMap', 'contour', 'histogram'], {
-        hrName: 'histogram_2d_contour',
-        description: [
-            'The sample data from which statistics are computed is set in `x`',
-            'and `y` (where `x` and `y` represent marginal distributions,',
-            'binning is set in `xbins` and `ybins` in this case)',
-            'or `z` (where `z` represent the 2D distribution and binning set,',
-            'binning is set by `x` and `y` in this case).',
-            'The resulting distribution is visualized as a contour plot.'
-        ].join(' ')
-    }
-);
 
 Histogram2dContour.attributes = require('./attributes');
 Histogram2dContour.supplyDefaults = require('./defaults');
@@ -34,5 +18,19 @@ Histogram2dContour.plot = require('../contour/plot');
 Histogram2dContour.style = require('../contour/style');
 Histogram2dContour.colorbar = require('../contour/colorbar');
 Histogram2dContour.hoverPoints = require('../contour/hover');
+
+Histogram2dContour._type = 'histogram2dcontour';
+Histogram2dContour._categories = ['cartesian', '2dMap', 'contour', 'histogram'];
+Histogram2dContour._meta = {
+    hrName: 'histogram_2d_contour',
+    description: [
+        'The sample data from which statistics are computed is set in `x`',
+        'and `y` (where `x` and `y` represent marginal distributions,',
+        'binning is set in `xbins` and `ybins` in this case)',
+        'or `z` (where `z` represent the 2D distribution and binning set,',
+        'binning is set by `x` and `y` in this case).',
+        'The resulting distribution is visualized as a contour plot.'
+    ].join(' ')
+};
 
 module.exports = Histogram2dContour;

--- a/src/traces/mesh3d/defaults.js
+++ b/src/traces/mesh3d/defaults.js
@@ -10,12 +10,13 @@
 'use strict';
 
 var Plotly = require('../../plotly');
-var Mesh3D = require('./');
+var Lib = require('../../lib');
+var attributes = require('./attributes');
 
 
 module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
     function coerce(attr, dflt) {
-        return Plotly.Lib.coerce(traceIn, traceOut, Mesh3D.attributes, attr, dflt);
+        return Lib.coerce(traceIn, traceOut, attributes, attr, dflt);
     }
 
     // read in face/vertex properties

--- a/src/traces/mesh3d/index.js
+++ b/src/traces/mesh3d/index.js
@@ -9,11 +9,16 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Mesh3D = {};
 
-Plots.register(Mesh3D, 'mesh3d', ['gl3d'], {
+Mesh3D.attributes = require('./attributes');
+Mesh3D.supplyDefaults = require('./defaults');
+Mesh3D.colorbar = require('../heatmap/colorbar');
+Mesh3D.plot = require('./convert');
+
+Mesh3D._type = 'mesh3d',
+Mesh3D._categories = ['gl3d'];
+Mesh3D._meta = {
     description: [
         'Draws sets of triangles with coordinates given by',
         'three 1-dimensional arrays in `x`, `y`, `z` and',
@@ -22,11 +27,6 @@ Plots.register(Mesh3D, 'mesh3d', ['gl3d'], {
         '(3) the Alpha-shape algorithm or',
         '(4) the Convex-hull algorithm'
     ].join(' ')
-});
-
-Mesh3D.attributes = require('./attributes');
-Mesh3D.supplyDefaults = require('./defaults');
-Mesh3D.colorbar = require('../heatmap/colorbar');
-Mesh3D.plot = require('./convert');
+};
 
 module.exports = Mesh3D;

--- a/src/traces/mesh3d/index.js
+++ b/src/traces/mesh3d/index.js
@@ -16,9 +16,10 @@ Mesh3D.supplyDefaults = require('./defaults');
 Mesh3D.colorbar = require('../heatmap/colorbar');
 Mesh3D.plot = require('./convert');
 
-Mesh3D._type = 'mesh3d',
-Mesh3D._categories = ['gl3d'];
-Mesh3D._meta = {
+Mesh3D.moduleType = 'trace';
+Mesh3D.name = 'mesh3d',
+Mesh3D.categories = ['gl3d'];
+Mesh3D.meta = {
     description: [
         'Draws sets of triangles with coordinates given by',
         'three 1-dimensional arrays in `x`, `y`, `z` and',

--- a/src/traces/mesh3d/index.js
+++ b/src/traces/mesh3d/index.js
@@ -9,11 +9,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-var Mesh3D = module.exports = {};
+var Mesh3D = {};
 
-Plotly.Plots.register(Mesh3D, 'mesh3d', ['gl3d'], {
+Plots.register(Mesh3D, 'mesh3d', ['gl3d'], {
     description: [
         'Draws sets of triangles with coordinates given by',
         'three 1-dimensional arrays in `x`, `y`, `z` and',
@@ -25,7 +25,8 @@ Plotly.Plots.register(Mesh3D, 'mesh3d', ['gl3d'], {
 });
 
 Mesh3D.attributes = require('./attributes');
-
 Mesh3D.supplyDefaults = require('./defaults');
-
 Mesh3D.colorbar = require('../heatmap/colorbar');
+Mesh3D.plot = require('./convert');
+
+module.exports = Mesh3D;

--- a/src/traces/pie/index.js
+++ b/src/traces/pie/index.js
@@ -8,18 +8,7 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
-
 var Pie = {};
-
-Plots.register(Pie, 'pie', ['pie', 'showLegend'], {
-    description: [
-        'A data visualized by the sectors of the pie is set in `values`.',
-        'The sector labels are set in `labels`.',
-        'The sector colors are set in `marker.colors`'
-    ].join(' ')
-});
 
 Pie.attributes = require('./attributes');
 Pie.supplyDefaults = require('./defaults');
@@ -29,5 +18,15 @@ Pie.calc = require('./calc');
 Pie.plot = require('./plot');
 Pie.style = require('./style');
 Pie.styleOne = require('./style_one');
+
+Pie._type = 'pie';
+Pie._categories = ['pie', 'showLegend'];
+Pie._meta = {
+    description: [
+        'A data visualized by the sectors of the pie is set in `values`.',
+        'The sector labels are set in `labels`.',
+        'The sector colors are set in `marker.colors`'
+    ].join(' ')
+};
 
 module.exports = Pie;

--- a/src/traces/pie/index.js
+++ b/src/traces/pie/index.js
@@ -8,9 +8,12 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-Plotly.Plots.register(exports, 'pie', ['pie', 'showLegend'], {
+
+var Pie = {};
+
+Plots.register(Pie, 'pie', ['pie', 'showLegend'], {
     description: [
         'A data visualized by the sectors of the pie is set in `values`.',
         'The sector labels are set in `labels`.',
@@ -18,11 +21,13 @@ Plotly.Plots.register(exports, 'pie', ['pie', 'showLegend'], {
     ].join(' ')
 });
 
-exports.attributes = require('./attributes');
-exports.supplyDefaults = require('./defaults');
-exports.supplyLayoutDefaults = require('./layout_defaults');
-exports.layoutAttributes = require('./layout_attributes');
-exports.calc = require('./calc');
-exports.plot = require('./plot');
-exports.style = require('./style');
-exports.styleOne = require('./style_one');
+Pie.attributes = require('./attributes');
+Pie.supplyDefaults = require('./defaults');
+Pie.supplyLayoutDefaults = require('./layout_defaults');
+Pie.layoutAttributes = require('./layout_attributes');
+Pie.calc = require('./calc');
+Pie.plot = require('./plot');
+Pie.style = require('./style');
+Pie.styleOne = require('./style_one');
+
+module.exports = Pie;

--- a/src/traces/pie/index.js
+++ b/src/traces/pie/index.js
@@ -19,9 +19,10 @@ Pie.plot = require('./plot');
 Pie.style = require('./style');
 Pie.styleOne = require('./style_one');
 
-Pie._type = 'pie';
-Pie._categories = ['pie', 'showLegend'];
-Pie._meta = {
+Pie.moduleType = 'trace';
+Pie.name = 'pie';
+Pie.categories = ['pie', 'showLegend'];
+Pie.meta = {
     description: [
         'A data visualized by the sectors of the pie is set in `values`.',
         'The sector labels are set in `labels`.',

--- a/src/traces/scatter/index.js
+++ b/src/traces/scatter/index.js
@@ -14,7 +14,6 @@ var isNumeric = require('fast-isnumeric');
 
 var Lib = require('../../lib');
 
-var Plots = require('../../plots/plots');
 var Fx = require('../../plots/cartesian/graph_interact');
 var Axes = require('../../plots/cartesian/axes');
 
@@ -34,17 +33,17 @@ scatter.isBubble = subtypes.isBubble;
 
 scatter.selectPoints = require('./select');
 
-Plots.register(scatter, 'scatter',
-    ['cartesian', 'symbols', 'markerColorscale', 'errorBarsOK', 'showLegend'], {
-        description: [
-            'The scatter trace type encompasses line charts, scatter charts, text charts, and bubble charts.',
-            'The data visualized as scatter point or lines is set in `x` and `y`.',
-            'Text (appearing either on the chart or on hover only) is via `text`.',
-            'Bubble charts are achieved by setting `marker.size` and/or `marker.color`',
-            'to a numerical arrays.'
-        ].join(' ')
-    }
-);
+scatter._type = 'scatter';
+scatter._categories = ['cartesian', 'symbols', 'markerColorscale', 'errorBarsOK', 'showLegend'];
+scatter._meta = {
+    description: [
+        'The scatter trace type encompasses line charts, scatter charts, text charts, and bubble charts.',
+        'The data visualized as scatter point or lines is set in `x` and `y`.',
+        'Text (appearing either on the chart or on hover only) is via `text`.',
+        'Bubble charts are achieved by setting `marker.size` and/or `marker.color`',
+        'to a numerical arrays.'
+    ].join(' ')
+};
 
 // traces with < this many points are by default shown
 // with points and lines, > just get lines

--- a/src/traces/scatter/index.js
+++ b/src/traces/scatter/index.js
@@ -33,9 +33,10 @@ scatter.isBubble = subtypes.isBubble;
 
 scatter.selectPoints = require('./select');
 
-scatter._type = 'scatter';
-scatter._categories = ['cartesian', 'symbols', 'markerColorscale', 'errorBarsOK', 'showLegend'];
-scatter._meta = {
+scatter.moduleType = 'trace';
+scatter.name = 'scatter';
+scatter.categories = ['cartesian', 'symbols', 'markerColorscale', 'errorBarsOK', 'showLegend'];
+scatter.meta = {
     description: [
         'The scatter trace type encompasses line charts, scatter charts, text charts, and bubble charts.',
         'The data visualized as scatter point or lines is set in `x` and `y`.',

--- a/src/traces/scatter3d/convert.js
+++ b/src/traces/scatter3d/convert.js
@@ -9,16 +9,17 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
-
 var createLinePlot = require('gl-line3d');
 var createScatterPlot = require('gl-scatter3d');
 var createErrorBars = require('gl-error3d');
 var createMesh = require('gl-mesh3d');
 var triangulate = require('delaunay-triangulate');
 
+var Lib = require('../../lib');
 var str2RgbaArray = require('../../lib/str2rgbarray');
 var formatColor = require('../../lib/gl_format_color');
+
+var Scatter = require('../scatter');
 
 var DASH_PATTERNS = require('../../constants/gl3d_dashes.json');
 var MARKER_SYMBOLS = require('../../constants/gl_markers.json');
@@ -156,7 +157,7 @@ function formatParam(paramIn, len, calculate, dflt, extraFn) {
         }
 
     }
-    else paramOut = calculate(paramIn, Plotly.Lib.identity);
+    else paramOut = calculate(paramIn, Lib.identity);
 
     return paramOut;
 }
@@ -209,7 +210,7 @@ function convertPlotlyOptions(scene, data) {
     }
 
     if ('marker' in data) {
-        var sizeFn = Plotly.Scatter.getBubbleSizeFn(data);
+        var sizeFn = Scatter.getBubbleSizeFn(data);
 
         params.scatterColor = formatColor(marker, 1, len);
         params.scatterSize = formatParam(marker.size, len, calculateSize, 20, sizeFn);
@@ -222,7 +223,7 @@ function convertPlotlyOptions(scene, data) {
     if ('textposition' in data) {
         params.textOffset = calculateTextOffset(data.textposition);  // arrayOk === false
         params.textColor = formatColor(data.textfont, 1, len);
-        params.textSize = formatParam(data.textfont.size, len, Plotly.Lib.identity, 12);
+        params.textSize = formatParam(data.textfont.size, len, Lib.identity, 12);
         params.textFont = data.textfont.family;  // arrayOk === false
         params.textAngle = 0;
     }

--- a/src/traces/scatter3d/defaults.js
+++ b/src/traces/scatter3d/defaults.js
@@ -9,15 +9,17 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
-var Scatter3D = require('./');
+var Scatter = require('../../traces/scatter');
+var Lib = require('../../lib');
+var ErrorBars = require('../../components/errorbars');
+
+var attributes = require('./attributes');
 
 
 module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
-    var Scatter = Plotly.Scatter;
 
     function coerce(attr, dflt) {
-        return Plotly.Lib.coerce(traceIn, traceOut, Scatter3D.attributes, attr, dflt);
+        return Lib.coerce(traceIn, traceOut, attributes, attr, dflt);
     }
 
     var len = handleXYZDefaults(traceIn, traceOut, coerce);
@@ -54,9 +56,9 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
         }
     }
 
-    Plotly.ErrorBars.supplyDefaults(traceIn, traceOut, defaultColor, {axis: 'z'});
-    Plotly.ErrorBars.supplyDefaults(traceIn, traceOut, defaultColor, {axis: 'y', inherit: 'z'});
-    Plotly.ErrorBars.supplyDefaults(traceIn, traceOut, defaultColor, {axis: 'x', inherit: 'z'});
+    ErrorBars.supplyDefaults(traceIn, traceOut, defaultColor, {axis: 'z'});
+    ErrorBars.supplyDefaults(traceIn, traceOut, defaultColor, {axis: 'y', inherit: 'z'});
+    ErrorBars.supplyDefaults(traceIn, traceOut, defaultColor, {axis: 'x', inherit: 'z'});
 };
 
 function handleXYZDefaults(traceIn, traceOut, coerce) {

--- a/src/traces/scatter3d/index.js
+++ b/src/traces/scatter3d/index.js
@@ -9,22 +9,8 @@
 'use strict';
 
 var Scatter = require('../scatter');
-var Plots = require('../../plots/plots');
 
 var Scatter3D = {};
-
-Plots.register(Scatter3D,
-    'scatter3d', ['gl3d', 'symbols', 'markerColorscale', 'showLegend'], {
-        hrName: 'scatter_3d',
-        description: [
-            'The data visualized as scatter point or lines in 3D dimension',
-            'is set in `x`, `y`, `z`.',
-            'Text (appearing either on the chart or on hover only) is via `text`.',
-            'Bubble charts are achieved by setting `marker.size` and/or `marker.color`',
-            'Projections are achieved via `projection`.',
-            'Surface fills are achieved via `surfaceaxis`.'
-        ].join(' ')
-    });
 
 Scatter3D.plot = require('./convert');
 Scatter3D.attributes = require('./attributes');
@@ -42,6 +28,20 @@ Scatter3D.calc = function(gd, trace) {
     Scatter.calcMarkerColorscales(trace);
 
     return cd;
+};
+
+Scatter3D._type = 'scatter3d';
+Scatter3D._categories = ['gl3d', 'symbols', 'markerColorscale', 'showLegend'];
+Scatter3D._meta = {
+    hrName: 'scatter_3d',
+    description: [
+        'The data visualized as scatter point or lines in 3D dimension',
+        'is set in `x`, `y`, `z`.',
+        'Text (appearing either on the chart or on hover only) is via `text`.',
+        'Bubble charts are achieved by setting `marker.size` and/or `marker.color`',
+        'Projections are achieved via `projection`.',
+        'Surface fills are achieved via `surfaceaxis`.'
+    ].join(' ')
 };
 
 module.exports = Scatter3D;

--- a/src/traces/scatter3d/index.js
+++ b/src/traces/scatter3d/index.js
@@ -6,14 +6,14 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
-var Plotly = require('../../plotly');
+var Scatter = require('../scatter');
+var Plots = require('../../plots/plots');
 
-var Scatter3D = module.exports = {};
+var Scatter3D = {};
 
-Plotly.Plots.register(Scatter3D,
+Plots.register(Scatter3D,
     'scatter3d', ['gl3d', 'symbols', 'markerColorscale', 'showLegend'], {
         hrName: 'scatter_3d',
         description: [
@@ -24,25 +24,24 @@ Plotly.Plots.register(Scatter3D,
             'Projections are achieved via `projection`.',
             'Surface fills are achieved via `surfaceaxis`.'
         ].join(' ')
-    }
-);
+    });
 
+Scatter3D.plot = require('./convert');
 Scatter3D.attributes = require('./attributes');
-
 Scatter3D.markerSymbols = require('../../constants/gl_markers.json');
-
 Scatter3D.supplyDefaults = require('./defaults');
-
-Scatter3D.colorbar = Plotly.Scatter.colorbar;
+Scatter3D.colorbar = require('../scatter/colorbar');
 
 Scatter3D.calc = function(gd, trace) {
     // this is a kludge to put the array attributes into
     // calcdata the way Scatter.plot does, so that legends and
     // popovers know what to do with them.
     var cd = [{x: false, y: false, trace: trace, t: {}}];
-    Plotly.Scatter.arraysToCalcdata(cd);
+    Scatter.arraysToCalcdata(cd);
 
-    Plotly.Scatter.calcMarkerColorscales(trace);
+    Scatter.calcMarkerColorscales(trace);
 
     return cd;
 };
+
+module.exports = Scatter3D;

--- a/src/traces/scatter3d/index.js
+++ b/src/traces/scatter3d/index.js
@@ -30,9 +30,10 @@ Scatter3D.calc = function(gd, trace) {
     return cd;
 };
 
-Scatter3D._type = 'scatter3d';
-Scatter3D._categories = ['gl3d', 'symbols', 'markerColorscale', 'showLegend'];
-Scatter3D._meta = {
+Scatter3D.moduleType = 'trace';
+Scatter3D.name = 'scatter3d';
+Scatter3D.categories = ['gl3d', 'symbols', 'markerColorscale', 'showLegend'];
+Scatter3D.meta = {
     hrName: 'scatter_3d',
     description: [
         'The data visualized as scatter point or lines in 3D dimension',

--- a/src/traces/scattergeo/defaults.js
+++ b/src/traces/scattergeo/defaults.js
@@ -9,15 +9,15 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
-var ScatterGeo = require('./');
+var Lib = require('../../lib');
+var Scatter = require('../scatter');
+var attributes = require('./attributes');
 
 
 module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
-    var Scatter = Plotly.Scatter;
 
     function coerce(attr, dflt) {
-        return Plotly.Lib.coerce(traceIn, traceOut, ScatterGeo.attributes, attr, dflt);
+        return Lib.coerce(traceIn, traceOut, attributes, attr, dflt);
     }
 
     var len = handleLonLatLocDefaults(traceIn, traceOut, coerce);

--- a/src/traces/scattergeo/index.js
+++ b/src/traces/scattergeo/index.js
@@ -12,7 +12,8 @@
 var Plots = require('../../plots/plots');
 var Scatter = require('../scatter');
 
-var ScatterGeo = module.exports = {};
+
+var ScatterGeo = {};
 
 Plots.register(ScatterGeo, 'scattergeo',
     ['geo', 'symbols', 'markerColorscale', 'showLegend'], {
@@ -22,17 +23,17 @@ Plots.register(ScatterGeo, 'scattergeo',
             'is provided either by longitude/latitude pairs in `lon` and `lat`',
             'respectively or by geographic location IDs or names in `locations`.'
         ].join(' ')
-    }
-);
+    });
 
 ScatterGeo.attributes = require('./attributes');
-
 ScatterGeo.supplyDefaults = require('./defaults');
-
 ScatterGeo.colorbar = Scatter.colorbar;
+ScatterGeo.plot = require('./plot');
 
 ScatterGeo.calc = function(gd, trace) {
 
     Scatter.calcMarkerColorscales(trace);
 
 };
+
+module.exports = ScatterGeo;

--- a/src/traces/scattergeo/index.js
+++ b/src/traces/scattergeo/index.js
@@ -9,31 +9,30 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
 var Scatter = require('../scatter');
 
-
 var ScatterGeo = {};
-
-Plots.register(ScatterGeo, 'scattergeo',
-    ['geo', 'symbols', 'markerColorscale', 'showLegend'], {
-        hrName: 'scatter_geo',
-        description: [
-            'The data visualized as scatter point or lines on a geographic map',
-            'is provided either by longitude/latitude pairs in `lon` and `lat`',
-            'respectively or by geographic location IDs or names in `locations`.'
-        ].join(' ')
-    });
 
 ScatterGeo.attributes = require('./attributes');
 ScatterGeo.supplyDefaults = require('./defaults');
 ScatterGeo.colorbar = Scatter.colorbar;
-ScatterGeo.plot = require('./plot');
+ScatterGeo.plot = require('./plot').plot;
 
 ScatterGeo.calc = function(gd, trace) {
 
     Scatter.calcMarkerColorscales(trace);
 
+};
+
+ScatterGeo._type = 'scattergeo';
+ScatterGeo._categories = ['geo', 'symbols', 'markerColorscale', 'showLegend'];
+ScatterGeo._meta = {
+    hrName: 'scatter_geo',
+    description: [
+        'The data visualized as scatter point or lines on a geographic map',
+        'is provided either by longitude/latitude pairs in `lon` and `lat`',
+        'respectively or by geographic location IDs or names in `locations`.'
+    ].join(' ')
 };
 
 module.exports = ScatterGeo;

--- a/src/traces/scattergeo/index.js
+++ b/src/traces/scattergeo/index.js
@@ -24,9 +24,10 @@ ScatterGeo.calc = function(gd, trace) {
 
 };
 
-ScatterGeo._type = 'scattergeo';
-ScatterGeo._categories = ['geo', 'symbols', 'markerColorscale', 'showLegend'];
-ScatterGeo._meta = {
+ScatterGeo.moduleType = 'trace';
+ScatterGeo.name = 'scattergeo';
+ScatterGeo.categories = ['geo', 'symbols', 'markerColorscale', 'showLegend'];
+ScatterGeo.meta = {
     hrName: 'scatter_geo',
     description: [
         'The data visualized as scatter point or lines on a geographic map',

--- a/src/traces/scattergeo/index.js
+++ b/src/traces/scattergeo/index.js
@@ -9,11 +9,12 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
+var Scatter = require('../scatter');
 
 var ScatterGeo = module.exports = {};
 
-Plotly.Plots.register(ScatterGeo, 'scattergeo',
+Plots.register(ScatterGeo, 'scattergeo',
     ['geo', 'symbols', 'markerColorscale', 'showLegend'], {
         hrName: 'scatter_geo',
         description: [
@@ -28,10 +29,10 @@ ScatterGeo.attributes = require('./attributes');
 
 ScatterGeo.supplyDefaults = require('./defaults');
 
-ScatterGeo.colorbar = Plotly.Scatter.colorbar;
+ScatterGeo.colorbar = Scatter.colorbar;
 
 ScatterGeo.calc = function(gd, trace) {
 
-    Plotly.Scatter.calcMarkerColorscales(trace);
+    Scatter.calcMarkerColorscales(trace);
 
 };

--- a/src/traces/scattergeo/plot.js
+++ b/src/traces/scattergeo/plot.js
@@ -16,6 +16,13 @@ var getTopojsonFeatures = require('../../lib/topojson_utils').getTopojsonFeature
 var locationToFeature = require('../../lib/geo_location_utils').locationToFeature;
 var arrayToCalcItem = require('../../lib/array_to_calc_item');
 
+var Color = require('../../components/color');
+var Drawing = require('../../components/drawing');
+
+var Scatter = require('../scatter');
+
+var attributes = require('./attributes');
+
 var plotScatterGeo = module.exports = {};
 
 
@@ -109,7 +116,6 @@ function makeLineGeoJSON(trace) {
 
 plotScatterGeo.plot = function(geo, scattergeoData) {
     var gScatterGeo = geo.framework.select('g.scattergeolayer'),
-        Scatter = Plotly.Scatter,
         topojson = geo.topojson;
 
     // TODO move to more d3-idiomatic pattern (that's work on replot)
@@ -204,12 +210,12 @@ plotScatterGeo.style = function(geo) {
     selection.selectAll('g.points')
         .each(function(trace){
             d3.select(this).selectAll('path.point')
-                .call(Plotly.Drawing.pointStyle, trace);
+                .call(Drawing.pointStyle, trace);
             d3.select(this).selectAll('text')
-                .call(Plotly.Drawing.textPointStyle, trace);
+                .call(Drawing.textPointStyle, trace);
         });
 
-    // GeoJSON calc data is incompatible with Plotly.Drawing.lineGroupStyle
+    // GeoJSON calc data is incompatible with Drawing.lineGroupStyle
     selection.selectAll('path.js-line')
         .style('fill', 'none')
         .each(function(d) {
@@ -217,8 +223,8 @@ plotScatterGeo.style = function(geo) {
                 line = trace.line || {};
 
             d3.select(this)
-                .call(Plotly.Color.stroke, line.color)
-                .call(Plotly.Drawing.dashLine, line.dash || '', line.width || 0);
+                .call(Color.stroke, line.color)
+                .call(Drawing.dashLine, line.dash || '', line.width || 0);
         });
 };
 
@@ -230,7 +236,7 @@ function makeCleanHoverLabelsFunc(geo, trace) {
     }
 
     var hoverinfoParts = (hoverinfo === 'all') ?
-        Plotly.ScatterGeo.attributes.hoverinfo.flags :
+        attributes.hoverinfo.flags :
         hoverinfo.split('+');
 
     var hasLocation = (hoverinfoParts.indexOf('location') !== -1 &&

--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -17,8 +17,13 @@ var createLine = require('gl-line2d');
 var createError = require('gl-error2d');
 var isNumeric = require('fast-isnumeric');
 
+var Lib = require('../../lib');
 var str2RGBArray = require('../../lib/str2rgbarray');
 var formatColor = require('../../lib/gl_format_color');
+
+var Scatter = require('../scatter');
+
+var ErrorBars = require('../../components/errorbars');
 
 var MARKER_SYMBOLS = require('../../constants/gl_markers.json');
 var DASHES = require('../../constants/gl2d_dashes.json');
@@ -185,7 +190,7 @@ function convertColorScale(containerIn, markerOpacity, traceOpacity, count) {
 
     colors = Array.isArray(colors[0]) ?
         colors :
-        _convertArray(Plotly.Lib.identity, [colors], count);
+        _convertArray(Lib.identity, [colors], count);
 
     return _convertColor(
         colors,
@@ -234,10 +239,10 @@ proto.update = function(options) {
         this.hasMarkers = false;
     }
     else {
-        this.hasLines = Plotly.Scatter.hasLines(options);
+        this.hasLines = Scatter.hasLines(options);
         this.hasErrorX = options.error_x.visible === true;
         this.hasErrorY = options.error_y.visible === true;
-        this.hasMarkers = Plotly.Scatter.hasMarkers(options);
+        this.hasMarkers = Scatter.hasMarkers(options);
     }
 
     this.textLabels = options.text;
@@ -254,7 +259,7 @@ proto.update = function(options) {
 
     // not quite on-par with 'scatter', but close enough for now
     // does not handle the colorscale case
-    this.color = Plotly.Scatter.getTraceColor(options, {});
+    this.color = Scatter.getTraceColor(options, {});
 };
 
 proto.updateFast = function(options) {
@@ -344,7 +349,7 @@ proto.updateFancy = function(options) {
     var y = this.yData = yaxis.makeCalcdata(options, 'y');
 
     // get error values
-    var errorVals = Plotly.ErrorBars.calcFromTrace(options, scene.fullLayout);
+    var errorVals = ErrorBars.calcFromTrace(options, scene.fullLayout);
 
     var len = x.length,
         idToIndex = new Array(len),
@@ -413,7 +418,7 @@ proto.updateFancy = function(options) {
         this.scatterOptions.colors = new Array(pId * 4);
         this.scatterOptions.borderColors = new Array(pId * 4);
 
-        var markerSizeFunc = Plotly.Scatter.getBubbleSizeFn(options),
+        var markerSizeFunc = Scatter.getBubbleSizeFn(options),
             markerOpts = options.marker,
             markerOpacity = markerOpts.opacity,
             traceOpacity = options.opacity,

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -8,21 +8,10 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots/');
 var Scatter = require('../scatter');
 var Scatter3D = require('../scatter3d');
 
 var ScatterGl = {};
-
-Plots.register(ScatterGl, 'scattergl',
-    ['gl2d', 'symbols', 'errorBarsOK', 'markerColorscale', 'showLegend'], {
-        description: [
-            'The data visualized as scatter point or lines is set in `x` and `y`',
-            'using the WebGl plotting engine.',
-            'Bubble charts are achieved by setting `marker.size` and/or `marker.color`',
-            'to a numerical arrays.'
-        ].join(' ')
-    });
 
 ScatterGl.attributes = require('./attributes');
 ScatterGl.supplyDefaults = require('./defaults');
@@ -31,5 +20,16 @@ ScatterGl.colorbar = Scatter.colorbar;
 // reuse the Scatter3D 'dummy' calc step so that legends know what to do
 ScatterGl.calc = Scatter3D.calc;
 ScatterGl.plot = require('./convert');
+
+ScatterGl._type = 'scattergl';
+ScatterGl._categories = ['gl2d', 'symbols', 'errorBarsOK', 'markerColorscale', 'showLegend'];
+ScatterGl._meta = {
+    description: [
+        'The data visualized as scatter point or lines is set in `x` and `y`',
+        'using the WebGl plotting engine.',
+        'Bubble charts are achieved by setting `marker.size` and/or `marker.color`',
+        'to a numerical arrays.'
+    ].join(' ')
+};
 
 module.exports = ScatterGl;

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -6,14 +6,15 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots/');
+var Scatter = require('../scatter');
+var Scatter3D = require('../scatter3d');
 
-var ScatterGl = module.exports = {};
+var ScatterGl = {};
 
-Plotly.Plots.register(ScatterGl, 'scattergl',
+Plots.register(ScatterGl, 'scattergl',
     ['gl2d', 'symbols', 'errorBarsOK', 'markerColorscale', 'showLegend'], {
         description: [
             'The data visualized as scatter point or lines is set in `x` and `y`',
@@ -21,14 +22,14 @@ Plotly.Plots.register(ScatterGl, 'scattergl',
             'Bubble charts are achieved by setting `marker.size` and/or `marker.color`',
             'to a numerical arrays.'
         ].join(' ')
-    }
-);
+    });
 
 ScatterGl.attributes = require('./attributes');
-
 ScatterGl.supplyDefaults = require('./defaults');
-
-ScatterGl.colorbar = Plotly.Scatter.colorbar;
+ScatterGl.colorbar = Scatter.colorbar;
 
 // reuse the Scatter3D 'dummy' calc step so that legends know what to do
-ScatterGl.calc = Plotly.Scatter3D.calc;
+ScatterGl.calc = Scatter3D.calc;
+ScatterGl.plot = require('./convert');
+
+module.exports = ScatterGl;

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -21,9 +21,10 @@ ScatterGl.colorbar = Scatter.colorbar;
 ScatterGl.calc = Scatter3D.calc;
 ScatterGl.plot = require('./convert');
 
-ScatterGl._type = 'scattergl';
-ScatterGl._categories = ['gl2d', 'symbols', 'errorBarsOK', 'markerColorscale', 'showLegend'];
-ScatterGl._meta = {
+ScatterGl.moduleType = 'trace';
+ScatterGl.name = 'scattergl';
+ScatterGl.categories = ['gl2d', 'symbols', 'errorBarsOK', 'markerColorscale', 'showLegend'];
+ScatterGl.meta = {
     description: [
         'The data visualized as scatter point or lines is set in `x` and `y`',
         'using the WebGl plotting engine.',

--- a/src/traces/surface/index.js
+++ b/src/traces/surface/index.js
@@ -9,11 +9,11 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
+var Plots = require('../../plots/plots');
 
-var Surface = module.exports = {};
+var Surface = {};
 
-Plotly.Plots.register(Surface, 'surface', ['gl3d', 'noOpacity'], {
+Plots.register(Surface, 'surface', ['gl3d', 'noOpacity'], {
     description: [
         'The data the describes the coordinates of the surface is set in `z`.',
         'Data in `z` should be a {2D array}.',
@@ -27,9 +27,9 @@ Plotly.Plots.register(Surface, 'surface', ['gl3d', 'noOpacity'], {
 });
 
 Surface.attributes = require('./attributes');
-
 Surface.supplyDefaults = require('./defaults');
-
 Surface.colorbar = require('../heatmap/colorbar');
-
 Surface.calc = require('./calc');
+Surface.plot = require('./convert');
+
+module.exports = Surface;

--- a/src/traces/surface/index.js
+++ b/src/traces/surface/index.js
@@ -17,9 +17,10 @@ Surface.colorbar = require('../heatmap/colorbar');
 Surface.calc = require('./calc');
 Surface.plot = require('./convert');
 
-Surface._type = 'surface';
-Surface._categories = ['gl3d', 'noOpacity'];
-Surface._meta = {
+Surface.moduleType = 'trace';
+Surface.name = 'surface';
+Surface.categories = ['gl3d', 'noOpacity'];
+Surface.meta = {
     description: [
         'The data the describes the coordinates of the surface is set in `z`.',
         'Data in `z` should be a {2D array}.',

--- a/src/traces/surface/index.js
+++ b/src/traces/surface/index.js
@@ -9,11 +9,17 @@
 
 'use strict';
 
-var Plots = require('../../plots/plots');
-
 var Surface = {};
 
-Plots.register(Surface, 'surface', ['gl3d', 'noOpacity'], {
+Surface.attributes = require('./attributes');
+Surface.supplyDefaults = require('./defaults');
+Surface.colorbar = require('../heatmap/colorbar');
+Surface.calc = require('./calc');
+Surface.plot = require('./convert');
+
+Surface._type = 'surface';
+Surface._categories = ['gl3d', 'noOpacity'];
+Surface._meta = {
     description: [
         'The data the describes the coordinates of the surface is set in `z`.',
         'Data in `z` should be a {2D array}.',
@@ -24,12 +30,6 @@ Plots.register(Surface, 'surface', ['gl3d', 'noOpacity'], {
         'If not provided in `x` and `y`, the x and y coordinates are assumed',
         'to be linear starting at 0 with a unit step.'
     ].join(' ')
-});
-
-Surface.attributes = require('./attributes');
-Surface.supplyDefaults = require('./defaults');
-Surface.colorbar = require('../heatmap/colorbar');
-Surface.calc = require('./calc');
-Surface.plot = require('./convert');
+};
 
 module.exports = Surface;

--- a/test/jasmine/tests/choropleth_test.js
+++ b/test/jasmine/tests/choropleth_test.js
@@ -1,10 +1,9 @@
 var Plotly = require('@src/plotly');
+var Choropleth = require('@src/traces/choropleth');
 
 
 describe('Test choropleth', function() {
     'use strict';
-
-    var Choropleth = Plotly.Choropleth;
 
     describe('supplyDefaults', function() {
         var traceIn,

--- a/test/jasmine/tests/colorscale_test.js
+++ b/test/jasmine/tests/colorscale_test.js
@@ -1,5 +1,7 @@
 var Plotly = require('@src/plotly');
 var Colorscale = require('@src/components/colorscale');
+var Heatmap = require('@src/traces/heatmap');
+var Scatter = require('@src/traces/scatter');
 
 
 describe('Test colorscale:', function() {
@@ -191,7 +193,7 @@ describe('Test colorscale:', function() {
         var traceIn, traceOut;
 
         function coerce(attr, dflt) {
-            return Plotly.Lib.coerce(traceIn, traceOut, Plotly.Heatmap.attributes, attr, dflt);
+            return Plotly.Lib.coerce(traceIn, traceOut, Heatmap.attributes, attr, dflt);
         }
 
         beforeEach(function() {
@@ -261,7 +263,7 @@ describe('Test colorscale:', function() {
         var traceIn, traceOut;
 
         function coerce(attr, dflt) {
-            return Plotly.Lib.coerce(traceIn, traceOut, Plotly.Scatter.attributes, attr, dflt);
+            return Plotly.Lib.coerce(traceIn, traceOut, Scatter.attributes, attr, dflt);
         }
 
         beforeEach(function() {

--- a/test/jasmine/tests/contour_test.js
+++ b/test/jasmine/tests/contour_test.js
@@ -1,4 +1,5 @@
-var Plotly = require('@src/plotly');
+var Plots = require('@src/plots/plots');
+var Contour = require('@src/traces/contour');
 
 
 describe('Test contour', function() {
@@ -10,10 +11,10 @@ describe('Test contour', function() {
 
         var defaultColor = '#444',
             layout = {
-                font: Plotly.Plots.layoutAttributes.font
+                font: Plots.layoutAttributes.font
             };
 
-        var supplyDefaults = Plotly.Contour.supplyDefaults;
+        var supplyDefaults = Contour.supplyDefaults;
 
         beforeEach(function() {
             traceOut = {};

--- a/test/jasmine/tests/heatmap_test.js
+++ b/test/jasmine/tests/heatmap_test.js
@@ -1,6 +1,6 @@
-var Plotly = require('@src/plotly');
-var Heatmap = require('@src/traces/heatmap');
 var convertColumnXYZ = require('@src/traces/heatmap/convert_column_xyz');
+var Heatmap = require('@src/traces/heatmap');
+var Plots = require('@src/plots/plots');
 
 
 describe('Test heatmap', function() {
@@ -12,7 +12,7 @@ describe('Test heatmap', function() {
 
         var defaultColor = '#444',
             layout = {
-                font: Plotly.Plots.layoutAttributes.font
+                font: Plots.layoutAttributes.font
             };
 
         var supplyDefaults = Heatmap.supplyDefaults;
@@ -44,13 +44,13 @@ describe('Test heatmap', function() {
                 type: 'heatmap',
                 z: [[1, 2], []]
             };
-            traceOut = Plotly.Plots.supplyDataDefaults(traceIn, 0, layout);
+            traceOut = Plots.supplyDataDefaults(traceIn, 0, layout);
 
             traceIn = {
                 type: 'heatmap',
                 z: [[], [1, 2], [1, 2, 3]]
             };
-            traceOut = Plotly.Plots.supplyDataDefaults(traceIn, 0, layout);
+            traceOut = Plots.supplyDataDefaults(traceIn, 0, layout);
             expect(traceOut.visible).toBe(true);
             expect(traceOut.visible).toBe(true);
         });

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -1,20 +1,24 @@
 var Plotly = require('@src/plotly');
+var Plots = require('@src/plots/plots');
+var Scatter = require('@src/traces/scatter');
+var Bar = require('@src/traces/bar');
+var Legend = require('@src/components/legend');
 
 describe('Test graph_obj', function() {
     'use strict';
 
     describe('Plotly.restyle', function() {
         beforeEach(function() {
-            spyOn(Plotly.Plots, 'previousPromises');
             spyOn(Plotly, 'plot');
-            spyOn(Plotly.Scatter, 'arraysToCalcdata');
-            spyOn(Plotly.Bar, 'arraysToCalcdata');
-            spyOn(Plotly.Plots, 'style');
-            spyOn(Plotly.Legend, 'draw');
+            spyOn(Plots, 'previousPromises');
+            spyOn(Scatter, 'arraysToCalcdata');
+            spyOn(Bar, 'arraysToCalcdata');
+            spyOn(Plots, 'style');
+            spyOn(Legend, 'draw');
         });
 
         function mockDefaultsAndCalc(gd) {
-            Plotly.Plots.supplyDefaults(gd);
+            Plots.supplyDefaults(gd);
             gd.calcdata = gd._fullData.map(function(trace) {
                 return [{x: 1, y: 1, trace: trace}];
             });
@@ -27,9 +31,9 @@ describe('Test graph_obj', function() {
             };
             mockDefaultsAndCalc(gd);
             Plotly.restyle(gd, {'marker.color': 'red'});
-            expect(Plotly.Scatter.arraysToCalcdata).toHaveBeenCalled();
-            expect(Plotly.Bar.arraysToCalcdata).not.toHaveBeenCalled();
-            expect(Plotly.Plots.style).toHaveBeenCalled();
+            expect(Scatter.arraysToCalcdata).toHaveBeenCalled();
+            expect(Bar.arraysToCalcdata).not.toHaveBeenCalled();
+            expect(Plots.style).toHaveBeenCalled();
             expect(Plotly.plot).not.toHaveBeenCalled();
             // "docalc" deletes gd.calcdata - make sure this didn't happen
             expect(gd.calcdata).toBeDefined();
@@ -42,9 +46,9 @@ describe('Test graph_obj', function() {
             };
             mockDefaultsAndCalc(gd);
             Plotly.restyle(gd, {'marker.color': 'red'});
-            expect(Plotly.Scatter.arraysToCalcdata).not.toHaveBeenCalled();
-            expect(Plotly.Bar.arraysToCalcdata).toHaveBeenCalled();
-            expect(Plotly.Plots.style).toHaveBeenCalled();
+            expect(Scatter.arraysToCalcdata).not.toHaveBeenCalled();
+            expect(Bar.arraysToCalcdata).toHaveBeenCalled();
+            expect(Plots.style).toHaveBeenCalled();
             expect(Plotly.plot).not.toHaveBeenCalled();
             expect(gd.calcdata).toBeDefined();
         });

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -1,17 +1,19 @@
 var Plotly = require('@src/plotly');
+var Plots = require('@src/plots/plots');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 
 
-describe('Test Plotly.Plots', function() {
+
+describe('Test Plots', function() {
     'use strict';
 
-    describe('Plotly.Plots.supplyLayoutGlobalDefaults should', function() {
+    describe('Plots.supplyLayoutGlobalDefaults should', function() {
         var layoutIn,
             layoutOut,
             expected;
 
-        var supplyLayoutDefaults = Plotly.Plots.supplyLayoutGlobalDefaults;
+        var supplyLayoutDefaults = Plots.supplyLayoutGlobalDefaults;
 
         beforeEach(function() {
             layoutOut = {};
@@ -65,8 +67,8 @@ describe('Test Plotly.Plots', function() {
 
     });
 
-    describe('Plotly.Plots.supplyDataDefaults', function() {
-        var supplyDataDefaults = Plotly.Plots.supplyDataDefaults,
+    describe('Plots.supplyDataDefaults', function() {
+        var supplyDataDefaults = Plots.supplyDataDefaults,
             layout = {};
 
         var traceIn, traceOut;
@@ -98,8 +100,8 @@ describe('Test Plotly.Plots', function() {
         });
     });
 
-    describe('Plotly.Plots.getSubplotIds', function() {
-        var getSubplotIds = Plotly.Plots.getSubplotIds;
+    describe('Plots.getSubplotIds', function() {
+        var getSubplotIds = Plots.getSubplotIds;
         var layout;
 
         it('returns scene ids', function() {
@@ -143,8 +145,8 @@ describe('Test Plotly.Plots', function() {
         });
     });
 
-    describe('Plotly.Plots.getSubplotIdsInData', function() {
-        var getSubplotIdsInData = Plotly.Plots.getSubplotIdsInData;
+    describe('Plots.getSubplotIdsInData', function() {
+        var getSubplotIdsInData = Plots.getSubplotIdsInData;
 
         var ids, data;
 
@@ -173,11 +175,11 @@ describe('Test Plotly.Plots', function() {
 
     });
 
-    describe('Plotly.Plots.register, getModule, and traceIs', function() {
+    describe('Plots.register, getModule, and traceIs', function() {
         beforeEach(function() {
-            this.modulesKeys = Object.keys(Plotly.Plots.modules);
-            this.allTypesKeys = Object.keys(Plotly.Plots.allTypes);
-            this.allCategoriesKeys = Object.keys(Plotly.Plots.allCategories);
+            this.modulesKeys = Object.keys(Plots.modules);
+            this.allTypesKeys = Object.keys(Plots.allTypes);
+            this.allCategoriesKeys = Object.keys(Plots.allCategories);
 
             this.fakeModule = {
                 calc: function() { return 42; },
@@ -187,7 +189,7 @@ describe('Test Plotly.Plots', function() {
                 plot: function() { throw new Error('nope!'); }
             };
 
-            Plotly.Plots.register(this.fakeModule, 'newtype', ['red', 'green']);
+            Plots.register(this.fakeModule, 'newtype', ['red', 'green']);
 
             spyOn(console, 'warn');
         });
@@ -199,42 +201,40 @@ describe('Test Plotly.Plots', function() {
                 });
             }
 
-            revertObj(Plotly.Plots.modules, this.modulesKeys);
-            revertObj(Plotly.Plots.allTypes, this.allTypesKeys);
-            revertObj(Plotly.Plots.allCategories, this.allCategoriesKeys);
+            revertObj(Plots.modules, this.modulesKeys);
+            revertObj(Plots.allTypes, this.allTypesKeys);
+            revertObj(Plots.allCategories, this.allCategoriesKeys);
         });
 
-        it('should error on attempts to reregister a type', function() {
-            var fm2 = this.fakeModule2;
-            expect(function() { Plotly.Plots.register(fm2, 'newtype', ['yellow', 'blue']); })
-                .toThrow(new Error('type newtype already registered'));
-            expect(Plotly.Plots.allCategories.yellow).toBeUndefined();
+        it('should warn on attempts to reregister a type', function() {
+            Plots.register(this.fakeModule2, 'newtype', ['yellow', 'blue']);
+            expect(Plots.allCategories.yellow).toBeUndefined();
         });
 
         it('should find the module for a type', function() {
-            expect(Plotly.Plots.getModule('newtype')).toBe(this.fakeModule);
-            expect(Plotly.Plots.getModule({type: 'newtype'})).toBe(this.fakeModule);
+            expect(Plots.getModule('newtype')).toBe(this.fakeModule);
+            expect(Plots.getModule({type: 'newtype'})).toBe(this.fakeModule);
         });
 
         it('should return false for types it doesn\'t know', function() {
-            expect(Plotly.Plots.getModule('notatype')).toBe(false);
-            expect(Plotly.Plots.getModule({type: 'notatype'})).toBe(false);
-            expect(Plotly.Plots.getModule({type: 'newtype', r: 'this is polar'})).toBe(false);
+            expect(Plots.getModule('notatype')).toBe(false);
+            expect(Plots.getModule({type: 'notatype'})).toBe(false);
+            expect(Plots.getModule({type: 'newtype', r: 'this is polar'})).toBe(false);
         });
 
         it('should find the categories for this type', function() {
-            expect(Plotly.Plots.traceIs('newtype', 'red')).toBe(true);
-            expect(Plotly.Plots.traceIs({type: 'newtype'}, 'red')).toBe(true);
+            expect(Plots.traceIs('newtype', 'red')).toBe(true);
+            expect(Plots.traceIs({type: 'newtype'}, 'red')).toBe(true);
         });
 
         it('should not find other real categories', function() {
-            expect(Plotly.Plots.traceIs('newtype', 'cartesian')).toBe(false);
-            expect(Plotly.Plots.traceIs({type: 'newtype'}, 'cartesian')).toBe(false);
+            expect(Plots.traceIs('newtype', 'cartesian')).toBe(false);
+            expect(Plots.traceIs({type: 'newtype'}, 'cartesian')).toBe(false);
             expect(console.warn).not.toHaveBeenCalled();
         });
     });
 
-    describe('Plotly.Plots.registerSubplot', function() {
+    describe('Plots.registerSubplot', function() {
         var fake = {
             name: 'fake',
             attr: 'abc',
@@ -242,9 +242,9 @@ describe('Test Plotly.Plots', function() {
             attributes: { stuff: { 'more stuff': 102102 } }
         };
 
-        Plotly.Plots.registerSubplot(fake);
+        Plots.registerSubplot(fake);
 
-        var subplotsRegistry = Plotly.Plots.subplotsRegistry;
+        var subplotsRegistry = Plots.subplotsRegistry;
 
         it('should register attr, idRoot and attributes', function() {
             expect(subplotsRegistry.fake.attr).toEqual('abc');
@@ -307,7 +307,7 @@ describe('Test Plotly.Plots', function() {
 
     });
 
-    describe('Plotly.Plots.purge', function() {
+    describe('Plots.purge', function() {
         var gd;
 
         beforeEach(function(done) {
@@ -324,7 +324,7 @@ describe('Test Plotly.Plots', function() {
                 '_hmpixcount', '_hmlumcount'
             ];
 
-            Plotly.Plots.purge(gd);
+            Plots.purge(gd);
             expect(Object.keys(gd)).toEqual(expectedKeys);
             expect(gd.data).toBeUndefined();
             expect(gd.layout).toBeUndefined();

--- a/test/jasmine/tests/register_test.js
+++ b/test/jasmine/tests/register_test.js
@@ -1,0 +1,48 @@
+var Plotly = require('@src/plotly');
+
+describe('the register function', function() {
+
+    it('should throw an error when no argument is given', function() {
+        expect(function() {
+            Plotly.register();
+        }).toThrowError(Error, 'No argument passed to Plotly.register.');
+    });
+
+    it('should work with a single module', function() {
+        var mockTrace1 = {
+            moduleType: 'trace',
+            name: 'mockTrace1',
+            meta: 'Meta string',
+            categories: ['categories', 'array']
+        };
+
+        expect(function() {
+            Plotly.register(mockTrace1);
+        }).not.toThrow();
+
+        expect(Plotly.Plots.getModule('mockTrace1')).toBe(mockTrace1);
+    });
+
+    it('should work with an array of modules', function() {
+        var mockTrace2 = {
+            moduleType: 'trace',
+            name: 'mockTrace2',
+            meta: 'Meta string',
+            categories: ['categories', 'array']
+        };
+
+        expect(function() {
+            Plotly.register([mockTrace2]);
+        }).not.toThrow();
+
+        expect(Plotly.Plots.getModule('mockTrace2')).toBe(mockTrace2);
+    });
+
+    it('should throw an error when an invalid module is given', function() {
+        var invalidTrace = { moduleType: 'invalid' };
+
+        expect(function() {
+            Plotly.register([invalidTrace]);
+        }).toThrowError(Error, 'Invalid module was attempted to be registered!');
+    });
+});

--- a/test/jasmine/tests/scattergeo_test.js
+++ b/test/jasmine/tests/scattergeo_test.js
@@ -1,9 +1,7 @@
-var Plotly = require('@src/plotly');
+var ScatterGeo = require('@src/traces/scattergeo');
 
 describe('Test scattergeo', function() {
     'use strict';
-
-    var ScatterGeo = Plotly.ScatterGeo;
 
     describe('supplyDefaults', function() {
         var traceIn,


### PR DESCRIPTION
There isn't much actual change in code, more just rearrangement and a few different accessors to use trace modules.

The traces still use the original `register` and `getModule` functions in `src/plots/plots`, however instead of being called from the trace module itself, `register` is now called from a `register` function exposed by `Plotly` so that end users will be able to pick and choose traces of their liking (once the trace modules are a bit more modularized out)

Because of the changes, some "side-effects" needed to be fixed - mainly with pathing in tests and a few other files.