### PR TITLE
Add Float32Array eslint global

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -5,6 +5,7 @@
   },
   "globals": {
     "Promise": true,
+    "Float32Array": true,
     "Uint8Array": true
   },
   "rules": {


### PR DESCRIPTION
* Fixes the reported eslint errors in `src/traces/surface/convert.js`
  and `src/traces/surface/convert.js`.