### PR TITLE
Update Descriptions for Colorscale

### DIFF
--- a/src/components/colorscale/attributes.js
+++ b/src/components/colorscale/attributes.js
@@ -37,9 +37,13 @@ module.exports = {
         description: [
             'Sets the colorscale.',
             'The colorscale must be an array containing',
-            'arrays mapping a normalized value to an rgb color. At minimum, a',
-            'mapping for the lowest (0) and highest (1) values are required.',
-            'For example, `[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`'
+            'arrays mapping a normalized value to an',
+            'rgb, rgba, hex, hsl, hsv, or named color string.',
+            'At minimum, a mapping for the lowest (0) and highest (1)',
+            'values are required. For example,',
+            '`[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`.',
+            'To control the bounds of the colorscale in z space,',
+            'use zmin and zmax'
         ].join(' ')
     },
     autocolorscale: {

--- a/src/components/colorscale/attributes.js
+++ b/src/components/colorscale/attributes.js
@@ -34,7 +34,13 @@ module.exports = {
     colorscale: {
         valType: 'colorscale',
         role: 'style',
-        description: 'Sets the colorscale.'
+        description: [
+            'Sets the colorscale.',
+            'The colorscale must be an array containing',
+            'arrays mapping a normalized value to an rgb color. At minimum, a',
+            'mapping for the lowest (0) and highest (1) values are required.',
+            'For example, `[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`'
+        ].join(' ')
     },
     autocolorscale: {
         valType: 'boolean',

--- a/src/traces/scatter/attributes.js
+++ b/src/traces/scatter/attributes.js
@@ -246,11 +246,15 @@ module.exports = {
             valType: 'colorscale',
             role: 'style',
             description: [
-                'Has only an effect if `marker.color` is set to a numerical array.',
-                'Sets the colorscale. The colorscale must be an array containing',
-                'arrays mapping a normalized value to an rgb color. At minimum, a',
-                'mapping for the lowest (0) and highest (1) values are required.',
-                'For example, `[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`'
+                'Sets the colorscale.',
+                'The colorscale must be an array containing',
+                'arrays mapping a normalized value to an',
+                'rgb, rgba, hex, hsl, hsv, or named color string.',
+                'At minimum, a mapping for the lowest (0) and highest (1)',
+                'values are required. For example,',
+                '`[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`.',
+                'To control the bounds of the colorscale in color space,',
+                'use cmin and cmax'
             ].join(' ')
         },
         cauto: {

--- a/src/traces/scatter/attributes.js
+++ b/src/traces/scatter/attributes.js
@@ -247,7 +247,10 @@ module.exports = {
             role: 'style',
             description: [
                 'Has only an effect if `marker.color` is set to a numerical array.',
-                'Sets the colorscale.'
+                'Sets the colorscale. The colorscale must be an array containing',
+                'arrays mapping a normalized value to an rgb color. At minimum, a',
+                'mapping for the lowest (0) and highest (1) values are required.',
+                'For example, `[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`'
             ].join(' ')
         },
         cauto: {

--- a/tasks/util/compress_attributes.js
+++ b/tasks/util/compress_attributes.js
@@ -15,7 +15,9 @@ attributeNamesToRemove.forEach(function(attr, i) {
     // one line string with or without trailing comma
     regexStr += attr + ': \'.*\'' + ',?' + '|';
     // array of strings with or without trailing comma
-    regexStr += attr + ': \\[[\\s\\S]*?\\].*' + ',?';
+    regexStr += attr + ':.*\\n*.*\\.join\\(\\\'\\s\\\'\\)';
+
+    // attr:.*\n.*\.join\(\'\s\'\)
 
     if(i !== attributeNamesToRemove.length-1) regexStr += '|';
 });


### PR DESCRIPTION
I'm not 100% sure if this is in the right place, and you may have a better way to word the description. Quick pr though. 

Also changed: the `compress_attributes` regex for string arrays that are `join`ed. This will allow for any content in the string (before, `[` and `]` would break it.