### PR TITLE
Make legend scrollbar valid svg elements

### DIFF
--- a/src/components/legend/index.js
+++ b/src/components/legend/index.js
@@ -479,7 +479,9 @@ legend.draw = function(td) {
         .attr({
             'class': 'scrollbar',
             'rx': 20,
-            'ry': 2
+            'ry': 2,
+            'width': 0,
+            'height': 0
         })
         .call(Color.fill, '#808BA4');
 
@@ -624,7 +626,7 @@ legend.draw = function(td) {
             window.addEventListener('mouseup', mUp);
         });
 
-            // Move scrollbar to starting position on the first render
+        // Move scrollbar to starting position on the first render
         scrollBar.call(
             Drawing.setRect,
             opts.width - (constants.scrollBarWidth + constants.scrollBarMargin),


### PR DESCRIPTION
@mdtusz 

Fixes a bug introduced in https://github.com/plotly/plotly.js/pull/243 and discovered on plot.ly pdf and eps image exports. 

To be a valid <svg> all <rect> must have set width and height attributes. From https://validator.w3.org:

![image](https://cloud.githubusercontent.com/assets/6675409/13440324/86ed82d2-dfbf-11e5-9875-7f3c5c23e99a.png)


