### PR TITLE
Miscellaneous mapbox tweaks

### DIFF
--- a/src/plots/mapbox/convert_text_opts.js
+++ b/src/plots/mapbox/convert_text_opts.js
@@ -1,0 +1,72 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+var Lib = require('../../lib');
+
+
+/**
+ * Convert plotly.js 'textposition' to mapbox-gl 'anchor' and 'offset'
+ * (with the help of the icon size).
+ *
+ * @param {string} textpostion : plotly.js textposition value
+ * @param {number} iconSize : plotly.js icon size (e.g. marker.size for traces)
+ *
+ * @return {object}
+ *      - anchor
+ *      - offset
+ */
+module.exports = function convertTextOpts(textposition, iconSize) {
+    var parts = textposition.split(' '),
+        vPos = parts[0],
+        hPos = parts[1];
+
+    // ballpack values
+    var factor = Array.isArray(iconSize) ? Lib.mean(iconSize) : iconSize,
+        xInc = 0.5 + (factor / 100),
+        yInc = 1.5 + (factor / 100);
+
+    var anchorVals = ['', ''],
+        offset = [0, 0];
+
+    switch(vPos) {
+        case 'top':
+            anchorVals[0] = 'top';
+            offset[1] = -yInc;
+            break;
+        case 'bottom':
+            anchorVals[0] = 'bottom';
+            offset[1] = yInc;
+            break;
+    }
+
+    switch(hPos) {
+        case 'left':
+            anchorVals[1] = 'right';
+            offset[0] = -xInc;
+            break;
+        case 'right':
+            anchorVals[1] = 'left';
+            offset[0] = xInc;
+            break;
+    }
+
+    // Mapbox text-anchor must be one of:
+    //  center, left, right, top, bottom,
+    //  top-left, top-right, bottom-left, bottom-right
+
+    var anchor;
+    if(anchorVals[0] && anchorVals[1]) anchor = anchorVals.join('-');
+    else if(anchorVals[0]) anchor = anchorVals[0];
+    else if(anchorVals[1]) anchor = anchorVals[1];
+    else anchor = 'center';
+
+    return { anchor: anchor, offset: offset };
+};

--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -182,6 +182,7 @@ function convertOpts(opts) {
             });
 
             Lib.extendFlat(paint, {
+                'icon-color': opts.color,
                 'text-color': symbol.textfont.color,
                 'text-opacity': opts.opacity
             });

--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -126,21 +126,32 @@ function convertPaintOpts(opts) {
 
     switch(opts.type) {
 
-        case 'line':
+        case 'circle':
+            var circle = opts.circle;
             Lib.extendFlat(paintOpts, {
-                'line-width': opts.line.width,
-                'line-color': opts.line.color,
+                'circle-radius': circle.radius,
+                'circle-color': circle.color,
+                'circle-opacity': opts.opacity
+            });
+            break;
+
+        case 'line':
+            var line = opts.line;
+            Lib.extendFlat(paintOpts, {
+                'line-width': line.width,
+                'line-color': line.color,
                 'line-opacity': opts.opacity
             });
             break;
 
         case 'fill':
+            var fill = opts.fill;
             Lib.extendFlat(paintOpts, {
-                'fill-color': opts.fillcolor,
-                'fill-outline-color': opts.line.color,
+                'fill-color': fill.color,
+                'fill-outline-color': fill.outlinecolor,
                 'fill-opacity': opts.opacity
 
-                // no way to pass line.width at the moment
+                // no way to pass specify outline width at the moment
             });
             break;
     }

--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -48,16 +48,13 @@ proto.update = function update(opts) {
 proto.needsNewSource = function(opts) {
 
     // for some reason changing layer to 'fill' or 'symbol'
-    // w/o changing the source throws an exception in mapbox-gl 0.18
-
-    var changesToFill = (this.layerType !== 'fill' && opts.type === 'fill'),
-        changesToSymbol = (this.layerType !== 'symbol' && opts.type === 'symbol');
+    // w/o changing the source throws an exception in mapbox-gl 0.18 ;
+    // stay safe and make new source on type changes
 
     return (
         this.sourceType !== opts.sourcetype ||
         this.source !== opts.source ||
-        changesToFill ||
-        changesToSymbol
+        this.layerType !== opts.type
     );
 };
 

--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -45,9 +45,15 @@ proto.update = function update(opts) {
 };
 
 proto.needsNewSource = function(opts) {
+
+    // for some reason changing layer to 'fill' w/o changing the source
+    // throws an exception in mapbox-gl 0.18
+    var changesToFill = (this.layerType !== 'fill' && opts.type === 'fill');
+
     return (
         this.sourceType !== opts.sourcetype ||
-        this.source !== opts.source
+        this.source !== opts.source ||
+        changesToFill
     );
 };
 

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
+var Lib = require('../../lib');
 var defaultLine = require('../../components/color').defaultLine;
+var fontAttrs = require('../font_attributes');
+var textposition = require('../../traces/scatter/attributes').textposition;
 
 
 module.exports = {
@@ -125,7 +128,7 @@ module.exports = {
 
         type: {
             valType: 'enumerated',
-            values: ['circle', 'line', 'fill'],
+            values: ['circle', 'line', 'fill', 'symbol'],
             dflt: 'line',
             role: 'info',
             description: [
@@ -206,6 +209,43 @@ module.exports = {
             }
         },
 
+        symbol: {
+            icon: {
+                valType: 'string',
+                dflt: 'circle',
+                role: 'style',
+                description: [
+                    'Sets the symbol icon image.',
+                    'Full list: https://www.mapbox.com/maki-icons/'
+                ].join(' ')
+            },
+            iconsize: {
+                valType: 'number',
+                dflt: 10,
+                role: 'style',
+                description: [
+                    'Sets the icon size.',
+                    'Has an effect only when `type` is set to *symbol*.'
+                ].join(' ')
+            },
+            text: {
+                valType: 'string',
+                dflt: '',
+                role: 'info',
+                description: [
+                    'Sets the symbol text.'
+                ].join(' ')
+            },
+            textfont: Lib.extendDeep({}, fontAttrs, {
+                description: [
+                    'Sets the icon text font.',
+                    'Has an effect only when `type` is set to *symbol*.'
+                ].join(' '),
+                family: {
+                    dflt: 'Open Sans Regular, Arial Unicode MS Regular'
+                }
+            }),
+            textposition: Lib.extendFlat({}, textposition, { arrayOk: false })
         }
     }
 

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -9,11 +9,7 @@
 
 'use strict';
 
-var scatterMapboxAttrs = require('../../traces/scattermapbox/attributes');
 var defaultLine = require('../../components/color').defaultLine;
-var extendFlat = require('../../lib').extendFlat;
-
-var lineAttrs = scatterMapboxAttrs.line;
 
 
 module.exports = {
@@ -129,12 +125,14 @@ module.exports = {
 
         type: {
             valType: 'enumerated',
-            values: ['line', 'fill'],
+            values: ['circle', 'line', 'fill'],
             dflt: 'line',
             role: 'info',
             description: [
                 'Sets the layer type.',
-                'Support for *raster*, *background* types is coming soon.'
+                'Support for *raster*, *background* types is coming soon.',
+                'Note that *line* and *fill* are not compatible with Point',
+                'GeoJSON geometry.'
             ].join(' ')
         },
 
@@ -150,14 +148,68 @@ module.exports = {
             ].join(' ')
         },
 
-        line: {
-            color: extendFlat({}, lineAttrs.color, {
-                dflt: defaultLine
-            }),
-            width: lineAttrs.width
+        circle: {
+            radius: {
+                valType: 'number',
+                dflt: 15,
+                role: 'style',
+                description: [
+                    'Sets the circle radius.',
+                    'Has an effect only when `type` is set to *circle*.'
+                ].join(' ')
+            },
+            color: {
+                valType: 'color',
+                dflt: defaultLine,
+                role: 'style',
+                description: [
+                    'Sets the circle color.',
+                    'Has an effect only when `type` is set to *circle*.'
+                ].join(' ')
+            }
         },
 
-        fillcolor: scatterMapboxAttrs.fillcolor,
+        line: {
+            width: {
+                valType: 'number',
+                dflt: 2,
+                role: 'style',
+                description: [
+                    'Sets the line radius.',
+                    'Has an effect only when `type` is set to *line*.'
+                ].join(' ')
+            },
+            color: {
+                valType: 'color',
+                dflt: defaultLine,
+                role: 'style',
+                description: [
+                    'Sets the line color.',
+                    'Has an effect only when `type` is set to *line*.'
+                ].join(' ')
+            }
+        },
+
+        fill: {
+            color: {
+                valType: 'color',
+                dflt: defaultLine,
+                role: 'style',
+                description: [
+                    'Sets the fill color.',
+                    'Has an effect only when `type` is set to *fill*.'
+                ].join(' ')
+            },
+            outlinecolor: {
+                valType: 'color',
+                dflt: defaultLine,
+                role: 'style',
+                description: [
+                    'Sets the fill outline color.',
+                    'Has an effect only when `type` is set to *fill*.'
+                ].join(' ')
+            }
+        },
 
         opacity: {
             valType: 'number',

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -224,7 +224,7 @@ module.exports = {
                 dflt: 10,
                 role: 'style',
                 description: [
-                    'Sets the icon size.',
+                    'Sets the symbol icon size.',
                     'Has an effect only when `type` is set to *symbol*.'
                 ].join(' ')
             },

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -212,7 +212,7 @@ module.exports = {
         symbol: {
             icon: {
                 valType: 'string',
-                dflt: 'circle',
+                dflt: 'marker',
                 role: 'style',
                 description: [
                     'Sets the symbol icon image.',

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -136,6 +136,7 @@ module.exports = {
             ].join(' ')
         },
 
+        // attributes shared between all types
         below: {
             valType: 'string',
             dflt: '',
@@ -147,7 +148,28 @@ module.exports = {
                 'the layer will be inserted above every existing layer.'
             ].join(' ')
         },
+        color: {
+            valType: 'color',
+            dflt: defaultLine,
+            role: 'style',
+            description: [
+                'Sets the primary layer color.',
+                'If `type` is *circle*, color corresponds to the circle color',
+                'If `type` is *line*, color corresponds to the line color',
+                'If `type` is *fill*, color corresponds to the fill color',
+                'If `type` is *symbol*, color corresponds to the icon color'
+            ].join(' ')
+        },
+        opacity: {
+            valType: 'number',
+            min: 0,
+            max: 1,
+            dflt: 1,
+            role: 'info',
+            description: 'Sets the opacity of the layer.'
+        },
 
+        // type-specific style attributes
         circle: {
             radius: {
                 valType: 'number',
@@ -155,15 +177,6 @@ module.exports = {
                 role: 'style',
                 description: [
                     'Sets the circle radius.',
-                    'Has an effect only when `type` is set to *circle*.'
-                ].join(' ')
-            },
-            color: {
-                valType: 'color',
-                dflt: defaultLine,
-                role: 'style',
-                description: [
-                    'Sets the circle color.',
                     'Has an effect only when `type` is set to *circle*.'
                 ].join(' ')
             }
@@ -178,28 +191,10 @@ module.exports = {
                     'Sets the line radius.',
                     'Has an effect only when `type` is set to *line*.'
                 ].join(' ')
-            },
-            color: {
-                valType: 'color',
-                dflt: defaultLine,
-                role: 'style',
-                description: [
-                    'Sets the line color.',
-                    'Has an effect only when `type` is set to *line*.'
-                ].join(' ')
             }
         },
 
         fill: {
-            color: {
-                valType: 'color',
-                dflt: defaultLine,
-                role: 'style',
-                description: [
-                    'Sets the fill color.',
-                    'Has an effect only when `type` is set to *fill*.'
-                ].join(' ')
-            },
             outlinecolor: {
                 valType: 'color',
                 dflt: defaultLine,
@@ -211,13 +206,6 @@ module.exports = {
             }
         },
 
-        opacity: {
-            valType: 'number',
-            min: 0,
-            max: 1,
-            dflt: 1,
-            role: 'info',
-            description: 'Sets the opacity of the layer.'
         }
     }
 

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -129,13 +129,13 @@ module.exports = {
         type: {
             valType: 'enumerated',
             values: ['circle', 'line', 'fill', 'symbol'],
-            dflt: 'line',
+            dflt: 'circle',
             role: 'info',
             description: [
                 'Sets the layer type.',
                 'Support for *raster*, *background* types is coming soon.',
                 'Note that *line* and *fill* are not compatible with Point',
-                'GeoJSON geometry.'
+                'GeoJSON geometries.'
             ].join(' ')
         },
 

--- a/src/plots/mapbox/layout_defaults.js
+++ b/src/plots/mapbox/layout_defaults.js
@@ -49,7 +49,7 @@ function handleLayerDefaults(containerIn, containerOut) {
     }
 
     for(var i = 0; i < layersIn.length; i++) {
-        layerIn = layersIn[i];
+        layerIn = layersIn[i] || {};
         layerOut = {};
 
         var sourceType = coerce('sourcetype');
@@ -57,18 +57,31 @@ function handleLayerDefaults(containerIn, containerOut) {
 
         if(sourceType === 'vector') coerce('sourcelayer');
 
-        // maybe add smart default based off 'fillcolor' ???
+        // maybe add smart default based off GeoJSON geometry
         var type = coerce('type');
 
-        var lineColor;
-        if(type === 'line' || type === 'fill') {
-            lineColor = coerce('line.color');
+        var dfltColor;
+
+        if(type === 'circle') {
+            dfltColor = (layerIn.line || {}).color || (layerIn.fill || {}).color;
+
+            coerce('circle.color', dfltColor);
+            coerce('circle.radius');
         }
 
-        // no way to pass line.width to fill layers
-        if(type === 'line') coerce('line.width');
+        if(type === 'line') {
+            dfltColor = (layerIn.circle || {}).color || (layerIn.fill || {}).color;
 
-        if(type === 'fill') coerce('fillcolor', lineColor);
+            coerce('line.color', dfltColor);
+            coerce('line.width');
+        }
+
+        if(type === 'fill') {
+            dfltColor = (layerIn.circle || {}).color || (layerIn.line || {}).color;
+
+            coerce('fill.color', dfltColor);
+            coerce('fill.outlinecolor', dfltColor);
+        }
 
         coerce('below');
         coerce('opacity');

--- a/src/plots/mapbox/layout_defaults.js
+++ b/src/plots/mapbox/layout_defaults.js
@@ -57,34 +57,25 @@ function handleLayerDefaults(containerIn, containerOut) {
 
         if(sourceType === 'vector') coerce('sourcelayer');
 
-        // maybe add smart default based off GeoJSON geometry
+        // maybe add smart default based off GeoJSON geometry?
         var type = coerce('type');
 
-        var dfltColor;
+        coerce('below');
+        coerce('color');
+        coerce('opacity');
 
         if(type === 'circle') {
-            dfltColor = (layerIn.line || {}).color || (layerIn.fill || {}).color;
-
-            coerce('circle.color', dfltColor);
             coerce('circle.radius');
         }
 
         if(type === 'line') {
-            dfltColor = (layerIn.circle || {}).color || (layerIn.fill || {}).color;
-
-            coerce('line.color', dfltColor);
             coerce('line.width');
         }
 
         if(type === 'fill') {
-            dfltColor = (layerIn.circle || {}).color || (layerIn.line || {}).color;
-
-            coerce('fill.color', dfltColor);
-            coerce('fill.outlinecolor', dfltColor);
+            coerce('fill.outlinecolor');
         }
 
-        coerce('below');
-        coerce('opacity');
 
         layersOut.push(layerOut);
     }

--- a/src/plots/mapbox/layout_defaults.js
+++ b/src/plots/mapbox/layout_defaults.js
@@ -76,6 +76,14 @@ function handleLayerDefaults(containerIn, containerOut) {
             coerce('fill.outlinecolor');
         }
 
+        if(type === 'symbol') {
+            coerce('symbol.icon');
+            coerce('symbol.iconsize');
+
+            coerce('symbol.text');
+            Lib.coerceFont(coerce, 'symbol.textfont');
+            coerce('symbol.textposition');
+        }
 
         layersOut.push(layerOut);
     }

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -96,7 +96,8 @@ proto.createMap = function(calcData, fullLayout, resolve, reject) {
     });
 
     // clear navigation container
-    var controlContainer = this.div.getElementsByClassName(constants.controlContainerClassName)[0];
+    var className = constants.controlContainerClassName,
+        controlContainer = this.div.getElementsByClassName(className)[0];
     this.div.removeChild(controlContainer);
 
     self.rejectOnError(reject);

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -114,6 +114,8 @@ proto.createMap = function(calcData, fullLayout, resolve, reject) {
         var center = map.getCenter();
         opts._input.center = opts.center = { lon: center.lng, lat: center.lat };
         opts._input.zoom = opts.zoom = map.getZoom();
+        opts._input.bearing = opts.bearing = map.getBearing();
+        opts._input.pitch = opts.pitch = map.getPitch();
     });
 
     map.on('mousemove', function(evt) {

--- a/src/traces/scattermapbox/attributes.js
+++ b/src/traces/scattermapbox/attributes.js
@@ -10,6 +10,7 @@
 
 var scatterGeoAttrs = require('../scattergeo/attributes');
 var scatterAttrs = require('../scatter/attributes');
+var mapboxAttrs = require('../../plots/mapbox/layout_attributes');
 var plotAttrs = require('../../plots/attributes');
 var extendFlat = require('../../lib/extend').extendFlat;
 
@@ -104,8 +105,8 @@ module.exports = {
     },
     fillcolor: scatterAttrs.fillcolor,
 
-    textfont: extendFlat({}, scatterAttrs.textfont, { arrayOk: false }),
-    textposition: extendFlat({}, scatterAttrs.textposition, { arrayOk: false }),
+    textfont: mapboxAttrs.layers.symbol.textfont,
+    textposition: mapboxAttrs.layers.symbol.textposition,
 
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {
         flags: ['lon', 'lat', 'text', 'name']

--- a/src/traces/scattermapbox/convert.js
+++ b/src/traces/scattermapbox/convert.js
@@ -11,6 +11,7 @@
 
 var Lib = require('../../lib');
 var subTypes = require('../scatter/subtypes');
+var convertTextOpts = require('../../plots/mapbox/convert_text_opts');
 
 var COLOR_PROP = 'circle-color';
 var SIZE_PROP = 'circle-radius';
@@ -108,7 +109,8 @@ module.exports = function convert(calcTrace) {
         }
 
         if(hasText) {
-            var textOpts = calcTextOpts(trace);
+            var iconSize = (trace.marker || {}).size,
+                textOpts = convertTextOpts(trace.textposition, iconSize);
 
             Lib.extendFlat(symbol.layout, {
                 'text-size': trace.textfont.size,
@@ -307,56 +309,6 @@ function calcCircleRadius(trace, hash) {
     }
 
     return out;
-}
-
-function calcTextOpts(trace) {
-    var textposition = trace.textposition,
-        parts = textposition.split(' '),
-        vPos = parts[0],
-        hPos = parts[1];
-
-    // ballpack values
-    var ms = (trace.marker || {}).size,
-        factor = Array.isArray(ms) ? Lib.mean(ms) : ms,
-        xInc = 0.5 + (factor / 100),
-        yInc = 1.5 + (factor / 100);
-
-    var anchorVals = ['', ''],
-        offset = [0, 0];
-
-    switch(vPos) {
-        case 'top':
-            anchorVals[0] = 'top';
-            offset[1] = -yInc;
-            break;
-        case 'bottom':
-            anchorVals[0] = 'bottom';
-            offset[1] = yInc;
-            break;
-    }
-
-    switch(hPos) {
-        case 'left':
-            anchorVals[1] = 'right';
-            offset[0] = -xInc;
-            break;
-        case 'right':
-            anchorVals[1] = 'left';
-            offset[0] = xInc;
-            break;
-    }
-
-    // Mapbox text-anchor must be one of:
-    //  center, left, right, top, bottom,
-    //  top-left, top-right, bottom-left, bottom-right
-
-    var anchor;
-    if(anchorVals[0] && anchorVals[1]) anchor = anchorVals.join('-');
-    else if(anchorVals[0]) anchor = anchorVals[0];
-    else if(anchorVals[1]) anchor = anchorVals[1];
-    else anchor = 'center';
-
-    return { anchor: anchor, offset: offset };
 }
 
 function getCoords(calcTrace) {

--- a/src/traces/scattermapbox/convert.js
+++ b/src/traces/scattermapbox/convert.js
@@ -111,10 +111,12 @@ module.exports = function convert(calcTrace) {
             var textOpts = calcTextOpts(trace);
 
             Lib.extendFlat(symbol.layout, {
-                'text-font': trace.textfont.textfont,
                 'text-size': trace.textfont.size,
                 'text-anchor': textOpts.anchor,
                 'text-offset': textOpts.offset
+
+                // TODO font family
+                //'text-font': symbol.textfont.family.split(', '),
             });
 
             Lib.extendFlat(symbol.paint, {

--- a/src/traces/scattermapbox/defaults.js
+++ b/src/traces/scattermapbox/defaults.js
@@ -45,7 +45,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     coerce('mode');
 
     if(subTypes.hasLines(traceOut)) {
-        handleLineDefaults(traceIn, traceOut, defaultColor, coerce);
+        handleLineDefaults(traceIn, traceOut, defaultColor, layout, coerce);
         coerce('connectgaps');
     }
 

--- a/test/image/assets/get_image_paths.js
+++ b/test/image/assets/get_image_paths.js
@@ -20,10 +20,10 @@ module.exports = function getImagePaths(mockName, format) {
     return {
         baseline: join(constants.pathToTestImageBaselines, mockName, format),
         test: join(constants.pathToTestImages, mockName, format),
-        diff: join(constants.pathToTestImagesDiff, mockName, format)
+        diff: join(constants.pathToTestImagesDiff, 'diff-' + mockName, format)
     };
 };
 
-function join(basePath, mockName, format) {
-    return path.join(basePath, mockName) + '.' + format;
+function join(basePath, fileName, format) {
+    return path.join(basePath, fileName) + '.' + format;
 }

--- a/test/image/mocks/mapbox_layers.json
+++ b/test/image/mocks/mapbox_layers.json
@@ -532,9 +532,7 @@
           },
           "type": "fill",
           "below": "water",
-          "fill": {
-            "color": "#ece2f0"
-          },
+          "color": "#ece2f0",
           "opacity": 0.8
         },
         {

--- a/test/image/mocks/mapbox_layers.json
+++ b/test/image/mocks/mapbox_layers.json
@@ -532,7 +532,9 @@
           },
           "type": "fill",
           "below": "water",
-          "fillcolor": "#ece2f0",
+          "fill": {
+            "color": "#ece2f0"
+          },
           "opacity": 0.8
         },
         {

--- a/test/image/mocks/mapbox_layers.json
+++ b/test/image/mocks/mapbox_layers.json
@@ -539,9 +539,10 @@
           "sourcetype": "vector",
           "source": "mapbox://mapbox.mapbox-terrain-v2",
           "sourcelayer": "contour",
+          "type": "line",
+          "color": "red",
           "line": {
-            "width": 2,
-            "color": "red"
+            "width": 2
           }
         }
       ]

--- a/test/jasmine/assets/has_webgl_support.js
+++ b/test/jasmine/assets/has_webgl_support.js
@@ -1,0 +1,22 @@
+'use strict';
+
+
+module.exports = function hasWebGLSupport(testName) {
+    var gl, canvas;
+
+    try {
+        canvas = document.createElement('canvas');
+        gl = canvas.getContext('webgl');
+    }
+    catch(err) {
+        gl = null;
+    }
+
+    var hasSupport = !!gl;
+
+    if(!hasSupport) {
+        console.warn('Cannot get WebGL context. Skip test *' + testName + '*');
+    }
+
+    return hasSupport;
+};

--- a/test/jasmine/karma.ciconf.js
+++ b/test/jasmine/karma.ciconf.js
@@ -17,9 +17,7 @@ function func(config) {
     func.defaultConfig.exclude = [
         'tests/gl_plot_interact_test.js',
         'tests/gl_plot_interact_basic_test.js',
-        'tests/gl2d_scatterplot_contour_test.js',
-        'tests/mapbox_test.js',
-        'tests/scattermapbox_test.js'
+        'tests/gl2d_scatterplot_contour_test.js'
     ];
 
     // if true, Karma captures browsers, runs the tests and exits

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -7,6 +7,7 @@ var supplyLayoutDefaults = require('@src/plots/mapbox/layout_defaults');
 var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
+var hasWebGLSupport = require('../assets/has_webgl_support');
 var mouseEvent = require('../assets/mouse_event');
 var customMatchers = require('../assets/custom_matchers');
 
@@ -121,6 +122,8 @@ describe('mapbox defaults', function() {
 describe('mapbox credentials', function() {
     'use strict';
 
+    if(!hasWebGLSupport('scattermapbox hover')) return;
+
     var dummyToken = 'asfdsa124331wersdsa1321q3';
     var gd;
 
@@ -167,6 +170,8 @@ describe('mapbox credentials', function() {
 
 describe('mapbox plots', function() {
     'use strict';
+
+    if(!hasWebGLSupport('scattermapbox hover')) return;
 
     var mock = require('@mocks/mapbox_0.json'),
         gd;

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -85,40 +85,47 @@ describe('mapbox defaults', function() {
     });
 
     it('should only coerce relevant layer style attributes', function() {
+        var base = {
+            line: { width: 3 },
+            fill: { outlinecolor: '#d3d3d3' },
+            circle: { radius: 20 },
+            symbol: { icon: 'monument' }
+        };
+
         layoutIn = {
             mapbox: {
-                layers: [{
-                    sourcetype: 'vector',
-                    type: 'line',
-                    line: {
-                        color: 'red',
-                        width: 3
-                    },
-                    fillcolor: 'blue'
-                }, {
-                    sourcetype: 'geojson',
-                    type: 'fill',
-                    line: {
-                        color: 'red',
-                        width: 3
-                    },
-                    fill: {
-                        color: 'blue',
-                        outlinecolor: 'green'
-                    }
-                }]
+                layers: [
+                    Lib.extendFlat({}, base, {
+                        type: 'line',
+                        color: 'red'
+                    }),
+                    Lib.extendFlat({}, base, {
+                        type: 'fill',
+                        color: 'blue'
+                    }),
+                    Lib.extendFlat({}, base, {
+                        type: 'circle',
+                        color: 'green'
+                    }),
             }
         };
 
         supplyLayoutDefaults(layoutIn, layoutOut, fullData);
 
-        expect(layoutOut.mapbox.layers[0].line.color).toEqual('red');
+        expect(layoutOut.mapbox.layers[0].color).toEqual('red');
         expect(layoutOut.mapbox.layers[0].line.width).toEqual(3);
         expect(layoutOut.mapbox.layers[0].fill).toBeUndefined();
+        expect(layoutOut.mapbox.layers[0].circle).toBeUndefined();
 
+        expect(layoutOut.mapbox.layers[1].color).toEqual('blue');
+        expect(layoutOut.mapbox.layers[1].fill.outlinecolor).toEqual('#d3d3d3');
         expect(layoutOut.mapbox.layers[1].line).toBeUndefined();
-        expect(layoutOut.mapbox.layers[1].fill.color).toEqual('blue');
-        expect(layoutOut.mapbox.layers[1].fill.outlinecolor).toEqual('green');
+        expect(layoutOut.mapbox.layers[1].circle).toBeUndefined();
+
+        expect(layoutOut.mapbox.layers[2].color).toEqual('green');
+        expect(layoutOut.mapbox.layers[2].circle.radius).toEqual(20);
+        expect(layoutOut.mapbox.layers[2].line).toBeUndefined();
+        expect(layoutOut.mapbox.layers[2].fill).toBeUndefined();
     });
 });
 

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -102,7 +102,10 @@ describe('mapbox defaults', function() {
                         color: 'red',
                         width: 3
                     },
-                    fillcolor: 'blue'
+                    fill: {
+                        color: 'blue',
+                        outlinecolor: 'green'
+                    }
                 }]
             }
         };
@@ -111,11 +114,11 @@ describe('mapbox defaults', function() {
 
         expect(layoutOut.mapbox.layers[0].line.color).toEqual('red');
         expect(layoutOut.mapbox.layers[0].line.width).toEqual(3);
-        expect(layoutOut.mapbox.layers[0].fillcolor).toBeUndefined();
+        expect(layoutOut.mapbox.layers[0].fill).toBeUndefined();
 
-        expect(layoutOut.mapbox.layers[1].line.color).toEqual('red');
-        expect(layoutOut.mapbox.layers[1].line.width).toBeUndefined();
-        expect(layoutOut.mapbox.layers[1].fillcolor).toEqual('blue');
+        expect(layoutOut.mapbox.layers[1].line).toBeUndefined();
+        expect(layoutOut.mapbox.layers[1].fill.color).toEqual('blue');
+        expect(layoutOut.mapbox.layers[1].fill.outlinecolor).toEqual('green');
     });
 });
 
@@ -353,8 +356,8 @@ describe('mapbox plots', function() {
         };
 
         var styleUpdate0 = {
-            'mapbox.layers[0].fillcolor': 'red',
-            'mapbox.layers[0].line.color': 'blue',
+            'mapbox.layers[0].fill.color': 'red',
+            'mapbox.layers[0].fill.outlinecolor': 'blue',
             'mapbox.layers[0].opacity': 0.3
         };
 

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -107,6 +107,11 @@ describe('mapbox defaults', function() {
                         type: 'circle',
                         color: 'green'
                     }),
+                    Lib.extendFlat({}, base, {
+                        type: 'symbol',
+                        color: 'yellow'
+                    })
+                ]
             }
         };
 
@@ -116,16 +121,25 @@ describe('mapbox defaults', function() {
         expect(layoutOut.mapbox.layers[0].line.width).toEqual(3);
         expect(layoutOut.mapbox.layers[0].fill).toBeUndefined();
         expect(layoutOut.mapbox.layers[0].circle).toBeUndefined();
+        expect(layoutOut.mapbox.layers[0].symbol).toBeUndefined();
 
         expect(layoutOut.mapbox.layers[1].color).toEqual('blue');
         expect(layoutOut.mapbox.layers[1].fill.outlinecolor).toEqual('#d3d3d3');
         expect(layoutOut.mapbox.layers[1].line).toBeUndefined();
         expect(layoutOut.mapbox.layers[1].circle).toBeUndefined();
+        expect(layoutOut.mapbox.layers[1].symbol).toBeUndefined();
 
         expect(layoutOut.mapbox.layers[2].color).toEqual('green');
         expect(layoutOut.mapbox.layers[2].circle.radius).toEqual(20);
         expect(layoutOut.mapbox.layers[2].line).toBeUndefined();
         expect(layoutOut.mapbox.layers[2].fill).toBeUndefined();
+        expect(layoutOut.mapbox.layers[2].symbol).toBeUndefined();
+
+        expect(layoutOut.mapbox.layers[3].color).toEqual('yellow');
+        expect(layoutOut.mapbox.layers[3].symbol.icon).toEqual('monument');
+        expect(layoutOut.mapbox.layers[3].line).toBeUndefined();
+        expect(layoutOut.mapbox.layers[3].fill).toBeUndefined();
+        expect(layoutOut.mapbox.layers[3].circle).toBeUndefined();
     });
 });
 
@@ -363,14 +377,14 @@ describe('mapbox plots', function() {
         };
 
         var styleUpdate0 = {
-            'mapbox.layers[0].fill.color': 'red',
+            'mapbox.layers[0].color': 'red',
             'mapbox.layers[0].fill.outlinecolor': 'blue',
             'mapbox.layers[0].opacity': 0.3
         };
 
         var styleUpdate1 = {
+            'mapbox.layers[1].color': 'blue',
             'mapbox.layers[1].line.width': 3,
-            'mapbox.layers[1].line.color': 'blue',
             'mapbox.layers[1].opacity': 0.6
         };
 

--- a/test/jasmine/tests/scattermapbox_test.js
+++ b/test/jasmine/tests/scattermapbox_test.js
@@ -7,6 +7,7 @@ var convert = require('@src/traces/scattermapbox/convert');
 
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
+var hasWebGLSupport = require('../assets/has_webgl_support');
 var customMatchers = require('../assets/custom_matchers');
 
 // until it is part of the main plotly.js bundle
@@ -410,6 +411,8 @@ describe('scattermapbox convert', function() {
 describe('scattermapbox hover', function() {
     'use strict';
 
+    if(!hasWebGLSupport('scattermapbox hover')) return;
+
     var hoverPoints = ScatterMapbox.hoverPoints;
 
     var gd;
@@ -456,7 +459,7 @@ describe('scattermapbox hover', function() {
 
         expect(out.index).toEqual(0);
         expect([out.x0, out.x1, out.y0, out.y1]).toBeCloseToArray([
-            444.444, 446.444, 105.410, 107.410
+            297.444, 299.444, 105.410, 107.410
         ]);
         expect(out.extraText).toEqual('(10°, 10°)<br>A');
         expect(out.color).toEqual('#1f77b4');
@@ -470,7 +473,7 @@ describe('scattermapbox hover', function() {
 
         expect(out.index).toEqual(0);
         expect([out.x0, out.x1, out.y0, out.y1]).toBeCloseToArray([
-            2492.444, 2494.444, 105.410, 107.410
+            2345.444, 2347.444, 105.410, 107.410
         ]);
         expect(out.extraText).toEqual('(10°, 10°)<br>A');
         expect(out.color).toEqual('#1f77b4');
@@ -484,7 +487,7 @@ describe('scattermapbox hover', function() {
 
         expect(out.index).toEqual(0);
         expect([out.x0, out.x1, out.y0, out.y1]).toBeCloseToArray([
-            -2627.555, -2625.555, 105.410, 107.410
+            -2774.555, -2772.555, 105.410, 107.410
         ]);
         expect(out.extraText).toEqual('(10°, 10°)<br>A');
         expect(out.color).toEqual('#1f77b4');


### PR DESCRIPTION
@chriddyp please review.

### What this PR adds

- Two  _new_ `mapbox.layers` types :arrow_right: `'circle'` and `'symbol'` (along side the current `'fill'` and `'line'`). This allows GeoJSON point geometries to be drawn as mapbox [`circle`](https://www.mapbox.com/mapbox-gl-style-spec/#layers-circle) or symbol layers.
- Some mapbox jasmine tests are now tested on CircleCi. All mapbox jasmine tests that do no required a `gl` context are now tested on CircleCI. So that hot fixes like https://github.com/plotly/plotly.js/commit/9c7254887954c77c8010d4896babd57fd9d703d2 won't be needed again. See https://github.com/plotly/plotly.js/commit/4a8563b5dcf3045b0407e9f7fe6acb4aaa4054ba for more.

### What this PR modifies

- The `mapbox.layers` attribute changed a little. They are now more one-to-one with the mapbox layer [specs](https://www.mapbox.com/mapbox-gl-style-spec/#layers) where each layer `type` gets a container object of its own to fill in style attribute. Note that color in inherited from container to container. See https://github.com/plotly/plotly.js/commit/32973fc9520ae893c116256d2474d8ec0bbc0209 for more details.
- `mapbox.layers[i].type` default is now `'circle'`. So that even Point GeoJSON can be seen with the default layer type.
-  `mapbox.layers[i].color` is now set layer-wide. It corresponds to the primary color of the layer regardless of its type.


### What this PR fixes

- Some edge case (probably a mapbox-gl bug) when switching the layer `type` to `'fill'` c1cd50cdb382fe5da15ae61c8a15552bca6010aa
- Bearing and pitch angles changed on mouse move are recorded in user data https://github.com/plotly/plotly.js/commit/17f3378053022aed5b9aff2bbda9e80b68075f18


![gifrecord_2016-06-22_161946](https://cloud.githubusercontent.com/assets/6675409/16282098/3fe5956c-3895-11e6-8024-22b21f42daf3.gif)
