### PR TITLE
Devtools: Add `getMock` method

### DIFF
--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -55,6 +55,18 @@ var Tabs = {
         });
     },
 
+    getMock: function(mockName, callback) {
+        var mockURL = '/test/image/mocks/' + mockName + '.json';
+
+        d3.json(mockURL, function(err, fig) {
+            if(typeof callback !== 'function') {
+                window.mock = fig;
+            } else {
+                callback(err, fig);
+            }
+        });
+    },
+
     // Save a png snapshot and display it below the plot
     snapshot: function(id) {
         var gd = Tabs.getGraph(id);


### PR DESCRIPTION
_Have you ever been working in the devtools dashboard and wanted to get a mock, only to have to open the mock in an editor, copy the mock, then paste it in the browser console? I know I have. That's why I added `getMock` to the devtools and I'm here to share it with you today!_

![mays](https://cloud.githubusercontent.com/assets/6494463/15256845/77925d36-1911-11e6-8871-4f994e066257.jpg)
