### PR TITLE
DRY up color attributes

### DIFF
--- a/src/components/colorscale/attributes.js
+++ b/src/components/colorscale/attributes.js
@@ -8,7 +8,6 @@
 
 'use strict';
 
-
 module.exports = {
     zauto: {
         valType: 'boolean',

--- a/src/components/colorscale/attributes.js
+++ b/src/components/colorscale/attributes.js
@@ -67,18 +67,5 @@ module.exports = {
         description: [
             'Determines whether or not a colorbar is displayed for this trace.'
         ].join(' ')
-    },
-
-    _deprecated: {
-        scl: {
-            valType: 'colorscale',
-            role: 'style',
-            description: 'Renamed to `colorscale`.'
-        },
-        reversescl: {
-            valType: 'boolean',
-            role: 'style',
-            description: 'Renamed to `reversescale`.'
-        }
     }
 };

--- a/src/components/colorscale/color_attributes.js
+++ b/src/components/colorscale/color_attributes.js
@@ -8,6 +8,9 @@
 
 'use strict';
 
+var colorScaleAttributes = require('./attributes');
+var extendDeep = require('../../lib/extend').extendDeep;
+
 module.exports = function makeColorScaleAttributes(context) {
     return {
         color: {
@@ -21,9 +24,7 @@ module.exports = function makeColorScaleAttributes(context) {
                 ' `cmin` and `cmax` if set.'
             ].join('')
         },
-        colorscale: {
-            valType: 'colorscale',
-            role: 'style',
+        colorscale: extendDeep({}, colorScaleAttributes.colorscale, {
             description: [
                 'Sets the colorscale and only has an effect',
                 ' if `', context, '.color` is set to a numerical array.',
@@ -36,57 +37,42 @@ module.exports = function makeColorScaleAttributes(context) {
                 ' To control the bounds of the colorscale in color space,',
                 ' use `', context, '.cmin` and `', context, '.cmax`.'
             ].join('')
-        },
-        cauto: {
-            valType: 'boolean',
-            dflt: true,
-            role: 'style',
+        }),
+        cauto: extendDeep({}, colorScaleAttributes.zauto, {
             description: [
                 'Has an effect only if `', context, '.color` is set to a numerical array.',
                 ' Determines the whether or not the color domain is computed',
                 ' automatically.'
             ].join('')
-        },
-        cmax: {
-            valType: 'number',
-            dflt: null,
-            role: 'info',
+        }),
+        cmax: extendDeep({}, colorScaleAttributes.zmax, {
             description: [
                 'Has an effect only if `', context, '.color` is set to a numerical array.',
                 ' Sets the upper bound of the color domain.',
                 ' Value should be associated to the `', context, '.color` array index,',
                 ' and if set, `', context, '.cmin` must be set as well.'
             ].join('')
-        },
-        cmin: {
-            valType: 'number',
-            dflt: null,
-            role: 'info',
+        }),
+        cmin: extendDeep({}, colorScaleAttributes.zmin, {
             description: [
                 'Has an effect only if `', context, '.color` is set to a numerical array.',
                 ' Sets the lower bound of the color domain.',
                 ' Value should be associated to the `', context, '.color` array index,',
                 ' and if set, `', context, '.cmax` must be set as well.'
             ].join('')
-        },
-        autocolorscale: {
-            valType: 'boolean',
-            dflt: true,
-            role: 'style',
+        }),
+        autocolorscale: extendDeep({}, colorScaleAttributes.autocolorscale, {
             description: [
                 'Has an effect only if `', context, '.color` is set to a numerical array.',
                 ' Determines whether or not the colorscale is picked using',
                 ' values inside `', context, '.color`.'
             ].join('')
-        },
-        reversescale: {
-            valType: 'boolean',
-            role: 'style',
-            dflt: false,
+        }),
+        reversescale: extendDeep({}, colorScaleAttributes.reversescale, {
             description: [
                 'Has an effect only if `', context, '.color` is set to a numerical array.',
                 ' Reverses the colorscale.'
             ].join('')
-        }
+        })
     };
 };

--- a/src/components/colorscale/color_attributes.js
+++ b/src/components/colorscale/color_attributes.js
@@ -1,0 +1,92 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+module.exports = function makeColorScaleAttributes(context) {
+    return {
+        color: {
+            valType: 'color',
+            arrayOk: true,
+            role: 'style',
+            description: [
+                'Sets the ', context, ' color. It accepts either a specific color',
+                ' or an array of values that are mapped to the colorscale',
+                ' relative to the max and min values of the array or relative to',
+                ' `cmin` and `cmax` if set.'
+            ].join('')
+        },
+        colorscale: {
+            valType: 'colorscale',
+            role: 'style',
+            description: [
+                'Sets the colorscale and only has an effect',
+                ' if `', context, '.color` is set to a numerical array.',
+                ' The colorscale must be an array containing',
+                ' arrays mapping a normalized value to an',
+                ' rgb, rgba, hex, hsl, hsv, or named color string.',
+                ' At minimum, a mapping for the lowest (0) and highest (1)',
+                ' values are required. For example,',
+                ' `[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`.',
+                ' To control the bounds of the colorscale in color space,',
+                ' use `', context, '.cmin` and `', context, '.cmax`.'
+            ].join('')
+        },
+        cauto: {
+            valType: 'boolean',
+            dflt: true,
+            role: 'style',
+            description: [
+                'Has an effect only if `', context, '.color` is set to a numerical array.',
+                ' Determines the whether or not the color domain is computed',
+                ' automatically.'
+            ].join('')
+        },
+        cmax: {
+            valType: 'number',
+            dflt: null,
+            role: 'info',
+            description: [
+                'Has an effect only if `', context, '.color` is set to a numerical array.',
+                ' Sets the upper bound of the color domain.',
+                ' Value should be associated to the `', context, '.color` array index,',
+                ' and if set, `', context, '.cmin` must be set as well.'
+            ].join('')
+        },
+        cmin: {
+            valType: 'number',
+            dflt: null,
+            role: 'info',
+            description: [
+                'Has an effect only if `', context, '.color` is set to a numerical array.',
+                ' Sets the lower bound of the color domain.',
+                ' Value should be associated to the `', context, '.color` array index,',
+                ' and if set, `', context, '.cmax` must be set as well.'
+            ].join('')
+        },
+        autocolorscale: {
+            valType: 'boolean',
+            dflt: true,
+            role: 'style',
+            description: [
+                'Has an effect only if `', context, '.color` is set to a numerical array.',
+                ' Determines whether or not the colorscale is picked using',
+                ' values inside `', context, '.color`.'
+            ].join('')
+        },
+        reversescale: {
+            valType: 'boolean',
+            role: 'style',
+            dflt: false,
+            description: [
+                'Has an effect only if `', context, '.color` is set to a numerical array.',
+                ' Reverses the colorscale.'
+            ].join('')
+        }
+    };
+};

--- a/src/traces/bar/attributes.js
+++ b/src/traces/bar/attributes.js
@@ -10,11 +10,10 @@
 
 var scatterAttrs = require('../scatter/attributes');
 var colorAttributes = require('../../components/colorscale/color_attributes');
-var extendDeep = require('../../lib/extend').extendDeep;
+var extendFlat = require('../../lib/extend').extendFlat;
 
 var scatterMarkerAttrs = scatterAttrs.marker;
 var scatterMarkerLineAttrs = scatterMarkerAttrs.line;
-
 
 module.exports = {
     x: scatterAttrs.x,
@@ -34,12 +33,14 @@ module.exports = {
             'along the vertical (horizontal).'
         ].join(' ')
     },
-    marker: extendDeep({}, colorAttributes('marker'), {
+    marker: extendFlat({}, {
         showscale: scatterMarkerAttrs.showscale,
-        line: extendDeep({}, colorAttributes('marker.line'), {
-            width: scatterMarkerLineAttrs.width
-        })
-    }),
+        line: extendFlat({},
+            {width: scatterMarkerLineAttrs.width},
+            colorAttributes('marker.line')
+        )},
+        colorAttributes('marker')
+    ),
 
     r: scatterAttrs.r,
     t: scatterAttrs.t,

--- a/src/traces/bar/attributes.js
+++ b/src/traces/bar/attributes.js
@@ -8,9 +8,12 @@
 
 'use strict';
 
-var scatterAttrs = require('../scatter/attributes'),
-    scatterMarkerAttrs = scatterAttrs.marker,
-    scatterMarkerLineAttrs = scatterMarkerAttrs.line;
+var scatterAttrs = require('../scatter/attributes');
+var colorAttributes = require('../../components/colorscale/color_attributes');
+var extendDeep = require('../../lib/extend').extendDeep;
+
+var scatterMarkerAttrs = scatterAttrs.marker;
+var scatterMarkerLineAttrs = scatterMarkerAttrs.line;
 
 
 module.exports = {
@@ -31,26 +34,12 @@ module.exports = {
             'along the vertical (horizontal).'
         ].join(' ')
     },
-    marker: {
-        color: scatterMarkerAttrs.color,
-        colorscale: scatterMarkerAttrs.colorscale,
-        cauto: scatterMarkerAttrs.cauto,
-        cmax: scatterMarkerAttrs.cmax,
-        cmin: scatterMarkerAttrs.cmin,
-        autocolorscale: scatterMarkerAttrs.autocolorscale,
-        reversescale: scatterMarkerAttrs.reversescale,
+    marker: extendDeep({}, colorAttributes('marker'), {
         showscale: scatterMarkerAttrs.showscale,
-        line: {
-            color: scatterMarkerLineAttrs.color,
-            colorscale: scatterMarkerLineAttrs.colorscale,
-            cauto: scatterMarkerLineAttrs.cauto,
-            cmax: scatterMarkerLineAttrs.cmax,
-            cmin: scatterMarkerLineAttrs.cmin,
-            width: scatterMarkerLineAttrs.width,
-            autocolorscale: scatterMarkerLineAttrs.autocolorscale,
-            reversescale: scatterMarkerLineAttrs.reversescale
-        }
-    },
+        line: extendDeep({}, colorAttributes('marker.line'), {
+            width: scatterMarkerLineAttrs.width
+        })
+    }),
 
     r: scatterAttrs.r,
     t: scatterAttrs.t,

--- a/src/traces/choropleth/attributes.js
+++ b/src/traces/choropleth/attributes.js
@@ -15,7 +15,7 @@ var extendFlat = require('../../lib/extend').extendFlat;
 
 var ScatterGeoMarkerLineAttrs = ScatterGeoAttrs.marker.line;
 
-module.exports = {
+module.exports = extendFlat({}, colorscaleAttrs, {
     locations: {
         valType: 'data_array',
         description: [
@@ -38,17 +38,10 @@ module.exports = {
             width: ScatterGeoMarkerLineAttrs.width
         }
     },
-    zauto: colorscaleAttrs.zauto,
-    zmin: colorscaleAttrs.zmin,
-    zmax: colorscaleAttrs.zmax,
-    colorscale: colorscaleAttrs.colorscale,
-    autocolorscale: colorscaleAttrs.autocolorscale,
-    reversescale: colorscaleAttrs.reversescale,
-    showscale: colorscaleAttrs.showscale,
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {
         flags: ['location', 'z', 'text', 'name']
     }),
     _nestedModules: {
         'colorbar': 'Colorbar'
     }
-};
+});

--- a/src/traces/choropleth/attributes.js
+++ b/src/traces/choropleth/attributes.js
@@ -15,7 +15,7 @@ var extendFlat = require('../../lib/extend').extendFlat;
 
 var ScatterGeoMarkerLineAttrs = ScatterGeoAttrs.marker.line;
 
-module.exports = extendFlat({}, colorscaleAttrs, {
+module.exports = extendFlat({}, {
     locations: {
         valType: 'data_array',
         description: [
@@ -44,4 +44,6 @@ module.exports = extendFlat({}, colorscaleAttrs, {
     _nestedModules: {
         'colorbar': 'Colorbar'
     }
-});
+},
+    colorscaleAttrs
+);

--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -16,8 +16,6 @@ var extendFlat = require('../../lib/extend').extendFlat;
 var scatterLineAttrs = scatterAttrs.line;
 
 module.exports = extendFlat({},
-    colorscaleAttrs,
-    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})},
     {
         z: heatmapAttrs.z,
         x: heatmapAttrs.x,
@@ -118,4 +116,7 @@ module.exports = extendFlat({},
         _nestedModules: {
             'colorbar': 'Colorbar'
         }
-    });
+    },
+    colorscaleAttrs,
+    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})}
+);

--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -10,116 +10,112 @@
 
 var heatmapAttrs = require('../heatmap/attributes');
 var scatterAttrs = require('../scatter/attributes');
+var colorscaleAttrs = require('../../components/colorscale/attributes');
 var extendFlat = require('../../lib/extend').extendFlat;
 
 var scatterLineAttrs = scatterAttrs.line;
 
-module.exports = {
-    z: heatmapAttrs.z,
-    x: heatmapAttrs.x,
-    x0: heatmapAttrs.x0,
-    dx: heatmapAttrs.dx,
-    y: heatmapAttrs.y,
-    y0: heatmapAttrs.y0,
-    dy: heatmapAttrs.dy,
-    text: heatmapAttrs.text,
-    transpose: heatmapAttrs.transpose,
-    xtype: heatmapAttrs.xtype,
-    ytype: heatmapAttrs.ytype,
+module.exports = extendFlat({},
+    colorscaleAttrs,
+    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})},
+    {
+        z: heatmapAttrs.z,
+        x: heatmapAttrs.x,
+        x0: heatmapAttrs.x0,
+        dx: heatmapAttrs.dx,
+        y: heatmapAttrs.y,
+        y0: heatmapAttrs.y0,
+        dy: heatmapAttrs.dy,
+        text: heatmapAttrs.text,
+        transpose: heatmapAttrs.transpose,
+        xtype: heatmapAttrs.xtype,
+        ytype: heatmapAttrs.ytype,
 
-    zauto: heatmapAttrs.zauto,
-    zmin: heatmapAttrs.zmin,
-    zmax: heatmapAttrs.zmax,
-    colorscale: heatmapAttrs.colorscale,
-    autocolorscale: heatmapAttrs.autocolorscale,
-    reversescale: heatmapAttrs.reversescale,
-    showscale: heatmapAttrs.showscale,
+        connectgaps: heatmapAttrs.connectgaps,
 
-    connectgaps: heatmapAttrs.connectgaps,
-
-    autocontour: {
-        valType: 'boolean',
-        dflt: true,
-        role: 'style',
-        description: [
-            'Determines whether or not the contour level attributes are',
-            'picked by an algorithm.',
-            'If *true*, the number of contour levels can be set in `ncontours`.',
-            'If *false*, set the contour level attributes in `contours`.'
-        ].join(' ')
-    },
-    ncontours: {
-        valType: 'integer',
-        dflt: 0,
-        role: 'style',
-        description: [
-            'Sets the number of contour levels.',
-            'Has an effect only if `autocontour` is *true*.'
-        ].join(' ')
-    },
-
-    contours: {
-        start: {
-            valType: 'number',
-            dflt: null,
-            role: 'style',
-            description: 'Sets the starting contour level value.'
-        },
-        end: {
-            valType: 'number',
-            dflt: null,
-            role: 'style',
-            description: 'Sets the end contour level value.'
-        },
-        size: {
-            valType: 'number',
-            dflt: null,
-            role: 'style',
-            description: 'Sets the step between each contour level.'
-        },
-        coloring: {
-            valType: 'enumerated',
-            values: ['fill', 'heatmap', 'lines', 'none'],
-            dflt: 'fill',
-            role: 'style',
-            description: [
-                'Determines the coloring method showing the contour values.',
-                'If *fill*, coloring is done evenly between each contour level',
-                'If *heatmap*, a heatmap gradient coloring is applied',
-                'between each contour level.',
-                'If *lines*, coloring is done on the contour lines.',
-                'If *none*, no coloring is applied on this trace.'
-            ].join(' ')
-        },
-        showlines: {
+        autocontour: {
             valType: 'boolean',
             dflt: true,
             role: 'style',
             description: [
-                'Determines whether or not the contour lines are drawn.',
-                'Has only an effect if `contours.coloring` is set to *fill*.'
+                'Determines whether or not the contour level attributes are',
+                'picked by an algorithm.',
+                'If *true*, the number of contour levels can be set in `ncontours`.',
+                'If *false*, set the contour level attributes in `contours`.'
             ].join(' ')
+        },
+        ncontours: {
+            valType: 'integer',
+            dflt: 0,
+            role: 'style',
+            description: [
+                'Sets the number of contour levels.',
+                'Has an effect only if `autocontour` is *true*.'
+            ].join(' ')
+        },
+
+        contours: {
+            start: {
+                valType: 'number',
+                dflt: null,
+                role: 'style',
+                description: 'Sets the starting contour level value.'
+            },
+            end: {
+                valType: 'number',
+                dflt: null,
+                role: 'style',
+                description: 'Sets the end contour level value.'
+            },
+            size: {
+                valType: 'number',
+                dflt: null,
+                role: 'style',
+                description: 'Sets the step between each contour level.'
+            },
+            coloring: {
+                valType: 'enumerated',
+                values: ['fill', 'heatmap', 'lines', 'none'],
+                dflt: 'fill',
+                role: 'style',
+                description: [
+                    'Determines the coloring method showing the contour values.',
+                    'If *fill*, coloring is done evenly between each contour level',
+                    'If *heatmap*, a heatmap gradient coloring is applied',
+                    'between each contour level.',
+                    'If *lines*, coloring is done on the contour lines.',
+                    'If *none*, no coloring is applied on this trace.'
+                ].join(' ')
+            },
+            showlines: {
+                valType: 'boolean',
+                dflt: true,
+                role: 'style',
+                description: [
+                    'Determines whether or not the contour lines are drawn.',
+                    'Has only an effect if `contours.coloring` is set to *fill*.'
+                ].join(' ')
+            }
+        },
+
+        line: {
+            color: extendFlat({}, scatterLineAttrs.color, {
+                description: [
+                    'Sets the color of the contour level.',
+                    'Has no if `contours.coloring` is set to *lines*.'
+                ].join(' ')
+            }),
+            width: scatterLineAttrs.width,
+            dash: scatterLineAttrs.dash,
+            smoothing: extendFlat({}, scatterLineAttrs.smoothing, {
+                description: [
+                    'Sets the amount of smoothing for the contour lines,',
+                    'where *0* corresponds to no smoothing.'
+                ].join(' ')
+            })
+        },
+
+        _nestedModules: {
+            'colorbar': 'Colorbar'
         }
-    },
-
-    line: {
-        color: extendFlat({}, scatterLineAttrs.color, {
-            description: [
-                'Sets the color of the contour level.',
-                'Has no if `contours.coloring` is set to *lines*.'
-            ].join(' ')
-        }),
-        width: scatterLineAttrs.width,
-        dash: scatterLineAttrs.dash,
-        smoothing: extendFlat({}, scatterLineAttrs.smoothing, {
-            description: [
-                'Sets the amount of smoothing for the contour lines,',
-                'where *0* corresponds to no smoothing.'
-            ].join(' ')
-        })
-    },
-
-    _nestedModules: {
-        'colorbar': 'Colorbar'
-    }
-};
+    });

--- a/src/traces/heatmap/attributes.js
+++ b/src/traces/heatmap/attributes.js
@@ -14,78 +14,73 @@ var colorscaleAttrs = require('../../components/colorscale/attributes');
 var extendFlat = require('../../lib/extend').extendFlat;
 
 
-module.exports = {
-    z: {
-        valType: 'data_array',
-        description: 'Sets the z data.'
-    },
-    x: scatterAttrs.x,
-    x0: scatterAttrs.x0,
-    dx: scatterAttrs.dx,
-    y: scatterAttrs.y,
-    y0: scatterAttrs.y0,
-    dy: scatterAttrs.dy,
-    text: {
-        valType: 'data_array',
-        description: 'Sets the text elements associated with each z value.'
-    },
-    transpose: {
-        valType: 'boolean',
-        dflt: false,
-        role: 'info',
-        description: 'Transposes the z data.'
-    },
-    xtype: {
-        valType: 'enumerated',
-        values: ['array', 'scaled'],
-        role: 'info',
-        description: [
-            'If *array*, the heatmap\'s x coordinates are given by *x*',
-            '(the default behavior when `x` is provided).',
-            'If *scaled*, the heatmap\'s x coordinates are given by *x0* and *dx*',
-            '(the default behavior when `x` is not provided).'
-        ].join(' ')
-    },
-    ytype: {
-        valType: 'enumerated',
-        values: ['array', 'scaled'],
-        role: 'info',
-        description: [
-            'If *array*, the heatmap\'s y coordinates are given by *y*',
-            '(the default behavior when `y` is provided)',
-            'If *scaled*, the heatmap\'s y coordinates are given by *y0* and *dy*',
-            '(the default behavior when `y` is not provided)'
-        ].join(' ')
-    },
-    zauto: colorscaleAttrs.zauto,
-    zmin: colorscaleAttrs.zmin,
-    zmax: colorscaleAttrs.zmax,
-    colorscale: colorscaleAttrs.colorscale,
-    autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale,
-        {dflt: false}),
-    reversescale: colorscaleAttrs.reversescale,
-    showscale: colorscaleAttrs.showscale,
-    zsmooth: {
-        valType: 'enumerated',
-        values: ['fast', 'best', false],
-        dflt: false,
-        role: 'style',
-        description: [
-            'Picks a smoothing algorithm use to smooth `z` data.'
-        ].join(' ')
-    },
-    connectgaps: {
-        valType: 'boolean',
-        dflt: false,
-        role: 'info',
-        description: [
-            'Determines whether or not gaps',
-            '(i.e. {nan} or missing values)',
-            'in the `z` data are filled in.'
-        ].join(' ')
-    },
+module.exports = extendFlat({},
+    colorscaleAttrs,
+    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})},
+    {
+        z: {
+            valType: 'data_array',
+            description: 'Sets the z data.'
+        },
+        x: scatterAttrs.x,
+        x0: scatterAttrs.x0,
+        dx: scatterAttrs.dx,
+        y: scatterAttrs.y,
+        y0: scatterAttrs.y0,
+        dy: scatterAttrs.dy,
+        text: {
+            valType: 'data_array',
+            description: 'Sets the text elements associated with each z value.'
+        },
+        transpose: {
+            valType: 'boolean',
+            dflt: false,
+            role: 'info',
+            description: 'Transposes the z data.'
+        },
+        xtype: {
+            valType: 'enumerated',
+            values: ['array', 'scaled'],
+            role: 'info',
+            description: [
+                'If *array*, the heatmap\'s x coordinates are given by *x*',
+                '(the default behavior when `x` is provided).',
+                'If *scaled*, the heatmap\'s x coordinates are given by *x0* and *dx*',
+                '(the default behavior when `x` is not provided).'
+            ].join(' ')
+        },
+        ytype: {
+            valType: 'enumerated',
+            values: ['array', 'scaled'],
+            role: 'info',
+            description: [
+                'If *array*, the heatmap\'s y coordinates are given by *y*',
+                '(the default behavior when `y` is provided)',
+                'If *scaled*, the heatmap\'s y coordinates are given by *y0* and *dy*',
+                '(the default behavior when `y` is not provided)'
+            ].join(' ')
+        },
+        zsmooth: {
+            valType: 'enumerated',
+            values: ['fast', 'best', false],
+            dflt: false,
+            role: 'style',
+            description: [
+                'Picks a smoothing algorithm use to smooth `z` data.'
+            ].join(' ')
+        },
+        connectgaps: {
+            valType: 'boolean',
+            dflt: false,
+            role: 'info',
+            description: [
+                'Determines whether or not gaps',
+                '(i.e. {nan} or missing values)',
+                'in the `z` data are filled in.'
+            ].join(' ')
+        },
 
-    _nestedModules: {
-        'colorbar': 'Colorbar'
-    }
-};
+        _nestedModules: {
+            'colorbar': 'Colorbar'
+        }
+    });

--- a/src/traces/heatmap/attributes.js
+++ b/src/traces/heatmap/attributes.js
@@ -13,10 +13,7 @@ var colorscaleAttrs = require('../../components/colorscale/attributes');
 
 var extendFlat = require('../../lib/extend').extendFlat;
 
-
 module.exports = extendFlat({},
-    colorscaleAttrs,
-    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})},
     {
         z: {
             valType: 'data_array',
@@ -83,4 +80,7 @@ module.exports = extendFlat({},
         _nestedModules: {
             'colorbar': 'Colorbar'
         }
-    });
+    },
+    colorscaleAttrs,
+    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})}
+);

--- a/src/traces/histogram/attributes.js
+++ b/src/traces/histogram/attributes.js
@@ -10,7 +10,10 @@
 'use strict';
 
 var barAttrs = require('../bar/attributes');
+var colorAttributes = require('../../components/colorscale/color_attributes');
+
 var extendFlat = require('../../lib').extendFlat;
+var extendDeep = require('../../lib/extend').extendDeep;
 
 var barMarkerAttrs = barAttrs.marker;
 var barMarkerLineAttrs = barMarkerAttrs.line;
@@ -112,26 +115,12 @@ module.exports = {
     },
     ybins: makeBinsAttr('y'),
 
-    marker: {
-        color: barMarkerAttrs.color,
-        colorscale: barMarkerAttrs.colorscale,
-        cauto: barMarkerAttrs.cauto,
-        cmax: barMarkerAttrs.cmax,
-        cmin: barMarkerAttrs.cmin,
-        autocolorscale: barMarkerAttrs.autocolorscale,
-        reversescale: barMarkerAttrs.reversescale,
+    marker: extendDeep({}, colorAttributes('marker'), {
         showscale: barMarkerAttrs.showscale,
-        line: {
-            color: barMarkerLineAttrs.color,
-            colorscale: barMarkerLineAttrs.colorscale,
-            cauto: barMarkerLineAttrs.cauto,
-            cmax: barMarkerLineAttrs.cmax,
-            cmin: barMarkerLineAttrs.cmin,
-            autocolorscale: barMarkerLineAttrs.autocolorscale,
-            reversescale: barMarkerLineAttrs.reversescale,
+        line: extendDeep({}, colorAttributes('marker.line'), {
             width: extendFlat({}, barMarkerLineAttrs.width, {dflt: 0})
-        }
-    },
+        })
+    }),
 
     _nestedModules: {
         'error_y': 'ErrorBars',

--- a/src/traces/histogram/attributes.js
+++ b/src/traces/histogram/attributes.js
@@ -6,18 +6,15 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
 var barAttrs = require('../bar/attributes');
 var colorAttributes = require('../../components/colorscale/color_attributes');
 
-var extendFlat = require('../../lib').extendFlat;
-var extendDeep = require('../../lib/extend').extendDeep;
+var extendFlat = require('../../lib/extend').extendDeep;
 
 var barMarkerAttrs = barAttrs.marker;
 var barMarkerLineAttrs = barMarkerAttrs.line;
-
 
 module.exports = {
     x: {
@@ -115,12 +112,14 @@ module.exports = {
     },
     ybins: makeBinsAttr('y'),
 
-    marker: extendDeep({}, colorAttributes('marker'), {
+    marker: extendFlat({}, {
         showscale: barMarkerAttrs.showscale,
-        line: extendDeep({}, colorAttributes('marker.line'), {
-            width: extendFlat({}, barMarkerLineAttrs.width, {dflt: 0})
-        })
-    }),
+        line: extendFlat({},
+            {width: extendFlat({}, barMarkerLineAttrs.width, {dflt: 0})},
+            colorAttributes('marker.line'))
+    },
+        colorAttributes('marker')
+    ),
 
     _nestedModules: {
         'error_y': 'ErrorBars',

--- a/src/traces/histogram2d/attributes.js
+++ b/src/traces/histogram2d/attributes.js
@@ -10,42 +10,40 @@
 
 var histogramAttrs = require('../histogram/attributes');
 var heatmapAttrs = require('../heatmap/attributes');
+var colorscaleAttrs = require('../../components/colorscale/attributes');
 
-module.exports = {
-    x: histogramAttrs.x,
-    y: histogramAttrs.y,
+var extendFlat = require('../../lib/extend').extendFlat;
 
-    z: {
-        valType: 'data_array',
-        description: 'Sets the aggregation data.'
-    },
-    marker: {
-        color: {
+module.exports = extendFlat({},
+    colorscaleAttrs,
+    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})},
+    {
+        x: histogramAttrs.x,
+        y: histogramAttrs.y,
+
+        z: {
             valType: 'data_array',
             description: 'Sets the aggregation data.'
+        },
+        marker: {
+            color: {
+                valType: 'data_array',
+                description: 'Sets the aggregation data.'
+            }
+        },
+
+        histnorm: histogramAttrs.histnorm,
+        histfunc: histogramAttrs.histfunc,
+        autobinx: histogramAttrs.autobinx,
+        nbinsx: histogramAttrs.nbinsx,
+        xbins: histogramAttrs.xbins,
+        autobiny: histogramAttrs.autobiny,
+        nbinsy: histogramAttrs.nbinsy,
+        ybins: histogramAttrs.ybins,
+
+        zsmooth: heatmapAttrs.zsmooth,
+
+        _nestedModules: {
+            'colorbar': 'Colorbar'
         }
-    },
-
-    histnorm: histogramAttrs.histnorm,
-    histfunc: histogramAttrs.histfunc,
-    autobinx: histogramAttrs.autobinx,
-    nbinsx: histogramAttrs.nbinsx,
-    xbins: histogramAttrs.xbins,
-    autobiny: histogramAttrs.autobiny,
-    nbinsy: histogramAttrs.nbinsy,
-    ybins: histogramAttrs.ybins,
-
-    zauto: heatmapAttrs.zauto,
-    zmin: heatmapAttrs.zmin,
-    zmax: heatmapAttrs.zmax,
-    colorscale: heatmapAttrs.colorscale,
-    autocolorscale: heatmapAttrs.autocolorscale,
-    reversescale: heatmapAttrs.reversescale,
-    showscale: heatmapAttrs.showscale,
-
-    zsmooth: heatmapAttrs.zsmooth,
-
-    _nestedModules: {
-        'colorbar': 'Colorbar'
-    }
-};
+    });

--- a/src/traces/histogram2d/attributes.js
+++ b/src/traces/histogram2d/attributes.js
@@ -15,8 +15,6 @@ var colorscaleAttrs = require('../../components/colorscale/attributes');
 var extendFlat = require('../../lib/extend').extendFlat;
 
 module.exports = extendFlat({},
-    colorscaleAttrs,
-    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})},
     {
         x: histogramAttrs.x,
         y: histogramAttrs.y,
@@ -46,4 +44,7 @@ module.exports = extendFlat({},
         _nestedModules: {
             'colorbar': 'Colorbar'
         }
-    });
+    },
+    colorscaleAttrs,
+    {autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false})}
+);

--- a/src/traces/histogram2dcontour/attributes.js
+++ b/src/traces/histogram2dcontour/attributes.js
@@ -10,8 +10,11 @@
 
 var histogram2dAttrs = require('../histogram2d/attributes');
 var contourAttrs = require('../contour/attributes');
+var colorscaleAttrs = require('../../components/colorscale/attributes');
 
-module.exports = {
+var extendFlat = require('../../lib/extend').extendFlat;
+
+module.exports = extendFlat({}, colorscaleAttrs, {
     x: histogram2dAttrs.x,
     y: histogram2dAttrs.y,
     z: histogram2dAttrs.z,
@@ -26,14 +29,6 @@ module.exports = {
     nbinsy: histogram2dAttrs.nbinsy,
     ybins: histogram2dAttrs.ybins,
 
-    zauto: contourAttrs.zauto,
-    zmin: contourAttrs.zmin,
-    zmax: contourAttrs.zmax,
-    colorscale: contourAttrs.colorscale,
-    autocolorscale: contourAttrs.autocolorscale,
-    reversescale: contourAttrs.reversescale,
-    showscale: contourAttrs.showscale,
-
     autocontour: contourAttrs.autocontour,
     ncontours: contourAttrs.ncontours,
     contours: contourAttrs.contours,
@@ -42,4 +37,4 @@ module.exports = {
     _nestedModules: {
         'colorbar': 'Colorbar'
     }
-};
+});

--- a/src/traces/histogram2dcontour/attributes.js
+++ b/src/traces/histogram2dcontour/attributes.js
@@ -14,7 +14,7 @@ var colorscaleAttrs = require('../../components/colorscale/attributes');
 
 var extendFlat = require('../../lib/extend').extendFlat;
 
-module.exports = extendFlat({}, colorscaleAttrs, {
+module.exports = extendFlat({}, {
     x: histogram2dAttrs.x,
     y: histogram2dAttrs.y,
     z: histogram2dAttrs.z,
@@ -37,4 +37,6 @@ module.exports = extendFlat({}, colorscaleAttrs, {
     _nestedModules: {
         'colorbar': 'Colorbar'
     }
-});
+},
+    colorscaleAttrs
+);

--- a/src/traces/scatter/attributes.js
+++ b/src/traces/scatter/attributes.js
@@ -14,8 +14,7 @@ var Drawing = require('../../components/drawing');
 
 var constants = require('./constants');
 
-var extendDeep = require('../../lib/extend').extendDeep;
-
+var extendFlat = require('../../lib/extend').extendFlat;
 
 module.exports = {
     x: {
@@ -185,7 +184,7 @@ module.exports = {
             'marker color, or marker line color, whichever is available.'
         ].join(' ')
     },
-    marker: extendDeep({}, colorAttributes('marker'), {
+    marker: extendFlat({}, {
         symbol: {
             valType: 'enumerated',
             values: Drawing.symbolList,
@@ -266,7 +265,7 @@ module.exports = {
                 'Determines whether or not a colorbar is displayed.'
             ].join(' ')
         },
-        line: extendDeep({}, colorAttributes('marker.line'), {
+        line: extendFlat({}, {
             width: {
                 valType: 'number',
                 min: 0,
@@ -274,8 +273,12 @@ module.exports = {
                 role: 'style',
                 description: 'Sets the width (in px) of the lines bounding the marker points.'
             }
-        })
-    }),
+        },
+            colorAttributes('marker.line')
+        )
+    },
+        colorAttributes('marker')
+    ),
     textposition: {
         valType: 'enumerated',
         values: [

--- a/src/traces/scatter/attributes.js
+++ b/src/traces/scatter/attributes.js
@@ -8,9 +8,13 @@
 
 'use strict';
 
+var colorAttributes = require('../../components/colorscale/color_attributes');
+
 var Drawing = require('../../components/drawing');
 
 var constants = require('./constants');
+
+var extendDeep = require('../../lib/extend').extendDeep;
 
 
 module.exports = {
@@ -181,7 +185,7 @@ module.exports = {
             'marker color, or marker line color, whichever is available.'
         ].join(' ')
     },
-    marker: {
+    marker: extendDeep({}, colorAttributes('marker'), {
         symbol: {
             valType: 'enumerated',
             values: Drawing.symbolList,
@@ -211,17 +215,6 @@ module.exports = {
             arrayOk: true,
             role: 'style',
             description: 'Sets the marker size (in px).'
-        },
-        color: {
-            valType: 'color',
-            arrayOk: true,
-            role: 'style',
-            description: [
-                'Sets the marker color. It accepts either a specific color',
-                'or an array of values that are mapped to the colorscale',
-                'relative to the max and min values of the array or relative to',
-                '`cmin` and `cmax` if set.'
-            ].join(' ')
         },
         maxdisplayed: {
             valType: 'number',
@@ -264,73 +257,6 @@ module.exports = {
                 'to pixels.'
             ].join(' ')
         },
-        colorscale: {
-            valType: 'colorscale',
-            role: 'style',
-            description: [
-                'Sets the colorscale and only has an effect',
-                'if `marker.color` is set to a numerical array.',
-                'The colorscale must be an array containing',
-                'arrays mapping a normalized value to an',
-                'rgb, rgba, hex, hsl, hsv, or named color string.',
-                'At minimum, a mapping for the lowest (0) and highest (1)',
-                'values are required. For example,',
-                '`[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`.',
-                'To control the bounds of the colorscale in color space,',
-                'use `marker.cmin` and `marker.cmax`.'
-            ].join(' ')
-        },
-        cauto: {
-            valType: 'boolean',
-            dflt: true,
-            role: 'style',
-            description: [
-                'Has an effect only if `marker.color` is set to a numerical array.',
-                'Determines the whether or not the color domain is computed',
-                'automatically.'
-            ].join(' ')
-        },
-        cmax: {
-            valType: 'number',
-            dflt: null,
-            role: 'info',
-            description: [
-                'Has an effect only if `marker.color` is set to a numerical array.',
-                'Sets the upper bound of the color domain.',
-                'Value should be associated to the `marker.color` array index,',
-                'and if set, `marker.cmin` must be set as well.'
-            ].join(' ')
-        },
-        cmin: {
-            valType: 'number',
-            dflt: null,
-            role: 'info',
-            description: [
-                'Has an effect only if `marker.color` is set to a numerical array.',
-                'Sets the lower bound of the color domain.',
-                'Value should be associated to the `marker.color` array index,',
-                'and if set, `marker.cmax` must be set as well.'
-            ].join(' ')
-        },
-        autocolorscale: {
-            valType: 'boolean',
-            dflt: true,
-            role: 'style',
-            description: [
-                'Has an effect only if `marker.color` is set to a numerical array.',
-                'Determines whether or not the colorscale is picked using',
-                'values inside `marker.color`.'
-            ].join(' ')
-        },
-        reversescale: {
-            valType: 'boolean',
-            role: 'style',
-            dflt: false,
-            description: [
-                'Has an effect only if `marker.color` is set to a numerical array.',
-                'Reverses the colorscale.'
-            ].join(' ')
-        },
         showscale: {
             valType: 'boolean',
             role: 'info',
@@ -340,94 +266,16 @@ module.exports = {
                 'Determines whether or not a colorbar is displayed.'
             ].join(' ')
         },
-        line: {
-            color: {
-                valType: 'color',
-                arrayOk: true,
-                role: 'style',
-                description: [
-                    'Sets the marker outline color. It accepts either a specific color',
-                    'or an array of values that are mapped to the colorscale',
-                    'relative to the max and min values of the array or relative to',
-                    '`cmin` and `cmax` if set.'
-                ].join(' ')
-            },
+        line: extendDeep({}, colorAttributes('marker.line'), {
             width: {
                 valType: 'number',
                 min: 0,
                 arrayOk: true,
                 role: 'style',
                 description: 'Sets the width (in px) of the lines bounding the marker points.'
-            },
-            colorscale: {
-                valType: 'colorscale',
-                role: 'style',
-                description: [
-                    'Sets the colorscale and only has an effect',
-                    'if `marker.line.color` is set to a numerical array.',
-                    'The colorscale must be an array containing',
-                    'arrays mapping a normalized value to an',
-                    'rgb, rgba, hex, hsl, hsv, or named color string.',
-                    'At minimum, a mapping for the lowest (0) and highest (1)',
-                    'values are required. For example,',
-                    '`[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`.',
-                    'To control the bounds of the colorscale in color space,',
-                    'use `marker.line.cmin` and `marker.line.cmax`.'
-                ].join(' ')
-            },
-            cauto: {
-                valType: 'boolean',
-                dflt: true,
-                role: 'style',
-                description: [
-                    'Has an effect only if `marker.line.color` is set to a numerical array.',
-                    'Determines the whether or not the color domain is computed',
-                    'with respect to the input data.'
-                ].join(' ')
-            },
-            cmax: {
-                valType: 'number',
-                dflt: null,
-                role: 'info',
-                description: [
-                    'Has an effect only if `marker.line.color` is set to a numerical array.',
-                    'Sets the upper bound of the color domain.',
-                    'Value should be associated to the `marker.line.color` array index,',
-                    'and if set, `marker.line.cmin` must be set as well.'
-                ].join(' ')
-            },
-            cmin: {
-                valType: 'number',
-                dflt: null,
-                role: 'info',
-                description: [
-                    'Has an effect only if `marker.line.color` is set to a numerical array.',
-                    'Sets the lower bound of the color domain.',
-                    'Value should be associated to the `marker.line.color` array index,',
-                    'and if set, `marker.line.cmax` must be set as well.'
-                ].join(' ')
-            },
-            autocolorscale: {
-                valType: 'boolean',
-                dflt: true,
-                role: 'style',
-                description: [
-                    'Has an effect only if `marker.line.color` is set to a numerical array.',
-                    'Determines whether or not the colorscale is picked using',
-                    'the sign of values inside `marker.line.color`.'
-                ].join(' ')
-            },
-            reversescale: {
-                valType: 'boolean',
-                dflt: false,
-                role: 'style',
-                description: [
-                    'Has an effect only if `marker.line.color` is set to a numerical array.',
-                    'Reverses the colorscale.'
-                ].join(' ')
             }
-        }
-    },
+        })
+    }),
     textposition: {
         valType: 'enumerated',
         values: [

--- a/src/traces/scatter3d/attributes.js
+++ b/src/traces/scatter3d/attributes.js
@@ -6,7 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
 var scatterAttrs = require('../scatter/attributes');
@@ -14,7 +13,6 @@ var colorAttributes = require('../../components/colorscale/color_attributes');
 
 var MARKER_SYMBOLS = require('../../constants/gl_markers');
 var extendFlat = require('../../lib/extend').extendFlat;
-var extendDeep = require('../../lib/extend').extendDeep;
 
 var scatterLineAttrs = scatterAttrs.line,
     scatterMarkerAttrs = scatterAttrs.marker,
@@ -104,7 +102,7 @@ module.exports = {
         width: scatterLineAttrs.width,
         dash: scatterLineAttrs.dash
     },
-    marker: extendDeep({}, colorAttributes('marker'), {  // Parity with scatter.js?
+    marker: extendFlat({}, {  // Parity with scatter.js?
         symbol: {
             valType: 'enumerated',
             values: Object.keys(MARKER_SYMBOLS),
@@ -129,10 +127,13 @@ module.exports = {
             ].join(' ')
         }),
         showscale: scatterMarkerAttrs.showscale,
-        line: extendDeep({}, colorAttributes('marker.line'), {
-            width: extendFlat({}, scatterMarkerLineAttrs.width, {arrayOk: false})
-        })
-    }),
+        line: extendFlat({},
+            {width: extendFlat({}, scatterMarkerLineAttrs.width, {arrayOk: false})},
+            colorAttributes('marker.line')
+        )
+    },
+        colorAttributes('marker')
+    ),
     textposition: extendFlat({}, scatterAttrs.textposition, {dflt: 'top center'}),
     textfont: scatterAttrs.textfont,
     _nestedModules: {

--- a/src/traces/scatter3d/attributes.js
+++ b/src/traces/scatter3d/attributes.js
@@ -104,9 +104,6 @@ module.exports = {
         width: scatterLineAttrs.width,
         dash: scatterLineAttrs.dash
     },
-    // Currently, `marker` etc. contain mixed attributes (colorAttributes
-    // and a bunch of others); maybe a future API change could wrap parts
-    // that belong together, under a `colorspec` or similar attribute name.
     marker: extendDeep({}, colorAttributes('marker'), {  // Parity with scatter.js?
         symbol: {
             valType: 'enumerated',

--- a/src/traces/scatter3d/attributes.js
+++ b/src/traces/scatter3d/attributes.js
@@ -10,8 +10,11 @@
 'use strict';
 
 var scatterAttrs = require('../scatter/attributes');
+var colorAttributes = require('../../components/colorscale/color_attributes');
+
 var MARKER_SYMBOLS = require('../../constants/gl_markers');
 var extendFlat = require('../../lib/extend').extendFlat;
+var extendDeep = require('../../lib/extend').extendDeep;
 
 var scatterLineAttrs = scatterAttrs.line,
     scatterMarkerAttrs = scatterAttrs.marker,
@@ -101,8 +104,10 @@ module.exports = {
         width: scatterLineAttrs.width,
         dash: scatterLineAttrs.dash
     },
-    marker: {  // Parity with scatter.js?
-        color: scatterMarkerAttrs.color,
+    // Currently, `marker` etc. contain mixed attributes (colorAttributes
+    // and a bunch of others); maybe a future API change could wrap parts
+    // that belong together, under a `colorspec` or similar attribute name.
+    marker: extendDeep({}, colorAttributes('marker'), {  // Parity with scatter.js?
         symbol: {
             valType: 'enumerated',
             values: Object.keys(MARKER_SYMBOLS),
@@ -126,24 +131,11 @@ module.exports = {
                 'to an rgba color and use its alpha channel.'
             ].join(' ')
         }),
-        colorscale: scatterMarkerAttrs.colorscale,
-        cauto: scatterMarkerAttrs.cauto,
-        cmax: scatterMarkerAttrs.cmax,
-        cmin: scatterMarkerAttrs.cmin,
-        autocolorscale: scatterMarkerAttrs.autocolorscale,
-        reversescale: scatterMarkerAttrs.reversescale,
         showscale: scatterMarkerAttrs.showscale,
-        line: {
-            color: scatterMarkerLineAttrs.color,
-            width: extendFlat({}, scatterMarkerLineAttrs.width, {arrayOk: false}),
-            colorscale: scatterMarkerLineAttrs.colorscale,
-            cauto: scatterMarkerLineAttrs.cauto,
-            cmax: scatterMarkerLineAttrs.cmax,
-            cmin: scatterMarkerLineAttrs.cmin,
-            autocolorscale: scatterMarkerLineAttrs.autocolorscale,
-            reversescale: scatterMarkerLineAttrs.reversescale
-        }
-    },
+        line: extendDeep({}, colorAttributes('marker.line'), {
+            width: extendFlat({}, scatterMarkerLineAttrs.width, {arrayOk: false})
+        })
+    }),
     textposition: extendFlat({}, scatterAttrs.textposition, {dflt: 'top center'}),
     textfont: scatterAttrs.textfont,
     _nestedModules: {

--- a/src/traces/scattergeo/attributes.js
+++ b/src/traces/scattergeo/attributes.js
@@ -13,12 +13,10 @@ var plotAttrs = require('../../plots/attributes');
 var colorAttributes = require('../../components/colorscale/color_attributes');
 
 var extendFlat = require('../../lib/extend').extendFlat;
-var extendDeep = require('../../lib/extend').extendDeep;
 
 var scatterMarkerAttrs = scatterAttrs.marker,
     scatterLineAttrs = scatterAttrs.line,
     scatterMarkerLineAttrs = scatterMarkerAttrs.line;
-
 
 module.exports = {
     lon: {
@@ -63,7 +61,7 @@ module.exports = {
         width: scatterLineAttrs.width,
         dash: scatterLineAttrs.dash
     },
-    marker: extendDeep({}, colorAttributes('marker'), {
+    marker: extendFlat({}, {
         symbol: scatterMarkerAttrs.symbol,
         opacity: scatterMarkerAttrs.opacity,
         size: scatterMarkerAttrs.size,
@@ -71,10 +69,13 @@ module.exports = {
         sizemin: scatterMarkerAttrs.sizemin,
         sizemode: scatterMarkerAttrs.sizemode,
         showscale: scatterMarkerAttrs.showscale,
-        line: extendDeep({}, colorAttributes('marker.line'), {
-            width: scatterMarkerLineAttrs.width
-        })
-    }),
+        line: extendFlat({},
+            {width: scatterMarkerLineAttrs.width},
+            colorAttributes('marker.line')
+        )
+    },
+        colorAttributes('marker')
+    ),
     textfont: scatterAttrs.textfont,
     textposition: scatterAttrs.textposition,
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {

--- a/src/traces/scattergeo/attributes.js
+++ b/src/traces/scattergeo/attributes.js
@@ -10,7 +10,10 @@
 
 var scatterAttrs = require('../scatter/attributes');
 var plotAttrs = require('../../plots/attributes');
+var colorAttributes = require('../../components/colorscale/color_attributes');
+
 var extendFlat = require('../../lib/extend').extendFlat;
+var extendDeep = require('../../lib/extend').extendDeep;
 
 var scatterMarkerAttrs = scatterAttrs.marker,
     scatterLineAttrs = scatterAttrs.line,
@@ -60,32 +63,18 @@ module.exports = {
         width: scatterLineAttrs.width,
         dash: scatterLineAttrs.dash
     },
-    marker: {
+    marker: extendDeep({}, colorAttributes('marker'), {
         symbol: scatterMarkerAttrs.symbol,
         opacity: scatterMarkerAttrs.opacity,
         size: scatterMarkerAttrs.size,
         sizeref: scatterMarkerAttrs.sizeref,
         sizemin: scatterMarkerAttrs.sizemin,
         sizemode: scatterMarkerAttrs.sizemode,
-        color: scatterMarkerAttrs.color,
-        colorscale: scatterMarkerAttrs.colorscale,
-        cauto: scatterMarkerAttrs.cauto,
-        cmax: scatterMarkerAttrs.cmax,
-        cmin: scatterMarkerAttrs.cmin,
-        autocolorscale: scatterMarkerAttrs.autocolorscale,
-        reversescale: scatterMarkerAttrs.reversescale,
         showscale: scatterMarkerAttrs.showscale,
-        line: {
-            color: scatterMarkerLineAttrs.color,
-            width: scatterMarkerLineAttrs.width,
-            colorscale: scatterMarkerLineAttrs.colorscale,
-            cauto: scatterMarkerLineAttrs.cauto,
-            cmax: scatterMarkerLineAttrs.cmax,
-            cmin: scatterMarkerLineAttrs.cmin,
-            autocolorscale: scatterMarkerLineAttrs.autocolorscale,
-            reversescale: scatterMarkerLineAttrs.reversescale
-        }
-    },
+        line: extendDeep({}, colorAttributes('marker.line'), {
+            width: scatterMarkerLineAttrs.width
+        })
+    }),
     textfont: scatterAttrs.textfont,
     textposition: scatterAttrs.textposition,
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {

--- a/src/traces/scattergl/attributes.js
+++ b/src/traces/scattergl/attributes.js
@@ -9,9 +9,12 @@
 'use strict';
 
 var scatterAttrs = require('../scatter/attributes');
+var colorAttributes = require('../../components/colorscale/color_attributes');
+
 var DASHES = require('../../constants/gl2d_dashes');
 var MARKERS = require('../../constants/gl_markers');
 var extendFlat = require('../../lib/extend').extendFlat;
+var extendDeep = require('../../lib/extend').extendDeep;
 
 var scatterLineAttrs = scatterAttrs.line,
     scatterMarkerAttrs = scatterAttrs.marker,
@@ -53,8 +56,7 @@ module.exports = {
             description: 'Sets the style of the lines.'
         }
     },
-    marker: {
-        color: scatterMarkerAttrs.color,
+    marker: extendDeep({}, colorAttributes('marker'), {
         symbol: {
             valType: 'enumerated',
             values: Object.keys(MARKERS),
@@ -68,24 +70,11 @@ module.exports = {
         sizemin: scatterMarkerAttrs.sizemin,
         sizemode: scatterMarkerAttrs.sizemode,
         opacity: scatterMarkerAttrs.opacity,
-        colorscale: scatterMarkerAttrs.colorscale,
-        cauto: scatterMarkerAttrs.cauto,
-        cmax: scatterMarkerAttrs.cmax,
-        cmin: scatterMarkerAttrs.cmin,
-        autocolorscale: scatterMarkerAttrs.autocolorscale,
-        reversescale: scatterMarkerAttrs.reversescale,
         showscale: scatterMarkerAttrs.showscale,
-        line: {
-            color: scatterMarkerLineAttrs.color,
-            width: scatterMarkerLineAttrs.width,
-            colorscale: scatterMarkerLineAttrs.colorscale,
-            cauto: scatterMarkerLineAttrs.cauto,
-            cmax: scatterMarkerLineAttrs.cmax,
-            cmin: scatterMarkerLineAttrs.cmin,
-            autocolorscale: scatterMarkerLineAttrs.autocolorscale,
-            reversescale: scatterMarkerLineAttrs.reversescale
-        }
-    },
+        line: extendDeep({}, colorAttributes('marker.line'), {
+            width: scatterMarkerLineAttrs.width
+        })
+    }),
     connectgaps: scatterAttrs.connectgaps,
     fill: extendFlat({}, scatterAttrs.fill, {
         values: ['none', 'tozeroy', 'tozerox']

--- a/src/traces/scatterternary/attributes.js
+++ b/src/traces/scatterternary/attributes.js
@@ -13,12 +13,10 @@ var plotAttrs = require('../../plots/attributes');
 var colorAttributes = require('../../components/colorscale/color_attributes');
 
 var extendFlat = require('../../lib/extend').extendFlat;
-var extendDeep = require('../../lib/extend').extendDeep;
 
 var scatterMarkerAttrs = scatterAttrs.marker,
     scatterLineAttrs = scatterAttrs.line,
     scatterMarkerLineAttrs = scatterMarkerAttrs.line;
-
 
 module.exports = {
     a: {
@@ -98,7 +96,7 @@ module.exports = {
         ].join(' ')
     }),
     fillcolor: scatterAttrs.fillcolor,
-    marker: extendDeep({}, colorAttributes('marker'), {
+    marker: extendFlat({}, {
         symbol: scatterMarkerAttrs.symbol,
         opacity: scatterMarkerAttrs.opacity,
         maxdisplayed: scatterMarkerAttrs.maxdisplayed,
@@ -107,10 +105,13 @@ module.exports = {
         sizemin: scatterMarkerAttrs.sizemin,
         sizemode: scatterMarkerAttrs.sizemode,
         showscale: scatterMarkerAttrs.showscale,
-        line: extendDeep({}, colorAttributes('marker'.line), {
-            width: scatterMarkerLineAttrs.width
-        })
-    }),
+        line: extendFlat({},
+            {width: scatterMarkerLineAttrs.width},
+            colorAttributes('marker'.line)
+        )
+    },
+        colorAttributes('marker')
+    ),
     textfont: scatterAttrs.textfont,
     textposition: scatterAttrs.textposition,
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {

--- a/src/traces/scatterternary/attributes.js
+++ b/src/traces/scatterternary/attributes.js
@@ -10,7 +10,10 @@
 
 var scatterAttrs = require('../scatter/attributes');
 var plotAttrs = require('../../plots/attributes');
+var colorAttributes = require('../../components/colorscale/color_attributes');
+
 var extendFlat = require('../../lib/extend').extendFlat;
+var extendDeep = require('../../lib/extend').extendDeep;
 
 var scatterMarkerAttrs = scatterAttrs.marker,
     scatterLineAttrs = scatterAttrs.line,
@@ -95,7 +98,7 @@ module.exports = {
         ].join(' ')
     }),
     fillcolor: scatterAttrs.fillcolor,
-    marker: {
+    marker: extendDeep({}, colorAttributes('marker'), {
         symbol: scatterMarkerAttrs.symbol,
         opacity: scatterMarkerAttrs.opacity,
         maxdisplayed: scatterMarkerAttrs.maxdisplayed,
@@ -103,25 +106,11 @@ module.exports = {
         sizeref: scatterMarkerAttrs.sizeref,
         sizemin: scatterMarkerAttrs.sizemin,
         sizemode: scatterMarkerAttrs.sizemode,
-        color: scatterMarkerAttrs.color,
-        colorscale: scatterMarkerAttrs.colorscale,
-        cauto: scatterMarkerAttrs.cauto,
-        cmax: scatterMarkerAttrs.cmax,
-        cmin: scatterMarkerAttrs.cmin,
-        autocolorscale: scatterMarkerAttrs.autocolorscale,
-        reversescale: scatterMarkerAttrs.reversescale,
         showscale: scatterMarkerAttrs.showscale,
-        line: {
-            color: scatterMarkerLineAttrs.color,
-            width: scatterMarkerLineAttrs.width,
-            colorscale: scatterMarkerLineAttrs.colorscale,
-            cauto: scatterMarkerLineAttrs.cauto,
-            cmax: scatterMarkerLineAttrs.cmax,
-            cmin: scatterMarkerLineAttrs.cmin,
-            autocolorscale: scatterMarkerLineAttrs.autocolorscale,
-            reversescale: scatterMarkerLineAttrs.reversescale
-        }
-    },
+        line: extendDeep({}, colorAttributes('marker'.line), {
+            width: scatterMarkerLineAttrs.width
+        })
+    }),
     textfont: scatterAttrs.textfont,
     textposition: scatterAttrs.textposition,
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {

--- a/src/traces/surface/attributes.js
+++ b/src/traces/surface/attributes.js
@@ -6,13 +6,11 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
 var Color = require('../../components/color');
 var colorscaleAttrs = require('../../components/colorscale/attributes');
 var extendFlat = require('../../lib/extend').extendFlat;
-
 
 function makeContourProjAttr(axLetter) {
     return {
@@ -121,6 +119,7 @@ module.exports = {
         ].join(' ')
     },
 
+    // Todo this block has a structure of colorscale/attributes.js but with colorscale/color_attributes.js names
     cauto: colorscaleAttrs.zauto,
     cmin: colorscaleAttrs.zmin,
     cmax: colorscaleAttrs.zmax,


### PR DESCRIPTION
This is a PR that is a prequel to #581 (covered with a PoC already) with the purpose of centralizing shared color attribute specifications. This is a non-functional change that consolidates attribute lines but should leave operations identical, beyond the odd case where the new version sometimes has more descriptive descriptions (the former code sometimes used `marker` even when the reference was included in `marker.line`). The new vertex/line color spec solution for #581 can thus use the new color spec attributes in bulk, without having to add them one by one.