### PR TITLE
autosize: Fix `Plots.resize` backwards-compatibility

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -293,9 +293,8 @@ plots.resize = function(gd) {
                 return;
             }
 
-            delete gd._fullLayout._initialAutoSizeIsDone;
-            if(!gd.layout.width) delete (gd._fullLayout || {}).width;
-            if(!gd.layout.height) delete (gd._fullLayout || {}).height;
+            delete gd.layout.width;
+            delete gd.layout.height;
 
             // autosizing doesn't count as a change that needs saving
             var oldchanged = gd.changed;
@@ -303,7 +302,7 @@ plots.resize = function(gd) {
             // nor should it be included in the undo queue
             gd.autoplay = true;
 
-            Plotly.plot(gd).then(function() {
+            Plotly.relayout(gd, { autosize: true }).then(function() {
                 gd.changed = oldchanged;
                 resolve(gd);
             });


### PR DESCRIPTION
See [this comment](https://github.com/plotly/plotly.js/pull/577/files/fbc01c3dc26b4bc3ba005cac87ce128f71fa9551#r66725021) for context.

If this is the desired behaviour for `Plots.resize(gd)`, I will add a test to the PR.