### PR TITLE
Run in testbed shortcut script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,12 +16,12 @@ dependencies:
   post:
     - npm run cibuild
     - docker run -d --name mytestbed -v $PWD:/var/www/streambed/image_server/plotly.js -p 9010:9010 plotly/testbed:latest
-    - sudo lxc-attach -n "$(docker inspect --format '{{.Id}}' mytestbed)" -- bash -c "cp -f /var/www/streambed/image_server/plotly.js/test/image/index.html /var/www/streambed/image_server/server_app/index.html"
+    - sudo ./tasks/run_in_testbed.sh mytestbed "cp -f test/image/index.html ../server_app/index.html"
     - wget --server-response --spider --tries=8 --retry-connrefused http://localhost:9010/ping
 test:
   override:
-    - sudo lxc-attach -n "$(docker inspect --format '{{.Id}}' mytestbed)" -- bash -c "cd /var/www/streambed/image_server/plotly.js && node test/image/compare_pixels_test.js"
-    - sudo lxc-attach -n "$(docker inspect --format '{{.Id}}' mytestbed)" -- bash -c "cd /var/www/streambed/image_server/plotly.js && node test/image/export_test.js"
+    - sudo ./tasks/run_in_testbed.sh mytestbed "node test/image/compare_pixels_test.js"
+    - sudo ./tasks/run_in_testbed.sh mytestbed "node test/image/export_test.js"
     - npm run citest-jasmine
     - npm run test-bundle
     - npm run test-syntax

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bundle": "node tasks/bundle.js",
     "header": "node tasks/header.js",
     "build": "npm run preprocess && npm run bundle && npm run header",
-    "cibuild": "node tasks/cibundle.js",
+    "cibuild": "npm run preprocess && node tasks/cibundle.js",
     "watch": "node tasks/watch_plotly.js",
     "lint": "eslint . || true",
     "lint-fix": "eslint . --fix",

--- a/tasks/run_in_testbed.sh
+++ b/tasks/run_in_testbed.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+#
+# Useful shortcut to run command inside the `testbed` docker container
+# on CircleCI.
+#
+# ===============================================================================
+
+ID="$1"
+CMD="$2"
+
+CONTAINER="$(docker inspect --format '{{.Id}}' $ID)"
+REPOPATH="/var/www/streambed/image_server/plotly.js"
+
+lxc-attach -n $CONTAINER -- bash -c "cd $REPOPATH && $CMD"


### PR DESCRIPTION
@mdtusz @perigee 

This PR DRYs up our `circle.yml`, while making it more readable (I think).

The script `run_in_testbed.sh` also works locally (once you have `lxc` installed), but isn't necessary as `docker exec` essentially does the same.

Note that `docker exec` does not work on CircleCI (see [here](https://circleci.com/docs/docker/#docker-exec)).
