### PR TITLE
Run jasmine tests with --ignore-gpu-blacklist

### DIFF
--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -75,7 +75,8 @@ func.defaultConfig = {
     customLaunchers: {
         Chrome_WindowSized: {
             base: 'Chrome',
-            flags: ['--window-size=1035,617'] // values came from observing default size; all test cases pass with it
+            // window-size values came from observing default size
+            flags: ['--window-size=1035,617', '--ignore-gpu-blacklist']
         }
     },
 


### PR DESCRIPTION
* This change allows the jasmine tests to be run within a VM.