### PR TITLE
Devtools patch

### DIFF
--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -100,7 +100,12 @@ var Tabs = {
         console.warn('plotly.js reloaded at ' + reloadTime);
         reloaded.textContent = 'last reload at ' + reloadTime;
 
-        Tabs.onReload();
+        var interval = setInterval(function() {
+            if(window.Plotly) {
+                clearInterval(interval);
+                Tabs.onReload();
+            }
+        }, 100);
     }
 };
 

--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -134,7 +134,24 @@ var searchBar = document.getElementById('mocks-search');
 var mocksList = document.getElementById('mocks-list');
 var plotArea = document.getElementById('plots');
 
-searchBar.addEventListener('keyup', function(e) {
+searchBar.addEventListener('keyup', debounce(searchMocks, 250));
+
+function debounce(func, wait, immediate) {
+    var timeout;
+    return function() {
+        var context = this, args = arguments;
+        var later = function() {
+            timeout = null;
+            if(!immediate) func.apply(context, args);
+        };
+        var callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if(callNow) func.apply(context, args);
+    };
+}
+
+function searchMocks(e) {
 
     // Clear results.
     while(mocksList.firstChild) {
@@ -162,4 +179,4 @@ searchBar.addEventListener('keyup', function(e) {
         var plotAreaWidth = Math.floor(window.innerWidth - listWidth);
         plotArea.setAttribute('style', 'width: ' + plotAreaWidth + 'px;');
     });
-});
+}


### PR DESCRIPTION
Fixes #404 and improves perceived search performance.

* Set interval check to run `onReload` function only after the new `plotly.js` bundle has loaded.
* Debounce the fuzzy search for mocks by 250ms.