### PR TITLE
add geo hover tests

### DIFF
--- a/test/jasmine/tests/geo_interact_test.js
+++ b/test/jasmine/tests/geo_interact_test.js
@@ -1,0 +1,68 @@
+var d3 = require('d3');
+
+var Plotly = require('@lib/index');
+
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+var mouseEvent = require('../assets/mouse_event');
+
+
+describe('Test geo interactions', function() {
+    'use strict';
+
+    afterEach(destroyGraphDiv);
+
+    describe('mock geo_first.json', function() {
+        var mock = require('@mocks/geo_first.json');
+
+        beforeEach(function(done) {
+            Plotly.plot(createGraphDiv(), mock.data, mock.layout).then(done);
+        });
+
+        describe('scattegeo hover labels', function() {
+            beforeEach(function() {
+                mouseEvent('mouseover', 459, 246);
+            });
+
+            it('should show one hover text group', function() {
+                expect(d3.selectAll('g.hovertext').size()).toEqual(1);
+            });
+
+            it('should show longitude and latitude values', function() {
+                var node = d3.selectAll('g.hovertext').selectAll('tspan')[0][0];
+
+                expect(node.innerHTML).toEqual('(0°, 0°)');
+            });
+
+            it('should show the trace name', function() {
+                var node = d3.selectAll('g.hovertext').selectAll('text')[0][0];
+
+                expect(node.innerHTML).toEqual('trace 0');
+            });
+        });
+
+        describe('choropleth hover labels', function() {
+            beforeEach(function() {
+                mouseEvent('mouseover', 628, 162);
+            });
+
+            it('should show one hover text group', function() {
+                expect(d3.selectAll('g.hovertext').size()).toEqual(1);
+            });
+
+            it('should show location and z values', function() {
+                var node = d3.selectAll('g.hovertext').selectAll('tspan')[0];
+
+                expect(node[0].innerHTML).toEqual('RUS');
+                expect(node[1].innerHTML).toEqual('10');
+            });
+
+            it('should show the trace name', function() {
+                var node = d3.selectAll('g.hovertext').selectAll('text')[0][0];
+
+                expect(node.innerHTML).toEqual('trace 1');
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
@mdtusz @cldougl 

part of https://github.com/plotly/plotly.js/issues/209

I found a nice way to determine the mouse (x,y) position. Open the Karma debugger, paste

```js
document.onmousemove = function(evt) { console.log(evt.clientX, evt.clientY); };
```

and hover over the position where you're trying to simulate a mouse over.