### PR TITLE
"chartset" typo to "charset"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To learn more about the plotly.js module architecture, refer to our [modularizin
 
 #### Non-ascii characters
 
-Important: the plotly.js code base contains some non-ascii characters. Therefore, please make sure to set the `chartset` attribute to `"utf-8"` in the script tag that imports your plotly.js bundle. For example:
+Important: the plotly.js code base contains some non-ascii characters. Therefore, please make sure to set the `charset` attribute to `"utf-8"` in the script tag that imports your plotly.js bundle. For example:
 
 ```html
 <script type="text/javascript" src="my-plotly-bundle.js" charset="utf-8"></script>


### PR DESCRIPTION
Although this typo is beautifully appropriate - we must deal with it.