### PR TITLE
Devtool patch

### DIFF
--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -31,7 +31,7 @@ var Tabs = {
         var graphDiv = Tabs.getGraph(id);
 
         if(graphDiv) {
-            graphDiv.remove();
+            graphDiv.parentNode.removeChild(graphDiv);
         }
 
         graphDiv = document.createElement('div');

--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -11,6 +11,13 @@ var d3 = window.d3 = Plotly.d3;
 // Our gracious testing object
 var Tabs = {
 
+    // Set plot config options
+    setPlotConfig: function() {
+
+        // use local topojson files
+        Plotly.setPlotConfig({ topojsonURL: '../../dist/topojson/' });
+    },
+
     // Return the specified plot container (or default one)
     getGraph: function(id) {
         id = id || 'graph';
@@ -110,6 +117,7 @@ var Tabs = {
         var interval = setInterval(function() {
             if(window.Plotly) {
                 clearInterval(interval);
+                Tabs.setPlotConfig();
                 Tabs.onReload();
             }
         }, 100);
@@ -125,6 +133,8 @@ setInterval(function() {
     window.fullData = window.gd._fullData;
 }, 1000);
 
+// Set plot config on first load
+Tabs.setPlotConfig();
 
 // Mocks search and plotting
 var f = new Fuse(mocks, {

--- a/devtools/test_dashboard/index.html
+++ b/devtools/test_dashboard/index.html
@@ -19,8 +19,8 @@
   </div>
   <div id="snapshot"></div>
 
+  <script type="text/javascript" src="../../dist/extras/mathjax/MathJax.js?config=TeX-AMS-MML_SVG"></script>
   <script id="source" type="text/javascript" src="../../build/plotly.js"></script>
   <script type="text/javascript" src="../../build/test_dashboard-bundle.js"></script>
 </body>
 </html>
-

--- a/devtools/test_dashboard/index.html
+++ b/devtools/test_dashboard/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Plotly.js Devtools</title>
+  <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>
 <body>


### PR DESCRIPTION
@mdtusz This PR adds back a few features that were (accidentally?) dropped during your devtool overhaul in https://github.com/plotly/plotly.js/pull/386. Namely:

- fonts are back
- MathJax is back
- Geo plots grab the required topojson files locally in `dist/`