### PR TITLE
Ignore files in the mock directory that aren't .json (e.g. .DS_Store)

### DIFF
--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -36,7 +36,10 @@ else runSingle(userFileName);
 function runAll() {
     test('testing mocks', function(t) {
 
-        var allMocks = fs.readdirSync(constants.pathToTestImageMocks);
+        var fileNames = fs.readdirSync(constants.pathToTestImageMocks);
+
+        // eliminate pollutants (e.g .DS_Store) that can accumulate in the mock directory
+        var allMocks = fileNames.filter(function(name) {return name.slice(-5) === '.json';});
 
         /* Test cases:
          *


### PR DESCRIPTION
(cherry picked from commit 8240de2)

This is another place where a non-json file can trip up the process. With this change, `npm run test-image` will only attempt to process `.json` files rather than reporting ILLEGAL token.