### PR TITLE
Un-skip troublesome image tests 

### DIFF
--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -9,6 +9,9 @@ var request = require('request');
 var test = require('tape');
 var gm = require('gm');
 
+var TOLERANCE = 1e-6;    // pixel comparison tolerance
+var BASE_TIMEOUT = 500;  // base timeout time
+var BATCH_SIZE = 5;      // size of each test 'batch'
 var touch = function(fileName) {
     fs.closeSync(fs.openSync(fileName, 'w'));
 };
@@ -55,9 +58,7 @@ function runAll() {
             );
         });
 
-        var BASE_TIMEOUT = 500,  // base timeout time
-            BATCH_SIZE = 5,      // size of each test 'batch'
-            cnt = 0;
+        var cnt = 0;
 
         function testFunction() {
             testMock(mocks[cnt++], t);
@@ -98,7 +99,7 @@ function testMock(fileName, t) {
         var options = {
             file: diffPath,
             highlightColor: 'purple',
-            tolerance: 1e-6
+            tolerance: TOLERANCE
         };
 
         /*

--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -12,6 +12,7 @@ var gm = require('gm');
 var TOLERANCE = 1e-6;    // pixel comparison tolerance
 var BASE_TIMEOUT = 500;  // base timeout time
 var BATCH_SIZE = 5;      // size of each test 'batch'
+
 var touch = function(fileName) {
     fs.closeSync(fs.openSync(fileName, 'w'));
 };
@@ -36,25 +37,19 @@ function runAll() {
 
         var allMocks = fs.readdirSync(constants.pathToTestImageMocks);
 
-        /*
-         * Some test cases exhibit run-to-run randomness;
-         * skip over these few test cases for now.
+        /* Test cases:
          *
-         * More info:
-         * https://github.com/plotly/plotly.js/issues/62
+         * - font-wishlist
+         * - all gl2d
          *
-         * 41 test cases are removed:
-         * - font-wishlist (1 test case)
-         * - all gl2d (38)
-         * - gl3d_bunny-hull (1)
-         * - polar_scatter (1)
+         * don't behave consistently from run-to-run and/or
+         * machine-to-machine; skip over them.
+         *
          */
         var mocks = allMocks.filter(function(mock) {
             return !(
                 mock === 'font-wishlist.json' ||
-                mock.indexOf('gl2d') !== -1 ||
-                mock === 'gl3d_bunny-hull.json' ||
-                mock === 'polar_scatter.json'
+                mock.indexOf('gl2d') !== -1
             );
         });
 


### PR DESCRIPTION
... that output random pixels from run to run.  

Now with a 1e-6 tolerance (added in https://github.com/plotly/plotly.js/pull/243/commits/1df89c53c0491acfcbd438ddd86a88977a7d2a18), these troublesome image test cases behave well from run to run.

Proof: see [CircleCI runs](https://circleci.com/gh/plotly/plotly.js/tree/add-back-random-image-tests). **Note that** the two failed runs were due to some other test failing.