### PR TITLE
Promises: Ensure all `gd._promises` resolve before final resolve

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -320,7 +320,7 @@ Plotly.plot = function(gd, data, layout, config) {
         gd.emit('plotly_afterplot');
     }
 
-    var donePlotting = Lib.syncOrAsync([
+    Lib.syncOrAsync([
         Plots.previousPromises,
         marginPushers,
         marginPushersAgain,
@@ -333,8 +333,9 @@ Plotly.plot = function(gd, data, layout, config) {
 
     // even if everything we did was synchronous, return a promise
     // so that the caller doesn't care which route we took
-    return (donePlotting && donePlotting.then) ?
-        donePlotting : Promise.resolve(gd);
+    return Promise.all(gd._promises).then(function() {
+        return gd;
+    });
 };
 
 // Get the container div: we store all variables for this plot as


### PR DESCRIPTION
Real quick PR.

**In brief**: ensures that all the promises pushed into `gd._promises` are resolved before the final resolve.

The call to `Lib.syncOrAsync` never completes "fast enough" to cause `donePlotting` to be returned (at least, not in my semi-scientific testing) and all async things _should_ be pushing their promises to gd._promises.