### PR TITLE
Make chart mouse hover feel responsive

### DIFF
--- a/src/plots/cartesian/constants.js
+++ b/src/plots/cartesian/constants.js
@@ -66,7 +66,7 @@ module.exports = {
     HOVERFONT: 'Arial, sans-serif',
 
     // minimum time (msec) between hover calls
-    HOVERMINTIME: 100,
+    HOVERMINTIME: 50,
 
     // max pixels off straight before a lasso select line counts as bent
     BENDPX: 1.5


### PR DESCRIPTION
100 ms causes a 10 fps performance which feels like it's lagging behind your cursor. 30 ms feels too fast and noisy, 50 ms feels snappy yet stable.

https://github.com/plotly/plotly.js/issues/503