### PR TITLE
trigger plotly_unhover on geo mouseout [fixes #409]

### DIFF
--- a/src/traces/choropleth/plot.js
+++ b/src/traces/choropleth/plot.js
@@ -80,6 +80,9 @@ plotChoropleth.plot = function(geo, choroplethData, geoLayout) {
             cleanHoverLabelsFunc = makeCleanHoverLabelsFunc(geo, trace),
             eventDataFunc = makeEventDataFunc(trace);
 
+        // keep ref to event data in this scope for plotly_unhover
+        var eventData = null;
+
         function handleMouseOver(pt, ptIndex) {
             if(!geo.showHover) return;
 
@@ -95,7 +98,9 @@ plotChoropleth.plot = function(geo, choroplethData, geoLayout) {
                 container: geo.hoverContainer.node()
             });
 
-            geo.graphDiv.emit('plotly_hover', eventDataFunc(pt, ptIndex));
+            eventData = eventDataFunc(pt, ptIndex);
+
+            geo.graphDiv.emit('plotly_hover', eventData);
         }
 
         function handleClick(pt, ptIndex) {
@@ -111,6 +116,8 @@ plotChoropleth.plot = function(geo, choroplethData, geoLayout) {
             .on('click', handleClick)
             .on('mouseout', function() {
                 Fx.loneUnhover(geo.hoverContainer);
+
+                geo.graphDiv.emit('plotly_unhover', eventData);
             })
             .on('mousedown', function() {
                 // to simulate the 'zoomon' event

--- a/src/traces/scattergeo/plot.js
+++ b/src/traces/scattergeo/plot.js
@@ -158,6 +158,9 @@ plotScatterGeo.plot = function(geo, scattergeoData) {
                 hoverinfo.indexOf('name') !== -1
             );
 
+        // keep ref to event data in this scope for plotly_unhover
+        var eventData = null;
+
         function handleMouseOver(pt, ptIndex) {
             if(!geo.showHover) return;
 
@@ -174,7 +177,9 @@ plotScatterGeo.plot = function(geo, scattergeoData) {
                 container: geo.hoverContainer.node()
             });
 
-            geo.graphDiv.emit('plotly_hover', eventDataFunc(pt, ptIndex));
+            eventData = eventDataFunc(pt, ptIndex);
+
+            geo.graphDiv.emit('plotly_hover', eventData);
         }
 
         function handleClick(pt, ptIndex) {
@@ -189,6 +194,8 @@ plotScatterGeo.plot = function(geo, scattergeoData) {
                 .on('click', handleClick)
                 .on('mouseout', function() {
                     Fx.loneUnhover(geo.hoverContainer);
+
+                    geo.graphDiv.emit('plotly_unhover', eventData);
                 })
                 .on('mousedown', function() {
                     // to simulate the 'zoomon' event

--- a/test/jasmine/tests/geo_interact_test.js
+++ b/test/jasmine/tests/geo_interact_test.js
@@ -121,6 +121,34 @@ describe('Test geo interactions', function() {
             });
         });
 
+        describe('scattergeo unhover events', function() {
+            var ptData;
+
+            beforeEach(function() {
+                gd.on('plotly_unhover', function(eventData) {
+                    ptData = eventData.points[0];
+                });
+
+                mouseEventScatterGeo('mouseover');
+                mouseEventScatterGeo('mouseout');
+            });
+
+            it('should contain the correct fields', function() {
+                expect(Object.keys(ptData)).toEqual([
+                    'data', 'fullData', 'curveNumber', 'pointNumber',
+                    'lon', 'lat', 'location'
+                ]);
+            });
+
+            it('should show the correct point data', function() {
+                expect(ptData.lon).toEqual(0);
+                expect(ptData.lat).toEqual(0);
+                expect(ptData.location).toBe(null);
+                expect(ptData.curveNumber).toEqual(0);
+                expect(ptData.pointNumber).toEqual(0);
+            });
+        });
+
         describe('choropleth hover labels', function() {
             beforeEach(function() {
                 mouseEventChoropleth('mouseover');
@@ -179,6 +207,33 @@ describe('Test geo interactions', function() {
                 });
 
                 mouseEventChoropleth('click');
+            });
+
+            it('should contain the correct fields', function() {
+                expect(Object.keys(ptData)).toEqual([
+                    'data', 'fullData', 'curveNumber', 'pointNumber',
+                    'location', 'z'
+                ]);
+            });
+
+            it('should show the correct point data', function() {
+                expect(ptData.location).toBe('RUS');
+                expect(ptData.z).toEqual(10);
+                expect(ptData.curveNumber).toEqual(1);
+                expect(ptData.pointNumber).toEqual(2);
+            });
+        });
+
+        describe('choropleth unhover events', function() {
+            var ptData;
+
+            beforeEach(function() {
+                gd.on('plotly_unhover', function(eventData) {
+                    ptData = eventData.points[0];
+                });
+
+                mouseEventChoropleth('mouseover');
+                mouseEventChoropleth('mouseout');
             });
 
             it('should contain the correct fields', function() {


### PR DESCRIPTION
@mdtusz easy

... but, really we have to bring geo hover on-par with cartesian at some point. This `mouseover` / `mouseout` business is minor league level at best.