### PR TITLE
Fix click_test.js sporadic failures (issue #567)

### DIFF
--- a/src/lib/notifier.js
+++ b/src/lib/notifier.js
@@ -12,6 +12,7 @@
 var d3 = require('d3');
 var isNumeric = require('fast-isnumeric');
 
+var DISABLED = false;
 var NOTEDATA = [];
 
 /**
@@ -22,6 +23,7 @@ var NOTEDATA = [];
  * @return {undefined} this function does not return a value
  */
 module.exports = function(text, displayLength) {
+    if(DISABLED) return;
     if(NOTEDATA.indexOf(text) !== -1) return;
 
     NOTEDATA.push(text);
@@ -72,4 +74,12 @@ module.exports = function(text, displayLength) {
                     .delay(ts)
                     .call(killNote);
         });
+};
+
+module.exports.disable = function() {
+    DISABLED = true;
+};
+
+module.exports.enable = function() {
+    DISABLED = false;
 };

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -27,9 +27,13 @@ describe('Test click interactions:', function() {
     beforeEach(function() {
         gd = createGraphDiv();
         mockCopy = Lib.extendDeep({}, mock);
+        Lib.notifier.disable();
     });
 
-    afterEach(destroyGraphDiv);
+    afterEach(function() {
+        Lib.notifier.enable();
+        destroyGraphDiv();
+    });
 
     // cartesian click events events use the hover data
     // from the mousemove events and then simulate
@@ -180,13 +184,7 @@ describe('Test click interactions:', function() {
 
     describe('drag interactions', function() {
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
-                // Do not let the notifier hide the drag elements
-                var tooltip = document.querySelector('.notifier-note');
-                if(tooltip) tooltip.style.display = 'None';
-
-                done();
-            });
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('on nw dragbox should update the axis ranges', function(done) {


### PR DESCRIPTION
This issue is another reincarnation of the bug fixed [here](https://github.com/plotly/plotly.js/commit/90700da4429496fe6b6ddde1dafcb42202ac6c46), triggered by the `Lib.notifier` div lingering from one test to the next one.

I've introduced new API to disable/enable `Lib.notifier`:
- `Lib.notifier.disable()`
- `Lib.notifier.enable()`

This solution disables `Lib.notifier` during `click_test`.
