### PR TITLE
Fix test failure in gl_plot_interact_test.js

### DIFF
--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -128,13 +128,12 @@ describe('Test gl plot interactions', function() {
             beforeEach(function(done) {
                 gd.on('plotly_click', function(eventData) {
                     ptData = eventData.points[0];
+                    delay(done);
                 });
 
                 // N.B. gl3d click events are 'mouseover' events
                 // with button 1 pressed
                 mouseEventScatter3d('mouseover', {buttons: 1});
-
-                delay(done);
             });
 
             it('should have', function() {


### PR DESCRIPTION
I only see this test failure when I ran the jasmine tests locally with Chromium.

Here's the log:
```
> plotly.js@1.10.0 test-jasmine /home/user/github/plotly.js
> karma start test/jasmine/karma.conf.js

28 04 2016 15:15:09.369:INFO [framework.browserify]: registering rebuild (autoWatch=true)
28 04 2016 15:15:18.304:INFO [framework.browserify]: 9144740 bytes written (8.14 seconds)
28 04 2016 15:15:18.390:INFO [framework.browserify]: bundle built
28 04 2016 15:15:18.412:WARN [karma]: No captured browser, open http://localhost:9876/
28 04 2016 15:15:18.417:INFO [karma]: Karma v0.13.22 server started at http://localhost:9876/
28 04 2016 15:15:18.422:INFO [launcher]: Starting browser Chrome
28 04 2016 15:15:20.711:INFO [Chromium 49.0.2623 (Ubuntu 0.0.0)]: Connected on socket /#-IbDZiJqsbLq5ARMAAAA with id 2677551
Chromium 49.0.2623 (Ubuntu 0.0.0) Test gl plot interactions gl3d plots scatter3d click events should have FAILED
	TypeError: Cannot convert undefined or null to object
	    at Object.<anonymous> (/tmp/1a0a3758dfbe017702f7f5c5e7464cd4.browserify:104802:31 <- tests/gl_plot_interact_test.js:141:0)
LOG: 'lost context'
LOG: 'lost context'
LOG: 'lost context'
LOG: 'lost context'
Chromium 49.0.2623 (Ubuntu 0.0.0): Executed 534 of 780 (1 FAILED) (0 secs / 49.479 secs)

```