### PR TITLE
Specify window size for the karma chrome launcher (Fixes #444)

### DIFF
--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -69,7 +69,15 @@ func.defaultConfig = {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['Chrome_WindowSized'],
+
+    // custom browser options
+    customLaunchers: {
+        Chrome_WindowSized: {
+            base: 'Chrome',
+            flags: ['--window-size=1035,617'] // values came from observing default size; all test cases pass with it
+        }
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/444 by specifying a certain window size for the Chrome launcher. The numbers are simply derived from observing the window size in the properly working case.

CI karma/jasmine testing isn't impacted because, while CI piggybacks on this baseline config file, it specifies a separate browser (currently, Firefox). @etpinard suggested we don't change CI starting options right now.

I haven't experienced any problems with the fact that the `browser` we use is named differently (we can't name it `Chrome` as it's wired to mean plain vanilla Chrome and is being referenced as the `base`.