### PR TITLE
[WIP] Fix issue #384 (invisible legends when y is negative)

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -227,7 +227,7 @@ module.exports = function draw(gd) {
             width: opts.width - 2 * opts.borderwidth + constants.scrollBarWidth
         });
 
-        clipPath.attr({
+        clipPath.select('rect').attr({
             width: opts.width + constants.scrollBarWidth
         });
 

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -368,7 +368,6 @@ function drawTexts(context, gd, d, i, traces) {
 
 function repositionLegend(gd, traces) {
     var fullLayout = gd._fullLayout,
-        gs = fullLayout._size,
         opts = fullLayout.legend,
         borderwidth = opts.borderwidth;
 
@@ -432,39 +431,27 @@ function repositionLegend(gd, traces) {
         .attr('width', (gd._context.editable ? 0 : opts.width) + 40);
 
     // now position the legend. for both x,y the positions are recorded as
-    // fractions of the plot area (left, bottom = 0,0). Outside the plot
-    // area is allowed but position will be clipped to the page.
-    // values <1/3 align the low side at that fraction, 1/3-2/3 align the
-    // center at that fraction, >2/3 align the right at that fraction
-
-    var lx = gs.l + gs.w * opts.x,
-        ly = gs.t + gs.h * (1-opts.y);
+    // fractions of the plot area (left, bottom = 0,0).
 
     var xanchor = 'left';
     if(anchorUtils.isRightAnchor(opts)) {
-        lx -= opts.width;
         xanchor = 'right';
     }
     if(anchorUtils.isCenterAnchor(opts)) {
-        lx -= opts.width / 2;
         xanchor = 'center';
     }
 
     var yanchor = 'top';
     if(anchorUtils.isBottomAnchor(opts)) {
-        ly -= opts.height;
         yanchor = 'bottom';
     }
     if(anchorUtils.isMiddleAnchor(opts)) {
-        ly -= opts.height / 2;
         yanchor = 'middle';
     }
 
     // make sure we're only getting full pixels
     opts.width = Math.ceil(opts.width);
     opts.height = Math.ceil(opts.height);
-    lx = Math.round(lx);
-    ly = Math.round(ly);
 
     // lastly check if the margin auto-expand has changed
     Plots.autoMargin(gd, 'legend', {

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -195,8 +195,8 @@ module.exports = function draw(gd) {
         ly -= opts.height / 2;
     }
 
-    lx = Math.round(lx);
-    ly = Math.round(ly);
+    //lx = Math.round(lx);
+    //ly = Math.round(ly);
 
     // Make sure the legend top is below the top margin
     if(ly < fullLayout.margin.t) ly = fullLayout.margin.t;

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -875,6 +875,36 @@ plots.autoMargin = function(gd, id, o) {
     }
 };
 
+// Similar to plots.autoMargin, except that it pads the request with the layout
+// margins, so that an object can be drawn without reaching the layout vertical
+// margins.
+plots.autoMarginVertical = function(gd, id, o) {
+    var fullLayout = gd._fullLayout;
+
+    if(!fullLayout._pushmargin) fullLayout._pushmargin = {};
+
+    if(fullLayout.margin.autoexpand !== false) {
+        if(!o) delete fullLayout._pushmargin[id];
+        else {
+            var pad = o.pad === undefined ? 12 : o.pad;
+
+            // if the item is too big, just give it enough automargin to
+            // make sure you can still grab it and bring it back
+            if(o.l+o.r > fullLayout.width*0.5) o.l = o.r = 0;
+            if(o.b+o.t > fullLayout.height*0.5) o.b = o.t = 0;
+
+            fullLayout._pushmargin[id] = {
+                l: {val: o.x, size: o.l + pad},
+                r: {val: o.x, size: o.r + pad},
+                b: {val: o.y, size: o.b + fullLayout.margin.b},
+                t: {val: o.y, size: o.t + fullLayout.margin.t}
+            };
+        }
+
+        if(!gd._replotting) plots.doAutoMargin(gd);
+    }
+};
+
 plots.doAutoMargin = function(gd) {
     var fullLayout = gd._fullLayout;
     if(!fullLayout._size) fullLayout._size = {};


### PR DESCRIPTION
TODO

* [ ] Rename `Plot.autoMarginVertical()` to something more sensible (any suggestions?)
* [x] Add missing `select('rect')`
* [x] Debug test failure: `pie hovering event data should contain the correct fields FAILED`
* [x] Debug test failure: `pie hovering event data should fire when moving from one slice to another FAILED`
* [x] Debug test failure: `the range slider when specified as visible should react to resizing the maximum handle FAILED`
* [ ] Check image test failures  (currently 27, 5, autorange-tozero-rangemode, and range-selector-style. All these mocks locate the legend above the axis, i.e. y > 1).
* [ ] New tests
