### PR TITLE
A slightly less ambitious take on orphan subplots and 'delete last trace'

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -50,16 +50,13 @@ var xmlnsNamespaces = require('../constants/xmlns_namespaces');
 Plotly.plot = function(gd, data, layout, config) {
     Lib.markTime('in plot');
 
-
     gd = getGraphDiv(gd);
 
-    /*
-     * Events.init is idempotent and bails early if gd has already been init'd
-     */
+    // Events.init is idempotent and bails early if gd has already been init'd
     Events.init(gd);
 
     var okToPlot = Events.triggerHandler(gd, 'plotly_beforeplot', [data, layout, config]);
-    if(okToPlot===false) return Promise.reject();
+    if(okToPlot === false) return Promise.reject();
 
     // if there's no data or layout, and this isn't yet a plotly plot
     // container, log a warning to help plotly.js users debug
@@ -89,22 +86,23 @@ Plotly.plot = function(gd, data, layout, config) {
     // complete, and empty out the promise list again.
     gd._promises = [];
 
+    var graphWasEmpty = ((gd.data || []).length === 0 && Array.isArray(data));
+
     // if there is already data on the graph, append the new data
     // if you only want to redraw, pass a non-array for data
-    var graphwasempty = ((gd.data||[]).length===0 && Array.isArray(data));
     if(Array.isArray(data)) {
         cleanData(data, gd.data);
 
-        if(graphwasempty) gd.data=data;
-        else gd.data.push.apply(gd.data,data);
+        if(graphWasEmpty) gd.data = data;
+        else gd.data.push.apply(gd.data, data);
 
         // for routines outside graph_obj that want a clean tab
         // (rather than appending to an existing one) gd.empty
         // is used to determine whether to make a new tab
-        gd.empty=false;
+        gd.empty = false;
     }
 
-    if(!gd.layout || graphwasempty) gd.layout = cleanLayout(layout);
+    if(!gd.layout || graphWasEmpty) gd.layout = cleanLayout(layout);
 
     // if the user is trying to drag the axes, allow new data and layout
     // to come in but don't allow a replot.
@@ -126,23 +124,24 @@ Plotly.plot = function(gd, data, layout, config) {
     // so we don't try to re-call Plotly.plot from inside
     // legend and colorbar, if margins changed
     gd._replotting = true;
-    var hasData = gd._fullData.length>0;
+    var hasData = gd._fullData.length > 0;
+
+    var subplots = Plotly.Axes.getSubplots(gd).join(''),
+        oldSubplots = Object.keys(gd._fullLayout._plots || {}).join(''),
+        hasSameSubplots = (oldSubplots === subplots);
 
     // Make or remake the framework (ie container and axes) if we need to
     // note: if they container already exists and has data,
     //  the new layout gets ignored (as it should)
     //  but if there's no data there yet, it's just a placeholder...
     //  then it should destroy and remake the plot
-    if (hasData) {
-        var subplots = Plotly.Axes.getSubplots(gd).join(''),
-            oldSubplots = Object.keys(gd._fullLayout._plots || {}).join('');
-
-        if(gd.framework!==makePlotFramework || graphwasempty || (oldSubplots!==subplots)) {
+    if(hasData) {
+        if(gd.framework !== makePlotFramework || graphWasEmpty || !hasSameSubplots) {
             gd.framework = makePlotFramework;
             makePlotFramework(gd);
         }
     }
-    else if(graphwasempty) makePlotFramework(gd);
+    else if(graphWasEmpty) makePlotFramework(gd);
 
     var fullLayout = gd._fullLayout;
 
@@ -160,7 +159,7 @@ Plotly.plot = function(gd, data, layout, config) {
     }
 
     // in case it has changed, attach fullData traces to calcdata
-    for (var i = 0; i < gd.calcdata.length; i++) {
+    for(var i = 0; i < gd.calcdata.length; i++) {
         gd.calcdata[i][0].trace = gd._fullData[i];
     }
 
@@ -2144,8 +2143,12 @@ Plotly.relayout = function relayout(gd, astr, val) {
         undoit[ai] = (pleaf === 'reverse') ? vi : p.get();
 
         // check autosize or autorange vs size and range
-        if(hw.indexOf(ai)!==-1) { doextra('autosize', false); }
-        else if(ai==='autosize') { doextra(hw, undefined); }
+        if(hw.indexOf(ai) !== -1) {
+            doextra('autosize', false);
+        }
+        else if(ai === 'autosize') {
+            doextra(hw, undefined);
+        }
         else if(pleafPlus.match(/^[xyz]axis[0-9]*\.range(\[[0|1]\])?$/)) {
             doextra(ptrunk+'.autorange', false);
         }
@@ -2318,10 +2321,12 @@ Plotly.relayout = function relayout(gd, astr, val) {
         seq.push(function layoutReplot() {
             // force plot() to redo the layout
             gd.layout = undefined;
+
             // force it to redo calcdata?
             if(docalc) gd.calcdata = undefined;
+
             // replot with the modified layout
-            return Plotly.plot(gd,'',layout);
+            return Plotly.plot(gd, '', layout);
         });
     }
     else if(ak.length) {

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -141,6 +141,10 @@ Plotly.plot = function(gd, data, layout, config) {
             makePlotFramework(gd);
         }
     }
+    else if(!hasSameSubplots) {
+        gd.framework = makePlotFramework;
+        makePlotFramework(gd);
+    }
     else if(graphWasEmpty) makePlotFramework(gd);
 
     var fullLayout = gd._fullLayout;

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2172,6 +2172,10 @@ Plotly.relayout = function relayout(gd, astr, val) {
         else if(pleaf === 'tickmode') {
             doextra([ptrunk + '.tick0', ptrunk + '.dtick'], undefined);
         }
+        else if(/[xy]axis[0-9]*?$/.test(pleaf) && !Object.keys(vi || {}).length) {
+            docalc = true;
+        }
+
         // toggling log without autorange: need to also recalculate ranges
         // logical XOR (ie are we toggling log)
         if(pleaf==='type' && ((parentFull.type === 'log') !== (vi === 'log'))) {

--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -112,3 +112,9 @@ exports.plot = function(gd) {
         if(cdPie.length) Pie.plot(gd, cdPie);
     }
 };
+
+exports.clean = function(newFullData, newFullLayout, oldFullData, oldFullLayout) {
+    if(oldFullLayout._hasPie && !newFullLayout._hasPie) {
+        oldFullLayout._pielayer.selectAll('g.trace').remove();
+    }
+};

--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -100,10 +100,8 @@ exports.plot = function(gd) {
         }
 
         // finally do all error bars at once
-        if(fullLayout._hasCartesian) {
-            ErrorBars.plot(gd, subplotInfo, cdError);
-            Lib.markTime('done ErrorBars');
-        }
+        ErrorBars.plot(gd, subplotInfo, cdError);
+        Lib.markTime('done ErrorBars');
     }
 
     // now draw stuff not on subplots (ie, only pies at the moment)

--- a/src/plots/geo/index.js
+++ b/src/plots/geo/index.js
@@ -65,3 +65,16 @@ exports.plot = function plotGeo(gd) {
         geo.plot(fullGeoData, fullLayout, gd._promises);
     }
 };
+
+exports.clean = function(newFullData, newFullLayout, oldFullData, oldFullLayout) {
+    var oldGeoKeys = Plots.getSubplotIds(oldFullLayout, 'geo');
+
+    for(var i = 0; i < oldGeoKeys.length; i++) {
+        var oldGeoKey = oldGeoKeys[i];
+        var oldGeo = oldFullLayout[oldGeoKey]._geo;
+
+        if(!newFullLayout[oldGeoKey] && !!oldGeo) {
+            oldGeo.geoDiv.remove();
+        }
+    }
+};

--- a/src/plots/geo/layout/defaults.js
+++ b/src/plots/geo/layout/defaults.js
@@ -17,6 +17,8 @@ var supplyGeoAxisLayoutDefaults = require('./axis_defaults');
 
 
 module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
+    if(!layoutOut._hasGeo) return;
+
     var geos = Plots.findSubplotIds(fullData, 'geo'),
         geosLength = geos.length;
 
@@ -28,7 +30,12 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
 
     for(var i = 0; i < geosLength; i++) {
         var geo = geos[i];
-        geoLayoutIn = layoutIn[geo] || {};
+
+        // geo traces get a layout geo for free!
+        if(layoutIn[geo]) geoLayoutIn = layoutIn[geo];
+        else geoLayoutIn = layoutIn[geo] = {};
+
+        geoLayoutIn = layoutIn[geo];
         geoLayoutOut = {};
 
         coerce('domain.x');

--- a/src/plots/geo/layout/defaults.js
+++ b/src/plots/geo/layout/defaults.js
@@ -17,7 +17,7 @@ var supplyGeoAxisLayoutDefaults = require('./axis_defaults');
 
 
 module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
-    var geos = Plots.getSubplotIdsInData(fullData, 'geo'),
+    var geos = Plots.findSubplotIds(fullData, 'geo'),
         geosLength = geos.length;
 
     var geoLayoutIn, geoLayoutOut;

--- a/src/plots/gl3d/index.js
+++ b/src/plots/gl3d/index.js
@@ -67,6 +67,18 @@ exports.plot = function plotGl3d(gd) {
     }
 };
 
+exports.clean = function(newFullData, newFullLayout, oldFullData, oldFullLayout) {
+    var oldSceneKeys = Plots.getSubplotIds(oldFullLayout, 'gl3d');
+
+    for(var i = 0; i < oldSceneKeys.length; i++) {
+        var oldSceneKey = oldSceneKeys[i];
+
+        if(!newFullLayout[oldSceneKey] && !!oldFullLayout[oldSceneKey]._scene) {
+            oldFullLayout[oldSceneKey]._scene.destroy();
+        }
+    }
+};
+
 // clean scene ids, 'scene1' -> 'scene'
 exports.cleanId = function cleanId(id) {
     if (!id.match(/^scene[0-9]*$/)) return;

--- a/src/plots/gl3d/layout/defaults.js
+++ b/src/plots/gl3d/layout/defaults.js
@@ -18,10 +18,8 @@ var supplyGl3dAxisLayoutDefaults = require('./axis_defaults');
 module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
     if(!layoutOut._hasGL3D) return;
 
-    var scenes = Plots.getSubplotIdsInData(fullData, 'gl3d');
-
-    // Get number of scenes to compute default scene domain
-    var scenesLength = scenes.length;
+    var scenes = Plots.findSubplotIds(fullData, 'gl3d'),
+        scenesLength = scenes.length;
 
     var sceneLayoutIn, sceneLayoutOut;
 

--- a/src/plots/gl3d/layout/defaults.js
+++ b/src/plots/gl3d/layout/defaults.js
@@ -57,7 +57,8 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
          * attributes like aspectratio can be written back dynamically.
          */
 
-        if(layoutIn[scene] !== undefined) sceneLayoutIn = layoutIn[scene];
+        // gl3d traces get a layout scene for free!
+        if(layoutIn[scene]) sceneLayoutIn = layoutIn[scene];
         else layoutIn[scene] = sceneLayoutIn = {};
 
         sceneLayoutOut = layoutOut[scene] || {};

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -140,8 +140,40 @@ plots.registerSubplot = function(_module) {
     subplotsRegistry[plotType] = _module;
 };
 
-// TODO separate the 'find subplot' step (which looks in layout)
-// from the 'get subplot ids' step (which looks in fullLayout._plots)
+/**
+ * Find subplot ids in data.
+ * Meant to be used in the defaults step.
+ *
+ * Use plots.getSubplotIds to grab the current
+ * subplot ids later on in Plotly.plot.
+ *
+ * @param {array} data plotly data array
+ *      (intended to be _fullData, but does not have to be).
+ * @param {string} type subplot type to look for.
+ *
+ * @return {array} list of subplot ids (strings).
+ *      N.B. these ids possibly un-ordered.
+ *
+ * TODO incorporate cartesian/gl2d axis finders in this paradigm.
+ */
+plots.findSubplotIds = function findSubplotIds(data, type) {
+    var subplotIds = [];
+
+    if(plots.subplotsRegistry[type] === undefined) return subplotIds;
+
+    var attr = plots.subplotsRegistry[type].attr;
+
+    for(var i = 0; i < data.length; i++) {
+        var trace = data[i];
+
+        if(plots.traceIs(trace, type) && subplotIds.indexOf(trace[attr]) === -1) {
+            subplotIds.push(trace[attr]);
+        }
+    }
+
+    return subplotIds;
+};
+
 plots.getSubplotIds = function getSubplotIds(layout, type) {
     if(plots.subplotsRegistry[type] === undefined) return [];
 
@@ -165,19 +197,6 @@ plots.getSubplotIds = function getSubplotIds(layout, type) {
     return subplotIds;
 };
 
-plots.getSubplotIdsInData = function getSubplotsInData(data, type) {
-    if(plots.subplotsRegistry[type] === undefined) return [];
-
-    var attr = plots.subplotsRegistry[type].attr,
-        subplotIds = [],
-        trace;
-
-    for (var i = 0; i < data.length; i++) {
-        trace = data[i];
-        if(Plotly.Plots.traceIs(trace, type) && subplotIds.indexOf(trace[attr])===-1) {
-            subplotIds.push(trace[attr]);
-        }
-    }
 
     return subplotIds;
 };

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -216,6 +216,16 @@ plots.getSubplotIds = function getSubplotIds(layout, type) {
     return subplotIds;
 };
 
+/**
+ * Get the data trace(s) associated with a given subplot.
+ *
+ * @param {array} data  plotly full data array.
+ * @param {object} layout plotly full layout object.
+ * @param {string} subplotId subplot ids to look for.
+ *
+ * @return {array} list of trace objects.
+ *
+ */
 plots.getSubplotData = function getSubplotData(data, type, subplotId) {
     if(plots.subplotsRegistry[type] === undefined) return [];
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -174,8 +174,19 @@ plots.findSubplotIds = function findSubplotIds(data, type) {
     return subplotIds;
 };
 
+/**
+ * Get the ids of the current subplots.
+ *
+ * @param {object} layout plotly full layout object.
+ * @param {string} type subplot type to look for.
+ *
+ * @return {array} list of ordered subplot ids (strings).
+ *
+ */
 plots.getSubplotIds = function getSubplotIds(layout, type) {
-    if(plots.subplotsRegistry[type] === undefined) return [];
+    var _module = plots.subplotsRegistry[type];
+
+    if(_module === undefined) return [];
 
     // layout must be 'fullLayout' here
     if(type === 'cartesian' && !layout._hasCartesian) return [];
@@ -184,19 +195,23 @@ plots.getSubplotIds = function getSubplotIds(layout, type) {
         return Object.keys(layout._plots);
     }
 
-    var idRegex = plots.subplotsRegistry[type].idRegex,
+    var idRegex = _module.idRegex,
         layoutKeys = Object.keys(layout),
-        subplotIds = [],
-        layoutKey;
+        subplotIds = [];
 
     for(var i = 0; i < layoutKeys.length; i++) {
-        layoutKey = layoutKeys[i];
+        var layoutKey = layoutKeys[i];
+
         if(idRegex.test(layoutKey)) subplotIds.push(layoutKey);
     }
 
-    return subplotIds;
-};
-
+    // order the ids
+    var idLen = _module.idRoot.length;
+    subplotIds.sort(function(a, b) {
+        var aNum = +(a.substr(idLen) || 1),
+            bNum = +(b.substr(idLen) || 1);
+        return aNum - bNum;
+    });
 
     return subplotIds;
 };

--- a/src/traces/mesh3d/convert.js
+++ b/src/traces/mesh3d/convert.js
@@ -141,7 +141,7 @@ proto.update = function(data) {
 };
 
 proto.dispose = function() {
-    this.glplot.remove(this.mesh);
+    this.scene.glplot.remove(this.mesh);
     this.mesh.dispose();
 };
 

--- a/src/traces/surface/convert.js
+++ b/src/traces/surface/convert.js
@@ -323,7 +323,7 @@ proto.update = function(data) {
 
 
 proto.dispose = function() {
-    this.glplot.remove(this.surface);
+    this.scene.glplot.remove(this.surface);
     this.surface.dispose();
 };
 

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -167,9 +167,12 @@ describe('Test axes', function() {
     });
 
     describe('supplyLayoutDefaults', function() {
-        var layoutIn = {},
-            layoutOut = {},
+        var layoutIn, layoutOut, fullData;
+
+        beforeEach(function() {
+            layoutOut = {};
             fullData = [];
+        });
 
         var supplyLayoutDefaults = Axes.supplyLayoutDefaults;
 
@@ -196,7 +199,7 @@ describe('Test axes', function() {
 
         it('should set linewidth to default if linecolor is supplied and valid', function() {
             layoutIn = {
-                xaxis: {linecolor:'black'}
+                xaxis: { linecolor: 'black' }
             };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.xaxis.linecolor).toBe('black');
@@ -205,7 +208,7 @@ describe('Test axes', function() {
 
         it('should set linecolor to default if linewidth is supplied and valid', function() {
             layoutIn = {
-                yaxis: {linewidth:2}
+                yaxis: { linewidth: 2 }
             };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.yaxis.linewidth).toBe(2);
@@ -252,6 +255,69 @@ describe('Test axes', function() {
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.xaxis.zerolinewidth).toBe(undefined);
             expect(layoutOut.xaxis.zerolinecolor).toBe(undefined);
+        });
+
+        it('should detect orphan axes (lone axes case)', function() {
+            layoutIn = {
+                xaxis: {},
+                yaxis: {}
+            };
+            fullData = [];
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut._hasCartesian).toBe(true);
+        });
+
+        it('should detect orphan axes (gl2d trace conflict case)', function() {
+            layoutIn = {
+                xaxis: {},
+                yaxis: {}
+            };
+            fullData = [{
+                type: 'scattergl',
+                xaxis: 'x',
+                yaxis: 'y'
+            }];
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut._hasCartesian).toBe(undefined);
+        });
+
+        it('should detect orphan axes (gl2d + cartesian case)', function() {
+            layoutIn = {
+                xaxis2: {},
+                yaxis2: {}
+            };
+            fullData = [{
+                type: 'scattergl',
+                xaxis: 'x',
+                yaxis: 'y'
+            }];
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut._hasCartesian).toBe(true);
+        });
+
+        it('should detect orphan axes (gl3d present case)', function() {
+            layoutIn = {
+                xaxis: {},
+                yaxis: {}
+            };
+            layoutOut._hasGL3D = true;
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut._hasCartesian).toBe(undefined);
+        });
+
+        it('should detect orphan axes (gl3d present case)', function() {
+            layoutIn = {
+                xaxis: {},
+                yaxis: {}
+            };
+            layoutOut._hasGeo = true;
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut._hasCartesian).toBe(undefined);
         });
     });
 

--- a/test/jasmine/tests/geo_interact_test.js
+++ b/test/jasmine/tests/geo_interact_test.js
@@ -24,6 +24,18 @@ describe('Test geo interactions', function() {
             mouseEvent(type, 400, 160);
         }
 
+        function countTraces(type) {
+            return d3.selectAll('g.trace.' + type).size();
+        }
+
+        function countGeos() {
+            return d3.select('div.geo-container').selectAll('div').size();
+        }
+
+        function countColorBars() {
+            return d3.select('g.infolayer').selectAll('.cbbg').size();
+        }
+
         beforeEach(function(done) {
             gd = createGraphDiv();
             Plotly.plot(gd, mock.data, mock.layout).then(done);
@@ -181,10 +193,6 @@ describe('Test geo interactions', function() {
         });
 
         describe('trace visibility toggle', function() {
-            function countTraces(type) {
-                return d3.selectAll('g.trace.' + type).size();
-            }
-
             it('should toggle scattergeo elements', function(done) {
                 expect(countTraces('scattergeo')).toBe(1);
                 expect(countTraces('choropleth')).toBe(1);
@@ -218,5 +226,37 @@ describe('Test geo interactions', function() {
             });
 
         });
+
+        describe('deleting traces and geos', function() {
+            it('should delete traces in succession', function(done) {
+                expect(countTraces('scattergeo')).toBe(1);
+                expect(countTraces('choropleth')).toBe(1);
+                expect(countGeos()).toBe(1);
+                expect(countColorBars()).toBe(1);
+
+                Plotly.deleteTraces(gd, [0]).then(function() {
+                    expect(countTraces('scattergeo')).toBe(0);
+                    expect(countTraces('choropleth')).toBe(1);
+                    expect(countGeos()).toBe(1);
+                    expect(countColorBars()).toBe(1);
+
+                    Plotly.deleteTraces(gd, [0]).then(function() {
+                        expect(countTraces('scattergeo')).toBe(0);
+                        expect(countTraces('choropleth')).toBe(0);
+                        expect(countGeos()).toBe(1);
+                        expect(countColorBars()).toBe(0);
+
+                        Plotly.relayout(gd, 'geo', null).then(function() {
+                            expect(countTraces('scattergeo')).toBe(0);
+                            expect(countTraces('choropleth')).toBe(0);
+                            expect(countGeos()).toBe(0);
+                            expect(countColorBars()).toBe(0);
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
     });
 });

--- a/test/jasmine/tests/geo_interact_test.js
+++ b/test/jasmine/tests/geo_interact_test.js
@@ -201,11 +201,12 @@ describe('Test geo interactions', function() {
                     expect(countTraces('scattergeo')).toBe(0);
                     expect(countTraces('choropleth')).toBe(1);
 
-                    Plotly.restyle(gd, 'visible', true, [0]).then(function() {
-                        expect(countTraces('scattergeo')).toBe(1);
-                        expect(countTraces('choropleth')).toBe(1);
-                        done();
-                    });
+                    return Plotly.restyle(gd, 'visible', true, [0]);
+                }).then(function() {
+                    expect(countTraces('scattergeo')).toBe(1);
+                    expect(countTraces('choropleth')).toBe(1);
+
+                    done();
                 });
             });
 
@@ -217,11 +218,12 @@ describe('Test geo interactions', function() {
                     expect(countTraces('scattergeo')).toBe(1);
                     expect(countTraces('choropleth')).toBe(0);
 
-                    Plotly.restyle(gd, 'visible', true, [1]).then(function() {
-                        expect(countTraces('scattergeo')).toBe(1);
-                        expect(countTraces('choropleth')).toBe(1);
-                        done();
-                    });
+                    return Plotly.restyle(gd, 'visible', true, [1]);
+                }).then(function() {
+                    expect(countTraces('scattergeo')).toBe(1);
+                    expect(countTraces('choropleth')).toBe(1);
+
+                    done();
                 });
             });
 
@@ -240,20 +242,21 @@ describe('Test geo interactions', function() {
                     expect(countGeos()).toBe(1);
                     expect(countColorBars()).toBe(1);
 
-                    Plotly.deleteTraces(gd, [0]).then(function() {
-                        expect(countTraces('scattergeo')).toBe(0);
-                        expect(countTraces('choropleth')).toBe(0);
-                        expect(countGeos()).toBe(1);
-                        expect(countColorBars()).toBe(0);
+                    return Plotly.deleteTraces(gd, [0]);
+                }).then(function() {
+                    expect(countTraces('scattergeo')).toBe(0);
+                    expect(countTraces('choropleth')).toBe(0);
+                    expect(countGeos()).toBe(1);
+                    expect(countColorBars()).toBe(0);
 
-                        Plotly.relayout(gd, 'geo', null).then(function() {
-                            expect(countTraces('scattergeo')).toBe(0);
-                            expect(countTraces('choropleth')).toBe(0);
-                            expect(countGeos()).toBe(0);
-                            expect(countColorBars()).toBe(0);
-                            done();
-                        });
-                    });
+                    return Plotly.relayout(gd, 'geo', null);
+                }).then(function() {
+                    expect(countTraces('scattergeo')).toBe(0);
+                    expect(countTraces('choropleth')).toBe(0);
+                    expect(countGeos()).toBe(0);
+                    expect(countColorBars()).toBe(0);
+
+                    done();
                 });
             });
         });

--- a/test/jasmine/tests/geo_interact_test.js
+++ b/test/jasmine/tests/geo_interact_test.js
@@ -246,7 +246,7 @@ describe('Test geo interactions', function() {
                 }).then(function() {
                     expect(countTraces('scattergeo')).toBe(0);
                     expect(countTraces('choropleth')).toBe(0);
-                    expect(countGeos()).toBe(1);
+                    expect(countGeos()).toBe(0, '- trace-less geo subplot are deleted');
                     expect(countColorBars()).toBe(0);
 
                     return Plotly.relayout(gd, 'geo', null);

--- a/test/jasmine/tests/geolayout_test.js
+++ b/test/jasmine/tests/geolayout_test.js
@@ -8,16 +8,28 @@ describe('Test Geo layout defaults', function() {
     var supplyLayoutDefaults = Geo.supplyLayoutDefaults;
 
     describe('supplyLayoutDefaults', function() {
-        var layoutIn, layoutOut;
-
-        var fullData = [{
-            type: 'scattergeo',
-            geo: 'geo'
-        }];
+        var layoutIn, layoutOut, fullData;
 
         beforeEach(function() {
-            layoutOut = {};
+            // if hasGeo is not at this stage, the default step is skipped
+            layoutOut = { _hasGeo: true };
+
+            // needs a geo-ref in a trace in order to be detected
+            fullData = [{ type: 'scattergeo', geo: 'geo' }];
         });
+
+        var seaFields = [
+            'showcoastlines', 'coastlinecolor', 'coastlinewidth',
+            'showocean', 'oceancolor'
+        ];
+
+        var subunitFields = [
+            'showsubunits', 'subunitcolor', 'subunitwidth'
+        ];
+
+        var frameFields = [
+            'showframe', 'framecolor', 'framewidth'
+        ];
 
         it('should not coerce projection.rotation if type is albers usa', function() {
             layoutIn = {
@@ -34,19 +46,25 @@ describe('Test Geo layout defaults', function() {
 
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.geo.projection.rotation).toBeUndefined();
+        });
 
-            delete layoutIn.geo.projection.type;
-            layoutOut = {};
+        it('should not coerce projection.rotation if type is albers usa (converse)', function() {
+            layoutIn = {
+                geo: {
+                    projection: {
+                        rotation: {
+                            lon: 10,
+                            lat: 10
+                        }
+                    }
+                }
+            };
+
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.geo.projection.rotation).toBeDefined();
         });
 
         it('should not coerce coastlines and ocean if type is albers usa', function() {
-            var fields = [
-                'showcoastlines', 'coastlinecolor', 'coastlinewidth',
-                'showocean', 'oceancolor'
-            ];
-
             layoutIn = {
                 geo: {
                     projection: {
@@ -58,14 +76,21 @@ describe('Test Geo layout defaults', function() {
             };
 
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            fields.forEach(function(field) {
+            seaFields.forEach(function(field) {
                 expect(layoutOut.geo[field]).toBeUndefined();
             });
+        });
 
-            delete layoutIn.geo.projection.type;
-            layoutOut = {};
+        it('should not coerce coastlines and ocean if type is albers usa (converse)', function() {
+            layoutIn = {
+                geo: {
+                    showcoastlines: true,
+                    showocean: true
+                }
+            };
+
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            fields.forEach(function(field) {
+            seaFields.forEach(function(field) {
                 expect(layoutOut.geo[field]).toBeDefined();
             });
         });
@@ -82,7 +107,7 @@ describe('Test Geo layout defaults', function() {
                         }
                     }
                 };
-                layoutOut = {};
+
                 supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             }
 
@@ -90,91 +115,114 @@ describe('Test Geo layout defaults', function() {
                 testOne(projType);
                 if (projType.indexOf('conic') !== -1) {
                     expect(layoutOut.geo.projection.parallels).toBeDefined();
-                } else {
+                }
+                else {
                     expect(layoutOut.geo.projection.parallels).toBeUndefined();
                 }
             });
         });
 
-        it('should coerce subunits only when available ', function() {
-            var fields = [
-                'showsubunits', 'subunitcolor', 'subunitwidth'
-            ];
-
+        it('should coerce subunits only when available (usa case)', function() {
             layoutIn = {
                 geo: { scope: 'usa' }
             };
-            layoutOut = {};
+
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            fields.forEach(function(field) {
+            subunitFields.forEach(function(field) {
                 expect(layoutOut.geo[field]).toBeDefined();
             });
+        });
 
-            delete layoutIn.geo.scope;
-            layoutOut = {};
+        it('should coerce subunits only when available (default case)', function() {
+            layoutIn = { geo: {} };
+
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            fields.forEach(function(field) {
+            subunitFields.forEach(function(field) {
                 expect(layoutOut.geo[field]).toBeUndefined();
             });
+        });
 
+        it('should coerce subunits only when available (NA case)', function() {
             layoutIn = {
                 geo: {
                     scope: 'north america',
                     resolution: 50
                 }
             };
-            layoutOut = {};
+
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            fields.forEach(function(field) {
+            subunitFields.forEach(function(field) {
                 expect(layoutOut.geo[field]).toBeDefined();
             });
+        });
 
+        it('should coerce subunits only when available (NA case 2)', function() {
             layoutIn = {
                 geo: {
                     scope: 'north america',
                     resolution: '50'
                 }
             };
-            layoutOut = {};
+
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            fields.forEach(function(field) {
+            subunitFields.forEach(function(field) {
                 expect(layoutOut.geo[field]).toBeDefined();
             });
+        });
 
-            delete layoutIn.geo.resolution;
-            layoutOut = {};
+        it('should coerce subunits only when available (NA case 2)', function() {
+            layoutIn = {
+                geo: {
+                    scope: 'north america'
+                }
+            };
+
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            fields.forEach(function(field) {
+            subunitFields.forEach(function(field) {
                 expect(layoutOut.geo[field]).toBeUndefined();
             });
         });
 
         it('should not coerce frame unless for world scope', function() {
-            var fields = [
-                    'showframe', 'framecolor', 'framewidth'
-                ],
-                scopes = layoutAttributes.scope.values;
+            var scopes = layoutAttributes.scope.values;
 
             function testOne(scope) {
                 layoutIn = {
                     geo: { scope: scope }
                 };
-                layoutOut = {};
+
                 supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             }
 
             scopes.forEach(function(scope) {
                 testOne(scope);
                 if(scope === 'world') {
-                    fields.forEach(function(field) {
+                    frameFields.forEach(function(field) {
                         expect(layoutOut.geo[field]).toBeDefined();
                     });
-                } else {
-                    fields.forEach(function(field) {
+                }
+                else {
+                    frameFields.forEach(function(field) {
                         expect(layoutOut.geo[field]).toBeUndefined();
                     });
                 }
             });
+        });
+
+        it('should add geo data-only geos into layoutIn', function() {
+            layoutIn = {};
+            fullData = [{ type: 'scattergeo', geo: 'geo' }];
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutIn.geo).toEqual({});
+        });
+
+        it('should add geo data-only geos into layoutIn (converse)', function() {
+            layoutIn = {};
+            fullData = [{ type: 'scatter' }];
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutIn.geo).toBe(undefined);
         });
 
     });

--- a/test/jasmine/tests/gl3dlayout_test.js
+++ b/test/jasmine/tests/gl3dlayout_test.js
@@ -5,16 +5,19 @@ describe('Test Gl3d layout defaults', function() {
     'use strict';
 
     describe('supplyLayoutDefaults', function() {
-        var supplyLayoutDefaults = Gl3d.supplyLayoutDefaults;
         var layoutIn, layoutOut, fullData;
 
+        var supplyLayoutDefaults = Gl3d.supplyLayoutDefaults;
+
         beforeEach(function() {
-            layoutOut = {_hasGL3D: true};
-            fullData = [{scene: 'scene', type: 'scatter3d'}];
+            // if hasGL3D is not at this stage, the default step is skipped
+            layoutOut = { _hasGL3D: true };
+
+            // needs a scene-ref in a trace in order to be detected
+            fullData = [ { type: 'scatter3d', scene: 'scene' }];
         });
 
         it('should coerce aspectmode=ratio when ratio data is valid', function() {
-
             var aspectratio = {
                 x: 1,
                 y: 2,
@@ -44,7 +47,6 @@ describe('Test Gl3d layout defaults', function() {
 
 
         it('should coerce aspectmode=auto when aspect ratio data is invalid', function() {
-
             var aspectratio = {
                 x: 'g',
                 y: 2,
@@ -72,7 +74,6 @@ describe('Test Gl3d layout defaults', function() {
 
 
         it('should coerce manual when valid ratio data but invalid aspectmode', function() {
-
             var aspectratio = {
                 x: 1,
                 y: 2,
@@ -100,7 +101,6 @@ describe('Test Gl3d layout defaults', function() {
 
 
         it('should not coerce manual when invalid ratio data but invalid aspectmode', function() {
-
             var aspectratio = {
                 x: 'g',
                 y: 2,
@@ -128,7 +128,6 @@ describe('Test Gl3d layout defaults', function() {
 
 
         it('should not coerce manual when valid ratio data and valid non-manual aspectmode', function() {
-
             var aspectratio = {
                 x: 1,
                 y: 2,
@@ -155,7 +154,7 @@ describe('Test Gl3d layout defaults', function() {
         });
 
         it('should coerce dragmode', function() {
-            layoutIn = {};
+            layoutIn = { scene: {} };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.dragmode)
                 .toBe('turntable', 'to turntable by default');
@@ -165,25 +164,25 @@ describe('Test Gl3d layout defaults', function() {
             expect(layoutOut.scene.dragmode)
                 .toBe('orbit', 'to user val if valid');
 
-            layoutIn = { dragmode: 'orbit' };
+            layoutIn = { scene: {}, dragmode: 'orbit' };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.dragmode)
                 .toBe('orbit', 'to user layout val if valid and 3d only');
 
-            layoutIn = { dragmode: 'orbit' };
+            layoutIn = { scene: {}, dragmode: 'orbit' };
             layoutOut._hasCartesian = true;
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.dragmode)
                 .toBe('turntable', 'to default if not 3d only');
 
-            layoutIn = { dragmode: 'not gonna work' };
+            layoutIn = { scene: {}, dragmode: 'not gonna work' };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.dragmode)
                 .toBe('turntable', 'to default if not valid');
         });
 
         it('should coerce hovermode', function() {
-            layoutIn = {};
+            layoutIn = { scene: {} };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.hovermode)
                 .toBe('closest', 'to closest by default');
@@ -193,21 +192,39 @@ describe('Test Gl3d layout defaults', function() {
             expect(layoutOut.scene.hovermode)
                 .toBe(false, 'to user val if valid');
 
-            layoutIn = { hovermode: false };
+            layoutIn = { scene: {}, hovermode: false };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.hovermode)
                 .toBe(false, 'to user layout val if valid and 3d only');
 
-            layoutIn = { hovermode: false };
+            layoutIn = { scene: {}, hovermode: false };
             layoutOut._hasCartesian = true;
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.hovermode)
                 .toBe('closest', 'to default if not 3d only');
 
-            layoutIn = { hovermode: 'not gonna work' };
+            layoutIn = { scene: {}, hovermode: 'not gonna work' };
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.hovermode)
                 .toBe('closest', 'to default if not valid');
+        });
+
+        it('should add data-only scenes into layoutIn', function() {
+            layoutIn = {};
+            fullData = [{ type: 'scatter3d', scene: 'scene' }];
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutIn.scene).toEqual({
+                aspectratio: { x: 1, y: 1, z: 1 }
+            });
+        });
+
+        it('should add scene data-only scenes into layoutIn (converse)', function() {
+            layoutIn = {};
+            fullData = [{ type: 'scatter' }];
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutIn.scene).toBe(undefined);
         });
     });
 });

--- a/test/jasmine/tests/plot_interact_test.js
+++ b/test/jasmine/tests/plot_interact_test.js
@@ -206,27 +206,28 @@ describe('Test plot structure', function() {
                         assertContourNodes(2);
                         expect(countColorBars()).toEqual(0);
 
-                        Plotly.deleteTraces(gd, [0]).then(function() {
-                            expect(countSubplots()).toEqual(4);
-                            assertHeatmapNodes(2);
-                            assertContourNodes(2);
-                            expect(countColorBars()).toEqual(0);
+                        return Plotly.deleteTraces(gd, [0]);
+                    }).then(function() {
+                        expect(countSubplots()).toEqual(4);
+                        assertHeatmapNodes(2);
+                        assertContourNodes(2);
+                        expect(countColorBars()).toEqual(0);
 
-                            Plotly.deleteTraces(gd, [0]).then(function() {
-                                expect(countSubplots()).toEqual(4);
-                                assertHeatmapNodes(1);
-                                assertContourNodes(1);
-                                expect(countColorBars()).toEqual(0);
+                        return Plotly.deleteTraces(gd, [0]);
+                    }).then(function() {
+                        expect(countSubplots()).toEqual(4);
+                        assertHeatmapNodes(1);
+                        assertContourNodes(1);
+                        expect(countColorBars()).toEqual(0);
 
-                                Plotly.deleteTraces(gd, [0]).then(function() {
-                                    expect(countSubplots()).toEqual(4);
-                                    assertHeatmapNodes(0);
-                                    assertContourNodes(0);
-                                    expect(countColorBars()).toEqual(0);
-                                    done();
-                                });
-                            });
-                        });
+                        return Plotly.deleteTraces(gd, [0]);
+                    }).then(function() {
+                        expect(countSubplots()).toEqual(4);
+                        assertHeatmapNodes(0);
+                        assertContourNodes(0);
+                        expect(countColorBars()).toEqual(0);
+
+                        done();
                     });
                 });
 

--- a/test/jasmine/tests/plot_interact_test.js
+++ b/test/jasmine/tests/plot_interact_test.js
@@ -39,7 +39,11 @@ describe('Test plot structure', function() {
 
             beforeEach(function(done) {
                 gd = createGraphDiv();
-                Plotly.plot(gd, mock.data, mock.layout).then(done);
+
+                var mockData = Lib.extendDeep([], mock.data),
+                    mockLayout = Lib.extendDeep({}, mock.layout);
+
+                Plotly.plot(gd, mockData, mockLayout).then(done);
             });
 
             it('has one *subplot xy* node', function() {
@@ -91,6 +95,35 @@ describe('Test plot structure', function() {
                     done();
                 });
             });
+
+            it('should restore layout axes when they get deleted', function(done) {
+                expect(countScatterTraces()).toEqual(mock.data.length);
+                expect(countSubplots()).toEqual(1);
+
+                Plotly.relayout(gd, {xaxis: null, yaxis: null}).then(function() {
+                    expect(countScatterTraces()).toEqual(1);
+                    expect(countSubplots()).toEqual(1);
+
+                    return Plotly.relayout(gd, 'xaxis', null);
+                }).then(function() {
+                    expect(countScatterTraces()).toEqual(1);
+                    expect(countSubplots()).toEqual(1);
+
+                    return Plotly.relayout(gd, 'xaxis', {});
+                }).then(function() {
+                    expect(countScatterTraces()).toEqual(1);
+                    expect(countSubplots()).toEqual(1);
+
+                    return Plotly.relayout(gd, 'yaxis', null);
+                }).then(function() {
+                    expect(countScatterTraces()).toEqual(1);
+                    expect(countSubplots()).toEqual(1);
+
+                    return Plotly.relayout(gd, 'yaxis', {});
+                }).then(function() {
+                    expect(countScatterTraces()).toEqual(1);
+                    expect(countSubplots()).toEqual(1);
+
                     done();
                 });
             });

--- a/test/jasmine/tests/plot_interact_test.js
+++ b/test/jasmine/tests/plot_interact_test.js
@@ -75,13 +75,22 @@ describe('Test plot structure', function() {
                 });
             });
 
-            it('should delete be able to get deleted', function(done) {
+            it('should be able to get deleted', function(done) {
                 expect(countScatterTraces()).toEqual(mock.data.length);
                 expect(countSubplots()).toEqual(1);
 
                 Plotly.deleteTraces(gd, [0]).then(function() {
                     expect(countScatterTraces()).toEqual(0);
                     expect(countSubplots()).toEqual(1);
+
+                    return Plotly.relayout(gd, {xaxis: null, yaxis: null});
+                }).then(function() {
+                    expect(countScatterTraces()).toEqual(0);
+                    expect(countSubplots()).toEqual(0);
+
+                    done();
+                });
+            });
                     done();
                 });
             });
@@ -222,7 +231,7 @@ describe('Test plot structure', function() {
 
                         return Plotly.deleteTraces(gd, [0]);
                     }).then(function() {
-                        expect(countSubplots()).toEqual(4);
+                        expect(countSubplots()).toEqual(3);
                         assertHeatmapNodes(0);
                         assertContourNodes(0);
                         expect(countColorBars()).toEqual(0);

--- a/test/jasmine/tests/plot_interact_test.js
+++ b/test/jasmine/tests/plot_interact_test.js
@@ -5,6 +5,7 @@ var Lib = require('@src/lib');
 
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
+var customMatchers = require('../assets/custom_matchers');
 
 
 describe('Test plot structure', function() {
@@ -97,32 +98,44 @@ describe('Test plot structure', function() {
             });
 
             it('should restore layout axes when they get deleted', function(done) {
+                jasmine.addMatchers(customMatchers);
+
                 expect(countScatterTraces()).toEqual(mock.data.length);
                 expect(countSubplots()).toEqual(1);
 
                 Plotly.relayout(gd, {xaxis: null, yaxis: null}).then(function() {
                     expect(countScatterTraces()).toEqual(1);
                     expect(countSubplots()).toEqual(1);
+                    expect(gd.layout.xaxis.range).toBeCloseToArray([-4.79980, 74.48580], 4);
+                    expect(gd.layout.yaxis.range).toBeCloseToArray([-1.2662, 17.67023], 4);
 
                     return Plotly.relayout(gd, 'xaxis', null);
                 }).then(function() {
                     expect(countScatterTraces()).toEqual(1);
                     expect(countSubplots()).toEqual(1);
+                    expect(gd.layout.xaxis.range).toBeCloseToArray([-4.79980, 74.48580], 4);
+                    expect(gd.layout.yaxis.range).toBeCloseToArray([-1.2662, 17.67023], 4);
 
                     return Plotly.relayout(gd, 'xaxis', {});
                 }).then(function() {
                     expect(countScatterTraces()).toEqual(1);
                     expect(countSubplots()).toEqual(1);
+                    expect(gd.layout.xaxis.range).toBeCloseToArray([-4.79980, 74.48580], 4);
+                    expect(gd.layout.yaxis.range).toBeCloseToArray([-1.2662, 17.67023], 4);
 
                     return Plotly.relayout(gd, 'yaxis', null);
                 }).then(function() {
                     expect(countScatterTraces()).toEqual(1);
                     expect(countSubplots()).toEqual(1);
+                    expect(gd.layout.xaxis.range).toBeCloseToArray([-4.79980, 74.48580], 4);
+                    expect(gd.layout.yaxis.range).toBeCloseToArray([-1.2662, 17.67023], 4);
 
                     return Plotly.relayout(gd, 'yaxis', {});
                 }).then(function() {
                     expect(countScatterTraces()).toEqual(1);
                     expect(countSubplots()).toEqual(1);
+                    expect(gd.layout.xaxis.range).toBeCloseToArray([-4.79980, 74.48580], 4);
+                    expect(gd.layout.yaxis.range).toBeCloseToArray([-1.2662, 17.67023], 4);
 
                     done();
                 });

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -102,12 +102,11 @@ describe('Test Plots', function() {
 
     describe('Plots.getSubplotIds', function() {
         var getSubplotIds = Plots.getSubplotIds;
-        var layout;
 
-        it('returns scene ids', function() {
-            layout = {
-                scene: {},
+        it('returns scene ids in order', function() {
+            var layout = {
                 scene2: {},
+                scene: {},
                 scene3: {}
             };
 
@@ -116,13 +115,32 @@ describe('Test Plots', function() {
 
             expect(getSubplotIds(layout, 'cartesian'))
                 .toEqual([]);
+            expect(getSubplotIds(layout, 'geo'))
+                .toEqual([]);
+            expect(getSubplotIds(layout, 'no-valid-subplot-type'))
+                .toEqual([]);
+        });
 
+        it('returns geo ids in order', function() {
+            var layout = {
+                geo2: {},
+                geo: {},
+                geo3: {}
+            };
+
+            expect(getSubplotIds(layout, 'geo'))
+                .toEqual(['geo', 'geo2', 'geo3']);
+
+            expect(getSubplotIds(layout, 'cartesian'))
+                .toEqual([]);
+            expect(getSubplotIds(layout, 'gl3d'))
+                .toEqual([]);
             expect(getSubplotIds(layout, 'no-valid-subplot-type'))
                 .toEqual([]);
         });
 
         it('returns cartesian ids', function() {
-            layout = {
+            var layout = {
                 _plots: { xy: {}, x2y2: {} }
             };
 
@@ -167,7 +185,6 @@ describe('Test Plots', function() {
             ids = findSubplotIds(data, 'gl3d');
             expect(ids).toEqual(['scene', 'scene2']);
         });
-
     });
 
     describe('Plots.register, getModule, and traceIs', function() {

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -145,31 +145,26 @@ describe('Test Plots', function() {
         });
     });
 
-    describe('Plots.getSubplotIdsInData', function() {
-        var getSubplotIdsInData = Plots.getSubplotIdsInData;
+    describe('Plots.findSubplotIds', function() {
+        var findSubplotIds = Plots.findSubplotIds;
+        var ids;
 
-        var ids, data;
+        it('should return subplots ids found in the data', function() {
+            var data = [{
+                type: 'scatter3d',
+                scene: 'scene'
+            }, {
+                type: 'surface',
+                scene: 'scene2'
+            }, {
+                type: 'choropleth',
+                geo: 'geo'
+            }];
 
-        it('it should return scene ids', function() {
-            data = [
-                {
-                    type: 'scatter3d',
-                    scene: 'scene'
-                },
-                {
-                    type: 'surface',
-                    scene: 'scene2'
-                },
-                {
-                    type: 'choropleth',
-                    geo: 'geo'
-                }
-            ];
-
-            ids = getSubplotIdsInData(data, 'geo');
+            ids = findSubplotIds(data, 'geo');
             expect(ids).toEqual(['geo']);
 
-            ids = getSubplotIdsInData(data, 'gl3d');
+            ids = findSubplotIds(data, 'gl3d');
             expect(ids).toEqual(['scene', 'scene2']);
         });
 


### PR DESCRIPTION
@alexcjohnson @mdtusz 

An alternative to https://github.com/plotly/plotly.js/pull/268 .

Comment https://github.com/plotly/plotly.js/pull/268#discussion_r53905458 made me realize that #268 was taking things a little too far.

This PR shares most commits with #268 but does **not** allow for orphan scenes and geos to be drawn. In other words, gl3d and geo subplots must be associated with a gl3d / geo trace respectively in order to be visible.

### List of fixed bugs

- `Plotly.deleteTraces` when applied to the last trace of a subplot now properly deletes that last trace 
  + deleting the last cartesian trace does **not** delete its axes (i.e orphan cartesian axes are allowed)
  + deleting the last gl3d/geo trace does delete its associated scene/geo
- `Plotly.deleteTraces` now works on heatmap and contour traces (yep, that didn't work before)
- `Plotly.deleteTraces` now works on surface and mesh3d traces
- `Plotly.deleteTraces` now properly delete color bars associated with deleted traces
- `Plotly.deleteTraces` now works on geo traces
- `Plotly.relayout('graph', { 'xaxis': null, 'yaxis': null });` delete the axes as desired
-  `Plotly.deleteTraces` now works on pie traces