### PR TITLE
Fix clipping of charts on IE11

### DIFF
--- a/src/css/_base.scss
+++ b/src/css/_base.scss
@@ -21,6 +21,10 @@ a {
 }
 
 .crisp { shape-rendering: crispEdges; }
+
+//Required for IE11. Other browsers set this by default.
+svg { overflow: hidden; }
+
 svg a { fill: $color-brand-primary; }
 svg a:hover { fill: #3c6dc5; }
 


### PR DESCRIPTION
**Repro**

(comment out style tag on IE11 to view broken behavior):
http://codepen.io/john-soklaski/pen/ZWYPbL

**Broken**

![image](https://cloud.githubusercontent.com/assets/12491965/13440227/de9cd524-dfa5-11e5-94ff-ed6eec369178.png)

**Fixed**

![image](https://cloud.githubusercontent.com/assets/12491965/13440266/12ffb908-dfa6-11e5-9eb8-c7acd617914d.png)