### PR TITLE
Toimage bug

### DIFF
--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -86,7 +86,7 @@ function svgToImg(opts) {
                     imgData = canvas.toDataURL('image/webp');
                     break;
                 case 'svg':
-                    imgData = svg;
+                    imgData = url;
                     break;
                 default:
                     reject(new Error('Image format is not jpeg, png or svg'));

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -105,7 +105,7 @@ describe('Plotly.toImage', function() {
             // now do svg
             return Plotly.toImage(gd, {format: 'svg'});
         }).then(function(url) {
-            expect(url.substr(1, 3)).toBe('svg');
+            expect(url.split('svg')[0]).toBe('data:image/');
             done();
         });
     });


### PR DESCRIPTION
Fixes #600.

This PR fixes a nasty little bug with image downloads. The culprit was font-family strings that were quoted and breaking the svg string used for image conversions.

The fix is not exactly _pretty_, but should be more robust now (previously, the quotation marks were escaped _before the svg was converted to a string_ - Chrome seems to not care for that and automatically replaces the double quotation marks.

