### PR TITLE
Fixup relayout images in { astr: val } notation

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2278,8 +2278,9 @@ Plotly.relayout = function relayout(gd, astr, val) {
             // as it is we get separate calls for x and y (or ax and ay) on move
             objModule.draw(gd, objNum, p.parts.slice(2).join('.'), aobj[ai]);
             delete aobj[ai];
-        } else if(p.parts[0] === 'images') {
-            var update = Lib.objectFromPath(astr, vi);
+        }
+        else if(p.parts[0] === 'images') {
+            var update = Lib.objectFromPath(ai, vi);
             Lib.extendDeepAll(gd.layout, update);
 
             Images.supplyLayoutDefaults(gd.layout, gd._fullLayout);

--- a/test/jasmine/tests/layout_images_test.js
+++ b/test/jasmine/tests/layout_images_test.js
@@ -260,6 +260,22 @@ describe('Layout images', function() {
             }).then(done);
         });
 
+        it('should update the image position if changed', function(done) {
+            var update = {
+                'images[0].x': 0,
+                'images[0].y': 1
+            };
+
+            var img = Plotly.d3.select('image');
+
+            expect([+img.attr('x'), +img.attr('y')]).toEqual([1160, -170]);
+
+            Plotly.relayout(gd, update).then(function() {
+                var newImg = Plotly.d3.select('image');
+                expect([+newImg.attr('x'), +newImg.attr('y')]).toEqual([80, 100]);
+            }).then(done);
+        });
+
         it('should remove the image tag if an invalid source', function(done) {
 
             var selection = Plotly.d3.select('image');


### PR DESCRIPTION
@mdtusz 

For example,

```js
Plotly.relayout(gd, { 'images[0].x': 0, 'images[0].y': 1 });
```

is broken currently.

The fix was easy ... once I made sense of all those tiny relayout variable names.