### PR TITLE
Fix compress attributes

### DIFF
--- a/build/ploticon.js
+++ b/build/ploticon.js
@@ -1,5 +1,3 @@
-/* jshint quotmark:true */
-
 'use strict';
 
 module.exports = {

--- a/tasks/util/compress_attributes.js
+++ b/tasks/util/compress_attributes.js
@@ -5,21 +5,31 @@ var through = require('through2');
  * of the plotly.js bundles
  */
 
-var attributeNamesToRemove = [
-    'description', 'requiredOpts', 'otherOpts', 'hrName', 'role'
-];
+
+// one line string with or without trailing comma
+function makeStringRegex(attr) {
+    return attr + ': \'.*\'' + ',?';
+}
+
+// joined array of strings with or without trailing comma
+function makeJoinedArrayRegex(attr) {
+    return attr + ': \\[[\\s\\S]*?\\]' + '\\.join\\(.*' + ',?';
+}
+
+// array with or without trailing comma
+function makeArrayRegex(attr) {
+    return attr + ': \\[[\\s\\S]*?\\]' + ',?';
+}
 
 // ref: http://www.regexr.com/3cmac
-var regexStr = '';
-attributeNamesToRemove.forEach(function(attr, i) {
-    // one line string with or without trailing comma
-    regexStr += attr + ': \'.*\'' + ',?' + '|';
-
-    // joined array of strings with or without trailing comma
-    regexStr += attr + ': \\[[\\s\\S]*?\\]\\.join\\(.*' + ',?';
-
-    if(i !== attributeNamesToRemove.length-1) regexStr += '|';
-});
+var regexStr = [
+    makeStringRegex('description'),
+    makeJoinedArrayRegex('description'),
+    makeArrayRegex('requiredOpts'),
+    makeArrayRegex('otherOpts'),
+    makeStringRegex('hrName'),
+    makeStringRegex('role')
+].join('|');
 
 var regex = new RegExp(regexStr, 'g');
 

--- a/tasks/util/compress_attributes.js
+++ b/tasks/util/compress_attributes.js
@@ -9,15 +9,14 @@ var attributeNamesToRemove = [
     'description', 'requiredOpts', 'otherOpts', 'hrName', 'role'
 ];
 
-// ref: http://www.regexr.com/3bj6p
+// ref: http://www.regexr.com/3cmac
 var regexStr = '';
 attributeNamesToRemove.forEach(function(attr, i) {
     // one line string with or without trailing comma
     regexStr += attr + ': \'.*\'' + ',?' + '|';
-    // array of strings with or without trailing comma
-    regexStr += attr + ':.*\\n*.*\\.join\\(\\\'\\s\\\'\\)';
 
-    // attr:.*\n.*\.join\(\'\s\'\)
+    // joined array of strings with or without trailing comma
+    regexStr += attr + ': \\[[\\s\\S]*?\\]\\.join\\(.*' + ',?';
 
     if(i !== attributeNamesToRemove.length-1) regexStr += '|';
 });


### PR DESCRIPTION
@mdtusz 

The compress attributes transform has been failing for some attribute descriptions since https://github.com/plotly/plotly.js/commit/ee66bb347d65eab65745b954b61a8dcea8d976fe e.g.

![image](https://cloud.githubusercontent.com/assets/6675409/12651842/4b7f0680-c5b6-11e5-955c-1722142577c2.png)
 
- taken from `dist/plotly.js`

The new regular expression is on display here: http://www.regexr.com/3cmac