### PR TITLE
fix gl2d replot

### DIFF
--- a/src/plots/gl2d/index.js
+++ b/src/plots/gl2d/index.js
@@ -69,12 +69,17 @@ exports.clean = function(newFullData, newFullLayout, oldFullData, oldFullLayout)
     var oldSceneKeys = Plots.getSubplotIds(oldFullLayout, 'gl2d');
 
     for(var i = 0; i < oldSceneKeys.length; i++) {
-        var oldSubplot = oldFullLayout._plots[oldSceneKeys[i]],
-            xaName = oldSubplot.xaxis._name,
-            yaName = oldSubplot.yaxis._name;
+        var id = oldSceneKeys[i],
+            oldSubplot = oldFullLayout._plots[id];
 
-        if(!!oldSubplot._scene2d && (!newFullLayout[xaName] || !newFullLayout[yaName])) {
+        // old subplot wasn't gl2d; nothing to do
+        if(!oldSubplot._scene2d) continue;
+
+        // if no traces are present, delete gl2d subplot
+        var subplotData = Plots.getSubplotData(newFullData, 'gl2d', id);
+        if(subplotData.length === 0) {
             oldSubplot._scene2d.destroy();
+            delete oldFullLayout._plots[id];
         }
     }
 };

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -193,7 +193,7 @@ plots.getSubplotIds = function getSubplotIds(layout, type) {
     if(type === 'cartesian' && (!layout._has || !layout._has('cartesian'))) return [];
     if(type === 'gl2d' && (!layout._has || !layout._has('gl2d'))) return [];
     if(type === 'cartesian' || type === 'gl2d') {
-        return Object.keys(layout._plots);
+        return Object.keys(layout._plots || {});
     }
 
     var idRegex = _module.idRegex,

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -584,7 +584,7 @@ describe('Test gl plot side effects', function() {
     it('should be able to replot from a blank graph', function(done) {
         var gd = createGraphDiv();
 
-        function assert(cnt) {
+        function countCanvases(cnt) {
             var nodes = d3.selectAll('canvas');
             expect(nodes.size()).toEqual(cnt);
         }
@@ -596,23 +596,23 @@ describe('Test gl plot side effects', function() {
         }];
 
         Plotly.plot(gd, []).then(function() {
-            assert(0);
+            countCanvases(0);
 
             return Plotly.plot(gd, data);
         }).then(function() {
-            assert(1);
+            countCanvases(1);
 
             return Plotly.purge(gd);
         }).then(function() {
-            assert(0);
+            countCanvases(0);
 
             return Plotly.plot(gd, data);
         }).then(function() {
-            assert(1);
+            countCanvases(1);
 
             return Plotly.deleteTraces(gd, [0]);
         }).then(function() {
-            assert(0);
+            countCanvases(0);
 
             return Plotly.purge(gd);
         }).then(done);

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -539,7 +539,7 @@ describe('Test gl plot interactions', function() {
                 expect(gd._fullLayout._plots.xy._scene2d.glplot).toBeDefined();
 
                 Plots.cleanPlot([], {}, gd._fullData, gd._fullLayout);
-                expect(gd._fullLayout._plots.xy._scene2d.glplot).toBe(null);
+                expect(gd._fullLayout._plots).toEqual({});
 
                 done();
             });

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -580,4 +580,41 @@ describe('Test gl plot side effects', function() {
             });
         });
     });
+
+    it('should be able to replot from a blank graph', function(done) {
+        var gd = createGraphDiv();
+
+        function assert(cnt) {
+            var nodes = d3.selectAll('canvas');
+            expect(nodes.size()).toEqual(cnt);
+        }
+
+        var data = [{
+            type: 'scattergl',
+            x: [1, 2, 3],
+            y: [2, 1, 2]
+        }];
+
+        Plotly.plot(gd, []).then(function() {
+            assert(0);
+
+            return Plotly.plot(gd, data);
+        }).then(function() {
+            assert(1);
+
+            return Plotly.purge(gd);
+        }).then(function() {
+            assert(0);
+
+            return Plotly.plot(gd, data);
+        }).then(function() {
+            assert(1);
+
+            return Plotly.deleteTraces(gd, [0]);
+        }).then(function() {
+            assert(0);
+
+            return Plotly.purge(gd);
+        }).then(done);
+    });
 });


### PR DESCRIPTION
@mdtusz replotting from a blank graph is currently broken for `gl2d` plots.

For example,

```js
Plotly.plot(gd, []);
Plotly.plot(gd, [{ type: 'scattergl', x: [1, 2, 3], y: [2, 1, 2] }];
```

is falling.

This PR fixes :arrow_double_up: , while robustifying the `gl2d` clean-plot step and adding a comprehensive test case.