### PR TITLE
Fix zoom overlay positioning (Fixes #359)

### DIFF
--- a/src/components/shapes/index.js
+++ b/src/components/shapes/index.js
@@ -89,7 +89,6 @@ function linearToData(ax) { return ax.type === 'category' ? ax.l2c : ax.l2d; }
 
 shapes.drawAll = function(gd) {
     var fullLayout = gd._fullLayout;
-    fullLayout._shapelayer.selectAll('path').remove();
     for(var i = 0; i < fullLayout.shapes.length; i++) {
         shapes.draw(gd, i);
     }

--- a/src/components/shapes/index.js
+++ b/src/components/shapes/index.js
@@ -183,7 +183,7 @@ function deleteShape(gd, index) {
         // so they bind to the right events
         gd._fullLayout._shapelayer
             .selectAll('[data-index="' + (i+1) + '"]')
-            .attr('data-index', String(i));
+            .attr('data-index', i);
         shapes.draw(gd, i);
     }
 
@@ -206,7 +206,7 @@ function insertShape(gd, index, newShape) {
     for(var i = gd._fullLayout.shapes.length - 1; i > index; i--) {
         gd._fullLayout._shapelayer
             .selectAll('[data-index="' + (i - 1) + '"]')
-            .attr('data-index', String(i));
+            .attr('data-index', i);
         shapes.draw(gd, i);
     }
 
@@ -292,7 +292,7 @@ function updateShape(gd, index, opt, value) {
     gd._fullLayout.shapes[index] = options;
 
     var attrs = {
-            'data-index': String(index),
+            'data-index': index,
             'fill-rule': 'evenodd',
             d: shapePath(gd, options)
         },

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -1431,11 +1431,11 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
     fx.dragElement(dragOptions);
 
-    var x0,
-        y0,
+    var zoomlayer = gd._fullLayout._shapelayer,
         xs = plotinfo.x()._offset,
         ys = plotinfo.y()._offset,
-        zoomlayer = gd._fullLayout._shapelayer,
+        x0,
+        y0,
         box,
         lum,
         path0,

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -1433,6 +1433,9 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
     var x0,
         y0,
+        xs = plotinfo.x()._offset,
+        ys = plotinfo.y()._offset,
+        zoomlayer = gd._fullLayout._shapelayer,
         box,
         lum,
         path0,
@@ -1453,15 +1456,16 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         dimmed = false;
         zoomMode = 'xy';
 
-        zb = plotinfo.plot.append('path')
+        zb = zoomlayer.append('path')
             .attr('class', 'zoombox')
             .style({
                 'fill': lum>0.2 ? 'rgba(0,0,0,0)' : 'rgba(255,255,255,0)',
                 'stroke-width': 0
             })
+            .attr('transform','translate(' + xs + ' ' + ys + ')')
             .attr('d', path0 + 'Z');
 
-        corners = plotinfo.plot.append('path')
+        corners = zoomlayer.append('path')
             .attr('class', 'zoombox-corners')
             .style({
                 fill: Plotly.Color.background,
@@ -1469,6 +1473,7 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 'stroke-width': 1,
                 opacity: 0
             })
+            .attr('transform','translate(' + xs + ' ' + ys + ')')
             .attr('d','M0,0Z');
 
         clearSelect();
@@ -1479,7 +1484,7 @@ function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         // until we get around to persistent selections, remove the outline
         // here. The selection itself will be removed when the plot redraws
         // at the end.
-        plotinfo.plot.selectAll('.select-outline').remove();
+        zoomlayer.selectAll('.select-outline').remove();
     }
 
     function zoomMove(dx0, dy0) {

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -22,8 +22,10 @@ var MINSELECT = constants.MINSELECT;
 function getAxId(ax) { return ax._id; }
 
 module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
-    var plot = dragOptions.plotinfo.plot,
+    var plot = dragOptions.gd._fullLayout._shapelayer,
         dragBBox = dragOptions.element.getBoundingClientRect(),
+        xs = dragOptions.plotinfo.x()._offset,
+        ys = dragOptions.plotinfo.y()._offset,
         x0 = startX - dragBBox.left,
         y0 = startY - dragBBox.top,
         x1 = x0,
@@ -45,6 +47,7 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
     outlines.enter()
         .append('path')
         .attr('class', function(d) { return 'select-outline select-outline-' + d; })
+        .attr('transform','translate(' + xs + ' ' + ys + ')')
         .attr('d', path0 + 'Z');
 
     var corners = plot.append('path')
@@ -54,6 +57,7 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
             stroke: color.defaultLine,
             'stroke-width': 1
         })
+        .attr('transform','translate(' + xs + ' ' + ys + ')')
         .attr('d','M0,0Z');
 
 

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -1,3 +1,5 @@
+var d3 = require('d3');
+
 var Plotly = require('@lib/index');
 var Lib = require('@src/lib');
 var DBLCLICKDELAY = require('@src/plots/cartesian/constants').DBLCLICKDELAY;
@@ -53,6 +55,80 @@ describe('select box and lasso', function() {
         expect(actual.x).toBeCloseToArray(expected.x, PRECISION);
         expect(actual.y).toBeCloseToArray(expected.y, PRECISION);
     }
+
+    describe('select elements', function() {
+        var mockCopy = Lib.extendDeep({}, mock);
+        mockCopy.layout.dragmode = 'select';
+
+        var gd;
+        beforeEach(function(done) {
+            gd = createGraphDiv();
+
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+                .then(done);
+        });
+
+        it('should be appended to the the shape layer', function() {
+            var x0 = 100;
+            var y0 = 200;
+            var x1 = 150;
+            var y1 = 200;
+
+            mouseEvent('mousemove', x0, y0);
+            expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+                .toEqual(0);
+
+            mouseEvent('mousedown', x0, y0);
+            mouseEvent('mousemove', x1, y1);
+            expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+                .toEqual(1);
+            expect(d3.selectAll('.shapelayer > .select-outline').size())
+                .toEqual(2);
+
+            mouseEvent('mouseup', x1, y1);
+            expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+                .toEqual(0);
+            expect(d3.selectAll('.shapelayer > .select-outline').size())
+                .toEqual(2);
+        });
+    });
+
+    describe('lasso elements', function() {
+        var mockCopy = Lib.extendDeep({}, mock);
+        mockCopy.layout.dragmode = 'lasso';
+
+        var gd;
+        beforeEach(function(done) {
+            gd = createGraphDiv();
+
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+                .then(done);
+        });
+
+        it('should be appended to the the shape layer', function() {
+            var x0 = 100;
+            var y0 = 200;
+            var x1 = 150;
+            var y1 = 200;
+
+            mouseEvent('mousemove', x0, y0);
+            expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+                .toEqual(0);
+
+            mouseEvent('mousedown', x0, y0);
+            mouseEvent('mousemove', x1, y1);
+            expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+                .toEqual(1);
+            expect(d3.selectAll('.shapelayer > .select-outline').size())
+                .toEqual(2);
+
+            mouseEvent('mouseup', x1, y1);
+            expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+                .toEqual(0);
+            expect(d3.selectAll('.shapelayer > .select-outline').size())
+                .toEqual(2);
+        });
+    });
 
     describe('select events', function() {
         var mockCopy = Lib.extendDeep({}, mock);

--- a/test/jasmine/tests/zoom_test.js
+++ b/test/jasmine/tests/zoom_test.js
@@ -1,0 +1,51 @@
+var d3 = require('d3');
+
+var Plotly = require('@lib/index');
+var Lib = require('@src/lib');
+
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+var mouseEvent = require('../assets/mouse_event');
+
+
+describe('zoom box element', function() {
+    var mock = require('@mocks/14.json');
+
+    var gd;
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+
+        var mockCopy = Lib.extendDeep({}, mock);
+        mockCopy.layout.dragmode = 'zoom';
+
+        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('should be appended to the the shape layer', function() {
+        var x0 = 100;
+        var y0 = 200;
+        var x1 = 150;
+        var y1 = 200;
+
+        mouseEvent('mousemove', x0, y0);
+        expect(d3.selectAll('.shapelayer > .zoombox').size())
+            .toEqual(0);
+        expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+            .toEqual(0);
+
+        mouseEvent('mousedown', x0, y0);
+        mouseEvent('mousemove', x1, y1);
+        expect(d3.selectAll('.shapelayer > .zoombox').size())
+            .toEqual(1);
+        expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+            .toEqual(1);
+
+        mouseEvent('mouseup', x1, y1);
+        expect(d3.selectAll('.shapelayer > .zoombox').size())
+            .toEqual(0);
+        expect(d3.selectAll('.shapelayer > .zoombox-corners').size())
+            .toEqual(0);
+    });
+});


### PR DESCRIPTION
This PR fixes #359 by moving the select and zoombox elements from the subplot svg to the shapelayer.

@etpinard @mdtusz do you have suggestions for any tests I could add?