### PR TITLE
Make invalid mapbox layers work with relayout 

### DIFF
--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -27,12 +27,21 @@ function MapboxLayer(mapbox, index) {
     this.source = null;
     this.layerType = null;
     this.below = null;
+
+    // is layer currently visible
+    this.visible = false;
 }
 
 var proto = MapboxLayer.prototype;
 
 proto.update = function update(opts) {
-    if(this.needsNewSource(opts)) {
+    if(!this.visible) {
+
+        // IMPORTANT: must create source before layer to not cause errors
+        this.updateSource(opts);
+        this.updateLayer(opts);
+    }
+    else if(this.needsNewSource(opts)) {
 
         // IMPORTANT: must delete layer before source to not cause errors
         this.updateLayer(opts);
@@ -43,6 +52,8 @@ proto.update = function update(opts) {
     }
 
     this.updateStyle(opts);
+
+    this.visible = isVisible(opts);
 };
 
 proto.needsNewSource = function(opts) {
@@ -209,10 +220,7 @@ function convertSourceOpts(opts) {
 module.exports = function createMapboxLayer(mapbox, index, opts) {
     var mapboxLayer = new MapboxLayer(mapbox, index);
 
-    // IMPORTANT: must create source before layer to not cause errors
-    mapboxLayer.updateSource(opts);
-    mapboxLayer.updateLayer(opts);
-    mapboxLayer.updateStyle(opts);
+    mapboxLayer.update(opts);
 
     return mapboxLayer;
 };

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -461,6 +461,16 @@ describe('mapbox plots', function() {
         }).then(function() {
             expect(countVisibleLayers(gd)).toEqual(0);
 
+            return Plotly.relayout(gd, 'mapbox.layers[0]', {});
+        }).then(function() {
+            expect(countVisibleLayers(gd)).toEqual(0);
+
+            // layer with no source are not drawn
+
+            return Plotly.relayout(gd, 'mapbox.layers[0].source', layer0.source);
+        }).then(function() {
+            expect(countVisibleLayers(gd)).toEqual(1);
+
             done();
         });
     });

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -146,7 +146,7 @@ describe('mapbox defaults', function() {
 describe('mapbox credentials', function() {
     'use strict';
 
-    if(!hasWebGLSupport('scattermapbox hover')) return;
+    if(!hasWebGLSupport('mapbox credentials')) return;
 
     var dummyToken = 'asfdsa124331wersdsa1321q3';
     var gd;
@@ -195,7 +195,7 @@ describe('mapbox credentials', function() {
 describe('mapbox plots', function() {
     'use strict';
 
-    if(!hasWebGLSupport('scattermapbox hover')) return;
+    if(!hasWebGLSupport('mapbox plots')) return;
 
     var mock = require('@mocks/mapbox_0.json'),
         gd;


### PR DESCRIPTION
Previously,

```js
// create an empty layer
relayout(gd, {'mapbox.layers[0]': {}});

// add geojson to that layer
relayout(gd, {'mapbox.layers[0].source': geojson});
```

resulted in errors. This PR fixes it.