### PR TITLE
Ternary restyle fix

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1575,6 +1575,7 @@ Plotly.restyle = function restyle(gd, astr, val, traces) {
         'mode','visible','type','orientation','fill',
         'histfunc','histnorm','text',
         'x', 'y', 'z',
+        'a', 'b', 'c',
         'xtype','x0','dx','ytype','y0','dy','xaxis','yaxis',
         'line.width',
         'connectgaps', 'transpose', 'zsmooth',

--- a/test/jasmine/tests/ternary_test.js
+++ b/test/jasmine/tests/ternary_test.js
@@ -88,6 +88,22 @@ describe('ternary plots', function() {
             });
         });
 
+        it('should be able to restyle', function(done) {
+            Plotly.restyle(gd, { a: [[1,2,3]]}, 0).then(function() {
+                var transforms = [];
+                d3.selectAll('.ternary .point').each(function() {
+                    var point = d3.select(this);
+                    transforms.push(point.attr('transform'));
+                });
+
+                expect(transforms).toEqual([
+                    'translate(186.45,209.8)',
+                    'translate(118.53,170.59)',
+                    'translate(248.76,117.69)'
+                ]);
+            }).then(done);
+        });
+
         it('should display to hover labels', function() {
             var hoverLabels;
 
@@ -180,7 +196,6 @@ describe('ternary plots', function() {
                 done();
             });
         });
-
     });
 
     function countTernarySubplot() {


### PR DESCRIPTION
Ternary plots were not being restyled when `a, b, c` were updated. This remedies it in the simplest possible way.

I can't think of a much better way to test this - it's not a _great_ test, but it is better than nothing, and will still check that the plotted points have changed.