### PR TITLE
Fix typo on modebar geo zoom out

### DIFF
--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -423,7 +423,7 @@ modeBarButtons.zoomInGeo = {
 
 modeBarButtons.zoomOutGeo = {
     name: 'zoomOutGeo',
-    title: 'Zoom in',
+    title: 'Zoom out',
     attr: 'zoom',
     val: 'out',
     icon: Icons.zoom_minus,


### PR DESCRIPTION
Quick typo that fixes https://github.com/plotly/plotly.js/issues/218.