### PR TITLE
Add init step when changing dragmode

### DIFF
--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -259,6 +259,7 @@ function handleCartesian(gd, ev) {
                 );
             }
             Plotly.Fx.supplyLayoutDefaults(gd.layout, fullLayout, gd._fullData);
+            Plotly.Fx.init(gd);
         }
     });
 }


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/177. The drag mode `moveFn` isn't changed when the mode is changed, but after the drag event itself, so the pan drag action wasn't visible until mouseup. There doesn't seem to be a good *clean* way to do this without repeating code, so I have just made a call to `Fx.init`. Because this is only on mode change, it shouldn't be an issue to run `init` again. 