### PR TITLE
Plots.resize returns a Promise

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -232,23 +232,27 @@ plots.redrawText = function(gd) {
 };
 
 // resize plot about the container size
-plots.resize = function(gd) {
-    if(!gd || d3.select(gd).style('display') === 'none') return;
+plots.resize = function (gd) {
+    if (!gd || d3.select(gd).style('display') === 'none') return;
 
-    if(gd._redrawTimer) clearTimeout(gd._redrawTimer);
+    return new Promise(function (resolve) {
+        
+        if (gd._redrawTimer) clearTimeout(gd._redrawTimer);
 
-    gd._redrawTimer = setTimeout(function() {
-        if((gd._fullLayout || {}).autosize) {
-            // autosizing doesn't count as a change that needs saving
-            var oldchanged = gd.changed;
+        gd._redrawTimer = setTimeout(function () {
+            if ((gd._fullLayout || {}).autosize) {
+                // autosizing doesn't count as a change that needs saving
+                var oldchanged = gd.changed;
 
-            // nor should it be included in the undo queue
-            gd.autoplay = true;
+                // nor should it be included in the undo queue
+                gd.autoplay = true;
 
-            Plotly.relayout(gd, {autosize: true});
-            gd.changed = oldchanged;
-        }
-    }, 100);
+                Plotly.relayout(gd, { autosize: true });
+                gd.changed = oldchanged;
+                resolve();
+            }
+        }, 100);
+    });
 };
 
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -232,14 +232,14 @@ plots.redrawText = function(gd) {
 };
 
 // resize plot about the container size
-plots.resize = function (gd) {
+plots.resize = function(gd) {
     if (!gd || d3.select(gd).style('display') === 'none') return;
 
-    return new Promise(function (resolve) {
-        
+    return new Promise(function(resolve) {
+
         if (gd._redrawTimer) clearTimeout(gd._redrawTimer);
 
-        gd._redrawTimer = setTimeout(function () {
+        gd._redrawTimer = setTimeout(function() {
             if ((gd._fullLayout || {}).autosize) {
                 // autosizing doesn't count as a change that needs saving
                 var oldchanged = gd.changed;


### PR DESCRIPTION
As the resize operation will modify the size of the plot only after a
timeout, if you call resize and then immediately do something based on
the current plot size, you'll get the "old" size. This fixes it.