### PR TITLE
Introducing Plotly.validate(data, layout)

### DIFF
--- a/src/components/colorscale/is_valid_scale_array.js
+++ b/src/components/colorscale/is_valid_scale_array.js
@@ -14,20 +14,24 @@ var tinycolor = require('tinycolor2');
 
 module.exports = function isValidScaleArray(scl) {
     var isValid = true,
-        highestVal = 0,
-        si;
+        highestVal = 0;
 
-    if(!Array.isArray(scl)) return false;
-    else {
-        if(+scl[0][0] !== 0 || +scl[scl.length - 1][0] !== 1) return false;
-        for(var i = 0; i < scl.length; i++) {
-            si = scl[i];
-            if(si.length !== 2 || +si[0] < highestVal || !tinycolor(si[1]).isValid()) {
-                isValid = false;
-                break;
-            }
-            highestVal = +si[0];
+    if(!Array.isArray(scl) || scl.length === 0) return false;
+
+    if(!scl[0] || !scl[scl.length - 1]) return false;
+
+    if(+scl[0][0] !== 0 || +scl[scl.length - 1][0] !== 1) return false;
+
+    for(var i = 0; i < scl.length; i++) {
+        var si = scl[i];
+
+        if(si.length !== 2 || +si[0] < highestVal || !tinycolor(si[1]).isValid()) {
+            isValid = false;
+            break;
         }
-        return isValid;
+
+        highestVal = +si[0];
     }
+
+    return isValid;
 };

--- a/src/components/colorscale/is_valid_scale_array.js
+++ b/src/components/colorscale/is_valid_scale_array.js
@@ -13,10 +13,9 @@ var tinycolor = require('tinycolor2');
 
 
 module.exports = function isValidScaleArray(scl) {
-    var isValid = true,
-        highestVal = 0;
+    var highestVal = 0;
 
-    if(!Array.isArray(scl) || scl.length === 0) return false;
+    if(!Array.isArray(scl) || scl.length < 2) return false;
 
     if(!scl[0] || !scl[scl.length - 1]) return false;
 
@@ -26,12 +25,11 @@ module.exports = function isValidScaleArray(scl) {
         var si = scl[i];
 
         if(si.length !== 2 || +si[0] < highestVal || !tinycolor(si[1]).isValid()) {
-            isValid = false;
-            break;
+            return false;
         }
 
         highestVal = +si[0];
     }
 
-    return isValid;
+    return true;
 };

--- a/src/core.js
+++ b/src/core.js
@@ -33,6 +33,7 @@ exports.setPlotConfig = require('./plot_api/set_plot_config');
 exports.register = Plotly.register;
 exports.toImage = require('./plot_api/to_image');
 exports.downloadImage = require('./snapshot/download');
+exports.validate = require('./plot_api/validate');
 
 // plot icons
 exports.Icons = require('../build/ploticon');

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -177,6 +177,18 @@ exports.valObjects = {
                 return;
             }
             propOut.set(dflt);
+        },
+        validateFunction: function(v, opts) {
+            var dflt = opts.dflt,
+                dlen = dflt.length;
+
+            if(v === dflt) return true;
+            if(typeof v !== 'string') return false;
+            if(v.substr(0, dlen) === dflt && idRegex.test(v.substr(dlen))) {
+                return true;
+            }
+
+            return false;
         }
     },
     flaglist: {

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -164,11 +164,11 @@ exports.valObjects = {
     subplotid: {
         description: [
             'An id string of a subplot type (given by dflt), optionally',
-            'followed by an integer >1. e.g. if dflt=\'geo\', we can  have',
+            'followed by an integer >1. e.g. if dflt=\'geo\', we can have',
             '\'geo\', \'geo2\', \'geo3\', ...'
         ].join(' '),
-        requiredOpts: [],
-        otherOpts: ['dflt'],
+        requiredOpts: ['dflt'],
+        otherOpts: [],
         coerceFunction: function(v, propOut, dflt) {
             var dlen = dflt.length;
             if(typeof v === 'string' && v.substr(0, dlen) === dflt &&

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -99,16 +99,18 @@ exports.valObjects = {
         // TODO 'values shouldn't be in there (edge case: 'dash' in Scatter)
         otherOpts: ['dflt', 'noBlank', 'strict', 'arrayOk', 'values'],
         coerceFunction: function(v, propOut, dflt, opts) {
-            if(opts.strict === true && typeof v !== 'string') {
-                propOut.set(dflt);
-                return;
-            }
+            if(typeof v !== 'string') {
+                var okToCoerce = (
+                    typeof v === 'number' ||
+                    v instanceof Date ||
+                    typeof v === 'boolean'
+                );
 
-            var s = String(v);
-            if(v === undefined || (opts.noBlank === true && !s)) {
-                propOut.set(dflt);
+                if(opts.strict === true || !okToCoerce) propOut.set(dflt);
+                else propOut.set(String(v));
             }
-            else propOut.set(s);
+            else if(opts.noBlank && !v) propOut.set(dflt);
+            else propOut.set(v);
         }
     },
     color: {

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -255,14 +255,16 @@ exports.valObjects = {
 
             var items = opts.items;
 
-            // valid when one item is valid (which is subject to debate)
+            if(v.length !== items.length) return false;
+
+            // valid when all items are valid
             for(var i = 0; i < items.length; i++) {
                 var isItemValid = exports.validate(v[i], opts.items[i]);
 
-                if(isItemValid) return true;
+                if(!isItemValid) return false;
             }
 
-            return false;
+            return true;
         }
     }
 };

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -309,3 +309,22 @@ exports.coerceFont = function(coerce, attr, dfltObj) {
 
     return out;
 };
+
+exports.validate = function(value, opts) {
+    var valObject = exports.valObjects[opts.valType];
+
+    if(opts.arrayOk && Array.isArray(value)) return true;
+
+    if(valObject.validateFunction) {
+        return valObject.validateFunction(value, opts);
+    }
+
+    var failed = {},
+        out = failed,
+        propMock = { set: function(v) { out = v; } };
+
+    // 'failed' just something mutable that won't be === anything else
+
+    valObject.coerceFunction(value, propMock, failed, opts);
+    return out !== failed;
+};

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -100,11 +100,7 @@ exports.valObjects = {
         otherOpts: ['dflt', 'noBlank', 'strict', 'arrayOk', 'values'],
         coerceFunction: function(v, propOut, dflt, opts) {
             if(typeof v !== 'string') {
-                var okToCoerce = (
-                    typeof v === 'number' ||
-                    v instanceof Date ||
-                    typeof v === 'boolean'
-                );
+                var okToCoerce = (typeof v === 'number');
 
                 if(opts.strict === true || !okToCoerce) propOut.set(dflt);
                 else propOut.set(String(v));

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -241,6 +241,20 @@ exports.valObjects = {
             }
 
             propOut.set(vOut);
+        },
+        validateFunction: function(v, opts) {
+            if(!Array.isArray(v)) return false;
+
+            var items = opts.items;
+
+            // valid when one item is valid (which is subject to debate)
+            for(var i = 0; i < items.length; i++) {
+                var isItemValid = exports.validate(v[i], opts.items[i]);
+
+                if(isItemValid) return true;
+            }
+
+            return false;
         }
     }
 };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -21,6 +21,7 @@ lib.valObjects = coerceModule.valObjects;
 lib.coerce = coerceModule.coerce;
 lib.coerce2 = coerceModule.coerce2;
 lib.coerceFont = coerceModule.coerceFont;
+lib.validate = coerceModule.validate;
 
 var datesModule = require('./dates');
 lib.dateTime2ms = datesModule.dateTime2ms;

--- a/src/plot_api/validate.js
+++ b/src/plot_api/validate.js
@@ -24,6 +24,9 @@ var code2msgFunc = {
     schema: function(path) {
         return 'key ' + path.join('.') + ' is not part of the schema';
     },
+    container: function(path) {
+        return 'key ' + path.join('.') + ' is supposed to be linked to a container';
+    },
     unused: function(path, valIn) {
         var prefix = isPlainObject(valIn) ? 'container' : 'key';
 
@@ -114,6 +117,9 @@ function crawl(objIn, objOut, schema, list, path) {
         }
         else if(isPlainObject(valIn) && isPlainObject(valOut)) {
             crawl(valIn, valOut, nestedSchema, list, p);
+        }
+        else if(!isPlainObject(valIn) && isPlainObject(valOut)) {
+            list.push(format('container', p, valIn));
         }
         else if(nestedSchema.items && Array.isArray(valIn)) {
             var itemName = k.substr(0, k.length - 1);

--- a/src/plot_api/validate.js
+++ b/src/plot_api/validate.js
@@ -1,0 +1,156 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+
+var Lib = require('../lib');
+var Plots = require('../plots/plots');
+var PlotSchema = require('./plot_schema');
+
+var isPlainObject = Lib.isPlainObject;
+
+// validation error codes
+var code2msgFunc = {
+    invisible: function(path) {
+        return 'trace ' + path + ' got defaulted to be not visible';
+    },
+    schema: function(path) {
+        return 'key ' + path.join('.') + ' is not part of the schema';
+    },
+    unused: function(path, valIn) {
+        var prefix = isPlainObject(valIn) ? 'container' : 'key';
+
+        return prefix + ' ' + path.join('.') + ' did not get coerced';
+    },
+    value: function(path, valIn) {
+        return 'key ' + path.join('.') + ' is set to an invalid value (' + valIn + ')';
+    }
+};
+
+module.exports = function valiate(data, layout) {
+    if(!Array.isArray(data)) {
+        throw new Error('data must be an array');
+    }
+
+    if(!isPlainObject(layout)) {
+        throw new Error('layout must be an object');
+    }
+
+    var gd = {
+        data: Lib.extendDeep([], data),
+        layout: Lib.extendDeep({}, layout)
+    };
+    Plots.supplyDefaults(gd);
+
+    var schema = PlotSchema.get();
+
+    var dataOut = gd._fullData,
+        len = data.length,
+        dataList = new Array(len);
+
+    for(var i = 0; i < len; i++) {
+        var traceIn = data[i];
+        var traceList = dataList[i] = [];
+
+        if(!isPlainObject(traceIn)) {
+            throw new Error('each data trace must be an object');
+        }
+
+        var traceOut = dataOut[i],
+            traceType = traceOut.type,
+            traceSchema = schema.traces[traceType].attributes;
+
+        // PlotSchema does something fancy with trace 'type', reset it here
+        // to make the trace schema compatible with Lib.validate.
+        traceSchema.type = {
+            valType: 'enumerated',
+            values: [traceType]
+        };
+
+        if(traceOut.visible === false && traceIn.visible !== false) {
+            traceList.push(format('invisible', i));
+        }
+
+        crawl(traceIn, traceOut, traceSchema, traceList);
+    }
+
+    var layoutOut = gd._fullLayout,
+        layoutSchema = fillLayoutSchema(schema, dataOut),
+        layoutList = [];
+
+    crawl(layout, layoutOut, layoutSchema, layoutList);
+
+    return {
+        data: dataList,
+        layout: layoutList
+    };
+};
+
+function crawl(objIn, objOut, schema, list, path) {
+    path = path || [];
+
+    var keys = Object.keys(objIn);
+
+    for(var i = 0; i < keys.length; i++) {
+        var k = keys[i];
+
+        var p = path.slice();
+        p.push(k);
+
+        var valIn = objIn[k],
+            valOut = objOut[k];
+
+        if(isPlainObject(valIn) && isPlainObject(valOut)) {
+            crawl(valIn, valOut, schema[k], list, p);
+        }
+        else if(!(k in schema)) {
+            list.push(format('schema', p));
+        }
+        else if(schema[k].items && Array.isArray(valIn)) {
+            var itemName = k.substr(0, k.length - 1);
+
+            for(var j = 0; j < valIn.length; j++) {
+                p[p.length - 1] = k + '[' + j + ']';
+
+                crawl(valIn[j], valOut[j], schema[k].items[itemName], list, p);
+            }
+        }
+        else if(!(k in objOut)) {
+            list.push(format('unused', p, valIn));
+        }
+        else if(!Lib.validate(valIn, schema[k])) {
+            list.push(format('value', p, valIn));
+        }
+    }
+
+    return list;
+}
+
+// the 'full' layout schema depends on the traces types presents
+function fillLayoutSchema(schema, dataOut) {
+    for(var i = 0; i < dataOut.length; i++) {
+        var traceType = dataOut[i].type,
+            traceLayoutAttr = schema.traces[traceType].layoutAttributes;
+
+        if(traceLayoutAttr) {
+            Lib.extendFlat(schema.layout.layoutAttributes, traceLayoutAttr);
+        }
+    }
+
+    return schema.layout.layoutAttributes;
+}
+
+function format(code, path, valIn) {
+    return {
+        code: code,
+        path: path,
+        msg: code2msgFunc[code](path, valIn)
+    };
+}

--- a/test/jasmine/tests/colorscale_test.js
+++ b/test/jasmine/tests/colorscale_test.js
@@ -20,6 +20,13 @@ describe('Test colorscale:', function() {
 
         it('should accept only array of 2-item arrays', function() {
             expect(isValidScale('a')).toBe(false);
+            expect(isValidScale([])).toBe(false);
+            expect(isValidScale([null, undefined])).toBe(false);
+            expect(isValidScale([{}, [1, 'rgb(0, 0, 200']])).toBe(false);
+            expect(isValidScale([[0, 'rgb(200, 0, 0)'], {}])).toBe(false);
+            expect(isValidScale([[0, 'rgb(0, 0, 200)'], undefined])).toBe(false);
+            expect(isValidScale([null, [1, 'rgb(0, 0, 200)']])).toBe(false);
+            expect(isValidScale(['a', 'b'])).toBe(false);
             expect(isValidScale(['a'])).toBe(false);
             expect(isValidScale([['a'], ['b']])).toBe(false);
 

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -526,13 +526,13 @@ describe('Test lib.js:', function() {
                     .toEqual('42');
 
                 expect(coerce({s: [1, 2, 3]}, {}, stringAttrs, 's'))
-                    .toEqual('1,2,3');
+                    .toEqual(dflt);
 
                 expect(coerce({s: true}, {}, stringAttrs, 's'))
                     .toEqual('true');
 
                 expect(coerce({s: {1: 2}}, {}, stringAttrs, 's'))
-                    .toEqual('[object Object]'); // useless, but that's what it does!!
+                    .toEqual(dflt);
             });
         });
 
@@ -861,27 +861,26 @@ describe('Test lib.js:', function() {
         });
 
         it('should work for valType \'string\' where', function() {
+            var date = new Date(2016, 1, 1);
 
-            // This fails as the coerceFunction coerce all values
-            // (except when 'strict' is true) using String()
-            //
-            // Things like undefined, null, {}, [] should be considered valid!
-            //
-            // The question becomes how the change this while not
-            // scarifying perf??
-
-            assert(['3', '4', 'a'], [undefined, {}, [], null], {
+            assert(['3', '4', 'a', 3, 1.2113, '', date, false], [undefined, {}, [], null], {
                 valType: 'string',
                 dflt: 'a'
             });
 
-            assert(['3', '4', 'a'], [undefined, {}, [], null, ''], {
+            assert(['3', '4', 'a', 3, 1.2113, date, true], ['', undefined, {}, [], null], {
                 valType: 'string',
                 dflt: 'a',
                 noBlank: true
             });
 
-            assert(['3', '4'], [undefined, 1, {}, [], null, ''], {
+            assert(['3', '4', ''], [undefined, 1, {}, [], null, date, true, false], {
+                valType: 'string',
+                dflt: 'a',
+                strict: true
+            });
+
+            assert(['3', '4'], [undefined, 1, {}, [], null, date, '', true, false], {
                 valType: 'string',
                 dflt: 'a',
                 strict: true,

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -905,8 +905,6 @@ describe('Test lib.js:', function() {
                 bad3 = [ ['red'], ['blue']],
                 bad4 = ['red', 'blue'];
 
-            // Fails at [], should be an easy fix though.
-
             var shouldPass = ['Viridis', 'Greens', good],
                 shouldFail = ['red', 1, undefined, null, {}, [], bad, bad2, bad3, bad4];
 

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -626,7 +626,22 @@ describe('Test lib.js:', function() {
                     .toEqual([0.5, 1]);
             });
 
+            it('should coerce unexpected input as best as it can', function() {
+                expect(coerce({range: [12]}, {}, infoArrayAttrs, 'range'))
+                    .toEqual([12]);
 
+                expect(coerce({range: [12]}, {}, infoArrayAttrs, 'range', [-1, 20]))
+                    .toEqual([12, 20]);
+
+                expect(coerce({domain: [0.5]}, {}, infoArrayAttrs, 'domain'))
+                    .toEqual([0.5, 1]);
+
+                expect(coerce({range: ['-10', 100, 12]}, {}, infoArrayAttrs, 'range'))
+                    .toEqual([-10, 100]);
+
+                expect(coerce({domain: [0, 0.5, 1]}, {}, infoArrayAttrs, 'domain'))
+                    .toEqual([0, 0.5]);
+            });
         });
 
         describe('subplotid valtype', function() {

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -938,14 +938,8 @@ describe('Test lib.js:', function() {
         });
 
         it('should work for valType \'subplotid\' where', function() {
-            var shouldPass = ['sp', 'sp1', 'sp4'],
-                shouldFail = [{}, [], 'sp0', 'spee1', null, undefined];
-
-            // This fails because coerceFunction depends on dflt
-            // having a length.
-            //
-            // Solution: don't use dflt as base string ->
-            // add other options to valObject
+            var shouldPass = ['sp', 'sp4', 'sp10'],
+                shouldFail = [{}, [], 'sp1', 'sp0', 'spee1', null, undefined, true];
 
             assert(shouldPass, shouldFail, {
                 valType: 'subplotid',

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -770,7 +770,7 @@ describe('Test lib.js:', function() {
         });
     });
 
-    fdescribe('validate', function() {
+    describe('validate', function() {
 
         function assert(shouldPass, shouldFail, valObject) {
             shouldPass.forEach(function(v) {
@@ -974,10 +974,8 @@ describe('Test lib.js:', function() {
         });
 
         it('should work for valType \'info_array\' where', function() {
-            var shouldPass = [[1, 2]],
+            var shouldPass = [[1, 2], [10], [null, 10], [1, 10, null]],
                 shouldFail = [{}, [], ['aads', null], 'red', null, undefined, ''];
-
-            // This fails. All array including [] are considered valid
 
             assert(shouldPass, shouldFail, {
                 valType: 'info_array',

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -529,7 +529,7 @@ describe('Test lib.js:', function() {
                     .toEqual(dflt);
 
                 expect(coerce({s: true}, {}, stringAttrs, 's'))
-                    .toEqual('true');
+                    .toEqual(dflt);
 
                 expect(coerce({s: {1: 2}}, {}, stringAttrs, 's'))
                     .toEqual(dflt);
@@ -878,12 +878,12 @@ describe('Test lib.js:', function() {
         it('should work for valType \'string\' where', function() {
             var date = new Date(2016, 1, 1);
 
-            assert(['3', '4', 'a', 3, 1.2113, '', date, false], [undefined, {}, [], null], {
+            assert(['3', '4', 'a', 3, 1.2113, ''], [undefined, {}, [], null, date, false], {
                 valType: 'string',
                 dflt: 'a'
             });
 
-            assert(['3', '4', 'a', 3, 1.2113, date, true], ['', undefined, {}, [], null], {
+            assert(['3', '4', 'a', 3, 1.2113], ['', undefined, {}, [], null, date, true], {
                 valType: 'string',
                 dflt: 'a',
                 noBlank: true

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -968,8 +968,12 @@ describe('Test lib.js:', function() {
         });
 
         it('should work for valType \'info_array\' where', function() {
-            var shouldPass = [[1, 2], [10], [null, 10], [1, 10, null]],
-                shouldFail = [{}, [], ['aads', null], 'red', null, undefined, ''];
+            var shouldPass = [[1, 2], [-20, '20']],
+                shouldFail = [
+                    {}, [], [10], [null, 10], ['aads', null],
+                    'red', null, undefined, '',
+                    [1, 10, null]
+                ];
 
             assert(shouldPass, shouldFail, {
                 valType: 'info_array',

--- a/test/jasmine/tests/validate_test.js
+++ b/test/jasmine/tests/validate_test.js
@@ -1,0 +1,109 @@
+var Plotly = require('@lib/index');
+
+
+describe('Plotly.validate', function() {
+
+    function assertErrorShape(out, dataSize, layoutSize) {
+        var actualDataSize = out.data.map(function(t) {
+            return t.length;
+        });
+
+        expect(actualDataSize).toEqual(dataSize);
+        expect(out.layout.length).toEqual(layoutSize);
+    }
+
+    function assertErrorContent(obj, code, path) {
+        expect(obj.code).toEqual(code);
+        expect(obj.path).toEqual(path);
+
+        // TODO test msg
+    }
+
+    it('should report when trace is defaulted to not be visible', function() {
+        var out = Plotly.validate([{
+            type: 'scatter'
+            // missing 'x' and 'y
+        }], {});
+
+        assertErrorShape(out, [1], 0);
+        assertErrorContent(out.data[0][0], 'invisible', 0, '');
+    });
+
+    it('should report when trace contains keys not part of the schema', function() {
+        var out = Plotly.validate([{
+            x: [1, 2, 3],
+            markerColor: 'blue'
+        }], {});
+
+        assertErrorShape(out, [1], 0);
+        assertErrorContent(out.data[0][0], 'schema', ['markerColor'], '');
+    });
+
+    it('should report when trace contains keys that are not coerced', function() {
+        var out = Plotly.validate([{
+            x: [1, 2, 3],
+            mode: 'lines',
+            marker: { color: 'blue' }
+        }, {
+            x: [1, 2, 3],
+            mode: 'markers',
+            marker: {
+                color: 'blue',
+                cmin: 10
+            }
+        }], {});
+
+        assertErrorShape(out, [1, 1], 0);
+        expect(out.layout.length).toEqual(0);
+        assertErrorContent(out.data[0][0], 'unused', ['marker'], '');
+        assertErrorContent(out.data[1][0], 'unused', ['marker', 'cmin'], '');
+
+    });
+
+    it('should report when trace contains keys set to invalid values', function() {
+        var out = Plotly.validate([{
+            x: [1, 2, 3],
+            mode: 'lines',
+            line: { width: 'a big number' }
+        }, {
+            x: [1, 2, 3],
+            mode: 'markers',
+            marker: { color: 10 }
+        }], {});
+
+        assertErrorShape(out, [1, 1], 0);
+        assertErrorContent(out.data[0][0], 'value', ['line', 'width'], '');
+        assertErrorContent(out.data[1][0], 'value', ['marker', 'color'], '');
+    });
+
+    it('should work with isLinkedToArray attributes', function() {
+        var out = Plotly.validate([], {
+            annotations: [{
+                text: 'some text'
+            }, {
+                arrowSymbol: 'cat'
+            }],
+            xaxis: {
+                type: 'date',
+                rangeselector: {
+                    buttons: [{
+                        label: '1 month',
+                        step: 'all',
+                        count: 10
+                    }, {
+                        title: '1 month'
+                    }]
+                }
+            },
+            shapes: [{
+                opacity: 'none'
+            }]
+        });
+
+        assertErrorShape(out, [], 4);
+        assertErrorContent(out.layout[0], 'schema', ['annotations[1]', 'arrowSymbol'], '');
+        assertErrorContent(out.layout[1], 'unused', ['xaxis', 'rangeselector', 'buttons[0]', 'count'], '');
+        assertErrorContent(out.layout[2], 'schema', ['xaxis', 'rangeselector', 'buttons[1]', 'title'], '');
+        assertErrorContent(out.layout[3], 'value', ['shapes[0]', 'opacity'], '');
+    });
+});

--- a/test/jasmine/tests/validate_test.js
+++ b/test/jasmine/tests/validate_test.js
@@ -125,11 +125,13 @@ describe('Plotly.validate', function() {
                 bgcolor: 'red'
             },
             geo0: {},
+            yaxis5: 'sup'
         });
 
         assertErrorShape(out, [], 4);
         assertErrorContent(out.layout[0], 'value', ['xaxis2', 'range'], '');
         assertErrorContent(out.layout[1], 'unused', ['scene10'], '');
         assertErrorContent(out.layout[2], 'schema', ['geo0'], '');
+        assertErrorContent(out.layout[3], 'container', ['yaxis5'], '');
     });
 });

--- a/test/jasmine/tests/validate_test.js
+++ b/test/jasmine/tests/validate_test.js
@@ -95,15 +95,41 @@ describe('Plotly.validate', function() {
                     }]
                 }
             },
+            xaxis2: {
+                type: 'date',
+                rangeselector: {
+                    buttons: [{
+                        title: '1 month'
+                    }]
+                }
+            },
             shapes: [{
                 opacity: 'none'
             }]
         });
 
-        assertErrorShape(out, [], 4);
+        assertErrorShape(out, [], 5);
         assertErrorContent(out.layout[0], 'schema', ['annotations[1]', 'arrowSymbol'], '');
         assertErrorContent(out.layout[1], 'unused', ['xaxis', 'rangeselector', 'buttons[0]', 'count'], '');
         assertErrorContent(out.layout[2], 'schema', ['xaxis', 'rangeselector', 'buttons[1]', 'title'], '');
-        assertErrorContent(out.layout[3], 'value', ['shapes[0]', 'opacity'], '');
+        assertErrorContent(out.layout[3], 'schema', ['xaxis2', 'rangeselector', 'buttons[0]', 'title'], '');
+        assertErrorContent(out.layout[4], 'value', ['shapes[0]', 'opacity'], '');
+    });
+
+    it('should work with isSubplotObj attributes', function() {
+        var out = Plotly.validate([], {
+            xaxis2: {
+                range: 30
+            },
+            scene10: {
+                bgcolor: 'red'
+            },
+            geo0: {},
+        });
+
+        assertErrorShape(out, [], 4);
+        assertErrorContent(out.layout[0], 'value', ['xaxis2', 'range'], '');
+        assertErrorContent(out.layout[1], 'unused', ['scene10'], '');
+        assertErrorContent(out.layout[2], 'schema', ['geo0'], '');
     });
 });


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/598

based off [`plotly-validate`](https://github.com/plotly/plotly.js/compare/plotly-validate) and [`lib-validate`](https://github.com/plotly/plotly.js/compare/lib-validate).

### Example

```js
var data = [{
  type: 'bar',
  y: [2, 1, 2],
  orientation: 'horizontal'
}];

var out = Plotly.validate(data);

console.log(out[0].msg));
// "In data trace 0, key orientation is set to an invalid value (horizontal)"
```

### In brief

This PR expose a top-level method allowing users to validate their input `data` and `layout`. 

`Plotly.validate` calls `Plots.supplyDefaults` and `PlotSchema.get` and a new [`Lib.validate`](https://github.com/plotly/plotly.js/commit/e94eec31ca160e29f221fdcd5d1f048f1b8cb117) method internally to determine if:

- [code `'object'`] a container key isn't linked to an object
- [code `'array'`] an array container key isn't linked to an array
- [code `'schema'`] a key was found in a trace or layout object that is not part of the plot schema
- [code `'unused'`] a key was found in user input but isn't used in the plotting code (i.e. the key isn't found `fullData` or `fullLayout` )
- [code `'value'`] a value is invalid
- [code `'invisible'`] a trace was made `visible = false` by an invalid set of attributes

### Some remaining questions

- [x] How to handle non-array `data` and non-object `layout` input? Error out?, Output with different other error code?
- [x] When no validate errors found, should `Plotly.validate` return `true`? More generally, should `Plotly.validate` always return the a `{ data: [], layout: [] }` object?

Those questions :arrow_double_up:  were resolved in https://github.com/plotly/plotly.js/pull/697/commits/54a6ed0ea20abeeb0be2e75a3927457d4d341d01


