### PR TITLE
Readme badges updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <a href="https://plot.ly/javascript/"><img src="http://images.plot.ly/logo/plotlyjs-logo@2x.png" height="70"></a>
 
 [![npm version](https://badge.fury.io/js/plotly.js.svg)](https://badge.fury.io/js/plotly.js)
-[![npm downloads](https://img.shields.io/npm//plotly.js.svg?style=flat-square)](https://www.npmjs.com/package/plotly.js)
 
 [![circle ci](https://circleci.com/gh/plotly/plotly.js.png?&style=shield&circle-token=1f42a03b242bd969756fc3e53ede204af9b507c0)](https://circleci.com/gh/plotly/plotly.js)
 [![Dependency Status](https://david-dm.org/plotly/plotly.js.svg?style=flat-square)](https://david-dm.org/plotly/plotly.js)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <a href="https://plot.ly/javascript/"><img src="http://images.plot.ly/logo/plotlyjs-logo@2x.png" height="70"></a>
 
 [![npm version](https://badge.fury.io/js/plotly.js.svg)](https://badge.fury.io/js/plotly.js)
-[![npm downloads](https://img.shields.io/npm/dm/plotly.js.svg?style=flat-square)](https://www.npmjs.com/package/plotly.js)
+[![npm downloads](https://img.shields.io/npm//plotly.js.svg?style=flat-square)](https://www.npmjs.com/package/plotly.js)
 
 [![circle ci](https://circleci.com/gh/plotly/plotly.js.png?&style=shield&circle-token=1f42a03b242bd969756fc3e53ede204af9b507c0)](https://circleci.com/gh/plotly/plotly.js)
-[![Dependency Status](https://img.shields.io/david/plotly/plotly.js.svg?style=flat-square)](https://david-dm.org/plotly/plotly.js)
-[![devDependency Status](https://img.shields.io/david/dev/plotly/plotly.js.svg?style=flat-square)](https://david-dm.org/plotly/plotly.js#info=devDependencies)
+[![Dependency Status](https://david-dm.org/plotly/plotly.js.svg?style=flat-square)](https://david-dm.org/plotly/plotly.js)
+[![devDependency Status](https://david-dm.org/plotly/plotly.js/dev-status.svg?style=flat-square)](https://david-dm.org/plotly/plotly.js#info=devDependencies)
 
 Built on top of [d3.js](http://d3js.org/) and [stack.gl](http://stack.gl/),
 plotly.js is a high-level, declarative charting library. plotly.js ships with 20


### PR DESCRIPTION
Something is up with the https://img.shields.io/ , where most our badges come from.

This PR grabs the dependency and dev-dependency badges directly from  https://david-dm.org/ and removes the npm-download badge to remedy the problem.