### PR TITLE
Remove offsetparent call

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -298,9 +298,7 @@ plots.addLinks = function(gd) {
     // IE doesn't like getComputedTextLength if an element
     // isn't visible, which it (sometimes?) isn't
     // apparently offsetParent is null for invisibles.
-    // http://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom
-    if (text && text.offsetParent &&
-            text.getComputedTextLength() >= (fullLayout.width - 20)) {
+    if (text && text.getComputedTextLength() >= (fullLayout.width - 20)) {
         // Align the text at the left
         attrs['text-anchor'] = 'start';
         attrs.x = 5;

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -1,0 +1,43 @@
+var Plotly = require('@src/plotly');
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+
+fdescribe('config argument', function() {
+
+    var gd;
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+        done();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    describe('showLink attribute', function() {
+
+        it('should not display the edit link by default', function() {
+            Plotly.plot(gd, [], {});
+
+            var link = document.getElementsByClassName('js-plot-link-container')[0];
+
+            expect(link.textContent).toBe('');
+
+            var bBox = link.getBoundingClientRect();
+            expect(bBox.width).toBe(0);
+            expect(bBox.height).toBe(0);
+        });
+
+        it('should display a link when true', function() {
+            Plotly.plot(gd, [], {}, { showLink: true });
+
+            var link = document.getElementsByClassName('js-plot-link-container')[0];
+
+            console.log(link);
+            expect(link.textContent).toBe('Edit chart »');
+
+            var bBox = link.getBoundingClientRect();
+            expect(bBox.width).toBeGreaterThan(0);
+            expect(bBox.height).toBeGreaterThan(0);
+        });
+    });
+});

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -2,7 +2,7 @@ var Plotly = require('@src/plotly');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 
-fdescribe('config argument', function() {
+describe('config argument', function() {
 
     var gd;
 


### PR DESCRIPTION
Resolves https://github.com/plotly/plotly.js/issues/222. It seems that the text.offsetParent call is unnecessary (except maybe in old versions of IE?).

In any case - chrome is deprecating it so we should remove it before then. 