### PR TITLE
Fix hover label after resize bug

### DIFF
--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -337,8 +337,13 @@ function hover(gd, evt, subplot) {
         // 'cartesian' case
         var plotObj = plots[spId];
         if(plotObj) {
-            xaArray[i] = plotObj.xaxis;
-            yaArray[i] = plotObj.yaxis;
+
+            // TODO make sure that fullLayout_plots axis refs
+            // get updated properly so that we don't have
+            // to use Axes.getFromId in general.
+
+            xaArray[i] = Axes.getFromId(gd, plotObj.xaxis._id);
+            yaArray[i] = Axes.getFromId(gd, plotObj.yaxis._id);
             continue;
         }
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2,6 +2,7 @@ var d3 = require('d3');
 
 var Plotly = require('@lib/index');
 var Fx = require('@src/plots/cartesian/graph_interact');
+var constants = require('@src/plots/cartesian/constants');
 var Lib = require('@src/lib');
 
 var createGraphDiv = require('../assets/create_graph_div');
@@ -602,6 +603,52 @@ describe('hover info on overlaid subplots', function() {
             expect(textNodes[1][0].innerHTML).toEqual('Revenue', 'with correct hover labels');
             expect(textNodes[1][1].innerHTML).toEqual('2,352.5', 'with correct hover labels');
 
+        }).then(done);
+    });
+});
+
+describe('hover after resizing', function() {
+    'use strict';
+
+    afterEach(destroyGraphDiv);
+
+    function assertLabelCount(pos, cnt, msg) {
+        return new Promise(function(resolve) {
+            mouseEvent('mousemove', pos[0], pos[1]);
+
+            setTimeout(function() {
+                var hoverText = d3.selectAll('g.hovertext');
+                expect(hoverText.size()).toEqual(cnt, msg);
+
+                resolve();
+            }, constants.HOVERMINTIME);
+        });
+    }
+
+    it('should work', function(done) {
+        var data = [{ y: [2, 1, 2] }],
+            layout = { width: 600, height: 500 },
+            gd = createGraphDiv();
+
+        var pos0 = [311, 409],
+            pos1 = [407, 128];
+
+        Plotly.plot(gd, data, layout).then(function() {
+            return assertLabelCount(pos0, 1, 'before resize, showing pt label');
+        }).then(function() {
+            return assertLabelCount(pos1, 0, 'before resize, not showing blank spot');
+        }).then(function() {
+            return Plotly.relayout(gd, 'width', 500);
+        }).then(function() {
+            return assertLabelCount(pos0, 0, 'after resize, not showing blank spot');
+        }).then(function() {
+            return assertLabelCount(pos1, 1, 'after resize, showing pt label');
+        }).then(function() {
+            return Plotly.relayout(gd, 'width', 600);
+        }).then(function() {
+            return assertLabelCount(pos0, 1, 'back to initial, showing pt label');
+        }).then(function() {
+            return assertLabelCount(pos1, 0, 'back to initial, not showing blank spot');
         }).then(done);
     });
 });


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/606

by grabbing refs to x/y axis using `Axes.getFromId` instead of looking into `fullLayout._plots` -
as it was done before commit https://github.com/plotly/plotly.js/pull/575/commits/858a3388a316544ee298ef86d65d70c83a160426 .

But really, the axis refs in `fullLayout._plots` should **always** be up-to-date. A future maintenance PR should address this.