### PR TITLE
add new promise-based toImage and downloadImage to Plotly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,7 @@
     "no-floating-decimal": [2],
     "space-infix-ops": [0, {"int32Hint": false}],
     "quotes": [2, "single"],
-    "dot-notation": [2, {"allowKeywords": false}],
+    "dot-notation": [2],
     "operator-linebreak": [2, "after"],
     "eqeqeq": [2],
     "new-cap": [0],

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -53,17 +53,17 @@ modeBarButtons.toImage = {
 
         Lib.notifier('Taking snapshot - this may take a few seconds', 'long');
 
-        if(Lib.isIE()){
+        if(Lib.isIE()) {
             Lib.notifier('IE only supports svg.  Changing format to svg.', 'long');
             format = 'svg';
         }
 
-        downloadImage(gd, {'format':format})
+        downloadImage(gd, {'format': format})
           .then(function(filename) {
               Lib.notifier('Snapshot succeeded - ' + filename, 'long');
           })
           .catch(function() {
-              Lib.notifier('Sorry there was a problem downloading your snapshot', 'long');
+              Lib.notifier('Sorry there was a problem downloading your snapshot!', 'long');
           });
     }
 };

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -49,9 +49,16 @@ modeBarButtons.toImage = {
     title: 'Download plot as a png',
     icon: Icons.camera,
     click: function(gd) {
+        var format = 'png';
+
         Lib.notifier('Taking snapshot - this may take a few seconds', 'long');
 
-        downloadImage(gd)
+        if(Lib.isIE()){
+            Lib.notifier('IE only supports svg.  Changing format to svg.', 'long');
+            format = 'svg';
+        }
+
+        downloadImage(gd, {'format':format})
           .then(function(filename) {
               Lib.notifier('Snapshot succeeded - ' + filename, 'long');
           })

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -12,7 +12,7 @@
 var Plotly = require('../../plotly');
 var Lib = require('../../lib');
 var setCursor = require('../../lib/setcursor');
-var Snapshot = require('../../snapshot');
+var downloadImage = require('../../snapshot/download');
 var Icons = require('../../../build/ploticon');
 
 
@@ -49,49 +49,15 @@ modeBarButtons.toImage = {
     title: 'Download plot as a png',
     icon: Icons.camera,
     click: function(gd) {
-        var format = 'png';
-
-        if(Lib.isIE()) {
-            Lib.notifier('Snapshotting is unavailable in Internet Explorer. ' +
-                         'Consider exporting your images using the Plotly Cloud', 'long');
-            return;
-        }
-
-        if(gd._snapshotInProgress) {
-            Lib.notifier('Snapshotting is still in progress - please hold', 'long');
-            return;
-        }
-
-        gd._snapshotInProgress = true;
         Lib.notifier('Taking snapshot - this may take a few seconds', 'long');
 
-        var ev = Snapshot.toImage(gd, {format: format});
-
-        var filename = gd.fn || 'newplot';
-        filename += '.' + format;
-
-        ev.once('success', function(result) {
-            gd._snapshotInProgress = false;
-
-            var downloadLink = document.createElement('a');
-            downloadLink.href = result;
-            downloadLink.download = filename; // only supported by FF and Chrome
-
-            document.body.appendChild(downloadLink);
-            downloadLink.click();
-            document.body.removeChild(downloadLink);
-
-            ev.clean();
-        });
-
-        ev.once('error', function(err) {
-            gd._snapshotInProgress = false;
-
-            Lib.notifier('Sorry there was a problem downloading your ' + format, 'long');
-            console.error(err);
-
-            ev.clean();
-        });
+        downloadImage(gd)
+          .then(function(filename) {
+              Lib.notifier('Snapshot succeeded - ' + filename, 'long');
+          })
+          .catch(function() {
+              Lib.notifier('Sorry there was a problem downloading your snapshot', 'long');
+          });
     }
 };
 

--- a/src/core.js
+++ b/src/core.js
@@ -31,6 +31,8 @@ exports.moveTraces = Plotly.moveTraces;
 exports.purge = Plotly.purge;
 exports.setPlotConfig = require('./plot_api/set_plot_config');
 exports.register = Plotly.register;
+exports.toImage = require('./plot_api/to_image');
+exports.downloadImage = require('./snapshot/download');
 
 // plot icons
 exports.Icons = require('../build/ploticon');

--- a/src/plot_api/to_image.js
+++ b/src/plot_api/to_image.js
@@ -1,0 +1,112 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+var Plotly = require('../plotly');
+
+var isNumeric = require('fast-isnumeric');
+
+/**
+ * @param {object} gd figure Object
+ * @param {object} opts option object
+ * @param opts.format 'jpeg' | 'png' | 'webp' | 'svg'
+ * @param opts.width width of snapshot in px
+ * @param opts.height height of snapshot in px
+ */
+function toImage(gd, opts) {
+    var Snapshot = require('../snapshot');
+
+    var promise = new Promise(function(resolve, reject) {
+        // check for undefined opts
+        opts = opts || {};
+        // default to png
+        opts.format = opts.format || 'png';
+
+        var isSizeGood = function(size) {
+            // undefined and null are valid options
+            if(size === undefined || size === null) {
+                return true;
+            }
+
+            if(isNumeric(size) && size > 1) {
+                return true;
+            }
+        };
+
+        if(!isSizeGood(opts.width) || !isSizeGood(opts.height)) {
+            reject(new Error('Height and width should be pixel values.'));
+        }
+
+        // first clone the GD so we can operate in a clean environment
+        var clone = Snapshot.clone(gd, {format: 'png', height: opts.height, width: opts.width});
+        var clonedGd = clone.td;
+
+        // put the cloned div somewhere off screen before attaching to DOM
+        clonedGd.style.position = 'absolute';
+        clonedGd.style.left = '-5000px';
+        document.body.appendChild(clonedGd);
+
+        function wait() {
+            var delay = Snapshot.getDelay(clonedGd._fullLayout);
+
+            return new Promise(function(resolve, reject) {
+                setTimeout(function() {
+                    var svg = Snapshot.toSVG(clonedGd);
+
+                    var canvasContainer = window.document.createElement('div');
+                    var canvas = window.document.createElement('canvas');
+
+                    // window.document.body.appendChild(canvasContainer);
+                    canvasContainer.appendChild(canvas);
+
+                    canvasContainer.id = Plotly.Lib.randstr();
+                    canvas.id = Plotly.Lib.randstr();
+
+                    Snapshot.svgToImg({
+                        format: opts.format,
+                        width: clonedGd._fullLayout.width,
+                        height: clonedGd._fullLayout.height,
+                        canvas: canvas,
+                        svg: svg,
+                        // ask svgToImg to return a Promise
+                        //  rather than EventEmitter
+                        //  leave EventEmitter for backward
+                        //  compatibility
+                        promise: true
+                    }).then(function(url) {
+                        if(clonedGd) clonedGd.remove();
+                        resolve(url);
+                    }).catch(function(err) {
+                        reject(err);
+                    });
+                }, delay);
+            });
+        }
+
+        var redrawFunc = Snapshot.getRedrawFunc(clonedGd);
+
+        Plotly.plot(clonedGd, clone.data, clone.layout, clone.config)
+            // TODO: the following is Plotly.Plots.redrawText but without the waiting.
+            // we shouldn't need to do this, but in *occasional* cases we do. Figure
+            // out why and take it out.
+
+            // not sure the above TODO makes sense anymore since
+            //   we have converted to promises
+            .then(redrawFunc)
+            .then(wait)
+            .then(function(url) { resolve(url); })
+            .catch(function(err) {
+                reject(err);
+            });
+    });
+
+    return promise;
+}
+
+module.exports = toImage;

--- a/src/plot_api/to_image.js
+++ b/src/plot_api/to_image.js
@@ -37,6 +37,8 @@ function toImage(gd, opts) {
             if(isNumeric(size) && size > 1) {
                 return true;
             }
+
+            return false;
         };
 
         if(!isSizeGood(opts.width) || !isSizeGood(opts.height)) {
@@ -80,7 +82,7 @@ function toImage(gd, opts) {
                         //  compatibility
                         promise: true
                     }).then(function(url) {
-                        if(clonedGd) clonedGd.remove();
+                        if(clonedGd) document.body.removeChild(clonedGd);
                         resolve(url);
                     }).catch(function(err) {
                         reject(err);

--- a/src/plot_api/to_image.js
+++ b/src/plot_api/to_image.js
@@ -64,7 +64,6 @@ function toImage(gd, opts) {
                     var canvasContainer = window.document.createElement('div');
                     var canvas = window.document.createElement('canvas');
 
-                    // window.document.body.appendChild(canvasContainer);
                     canvasContainer.appendChild(canvas);
 
                     canvasContainer.id = Plotly.Lib.randstr();

--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -40,7 +40,7 @@ function downloadImage(gd, opts) {
         //   does not allow toDataURL
         //   svg format will work though
         if(Lib.isIE() && opts.format !== 'svg') {
-            reject(new Error('Sorry IE does not support downloading from canvas.'));
+            reject(new Error('Sorry IE does not support downloading from canvas. Try {format:"svg"} instead.'));
         }
 
         gd._snapshotInProgress = true;

--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -1,0 +1,64 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+var toImage = require('../plot_api/to_image');
+var Lib = require('../lib'); // for isIE
+var fileSaver = require('./filesaver');
+
+/**
+ * @param {object} gd figure Object
+ * @param {object} opts option object
+ * @param opts.format 'jpeg' | 'png' | 'webp' | 'svg'
+ * @param opts.width width of snapshot in px
+ * @param opts.height height of snapshot in px
+ * @param opts.filename name of file excluding extension
+ */
+function downloadImage(gd, opts) {
+
+    // check for undefined opts
+    opts = opts || {};
+
+    // default to png
+    opts.format = opts.format || 'png';
+
+    return new Promise(function(resolve,reject) {
+        if(gd._snapshotInProgress) {
+            reject(new Error('Snapshotting already in progress.'));
+        }
+
+        // see comments within svgtoimg for additional
+        //   discussion of problems with IE
+        //   can now draw to canvas, but CORS tainted canvas
+        //   does not allow toDataURL
+        //   svg format will work though
+        if(Lib.isIE() && opts.format !== 'svg') {
+            reject(new Error('Sorry IE does not support downloading from canvas.'));
+        }
+
+        gd._snapshotInProgress = true;
+        var promise = toImage(gd, opts);
+
+        var filename = opts.filename || gd.fn || 'newplot';
+        filename += '.' + opts.format;
+
+        promise.then(function(result) {
+            gd._snapshotInProgress = false;
+            return fileSaver(result,filename);
+        }).then(function(name) {
+            resolve(name);
+        }).catch(function(err) {
+            gd._snapshotInProgress = false;
+            reject(err);
+        });
+    });
+}
+
+module.exports = downloadImage;

--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -40,7 +40,7 @@ function downloadImage(gd, opts) {
         //   does not allow toDataURL
         //   svg format will work though
         if(Lib.isIE() && opts.format !== 'svg') {
-            reject(new Error('Sorry IE does not support downloading from canvas. Try {format:"svg"} instead.'));
+            reject(new Error('Sorry IE does not support downloading from canvas. Try {format:\'svg\'} instead.'));
         }
 
         gd._snapshotInProgress = true;

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -1,0 +1,66 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+/*
+* substantial portions of this code from FileSaver.js
+* https://github.com/eligrey/FileSaver.js
+* License: https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
+* FileSaver.js
+* A saveAs() FileSaver implementation.
+* 1.1.20160328
+*
+* By Eli Grey, http://eligrey.com
+* License: MIT
+*   See https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
+*/
+
+'use strict';
+
+var fileSaver = function(url, name) {
+    var saveLink = document.createElement('a');
+    var canUseSaveLink = 'download' in saveLink;
+    var isSafari = /Version\/[\d\.]+.*Safari/.test(navigator.userAgent);
+    var promise = new Promise(function(resolve, reject) {
+        // IE <10 is explicitly unsupported
+        if(typeof navigator !== 'undefined' && /MSIE [1-9]\./.test(navigator.userAgent)) {
+            reject(new Error('IE < 10 unsupported'));
+        }
+
+        // First try a.download, then web filesystem, then object URLs
+        if(isSafari) {
+            // Safari doesn't allow downloading of blob urls
+            document.location.href = 'data:attachment/file' + url.slice(url.search(/[,;]/));
+            resolve(name);
+        }
+
+        if(!name) {
+            name = 'download';
+        }
+
+        if(canUseSaveLink) {
+            saveLink.href = url;
+            saveLink.download = name;
+            document.body.appendChild(saveLink);
+            saveLink.click();
+            document.body.removeChild(saveLink);
+            resolve(name);
+        }
+
+        // IE 10+ (native saveAs)
+        if(typeof navigator !== 'undefined' && navigator.msSaveOrOpenBlob) {
+            navigator.msSaveOrOpenBlob(url, name);
+            resolve(name);
+        }
+
+        reject(new Error('download error'));
+    });
+
+    return promise;
+};
+
+module.exports = fileSaver;

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -52,8 +52,8 @@ var fileSaver = function(url, name) {
         }
 
         // IE 10+ (native saveAs)
-        if(typeof navigator !== 'undefined' && navigator.msSaveOrOpenBlob) {
-            navigator.msSaveOrOpenBlob(url, name);
+        if(typeof navigator !== 'undefined' && navigator.msSaveBlob) {
+            navigator.msSaveBlob(new Blob([url]), name);
             resolve(name);
         }
 

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -34,7 +34,7 @@ var fileSaver = function(url, name) {
         // First try a.download, then web filesystem, then object URLs
         if(isSafari) {
             // Safari doesn't allow downloading of blob urls
-            document.location.href = 'data:attachment/file' + url.slice(url.search(/[,;]/));
+            document.location.href = 'data:application/octet-stream' + url.slice(url.search(/[,;]/));
             resolve(name);
         }
 

--- a/src/snapshot/index.js
+++ b/src/snapshot/index.js
@@ -36,7 +36,8 @@ var Snapshot = {
     clone: require('./cloneplot'),
     toSVG: require('./tosvg'),
     svgToImg: require('./svgtoimg'),
-    toImage: require('./toimage')
+    toImage: require('./toimage'),
+    downloadImage: require('./download')
 };
 
 module.exports = Snapshot;

--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -6,63 +6,105 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
+var Lib = require('../lib');
 var EventEmitter = require('events').EventEmitter;
 
 function svgToImg(opts) {
 
-    var ev = opts.emitter ? opts.emitter : new EventEmitter();
+    var ev = opts.emitter || new EventEmitter();
 
-    var Image = window.Image;
-    var Blob = window.Blob;
+    var promise = new Promise(function(resolve, reject) {
 
-    var svg = opts.svg;
-    var format = opts.format || 'png';
-    var canvas = opts.canvas;
+        var Image = window.Image;
 
-    var ctx = canvas.getContext('2d');
-    var img = new Image();
-    var DOMURL = window.URL || window.webkitURL;
-    var svgBlob = new Blob([svg], {type: 'image/svg+xml;charset=utf-8'});
-    var url = DOMURL.createObjectURL(svgBlob);
+        var svg = opts.svg;
+        var format = opts.format || 'png';
+        var canvas = opts.canvas;
 
-    canvas.height = opts.height || 150;
-    canvas.width = opts.width || 300;
+        var ctx = canvas.getContext('2d');
+        var img = new Image();
 
-    img.onload = function() {
-        var imgData;
-
-        DOMURL.revokeObjectURL(url);
-        ctx.drawImage(img, 0, 0);
-
-        switch(format) {
-            case 'jpeg':
-                imgData = canvas.toDataURL('image/jpeg');
-                break;
-            case 'png':
-                imgData = canvas.toDataURL('image/png');
-                break;
-            case 'webp':
-                imgData = canvas.toDataURL('image/webp');
-                break;
-            case 'svg':
-                imgData = svg;
-                break;
-            default:
-                return ev.emit('error', 'Image format is not jpeg, png or svg');
+        // IE is very strict, so we will need to clean
+        //  svg with the following regex
+        //  yes this is messy, but do not know a better way
+        // Even with this IE will not work due to tainted canvas
+        //  see https://github.com/kangax/fabric.js/issues/1957
+        //      http://stackoverflow.com/questions/18112047/canvas-todataurl-working-in-all-browsers-except-ie10
+        // Leave here just in case the CORS/tainted IE issue gets resolved
+        if(Lib.isIE()) {
+            // replace double quote with single quote
+            svg = svg.replace(/"/gi,"'");
+            // url in svg are single quoted
+            //   since we changed double to single
+            //   we'll need to change these to double-quoted
+            svg = svg.replace(/(\('#)(.*)('\))/gi,'(\"$2\")');
+            // font names with spaces will be escaped single-quoted
+            //   we'll need to change these to double-quoted
+            svg = svg.replace(/(\\')/gi,'\"');
         }
 
-        ev.emit('success', imgData);
-    };
+        // for Safari support, eliminate createObjectURL
+        //  this decision could cause problems if content
+        //  is not restricted to svg
+        var url = 'data:image/svg+xml,' + encodeURIComponent(svg);
 
-    img.onerror = function(err) {
-        DOMURL.revokeObjectURL(url);
-        return ev.emit('error', err);
-    };
+        canvas.height = opts.height || 150;
+        canvas.width = opts.width || 300;
 
-    img.src = url;
+        img.onload = function() {
+            var imgData;
+
+            ctx.drawImage(img, 0, 0);
+
+            switch(format) {
+                case 'jpeg':
+                    imgData = canvas.toDataURL('image/jpeg');
+                    break;
+                case 'png':
+                    imgData = canvas.toDataURL('image/png');
+                    break;
+                case 'webp':
+                    imgData = canvas.toDataURL('image/webp');
+                    break;
+                case 'svg':
+                    imgData = svg;
+                    break;
+                default:
+                    reject(new Error('Image format is not jpeg, png or svg'));
+                    // eventually remove the ev
+                    //  in favor of promises
+                    if(!opts.promise) {
+                        return ev.emit('error', 'Image format is not jpeg, png or svg');
+                    }
+            }
+            resolve(imgData);
+            // eventually remove the ev
+            //  in favor of promises
+            if(!opts.promise) {
+                ev.emit('success', imgData);
+            }
+        };
+
+        img.onerror = function(err) {
+            reject(err);
+            // eventually remove the ev
+            //  in favor of promises
+            if(!opts.promise) {
+                return ev.emit('error', err);
+            }
+        };
+
+        img.src = url;
+    });
+
+    // temporary for backward compatibility
+    //  move to only Promise in 2.0.0
+    //  and eliminate the EventEmitter
+    if(opts.promise) {
+        return promise;
+    }
 
     return ev;
 }

--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -35,7 +35,7 @@ function svgToImg(opts) {
         // Leave here just in case the CORS/tainted IE issue gets resolved
         if(Lib.isIE()) {
             // replace double quote with single quote
-            svg = svg.replace(/"/gi,"'");
+            svg = svg.replace(/"/gi,'\'');
             // url in svg are single quoted
             //   since we changed double to single
             //   we'll need to change these to double-quoted

--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -21,10 +21,6 @@ function svgToImg(opts) {
 
         var svg = opts.svg;
         var format = opts.format || 'png';
-        var canvas = opts.canvas;
-
-        var ctx = canvas.getContext('2d');
-        var img = new Image();
 
         // IE is very strict, so we will need to clean
         //  svg with the following regex
@@ -43,7 +39,24 @@ function svgToImg(opts) {
             // font names with spaces will be escaped single-quoted
             //   we'll need to change these to double-quoted
             svg = svg.replace(/(\\')/gi,'\"');
+            // IE only support svg
+            if(format!=='svg') {
+                var ieSvgError = new Error('Sorry IE does not support downloading from canvas. Try {format:\'svg\'} instead.');
+                reject(ieSvgError);
+                // eventually remove the ev
+                //  in favor of promises
+                if(!opts.promise) {
+                    return ev.emit('error', ieSvgError);
+                } else {
+                    return promise;
+                }
+            }
         }
+
+        var canvas = opts.canvas;
+
+        var ctx = canvas.getContext('2d');
+        var img = new Image();
 
         // for Safari support, eliminate createObjectURL
         //  this decision could cause problems if content

--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -56,7 +56,11 @@ function svgToImg(opts) {
         img.onload = function() {
             var imgData;
 
-            ctx.drawImage(img, 0, 0);
+            // don't need to draw to canvas if svg
+            //  save some time and also avoid failure on IE
+            if(format !== 'svg') {
+                ctx.drawImage(img, 0, 0);
+            }
 
             switch(format) {
                 case 'jpeg':

--- a/src/snapshot/toimage.js
+++ b/src/snapshot/toimage.js
@@ -57,7 +57,7 @@ function toImage(gd, opts) {
             });
 
             ev.clean = function() {
-                if(clonedGd) clonedGd.remove();
+                if(clonedGd) document.body.removeChild(clonedGd);
             };
 
         }, delay);

--- a/test/jasmine/tests/download_test.js
+++ b/test/jasmine/tests/download_test.js
@@ -1,0 +1,88 @@
+var Plotly = require('@lib/index');
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+var textchartMock = require('@mocks/text_chart_arrays.json');
+
+describe('Plotly.downloadImage', function() {
+    'use strict';
+    var gd;
+    var originalTimeout;
+
+    // override click handler on createElement
+    //  so these tests will not actually
+    //  download an image each time they are run
+    //  full credit goes to @etpinard; thanks
+    var createElement = document.createElement;
+    beforeAll(function() {
+        document.createElement = function(args) {
+            var el = createElement.call(document, args);
+            el.click = function() {};
+            return el;
+        };
+    });
+
+    afterAll(function() {
+        document.createElement = createElement;
+    });
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+
+        // downloadImage can take a little longer
+        //  so give it a little more time to finish
+        originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+    });
+
+    afterEach(function() {
+        destroyGraphDiv();
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+    });
+
+    it('should be attached to Plotly', function() {
+        expect(Plotly.downloadImage).toBeDefined();
+    });
+
+    it('should create link, remove link, accept options', function(done) {
+        //use MutationObserver to monitor the DOM
+        //for changes
+        //code modeled after
+        //https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+        // select the target node
+        var target = document.body;
+        var domchanges = [];
+
+        // create an observer instance
+        var observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutation) {
+                domchanges.push(mutation);
+            });
+        });
+
+        Plotly.plot(gd, textchartMock.data, textchartMock.layout).then(function(gd) {
+            // start observing dom
+            // configuration of the observer:
+            var config = { childList: true };
+
+            // pass in the target node and observer options
+            observer.observe(target, config);
+
+            return Plotly.downloadImage(gd, {format: 'jpeg', height: 300, width: 300, filename: 'plotly_download'});
+        }).then(function(filename) {
+            // stop observing
+            observer.disconnect();
+            // look for an added and removed link
+            var linkadded = domchanges[domchanges.length-2].addedNodes[0].outerHTML;
+            var linkdeleted = domchanges[domchanges.length-1].removedNodes[0].outerHTML;
+
+            // check for a <a element and proper file type
+            expect(linkadded.split('href="')[1].split('jpeg;')[0]).toEqual('data:image/');
+            // check that filename option handled properly
+            expect(filename).toBe('plotly_download.jpeg');
+
+            // check that link removed
+            expect(linkadded).toBe(linkdeleted);
+            done();
+        });
+    });
+});

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -1,0 +1,112 @@
+// move toimage to plot_api_test.js
+//  once established and confirmed?
+
+var Plotly = require('@lib/index');
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+var subplotMock = require('@mocks/multiple_subplots.json');
+
+
+describe('Plotly.toImage', function() {
+    'use strict';
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('should be attached to Plotly', function() {
+        expect(Plotly.toImage).toBeDefined();
+    });
+
+    it('should return a promise', function(done) {
+        function isPromise(x) {
+            return !!x.then || typeof x.then === 'function';
+        }
+
+        var returnValue = Plotly.plot(gd, subplotMock.data, subplotMock.layout)
+               .then(Plotly.toImage);
+
+        expect(isPromise(returnValue)).toBe(true);
+
+        returnValue.then(done);
+    });
+
+    it('should throw error with unsupported file type',function(done) {
+        // error should actually come in the svgToImg step
+
+        Plotly.plot(gd, subplotMock.data, subplotMock.layout)
+            .then(function(gd) {
+                Plotly.toImage(gd,{format: 'x'}).catch(function(err) {
+                    expect(err.message).toEqual('Image format is not jpeg, png or svg');
+                    done();
+                });
+            });
+
+    });
+
+    it('should throw error with height and/or width < 1', function(done) {
+        // let user know that Plotly expects pixel values
+        Plotly.plot(gd, subplotMock.data, subplotMock.layout)
+            .then(function(gd) {
+                return Plotly.toImage(gd, {height: 0.5}).catch(function(err) {
+                    expect(err.message).toEqual('Height and width should be pixel values.');
+                });
+            }).then(function() {
+                Plotly.toImage(gd, {width: 0.5}).catch(function(err) {
+                    expect(err.message).toEqual('Height and width should be pixel values.');
+                    done();
+                });
+            });
+    });
+
+    it('should create img with proper height and width', function(done) {
+        var img = document.createElement('img');
+
+        // specify height and width
+        subplotMock.layout.height = 600;
+        subplotMock.layout.width = 700;
+
+        Plotly.plot(gd, subplotMock.data, subplotMock.layout).then(function(gd) {
+            return Plotly.toImage(gd);
+        }).then(function(url) {
+            return new Promise(function(resolve) {
+                img.src = url;
+                img.onload = function() {
+                    expect(img.height).toBe(600);
+                    expect(img.width).toBe(700);
+                };
+                // now provide height and width in opts
+                resolve(Plotly.toImage(gd, {height: 400, width: 400}));
+            });
+        }).then(function(url) {
+            img.src = url;
+            img.onload = function() {
+                expect(img.height).toBe(400);
+                expect(img.width).toBe(400);
+                done();
+            };
+        });
+    });
+
+    it('should create proper file type', function(done) {
+        var plot = Plotly.plot(gd, subplotMock.data, subplotMock.layout);
+
+        plot.then(function(gd) {
+            return Plotly.toImage(gd, {format: 'png'});
+        }).then(function(url) {
+            expect(url.split('png')[0]).toBe('data:image/');
+            // now do jpeg
+            return Plotly.toImage(gd, {format: 'jpeg'});
+        }).then(function(url) {
+            expect(url.split('jpeg')[0]).toBe('data:image/');
+            // now do svg
+            return Plotly.toImage(gd, {format: 'svg'});
+        }).then(function(url) {
+            expect(url.substr(1,3)).toBe('svg');
+            done();
+        });
+    });
+});

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -23,7 +23,7 @@ describe('Plotly.toImage', function() {
 
     it('should return a promise', function(done) {
         function isPromise(x) {
-            return !!x.then || typeof x.then === 'function';
+            return !!x.then && typeof x.then === 'function';
         }
 
         var returnValue = Plotly.plot(gd, subplotMock.data, subplotMock.layout)


### PR DESCRIPTION
*ref original pull https://github.com/timelyportfolio/plotly.js/pull/1 for very long discussion and commits*

-----

Addresses
- https://github.com/plotly/plotly.js/issues/83
- https://github.com/plotly/plotly.js/issues/89
- https://github.com/plotly/plotly.js/issues/264
- https://github.com/plotly/plotly.js/issues/345
- https://github.com/ropensci/plotly/issues/311

-----

### Summary of Changes
- [x] attach promise-based `toImage` directly to `Plotly`
- [x] attach promise-based `downloadImage` directly to `Plotly`
- [x] preserve existing unofficial `Plotly.Snapshot` for backward compatibility with exception of adding `promise` option in `svgToImg`

----- 

### Example Usage

**Plotly.toImage**
```
var img = document.createElement('img');
document.body.appendChild(img);

Plotly.plot()
    .then(Plotly.toImage)
    .then(function(url){
        img.src = url;
    });

// all the options
Plotly.plot()
    .then(function(gd){
        return Plotly.toImage({
            format: 'png', //also can use 'jpeg', 'webp', 'svg'
            height: 500,
            width: 700
        });
    })
    .then(function(url){
        img.src = url;
    });
```

**Plotly.downloadImage**
```
Plotly.plot()
    .then(Plotly.downloadImage)
    .then(function(filename){
        console.log(filename);
    });

// all the options
Plotly.plot()
    .then(function(gd){
        return Plotly.downloadImage({
            filename: 'myspecialplot',
            format: 'png', //also can use 'jpeg', 'webp', 'svg'
            height: 500,
            width: 700
        });
    })
    .then(function(filename){
        console.log(filename);
    });
```