### PR TITLE
Log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ chart types, including 3D charts, statistical graphs, and SVG maps.
 
 ## Quick start options
 
+**It is important to note that logging is turned off by default in v1.13.0 onwards.**
+To turn logging on for development, you will want to run
+`Plotly.setPlotConfig({ logging: 2 })` before any plotting.
+See [this file](https://github.com/plotly/plotly.js/blob/master/src/lib/loggers.js) for more details.
+
 #### Download the latest release
 [Latest Release on Github](https://github.com/plotly/plotly.js/releases/)
 

--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -129,7 +129,7 @@ var Tabs = {
         var interval = setInterval(function() {
             if(window.Plotly) {
                 clearInterval(interval);
-                Tabs.setPlotConfig();
+                Tabs.setPlotConfig({ logging: 2 });
                 Tabs.onReload();
             }
         }, 100);

--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -13,9 +13,11 @@ var Tabs = {
 
     // Set plot config options
     setPlotConfig: function() {
-
-        // use local topojson files
-        Plotly.setPlotConfig({ topojsonURL: '../../dist/topojson/' });
+        Plotly.setPlotConfig({
+            // use local topojson files
+            topojsonURL: '../../dist/topojson/',
+            logging: 2
+        });
     },
 
     // Return the specified plot container (or default one)
@@ -129,7 +131,7 @@ var Tabs = {
         var interval = setInterval(function() {
             if(window.Plotly) {
                 clearInterval(interval);
-                Tabs.setPlotConfig({ logging: 2 });
+                Tabs.setPlotConfig();
                 Tabs.onReload();
             }
         }, 100);

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -9,6 +9,7 @@
     "Uint8Array": true
   },
   "rules": {
-    "strict": [2, "global"]
+    "strict": [2, "global"],
+    "no-console": [1]
   }
 }

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -10,6 +10,6 @@
   },
   "rules": {
     "strict": [2, "global"],
-    "no-console": [1]
+    "no-console": [2]
   }
 }

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -122,7 +122,7 @@ drawing.fillGroupStyle = function(s) {
             shape.call(Color.fill, d[0].trace.fillcolor);
         }
         catch(e) {
-            console.log(e, s);
+            Lib.error(e, s);
             shape.remove();
         }
     });

--- a/src/components/rangeslider/range_plot.js
+++ b/src/components/rangeslider/range_plot.js
@@ -10,6 +10,7 @@
 
 var d3 = require('d3');
 
+var Lib = require('../../lib');
 var Symbols = require('../drawing/symbol_defs');
 var Drawing = require('../drawing');
 
@@ -53,7 +54,7 @@ module.exports = function rangePlot(gd, w, h) {
             pointPairs = [];
 
         if(allowedTypes.indexOf(trace.type) < 0) {
-            console.log('Trace type ' + trace.type + ' not supported for range slider!');
+            Lib.warn('Trace type ' + trace.type + ' not supported for range slider!');
             continue;
         }
 
@@ -161,7 +162,7 @@ function makeScatter(trace, pointPairs, w, h) {
                 break;
 
             default:
-                console.log('Fill type ' + trace.fill + ' not supported for range slider! (yet...)');
+                Lib.warn('Fill type ' + trace.fill + ' not supported for range slider! (yet...)');
                 break;
         }
 

--- a/src/components/shapes/index.js
+++ b/src/components/shapes/index.js
@@ -351,7 +351,7 @@ function getShapeLayer(gd, index) {
         shapeLayer = gd._fullLayout._shapeUpperLayer;
 
     if(!shape) {
-        console.log('getShapeLayer: undefined shape: index', index);
+        Lib.log('getShapeLayer: undefined shape: index', index);
     }
     else if(shape.layer === 'below') {
         shapeLayer = (shape.xref === 'paper' && shape.yref === 'paper') ?
@@ -491,7 +491,7 @@ shapes.convertPath = function(pathIn, x2p, y2p) {
 
         if(paramNumber > nParams) {
             paramString = paramString.replace(/[\s,]*X.*/, '');
-            console.log('ignoring extra params in segment ' + segment);
+            Lib.log('Ignoring extra params in segment ' + segment);
         }
 
         return segmentType + paramString;

--- a/src/lib/dates.js
+++ b/src/lib/dates.js
@@ -12,6 +12,8 @@
 var d3 = require('d3');
 var isNumeric = require('fast-isnumeric');
 
+var Lib = require('../lib');
+
 
 /**
  * dateTime2ms - turn a date object or string s of the form
@@ -122,7 +124,7 @@ function lpad(val, digits) {
  */
 exports.ms2DateTime = function(ms, r) {
     if(typeof(d3) === 'undefined') {
-        console.log('d3 is not defined');
+        Lib.error('d3 is not defined.');
         return;
     }
 

--- a/src/lib/geo_location_utils.js
+++ b/src/lib/geo_location_utils.js
@@ -10,7 +10,7 @@
 'use strict';
 
 var countryRegex = require('country-regex');
-var Lib = require('./');
+var Lib = require('../lib');
 
 
 // make list of all country iso3 ids from at runtime
@@ -32,8 +32,8 @@ exports.locationToFeature = function(locationmode, location, features) {
         if(feature.id === locationId) return feature;
     }
 
-    console.warn([
-        'location with id', locationId,
+    Lib.warn([
+        'Location with id', locationId,
         'does not have a matching topojson feature at this resolution.'
     ].join(' '));
 };
@@ -53,5 +53,5 @@ function countryNameToISO3(countryName) {
         if(regex.test(countryName.toLowerCase())) return iso3;
     }
 
-    console.warn('unrecognized country name: ' + countryName + '.');
+    Lib.warn('Unrecognized country name: ' + countryName + '.');
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -99,19 +99,36 @@ lib.pauseEvent = function(e) {
  * ------------------------------------------
  */
 
-// set VERBOSE to true to get a lot more logging and tracing
-lib.VERBOSE = false;
-// console.log that only runs if VERBOSE is on
+/* eslint-disable no-console */
 lib.log = function() {
-    if(lib.VERBOSE) console.log.apply(console, arguments);
     if(config.logging > 1) {
-        console.log.apply(console, arguments);
+        var messages = ['LOG:'];
+
+        for(var i = 0; i < arguments.length; i++) {
+            messages.push(arguments[i]);
+        }
+
+        if(console.trace) {
+            console.trace.apply(console, messages);
+        } else {
+            console.log.apply(console, messages);
+        }
     }
 };
 
 lib.warn = function() {
     if(config.logging > 0) {
-        console.warn.apply(console, arguments);
+        var messages = ['WARN:'];
+
+        for(var i = 0; i < arguments.length; i++) {
+            messages.push(arguments[i]);
+        }
+
+        if(console.trace) {
+            console.trace.apply(console, messages);
+        } else {
+            console.log.apply(console, messages);
+        }
     }
 };
 
@@ -120,6 +137,7 @@ lib.error = function() {
         console.error.apply(console, arguments);
     }
 };
+/* eslint-enable no-console */
 
 // constrain - restrict a number v to be between v0 and v1
 lib.constrain = function(v, v0, v1) {
@@ -432,7 +450,6 @@ lib.addStyleRule = function(selector, styleString) {
     else if(styleSheet.addRule) {
         styleSheet.addRule(selector, styleString, 0);
     }
-    else console.warn('addStyleRule failed');
     else lib.warn('addStyleRule failed');
 };
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -12,7 +12,6 @@
 var d3 = require('d3');
 
 var lib = module.exports = {};
-var config = require('../plot_api/plot_config');
 
 lib.nestedProperty = require('./nested_property');
 lib.isPlainObject = require('./is_plain_object');
@@ -59,6 +58,11 @@ lib.extendFlat = extendModule.extendFlat;
 lib.extendDeep = extendModule.extendDeep;
 lib.extendDeepAll = extendModule.extendDeepAll;
 
+var loggersModule = require('./loggers');
+lib.log = loggersModule.log;
+lib.warn = loggersModule.warn;
+lib.error = loggersModule.error;
+
 lib.notifier = require('./notifier');
 
 /**
@@ -92,52 +96,6 @@ lib.pauseEvent = function(e) {
     e.cancelBubble = true;
     return false;
 };
-
-/**
- * ------------------------------------------
- * debugging tools
- * ------------------------------------------
- */
-
-/* eslint-disable no-console */
-lib.log = function() {
-    if(config.logging > 1) {
-        var messages = ['LOG:'];
-
-        for(var i = 0; i < arguments.length; i++) {
-            messages.push(arguments[i]);
-        }
-
-        if(console.trace) {
-            console.trace.apply(console, messages);
-        } else {
-            console.log.apply(console, messages);
-        }
-    }
-};
-
-lib.warn = function() {
-    if(config.logging > 0) {
-        var messages = ['WARN:'];
-
-        for(var i = 0; i < arguments.length; i++) {
-            messages.push(arguments[i]);
-        }
-
-        if(console.trace) {
-            console.trace.apply(console, messages);
-        } else {
-            console.log.apply(console, messages);
-        }
-    }
-};
-
-lib.error = function() {
-    if(config.logging > 0) {
-        console.error.apply(console, arguments);
-    }
-};
-/* eslint-enable no-console */
 
 // constrain - restrict a number v to be between v0 and v1
 lib.constrain = function(v, v0, v1) {

--- a/src/lib/loggers.js
+++ b/src/lib/loggers.js
@@ -53,6 +53,12 @@ loggers.warn = function() {
 
 loggers.error = function() {
     if(config.logging > 0) {
+        var messages = ['ERROR:'];
+
+        for(var i = 0; i < arguments.length; i++) {
+            messages.push(arguments[i]);
+        }
+
         console.error.apply(console, arguments);
     }
 };

--- a/src/lib/loggers.js
+++ b/src/lib/loggers.js
@@ -1,0 +1,59 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+var config = require('../plot_api/plot_config');
+
+var loggers = module.exports = {};
+
+/**
+ * ------------------------------------------
+ * debugging tools
+ * ------------------------------------------
+ */
+
+/* eslint-disable no-console */
+loggers.log = function() {
+    if(config.logging > 1) {
+        var messages = ['LOG:'];
+
+        for(var i = 0; i < arguments.length; i++) {
+            messages.push(arguments[i]);
+        }
+
+        if(console.trace) {
+            console.trace.apply(console, messages);
+        } else {
+            console.log.apply(console, messages);
+        }
+    }
+};
+
+loggers.warn = function() {
+    if(config.logging > 0) {
+        var messages = ['WARN:'];
+
+        for(var i = 0; i < arguments.length; i++) {
+            messages.push(arguments[i]);
+        }
+
+        if(console.trace) {
+            console.trace.apply(console, messages);
+        } else {
+            console.log.apply(console, messages);
+        }
+    }
+};
+
+loggers.error = function() {
+    if(config.logging > 0) {
+        console.error.apply(console, arguments);
+    }
+};
+/* eslint-enable no-console */

--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -11,6 +11,8 @@
 
 var isNumeric = require('fast-isnumeric');
 
+var Lib = require('../lib');
+
 
 /**
  * findBin - find the bin for val - note that it can return outside the
@@ -45,7 +47,7 @@ exports.findBin = function(val, bins, linelow) {
             if(test(bins[n], val)) n1 = n + 1;
             else n2 = n;
         }
-        if(c > 90) console.log('Long binary search...');
+        if(c > 90) Lib.log('Long binary search...');
         return n1 - 1;
     }
 };

--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -14,6 +14,7 @@
 var Plotly = require('../plotly');
 var d3 = require('d3');
 
+var Lib = require('../lib');
 var xmlnsNamespaces = require('../constants/xmlns_namespaces');
 
 var util = module.exports = {};
@@ -36,7 +37,7 @@ d3.selection.prototype.appendSVG = function(_svgString) {
         childNode = childNode.nextSibling;
     }
     if(dom.querySelector('parsererror')) {
-        console.log(dom.querySelector('parsererror div').textContent);
+        Lib.log(dom.querySelector('parsererror div').textContent);
         return null;
     }
     return d3.select(this.node().lastChild);
@@ -202,7 +203,7 @@ function texToSVG(_texString, _config, _callback) {
         var glyphDefs = d3.select('body').select('#MathJax_SVG_glyphs');
 
         if(tmpDiv.select('.MathJax_SVG').empty() || !tmpDiv.select('svg').node()) {
-            console.log('There was an error in the tex syntax.', _texString);
+            Lib.log('There was an error in the tex syntax.', _texString);
             _callback();
         }
         else {

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -63,7 +63,7 @@ Plotly.plot = function(gd, data, layout, config) {
     // if there's no data or layout, and this isn't yet a plotly plot
     // container, log a warning to help plotly.js users debug
     if(!data && !layout && !Lib.isPlotDiv(gd)) {
-        console.log('Warning: calling Plotly.plot as if redrawing ' +
+        Lib.warn('Calling Plotly.plot as if redrawing ' +
             'but this container doesn\'t yet have a plot.', gd);
     }
 
@@ -539,7 +539,7 @@ function cleanLayout(layout) {
     }
 
     if(layout.annotations !== undefined && !Array.isArray(layout.annotations)) {
-        console.log('annotations must be an array');
+        Lib.warn('Annotations must be an array.');
         delete layout.annotations;
     }
     var annotationsLen = (layout.annotations || []).length;
@@ -561,7 +561,7 @@ function cleanLayout(layout) {
     }
 
     if(layout.shapes !== undefined && !Array.isArray(layout.shapes)) {
-        console.log('shapes must be an array');
+        Lib.warn('Shapes must be an array.');
         delete layout.shapes;
     }
     var shapesLen = (layout.shapes || []).length;
@@ -785,9 +785,7 @@ function cleanData(data, existingData) {
 
         // sanitize rgb(fractions) and rgba(fractions) that old tinycolor
         // supported, but new tinycolor does not because they're not valid css
-        Lib.markTime('finished rest of cleanData, starting color');
         Color.clean(trace);
-        Lib.markTime('finished cleanData color.clean');
     }
 }
 
@@ -816,7 +814,7 @@ Plotly.redraw = function(gd) {
     gd = getGraphDiv(gd);
 
     if(!Lib.isPlotDiv(gd)) {
-        console.log('This element is not a Plotly Plot', gd);
+        Lib.warn('This element is not a Plotly plot.', gd);
         return;
     }
 
@@ -891,7 +889,6 @@ function doCalcdata(gd) {
         if(!cd[0].t) cd[0].t = {};
         cd[0].trace = trace;
 
-        Lib.markTime('done with calcdata for ' + i);
         calcdata[i] = cd;
     }
 }
@@ -1548,7 +1545,7 @@ Plotly.restyle = function restyle(gd, astr, val, traces) {
         if(traces === undefined) traces = val; // the 3-arg form
     }
     else {
-        console.log('restyle fail', astr, val, traces);
+        Lib.warn('Restyle fail.', astr, val, traces);
         return Promise.reject();
     }
 
@@ -2092,7 +2089,7 @@ Plotly.relayout = function relayout(gd, astr, val) {
     if(typeof astr === 'string') aobj[astr] = val;
     else if(Lib.isPlainObject(astr)) aobj = astr;
     else {
-        console.log('relayout fail', astr, val);
+        Lib.warn('Relayout fail.', astr, val);
         return Promise.reject();
     }
 
@@ -2283,7 +2280,7 @@ Plotly.relayout = function relayout(gd, astr, val) {
                     }
                     else undoit[ai] = obji;
                 }
-                else console.log('???', aobj);
+                else Lib.log('???', aobj);
             }
             if((refAutorange(obji, 'x') || refAutorange(obji, 'y')) &&
                     !Lib.containsAny(ai, ['color', 'opacity', 'align', 'dash'])) {

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -51,7 +51,6 @@ var xmlnsNamespaces = require('../constants/xmlns_namespaces');
  *
  */
 Plotly.plot = function(gd, data, layout, config) {
-    Lib.markTime('in plot');
 
     gd = getGraphDiv(gd);
 
@@ -223,11 +222,9 @@ Plotly.plot = function(gd, data, layout, config) {
             }
         }
 
-        Lib.markTime('done with bar/box adjustments');
 
         // calc and autorange for errorbars
         ErrorBars.calc(gd);
-        Lib.markTime('done ErrorBars.calc');
 
         // TODO: autosize extra for text markers
         return Lib.syncOrAsync([
@@ -282,7 +279,6 @@ Plotly.plot = function(gd, data, layout, config) {
 
         // styling separate from drawing
         Plots.style(gd);
-        Lib.markTime('done Plots.style');
 
         // show annotations and shapes
         Shapes.drawAll(gd);
@@ -312,7 +308,6 @@ Plotly.plot = function(gd, data, layout, config) {
     function cleanUp() {
         // now we're REALLY TRULY done plotting...
         // so mark it as done and let other procedures call a replot
-        Lib.markTime('done plot');
         gd.emit('plotly_afterplot');
     }
 
@@ -641,9 +636,7 @@ function cleanLayout(layout) {
 
     // sanitize rgb(fractions) and rgba(fractions) that old tinycolor
     // supported, but new tinycolor does not because they're not valid css
-    Lib.markTime('finished rest of cleanLayout, starting color');
     Color.clean(layout);
-    Lib.markTime('finished cleanLayout color.clean');
 
     return layout;
 }

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -6,8 +6,9 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
+
+var Lib = require('../lib');
 
 /**
  * This will be transfered over to gd and overridden by
@@ -83,8 +84,10 @@ module.exports = {
     setBackground: defaultSetBackground,
 
     // URL to topojson files used in geo charts
-    topojsonURL: 'https://cdn.plot.ly/'
+    topojsonURL: 'https://cdn.plot.ly/',
 
+    // Turn all console logging on or off (errors will be thrown)
+    logging: false
 };
 
 // where and how the background gets set can be overridden by context
@@ -93,5 +96,5 @@ function defaultSetBackground(gd, bgColor) {
     try {
         gd._fullLayout._paper.style('background', bgColor);
     }
-    catch(e) { console.log(e); }
+    catch(e) { Lib.error(e); }
 }

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -87,6 +87,7 @@ module.exports = {
     topojsonURL: 'https://cdn.plot.ly/',
 
     // Turn all console logging on or off (errors will be thrown)
+    // This should ONLY be set via Plotly.setPlotConfig
     logging: false
 };
 

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1412,7 +1412,7 @@ axes.doTicks = function(gd, axid, skipTitle) {
         };
     }
     else {
-        console.log('unrecognized doTicks axis', axid);
+        Lib.warn('Unrecognized doTicks axis:', axid);
         return;
     }
     var axside = ax.side || sides[0],

--- a/src/plots/cartesian/clean_datum.js
+++ b/src/plots/cartesian/clean_datum.js
@@ -30,7 +30,7 @@ module.exports = function cleanDatum(c) {
         c = c.toString().replace(/['"%,$# ]/g, '');
     }
     catch(e) {
-        console.log(e, c);
+        Lib.error(e, c);
     }
 
     return c;

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -372,7 +372,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         var wheelDelta = -e.deltaY;
         if(!isFinite(wheelDelta)) wheelDelta = e.wheelDelta / 10;
         if(!isFinite(wheelDelta)) {
-            console.log('did not find wheel motion attributes', e);
+            Lib.log('Did not find wheel motion attributes: ', e);
             return;
         }
 

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -442,7 +442,7 @@ function hover(gd, evt, subplot) {
         else yvalArray = p2c(yaArray, ypx);
 
         if(!isNumeric(xvalArray[0]) || !isNumeric(yvalArray[0])) {
-            console.log('Plotly.Fx.hover failed', evt, gd);
+            Lib.warn('Plotly.Fx.hover failed', evt, gd);
             return dragElement.unhoverRaw(gd, evt);
         }
     }
@@ -529,7 +529,7 @@ function hover(gd, evt, subplot) {
             }
         }
         else {
-            console.log('unrecognized trace type in hover', trace);
+            Lib.log('Unrecognized trace type in hover:', trace);
         }
 
         // in closest mode, remove any existing (farther) points

--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-var Lib = require('../../lib');
 var Plots = require('../plots');
 
 var constants = require('./constants');

--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -81,8 +81,6 @@ exports.plot = function(gd) {
             // plot all traces of this type on this subplot at once
             var cdModule = getCdModule(cdSubplot, _module);
             _module.plot(gd, subplotInfo, cdModule);
-
-            Lib.markTime('done ' + (cdModule[0] && cdModule[0][0].trace.type));
         }
     }
 };

--- a/src/plots/cartesian/set_convert.js
+++ b/src/plots/cartesian/set_convert.js
@@ -167,7 +167,7 @@ module.exports = function setConvert(ax) {
                     ax.range[1] = ar1[1];
                 }
             }
-            catch(e) { console.log(e, ax.range); }
+            catch(e) { Lib.error(e, ax.range); }
         }
     }
     else if(ax.type === 'category') {

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -183,7 +183,7 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
 
     if(!scene.staticMode) {
         scene.glplot.canvas.addEventListener('webglcontextlost', function(ev) {
-            console.log('lost context');
+            Lib.warn('Lost WebGL context.');
             ev.preventDefault();
         });
     }
@@ -281,7 +281,7 @@ proto.recoverContext = function() {
             return;
         }
         if(!initializeGLPlot(scene, scene.fullLayout, canvas, gl)) {
-            console.error('catastrophic/unrecoverable webgl error.  context lost.');
+            Lib.error('Catastrophic and unrecoverable WebGL error. Context lost.');
             return;
         }
         scene.plot.apply(scene, scene.plotArgs);

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -42,7 +42,7 @@ plots.fontWeight = 'normal';
  */
 plots.register = function(_module, thisType, categoriesIn, meta) {
     if(modules[thisType]) {
-        console.log('type ' + thisType + ' already registered');
+        Lib.log('Type ' + thisType + ' already registered');
         return;
     }
 
@@ -71,7 +71,7 @@ function getTraceType(traceType) {
 
 plots.getModule = function(trace) {
     if(trace.r !== undefined) {
-        console.log('Oops, tried to put a polar trace ' +
+        Lib.warn('Tried to put a polar trace ' +
             'on an incompatible graph of cartesian ' +
             'data. Ignoring this dataset.', trace
         );
@@ -99,7 +99,7 @@ plots.traceIs = function traceIs(traceType, category) {
 
     if(!_module) {
         if(traceType !== undefined) {
-            console.warn('unrecognized trace type ' + traceType);
+            Lib.log('Unrecognized trace type ' + traceType + '.');
         }
         _module = modules[plots.attributes.type.dflt];
     }
@@ -133,7 +133,7 @@ plots.registerSubplot = function(_module) {
     var plotType = _module.name;
 
     if(subplotsRegistry[plotType]) {
-        console.log('plot type ' + plotType + ' already registered');
+        Lib.log('Plot type ' + plotType + ' already registered.');
         return;
     }
 

--- a/src/plots/polar/micropolar_manager.js
+++ b/src/plots/polar/micropolar_manager.js
@@ -50,11 +50,9 @@ manager.framework = function(_gd) {
         (function(_configClone, _previousConfigClone) {
             undoManager.add({
                 undo: function() {
-                    //console.log('undo', _previousConfigClone);
                     if(_previousConfigClone) that(_previousConfigClone);
                 },
                 redo: function() {
-                    //console.log('redo', _configClone);
                     that(_configClone);
                 }
             });

--- a/src/traces/contour/plot.js
+++ b/src/traces/contour/plot.js
@@ -235,7 +235,7 @@ function makePath(pi, loc, edgeflag) {
 
         marchStep = NEWDELTA[mi];
         if(!marchStep) {
-            console.log('found bad marching index', mi, loc, pi.level);
+            Lib.log('Found bad marching index:', mi, loc, pi.level);
             break;
         }
 
@@ -259,7 +259,7 @@ function makePath(pi, loc, edgeflag) {
     }
 
     if(cnt === 10000) {
-        console.log('Infinite loop in contour?');
+        Lib.log('Infinite loop in contour?');
     }
     var closedpath = equalPts(pts[0], pts[pts.length - 1]),
         totaldist = 0,
@@ -343,7 +343,7 @@ function makePath(pi, loc, edgeflag) {
     }
     else {
         if(!edgeflag) {
-            console.log('unclosed interior contour?',
+            Lib.log('Unclosed interior contour?',
                 pi.level, startLocStr, pts.join('L'));
         }
 
@@ -410,7 +410,7 @@ function findAllPaths(pathinfo) {
             startLoc = Object.keys(pi.crossings)[0].split(',').map(Number);
             makePath(pi, startLoc);
         }
-        if(cnt === 10000) console.log('Infinite loop in contour?');
+        if(cnt === 10000) Lib.log('Infinite loop in contour?');
     }
 }
 
@@ -545,7 +545,7 @@ function joinAllPaths(pi, perimeter) {
         //now loop through sides, moving our endpoint until we find a new start
         for(cnt = 0; cnt < 4; cnt++) { // just to prevent infinite loops
             if(!endpt) {
-                console.log('missing end?', i, pi);
+                Lib.log('Missing end?', i, pi);
                 break;
             }
 
@@ -572,7 +572,7 @@ function joinAllPaths(pi, perimeter) {
                     }
                 }
                 else {
-                    console.log('endpt to newendpt is not vert. or horz.',
+                    Lib.log('endpt to newendpt is not vert. or horz.',
                         endpt, newendpt, ptNew);
                 }
             }
@@ -584,7 +584,7 @@ function joinAllPaths(pi, perimeter) {
         }
 
         if(nexti === pi.edgepaths.length) {
-            console.log('unclosed perimeter path');
+            Lib.log('unclosed perimeter path');
             break;
         }
 

--- a/src/traces/contour/plot.js
+++ b/src/traces/contour/plot.js
@@ -51,7 +51,6 @@ var BOTTOMSTART = [1, 9, 13, 104, 713],
     SADDLEREMAINDER = {1: 4, 2: 8, 4: 1, 7: 13, 8: 2, 11: 14, 13: 7, 14: 11};
 
 function plotOne(gd, plotinfo, cd) {
-    Lib.markTime('in Contour.plot');
     var trace = cd[0].trace,
         x = cd[0].x,
         y = cd[0].y,
@@ -103,8 +102,6 @@ function plotOne(gd, plotinfo, cd) {
     makeFills(plotGroup, pathinfo, perimeter, contours);
     makeLines(plotGroup, pathinfo, contours);
     clipGaps(plotGroup, plotinfo, cd[0], perimeter);
-
-    Lib.markTime('done Contour.plot');
 }
 
 function emptyPathinfo(contours, plotinfo, cd0) {

--- a/src/traces/heatmap/calc.js
+++ b/src/traces/heatmap/calc.js
@@ -23,8 +23,6 @@ var maxRowLength = require('./max_row_length');
 
 
 module.exports = function calc(gd, trace) {
-    Lib.markTime('start convert x&y');
-
     // prepare the raw data
     // run makeCalcdata on x and y even for heatmaps, in case of category mappings
     var xa = Axes.getFromId(gd, trace.xaxis || 'x'),
@@ -44,8 +42,6 @@ module.exports = function calc(gd, trace) {
     // cancel minimum tick spacings (only applies to bars and boxes)
     xa._minDtick = 0;
     ya._minDtick = 0;
-
-    Lib.markTime('done convert x&y');
 
     if(isHist) {
         var binned = histogram2dCalc(gd, trace);

--- a/src/traces/heatmap/calc.js
+++ b/src/traces/heatmap/calc.js
@@ -264,7 +264,7 @@ function interp2d(z, emptyPoints, savedInterpZ) {
             correctionOvershoot(maxFractionalChange));
     }
     if(maxFractionalChange > INTERPTHRESHOLD) {
-        console.log('interp2d didn\'t converge quickly', maxFractionalChange);
+        Lib.log('interp2d didn\'t converge quickly', maxFractionalChange);
     }
 
     return z;

--- a/src/traces/heatmap/colorbar.js
+++ b/src/traces/heatmap/colorbar.js
@@ -41,6 +41,4 @@ module.exports = function colorbar(gd, cd) {
             .range(scl.map(function(v) { return v[1]; })))
         .filllevels({start: zmin, end: zmax, size: (zmax - zmin) / 254})
         .options(trace.colorbar)();
-
-    Lib.markTime('done colorbar');
 };

--- a/src/traces/heatmap/hover.js
+++ b/src/traces/heatmap/hover.js
@@ -38,7 +38,7 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, contour)
             ny = Math.round(pointData.index[0]);
         }
         catch(e) {
-            console.log('Error hovering on heatmap, ' +
+            Lib.error('Error hovering on heatmap, ' +
                 'pointNumber must be [row,col], found:', pointData.index);
             return;
         }

--- a/src/traces/heatmap/plot.js
+++ b/src/traces/heatmap/plot.js
@@ -28,8 +28,6 @@ module.exports = function(gd, plotinfo, cdheatmaps) {
 
 // From http://www.xarg.org/2010/03/generate-client-side-png-files-using-javascript/
 function plotOne(gd, plotinfo, cd) {
-    Lib.markTime('in Heatmap.plot');
-
     var trace = cd[0].trace,
         uid = trace.uid,
         xa = plotinfo.x(),
@@ -286,8 +284,6 @@ function plotOne(gd, plotinfo, cd) {
         return setColor(z00 + xinterp.frac * dx + yinterp.frac * (dy + xinterp.frac * dxy));
     }
 
-    Lib.markTime('done init png');
-
     if(zsmooth) { // best or fast, works fastest with imageData
         var pxIndex = 0,
             pixels = new Uint8Array(imageWidth * imageHeight * 4);
@@ -359,8 +355,6 @@ function plotOne(gd, plotinfo, cd) {
         }
     }
 
-    Lib.markTime('done filling png');
-
     rcount = Math.round(rcount / pixcount);
     gcount = Math.round(gcount / pixcount);
     bcount = Math.round(bcount / pixcount);
@@ -391,6 +385,4 @@ function plotOne(gd, plotinfo, cd) {
         y: top,
         preserveAspectRatio: 'none'
     });
-
-    Lib.markTime('done showing png');
 }

--- a/src/traces/histogram2d/calc.js
+++ b/src/traces/histogram2d/calc.js
@@ -33,7 +33,6 @@ module.exports = function calc(gd, trace) {
     if(x.length > serieslen) x.splice(serieslen, x.length - serieslen);
     if(y.length > serieslen) y.splice(serieslen, y.length - serieslen);
 
-    Lib.markTime('done convert data');
 
     // calculate the bins
     if(trace.autobinx || !('xbins' in trace)) {
@@ -54,7 +53,6 @@ module.exports = function calc(gd, trace) {
         }
         trace._input.ybins = trace.ybins;
     }
-    Lib.markTime('done autoBin');
 
     // make the empty bin array & scale the map
     z = [];
@@ -138,7 +136,6 @@ module.exports = function calc(gd, trace) {
     }
 
 
-    Lib.markTime('done making bins');
     // put data into bins
     for(i = 0; i < serieslen; i++) {
         n = Lib.findBin(x[i], xbins);
@@ -154,7 +151,6 @@ module.exports = function calc(gd, trace) {
     if(normfunc) {
         for(m = 0; m < ny; m++) normfunc(z[m], total, xinc, yinc[m]);
     }
-    Lib.markTime('done binning');
 
     return {
         x: x,

--- a/src/traces/scatter/calc.js
+++ b/src/traces/scatter/calc.js
@@ -21,13 +21,9 @@ var calcMarkerColorscale = require('./marker_colorscale_calc');
 module.exports = function calc(gd, trace) {
     var xa = Axes.getFromId(gd, trace.xaxis || 'x'),
         ya = Axes.getFromId(gd, trace.yaxis || 'y');
-    Lib.markTime('in Scatter.calc');
 
-    var x = xa.makeCalcdata(trace, 'x');
-    Lib.markTime('finished convert x');
-
-    var y = ya.makeCalcdata(trace, 'y');
-    Lib.markTime('finished convert y');
+    var x = xa.makeCalcdata(trace, 'x'),
+        y = ya.makeCalcdata(trace, 'y');
 
     var serieslen = Math.min(x.length, y.length),
         marker,
@@ -111,11 +107,8 @@ module.exports = function calc(gd, trace) {
         yOptions.padded = false;
     }
 
-    Lib.markTime('ready for Axes.expand');
     Axes.expand(xa, x, xOptions);
-    Lib.markTime('done expand x');
     Axes.expand(ya, y, yOptions);
-    Lib.markTime('done expand y');
 
     // create the "calculated data" to plot
     var cd = new Array(serieslen);

--- a/src/traces/scatter/colorbar.js
+++ b/src/traces/scatter/colorbar.js
@@ -48,6 +48,4 @@ module.exports = function colorbar(gd, cd) {
             .range(scl.map(function(v) { return v[1]; })))
         .filllevels({start: cmin, end: cmax, size: (cmax - cmin) / 254})
         .options(marker.colorbar)();
-
-    Lib.markTime('done colorbar');
 };

--- a/src/traces/surface/colorbar.js
+++ b/src/traces/surface/colorbar.js
@@ -42,6 +42,4 @@ module.exports = function colorbar(gd, cd) {
             .range(scl.map(function(v) { return v[1]; })))
         .filllevels({start: zmin, end: zmax, size: (zmax - zmin) / 254})
         .options(trace.colorbar)();
-
-    Lib.markTime('done colorbar');
 };

--- a/test/jasmine/bundle_tests/core_test.js
+++ b/test/jasmine/bundle_tests/core_test.js
@@ -12,8 +12,6 @@ describe('Bundle with core only', function() {
     var mock = require('@mocks/bar_line.json');
 
     beforeEach(function(done) {
-        spyOn(console, 'warn');
-
         Plotly.plot(createGraphDiv(), mock.data, mock.layout).then(done);
     });
 
@@ -29,9 +27,5 @@ describe('Bundle with core only', function() {
         var nodes = d3.selectAll('g.trace.bars');
 
         expect(nodes.size()).toEqual(0);
-    });
-
-    it('should warn users about unregistered bar trace type', function() {
-        expect(console.warn).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Resolves #565.

In brief:
* remove `Lib.markTime` calls - these can be done using `console.time` and `console.timeEnd` while developing, then should be removed before committing/pushing
* Add `Lib.log`, `Lib.warn`, and `Lib.error` which can be toggled by setting the `logging` config value

| Logging level | Result |
|--------------------|---------|
| `0 || false` | Nothing will be output |
| `1` | Only warnings and errors will be output |
| `2` | Warnings, errors, and log messages will be output |

There is a downside: the line number when logged shows up as from the `lib/index.js` file. I have somewhat "fixed" this by having stack traces printed with logs, but it is not ideal (in my mind) and the methods for circumventing this aren't very robust and don't work with `strict mode` (using `arguments.caller.callee` or overwriting `Error.prepareStackTrace`). 

I think any downsides (i.e. having to click to see the stacktrace on a log message) is worth the benefits of keeping the library quiet in a production setting. 