### PR TITLE
scattergl lines fixes for opacity and connectgaps

### DIFF
--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -107,6 +107,7 @@ var proto = LineWithMarkers.prototype;
 
 proto.handlePick = function(pickResult) {
     var index = pickResult.pointId;
+
     if(pickResult.object !== this.line || this.connectgaps) {
         index = this.idToIndex[pickResult.pointId];
     }
@@ -136,19 +137,20 @@ proto.isFancy = function(options) {
 
     if(!options.x || !options.y) return true;
 
-    var marker = options.marker || {};
-    if(Array.isArray(marker.symbol) ||
-         marker.symbol !== 'circle' ||
-         Array.isArray(marker.size) ||
-         Array.isArray(marker.line.width) ||
-         Array.isArray(marker.opacity)
-    ) return true;
+    if(this.hasMarkers) {
+        var marker = options.marker || {};
 
-    var markerColor = marker.color;
-    if(Array.isArray(markerColor)) return true;
+        if(Array.isArray(marker.symbol) ||
+             marker.symbol !== 'circle' ||
+             Array.isArray(marker.size) ||
+             Array.isArray(marker.color) ||
+             Array.isArray(marker.line.width) ||
+             Array.isArray(marker.line.color) ||
+             Array.isArray(marker.opacity)
+        ) return true;
+    }
 
-    var lineColor = Array.isArray(marker.line.color);
-    if(Array.isArray(lineColor)) return true;
+    if(this.hasLines && !this.connectgaps) return true;
 
     if(this.hasErrorX) return true;
     if(this.hasErrorY) return true;
@@ -471,8 +473,10 @@ proto.updateFancy = function(options) {
 
 proto.updateLines = function(options, positions) {
     var i;
+
     if(this.hasLines) {
         var linePositions = positions;
+
         if(!options.connectgaps) {
             var p = 0;
             var x = this.xData;
@@ -484,8 +488,8 @@ proto.updateLines = function(options, positions) {
                 linePositions[p++] = y[i];
             }
         }
-        this.lineOptions.positions = linePositions;
 
+        this.lineOptions.positions = linePositions;
 
         var lineColor = convertColor(options.line.color, options.opacity, 1),
             lineWidth = Math.round(0.5 * this.lineOptions.width),

--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -486,10 +486,9 @@ proto.updateLines = function(options, positions) {
         }
         this.lineOptions.positions = linePositions;
 
-        var lineColor = str2RGBArray(options.line.color);
-        if(this.hasMarkers) lineColor[3] *= options.marker.opacity;
 
-        var lineWidth = Math.round(0.5 * this.lineOptions.width),
+        var lineColor = convertColor(options.line.color, options.opacity, 1),
+            lineWidth = Math.round(0.5 * this.lineOptions.width),
             dashes = (DASHES[options.line.dash] || [1]).slice();
 
         for(i = 0; i < dashes.length; ++i) dashes[i] *= lineWidth;

--- a/test/image/mocks/gl2d_line_opacity.json
+++ b/test/image/mocks/gl2d_line_opacity.json
@@ -1,0 +1,44 @@
+{
+  "data": [
+    {
+      "x": [
+        1,
+        2,
+        null,
+        4,
+        5
+      ],
+      "y": [
+        1,
+        2,
+        null,
+        4,
+        5
+      ],
+      "connectgaps": false,
+      "type": "scattergl",
+      "opacity": 0.4
+    }
+  ],
+  "layout": {
+    "xaxis": {
+      "type": "linear",
+      "range": [
+        0.9867209252516599,
+        5.01327907474834
+      ],
+      "autorange": true
+    },
+    "yaxis": {
+      "type": "linear",
+      "range": [
+        0.9529946929492039,
+        5.047005307050796
+      ],
+      "autorange": true
+    },
+    "height": 450,
+    "width": 1100,
+    "autosize": true
+  }
+}


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/585 and https://github.com/plotly/plotly.js/issues/586

I added one test mock but without its corresponding baseline image (I can't wait for https://github.com/plotly/plotly.js/pull/572)

In the meantime, here's the proof:

![image](https://cloud.githubusercontent.com/assets/6675409/15682494/f0809ad2-272b-11e6-9ec9-6e02c77dd1ae.png)

the graph above is `gl2d` and the graph below is `svg`.