### PR TITLE
Don't override saved initial ranges on data-updating restyle calls [fixes #346]

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -147,20 +147,17 @@ Plotly.plot = function(gd, data, layout, config) {
     }
     else if(graphWasEmpty) makePlotFramework(gd);
 
+    // save initial axis range once per graph
+    if(graphWasEmpty) Plotly.Axes.saveRangeInitial(gd);
+
     var fullLayout = gd._fullLayout;
 
     // prepare the data and find the autorange
 
     // generate calcdata, if we need to
     // to force redoing calcdata, just delete it before calling Plotly.plot
-    var recalc = !gd.calcdata || gd.calcdata.length!==(gd.data||[]).length;
-    if(recalc) {
-        doCalcdata(gd);
-
-        if(gd._context.doubleClick!==false || gd._context.displayModeBar!==false) {
-            Plotly.Axes.saveRangeInitial(gd);
-        }
-    }
+    var recalc = !gd.calcdata || gd.calcdata.length !== (gd.data || []).length;
+    if(recalc) doCalcdata(gd);
 
     // in case it has changed, attach fullData traces to calcdata
     for(var i = 0; i < gd.calcdata.length; i++) {

--- a/test/jasmine/.eslintrc
+++ b/test/jasmine/.eslintrc
@@ -3,5 +3,8 @@
   "env": {
     "browser": true,
     "jasmine": true
+  },
+  "globals": {
+    "Promise": true
   }
 }

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -8,7 +8,7 @@ var mouseEvent = require('../assets/mouse_event');
 var customMatchers = require('../assets/custom_matchers');
 
 
-describe('click interactions', function() {
+describe('Test click interactions:', function() {
     var mock = require('@mocks/14.json'),
         gd;
 
@@ -26,12 +26,15 @@ describe('click interactions', function() {
         mouseEvent('mouseup', x, y);
     }
 
-    function doubleClick(x, y, cb) {
-        click(x, y);
-        setTimeout(function() {
+    function doubleClick(x, y) {
+        return new Promise(function(resolve) {
             click(x, y);
-            cb();
-        }, DBLCLICKDELAY / 2);
+
+            setTimeout(function() {
+                click(x, y);
+                resolve();
+            }, DBLCLICKDELAY / 2);
+        });
     }
 
     describe('click events', function() {
@@ -87,7 +90,7 @@ describe('click interactions', function() {
         });
 
         it('should return null', function(done) {
-            doubleClick(pointPos[0], pointPos[1], function() {
+            doubleClick(pointPos[0], pointPos[1]).then(function() {
                 expect(futureData).toBe(null);
                 done();
             });
@@ -139,12 +142,12 @@ describe('click interactions', function() {
                     expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
                     expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
 
-                    doubleClick(blankPos[0], blankPos[1], function() {
-                        expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
-                        expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
+                    return doubleClick(blankPos[0], blankPos[1]);
+                }).then(function() {
+                    expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
+                    expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                        done();
-                    });
+                    done();
                 });
             });
         });
@@ -156,17 +159,17 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                Plotly.relayout(gd, update).then(function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
+                return Plotly.relayout(gd, update);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
 
-                    doubleClick(blankPos[0], blankPos[1], function() {
-                        expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
-                        expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                        done();
-                    });
-                });
+                done();
             });
         });
 
@@ -177,17 +180,19 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                doubleClick(blankPos[0], blankPos[1], function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                    doubleClick(blankPos[0], blankPos[1], function() {
-                        expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
-                        expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                        done();
-                    });
-                });
+                done();
+            });
+        });
             });
         });
 
@@ -196,17 +201,17 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                Plotly.relayout(gd, update).then(function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
+                return Plotly.relayout(gd, update);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
 
-                    doubleClick(blankPos[0], blankPos[1], function() {
-                        expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
-                        expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                        done();
-                    });
-                });
+                done();
             });
         });
 
@@ -217,17 +222,17 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                Plotly.relayout(gd, update).then(function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
+                return Plotly.relayout(gd, update);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
 
-                    doubleClick(blankPos[0], blankPos[1], function() {
-                        expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
-                        expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                        done();
-                    });
-                });
+                done();
             });
         });
 
@@ -238,12 +243,12 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                doubleClick(blankPos[0], blankPos[1], function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                    done();
-                });
+                done();
             });
         });
 
@@ -252,17 +257,17 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                Plotly.relayout(gd, update).then(function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
+                return Plotly.relayout(gd, update);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
 
-                    doubleClick(blankPos[0], blankPos[1], function() {
-                        expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
-                        expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                        done();
-                    });
-                });
+                done();
             });
         });
 
@@ -273,17 +278,17 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                Plotly.relayout(gd, update).then(function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
+                return Plotly.relayout(gd, update);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
 
-                    doubleClick(blankPos[0], blankPos[1], function() {
-                        expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
-                        expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                        done();
-                    });
-                });
+                done();
             });
         });
 
@@ -294,12 +299,12 @@ describe('click interactions', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
-                doubleClick(blankPos[0], blankPos[1], function() {
-                    expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
-                    expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                    done();
-                });
+                done();
             });
         });
 

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -116,9 +116,11 @@ describe('Test click interactions:', function() {
             'yaxis.range[1]': zoomRangeY[1]
         };
 
-        beforeEach(function() {
+        beforeAll(function() {
             jasmine.addMatchers(customMatchers);
+        });
 
+        beforeEach(function() {
             gd = createGraphDiv();
             mockCopy = Lib.extendDeep({}, mock);
         });

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -195,6 +195,36 @@ describe('Test click interactions:', function() {
                 done();
             });
         });
+
+        it('when set to \'reset+autorange\' (the default) should follow updated auto ranges', function(done) {
+            var newAutoRangeX = [-3.004307330498139, 2.0373089852019897],
+                newAutoRangeY = [-0.8770465137596604, 1.275194639444453];
+
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
+
+                return Plotly.relayout(gd, update);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
+
+                return Plotly.restyle(gd, 'y', [[1, 2, 1]]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
+
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(newAutoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(newAutoRangeY);
+
+                return doubleClick(blankPos[0], blankPos[1]);
+            }).then(function() {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(newAutoRangeX);
+                expect(gd.layout.yaxis.range).toBeCloseToArray(newAutoRangeY);
+
+                done();
             });
         });
 

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -197,8 +197,13 @@ describe('Test click interactions:', function() {
         });
 
         it('when set to \'reset+autorange\' (the default) should follow updated auto ranges', function(done) {
-            var newAutoRangeX = [-3.004307330498139, 2.0373089852019897],
-                newAutoRangeY = [-0.8770465137596604, 1.275194639444453];
+            var updateData = {
+                x: [[1e-4, 0, 1e3]],
+                y: [[30, 0, 30]]
+            };
+
+            var newAutoRangeX = [-4.482371794871794, 3.4823717948717943],
+                newAutoRangeY = [-0.8892256657741471, 1.6689872212461876];
 
             Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
@@ -209,7 +214,7 @@ describe('Test click interactions:', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);
 
-                return Plotly.restyle(gd, 'y', [[1, 2, 1]]);
+                return Plotly.restyle(gd, updateData);
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(zoomRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(zoomRangeY);


### PR DESCRIPTION
@mdtusz 

A cheeky edge case discovered by @Jodana in https://github.com/plotly/plotly.js/issues/346 .