### PR TITLE
Fix hovermode 'closest'  + hoverinfo 'none' with superimposed data bug

### DIFF
--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -618,7 +618,7 @@ fx.getClosest = function(cd, distfn, pointData) {
         // do this for 'closest'
         for(var i=0; i<cd.length; i++) {
             var newDistance = distfn(cd[i]);
-            if(newDistance < pointData.distance) {
+            if(newDistance <= pointData.distance) {
                 pointData.index = i;
                 pointData.distance = newDistance;
             }

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -269,6 +269,70 @@ describe('hover info', function() {
         });
     });
 
+    describe('\'closest\' hover info (superimposed case)', function() {
+        var mockCopy = Lib.extendDeep({}, mock);
+
+        // superimposed traces
+        mockCopy.data.push(Lib.extendDeep({}, mockCopy.data[0]));
+        mockCopy.layout.hovermode = 'closest';
+
+        var gd;
+
+        beforeEach(function(done) {
+            gd = createGraphDiv();
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+        });
+
+        it('render hover labels of the above trace', function() {
+            Fx.hover('graph', evt, 'xy');
+
+            expect(gd._hoverdata.length).toEqual(1);
+
+            var hoverTrace = gd._hoverdata[0];
+
+            expect(hoverTrace.fullData.index).toEqual(1);
+            expect(hoverTrace.curveNumber).toEqual(1);
+            expect(hoverTrace.pointNumber).toEqual(16);
+            expect(hoverTrace.x).toEqual(0.33);
+            expect(hoverTrace.y).toEqual(1.25);
+
+            expect(d3.selectAll('g.axistext').size()).toEqual(0);
+            expect(d3.selectAll('g.hovertext').size()).toEqual(1);
+
+            var expectations = ['PV learning ...', '(0.33, 1.25)'];
+            d3.selectAll('g.hovertext').selectAll('text').each(function(_, i) {
+                expect(d3.select(this).html()).toEqual(expectations[i]);
+            });
+        });
+
+        it('render only non-hoverinfo \'none\' hover labels', function(done) {
+
+            Plotly.restyle(gd, 'hoverinfo', ['none', 'name']).then(function() {
+                Fx.hover('graph', evt, 'xy');
+
+                expect(gd._hoverdata.length).toEqual(1);
+
+                var hoverTrace = gd._hoverdata[0];
+
+                expect(hoverTrace.fullData.index).toEqual(1);
+                expect(hoverTrace.curveNumber).toEqual(1);
+                expect(hoverTrace.pointNumber).toEqual(16);
+                expect(hoverTrace.x).toEqual(0.33);
+                expect(hoverTrace.y).toEqual(1.25);
+
+                expect(d3.selectAll('g.axistext').size()).toEqual(0);
+                expect(d3.selectAll('g.hovertext').size()).toEqual(1);
+
+                var text = d3.selectAll('g.hovertext').select('text');
+                expect(text.size()).toEqual(1);
+                expect(text.html()).toEqual('PV learning ...');
+
+                done();
+            });
+
+        });
+    });
+
     describe('hoverformat', function() {
 
         var data = [{


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/493

@mdtusz this commit https://github.com/plotly/plotly.js/pull/438/commits/c8b05edc2ed13ac3ec58f0b1ef45bed47554f253  in PR https://github.com/plotly/plotly.js/pull/438 introduced the bug in `v1.10.0`.

### In brief

`hoverinfo: 'none'`  traces used to be skipped over in the search-closest-data routine before `v1.10.0` which fixed issue https://github.com/plotly/plotly.js/issues/313 . But, as a side-effect, that patch allowed  `Fx.getClosest` to pick `hoverinfo: 'none'` data points which were then passed to the hover label routine resulting in non apparent hover labels.

### More info on `Fx.getClosest`

Note that `hovermode: 'closest'` only shows the hover label for the closest point. Previously, if two points were superimposed, only the data point of the first trace (as ordered in `data`) was passed to the hover label routine. Now, all superimposed points (i.e with the same distance to cursor) are passed to the hover label routine.