### PR TITLE
Remove explict dependency on Pie module from plot routine

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -266,12 +266,16 @@ Plotly.plot = function(gd, data, layout, config) {
 
         function getCdModule(cdSubplot, _module) {
             var cdModule = [];
-            var i, cd, trace;
-            for (i = 0; i < cdSubplot.length; i++) {
-                cd = cdSubplot[i];
-                trace = cd[0].trace;
-                if (trace._module === _module && trace.visible === true) cdModule.push(cd);
+
+            for(var i = 0; i < cdSubplot.length; i++) {
+                var cd = cdSubplot[i];
+                var trace = cd[0].trace;
+
+                if((trace._module === _module) && (trace.visible === true)) {
+                    cdModule.push(cd);
+                }
             }
+
             return cdModule;
         }
 
@@ -299,7 +303,7 @@ Plotly.plot = function(gd, data, layout, config) {
 
         for (i = 0; i < subplots.length; i++) {
             subplot = subplots[i];
-            subplotInfo = gd._fullLayout._plots[subplot];
+            subplotInfo = fullLayout._plots[subplot];
             cdSubplot = getCdSubplot(calcdata, subplot);
             cdError = [];
 
@@ -325,7 +329,7 @@ Plotly.plot = function(gd, data, layout, config) {
             }
 
             // finally do all error bars at once
-            if(gd._fullLayout._hasCartesian) {
+            if(fullLayout._hasCartesian) {
                 ErrorBars.plot(gd, subplotInfo, cdError);
                 Lib.markTime('done ErrorBars');
             }

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -21,8 +21,6 @@ var Queue = require('../lib/queue');
 var Plots = require('../plots/plots');
 var Fx = require('../plots/cartesian/graph_interact');
 
-var Pie = require('../traces/pie');
-
 var Color = require('../components/color');
 var Drawing = require('../components/drawing');
 var ErrorBars = require('../components/errorbars');
@@ -333,10 +331,13 @@ Plotly.plot = function(gd, data, layout, config) {
             }
         }
 
-        // now draw stuff not on subplots (ie, pies)
-        // TODO: gotta be a better way to handle this
-        var cdPie = getCdModule(calcdata, Pie);
-        if(cdPie.length) Pie.plot(gd, cdPie);
+        // now draw stuff not on subplots (ie, only pies at the moment)
+        if(fullLayout._hasPie) {
+            var Pie = Plots.modules.pie._module;
+            var cdPie = getCdModule(calcdata, Pie);
+
+            if(cdPie.length) Pie.plot(gd, cdPie);
+        }
 
         // styling separate from drawing
         Plots.style(gd);

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -312,7 +312,8 @@ Plotly.plot = function(gd, data, layout, config) {
 
             for(j = 0; j < modules.length; j++) {
                 _module = modules[j];
-                if(!_module.plot) continue;
+
+                if(!_module.plot && (_module.name === 'pie')) continue;
 
                 // plot all traces of this type on this subplot at once
                 cdModule = getCdModule(cdSubplot, _module);

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -337,7 +337,7 @@ Plotly.plot = function(gd, data, layout, config) {
 
         // now draw stuff not on subplots (ie, only pies at the moment)
         if(fullLayout._hasPie) {
-            var Pie = Plots.modules.pie._module;
+            var Pie = Plots.getModule('pie');
             var cdPie = getCdModule(calcdata, Pie);
 
             if(cdPie.length) Pie.plot(gd, cdPie);

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -52,7 +52,7 @@ plots.register = function(_module, thisType, categoriesIn, meta) {
     }
 
     modules[thisType] = {
-        module: _module,
+        _module: _module,
         categories: categoryObj
     };
 
@@ -79,7 +79,7 @@ plots.getModule = function(trace) {
 
     var _module = modules[getTraceType(trace)];
     if(!_module) return false;
-    return _module.module;
+    return _module._module;
 };
 
 
@@ -678,7 +678,7 @@ plots.supplyLayoutModuleDefaults = function(layoutIn, layoutOut, fullData) {
     // trace module layout defaults
     var traceTypes = Object.keys(modules);
     for(i = 0; i < traceTypes.length; i++) {
-        _module = modules[allTypes[i]].module;
+        _module = modules[allTypes[i]]._module;
 
         if(_module.supplyLayoutDefaults) {
             _module.supplyLayoutDefaults(layoutIn, layoutOut, fullData);


### PR DESCRIPTION
@mdtusz 

I found a simple way to remove the explicit dependency on `Pie` in plot_api.js meaning that `Pie` won't have to be part of core module.

