### PR TITLE
Bump dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "fuse.js": "^2.2.0",
     "glob": "^7.0.0",
     "jasmine-core": "^2.4.1",
-    "karma": "^0.13.15",
+    "karma": "^1.1.0",
     "karma-browserify": "^5.0.1",
     "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "browserify": "^13.0.0",
     "browserify-transform-tools": "^1.5.1",
     "ecstatic": "^1.4.0",
-    "eslint": "^2.8.0",
+    "eslint": "^3.0.0",
     "falafel": "^1.2.0",
     "fs-extra": "^0.30.0",
     "fuse.js": "^2.2.0",


### PR DESCRIPTION
This PR

- bumps `karma` to `1.1.0` 
- bumps `eslint` to `3.0.0`

with no patches to our code required, this is, if we trust CircleCI.

