### PR TITLE
Memory leak fixes

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -835,6 +835,10 @@ Plotly.redraw = function(gd) {
  */
 Plotly.newPlot = function(gd, data, layout, config) {
     gd = getGraphDiv(gd);
+
+    // remove gl contexts
+    Plots.cleanPlot([], {}, gd._fullData || {}, gd._fullLayout || {});
+
     Plots.purge(gd);
     return Plotly.plot(gd, data, layout, config);
 };

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -319,12 +319,12 @@ proto.destroy = function() {
     this.glplot = null;
     this.stopped = true;
 
-    var traces = this.traces
+    var traces = this.traces;
     if(traces) {
         Object.keys(traces).map(function(key) {
             traces[key].dispose();
             traces[key] = null;
-        })
+        });
     }
 };
 

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -318,6 +318,14 @@ proto.destroy = function() {
 
     this.glplot = null;
     this.stopped = true;
+
+    var traces = this.traces
+    if(traces) {
+        Object.keys(traces).map(function(key) {
+            traces[key].dispose();
+            traces[key] = null;
+        })
+    }
 };
 
 proto.plot = function(fullData, calcData, fullLayout) {

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -310,6 +310,16 @@ proto.cameraChanged = function() {
 };
 
 proto.destroy = function() {
+
+    var traces = this.traces;
+
+    if(traces) {
+        Object.keys(traces).map(function(key) {
+            traces[key].dispose();
+            delete traces[key];
+        });
+    }
+
     this.glplot.dispose();
 
     if(!this.staticPlot) this.container.removeChild(this.canvas);
@@ -318,14 +328,6 @@ proto.destroy = function() {
 
     this.glplot = null;
     this.stopped = true;
-
-    var traces = this.traces;
-    if(traces) {
-        Object.keys(traces).map(function(key) {
-            traces[key].dispose();
-            traces[key] = null;
-        });
-    }
 };
 
 proto.plot = function(fullData, calcData, fullLayout) {

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -809,6 +809,16 @@ plots.purge = function(gd) {
     // remove modebar
     if(fullLayout._modeBar) fullLayout._modeBar.destroy();
 
+    if(fullLayout._plots) {
+        Object.keys(fullLayout._plots).map(function(key) {
+            var plot = fullLayout._plots[key];
+            if(plot._scene2d) {
+                plot._scene2d.destroy();
+                plot._scene2d = null;
+            }
+        });
+    }
+
     // data and layout
     delete gd.data;
     delete gd.layout;

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -809,16 +809,6 @@ plots.purge = function(gd) {
     // remove modebar
     if(fullLayout._modeBar) fullLayout._modeBar.destroy();
 
-    if(fullLayout._plots) {
-        Object.keys(fullLayout._plots).map(function(key) {
-            var plot = fullLayout._plots[key];
-            if(plot._scene2d) {
-                plot._scene2d.destroy();
-                plot._scene2d = null;
-            }
-        });
-    }
-
     // data and layout
     delete gd.data;
     delete gd.layout;

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -507,41 +507,131 @@ describe('Test gl plot interactions', function() {
         });
     });
 
-    describe('Plots.cleanPlot', function() {
+    describe('Removal of gl contexts', function() {
 
-        it('should remove gl context from the graph div of a gl3d plot', function(done) {
-            gd = createGraphDiv();
+        var mockData2d = [{
+            type: 'scattergl',
+            x: [1, 2, 3],
+            y: [2, 1, 3]
+        }];
 
-            var mockData = [{
-                type: 'scatter3d'
-            }];
 
-            Plotly.plot(gd, mockData).then(function() {
-                expect(gd._fullLayout.scene._scene.glplot).toBeDefined();
+        var mockData3d = [{
+            type: 'scatter3d',
+            x: [1, 2, 3],
+            y: [2, 1, 3],
+            z: [3, 2, 1]
+        }];
 
-                Plots.cleanPlot([], {}, gd._fullData, gd._fullLayout);
-                expect(gd._fullLayout.scene._scene.glplot).toBe(null);
+        describe('Plots.cleanPlot', function() {
 
-                done();
+            it('should remove gl context from the graph div of a gl3d plot', function(done) {
+                gd = createGraphDiv();
+
+                Plotly.plot(gd, mockData3d).then(function() {
+                    expect(gd._fullLayout.scene._scene.glplot).toBeDefined();
+
+                    Plots.cleanPlot([], {}, gd._fullData, gd._fullLayout);
+                    expect(gd._fullLayout.scene._scene.glplot).toBe(null);
+
+                    done();
+                });
+            });
+
+            it('should remove gl context from the graph div of a gl2d plot', function(done) {
+                gd = createGraphDiv();
+
+                Plotly.plot(gd, mockData2d).then(function() {
+                    expect(gd._fullLayout._plots.xy._scene2d.glplot).toBeDefined();
+
+                    Plots.cleanPlot([], {}, gd._fullData, gd._fullLayout);
+                    expect(gd._fullLayout._plots).toEqual({});
+
+                    done();
+                });
             });
         });
+        describe('Plotly.newPlot', function() {
 
-        it('should remove gl context from the graph div of a gl2d plot', function(done) {
-            gd = createGraphDiv();
-
-            var mockData = [{
+            var mockData2dNew = [{
                 type: 'scattergl',
-                x: [1, 2, 3],
-                y: [1, 2, 3]
+                x: [1, 3, 2],
+                y: [2, 3, 1]
             }];
 
-            Plotly.plot(gd, mockData).then(function() {
-                expect(gd._fullLayout._plots.xy._scene2d.glplot).toBeDefined();
 
-                Plots.cleanPlot([], {}, gd._fullData, gd._fullLayout);
-                expect(gd._fullLayout._plots).toEqual({});
+            var mockData3dNew = [{
+                type: 'scatter3d',
+                x: [2, 1, 3],
+                y: [1, 2, 3],
+                z: [2, 1, 3]
+            }];
 
-                done();
+
+            it('should remove gl context from the graph div of a gl3d plot', function(done) {
+                gd = createGraphDiv();
+
+                Plotly.plot(gd, mockData3d).then(function() {
+
+                    var firstGlplotObject = gd._fullLayout.scene._scene.glplot;
+                    var firstGlContext = firstGlplotObject.gl;
+                    var firstCanvas = firstGlContext.canvas;
+
+                    expect(firstGlplotObject).toBeDefined();
+
+                    Plotly.newPlot(gd, mockData3dNew, {}).then(function() {
+
+                        var secondGlplotObject = gd._fullLayout.scene._scene.glplot;
+                        var secondGlContext = secondGlplotObject.gl;
+                        var secondCanvas = secondGlContext.canvas;
+
+                        expect(secondGlplotObject).not.toBe(firstGlplotObject);
+                        expect(firstGlplotObject.gl === null);
+                        expect(secondGlContext instanceof WebGLRenderingContext);
+                        expect(secondGlContext).not.toBe(firstGlContext);
+
+                        // The same canvas can't possibly be reassinged a new WebGL context, but let's leave room
+                        // for the implementation to make the context get lost and have the old canvas stick around
+                        // in a disused state.
+                        expect(firstCanvas.parentNode === null ||
+                            firstCanvas !== secondCanvas && firstGlContext.isContextLost());
+
+                        done();
+
+                    });
+                });
+            });
+
+            it('should remove gl context from the graph div of a gl2d plot', function(done) {
+                gd = createGraphDiv();
+
+                Plotly.plot(gd, mockData2d).then(function() {
+
+                    var firstGlplotObject = gd._fullLayout._plots.xy._scene2d.glplot;
+                    var firstGlContext = firstGlplotObject.gl;
+                    var firstCanvas = firstGlContext.canvas;
+
+                    expect(firstGlplotObject).toBeDefined();
+                    expect(firstGlContext).toBeDefined();
+                    expect(firstGlContext instanceof WebGLRenderingContext);
+
+                    Plotly.newPlot(gd, mockData2dNew, {}).then(function() {
+
+                        var secondGlplotObject = gd._fullLayout._plots.xy._scene2d.glplot;
+                        var secondGlContext = secondGlplotObject.gl;
+                        var secondCanvas = secondGlContext.canvas;
+
+                        expect(Object.keys(gd._fullLayout._plots).length === 1);
+                        expect(secondGlplotObject).not.toBe(firstGlplotObject);
+                        expect(firstGlplotObject.gl === null);
+                        expect(secondGlContext instanceof WebGLRenderingContext);
+                        expect(secondGlContext).not.toBe(firstGlContext);
+                        expect(firstCanvas.parentNode === null ||
+                            firstCanvas !== secondCanvas && firstGlContext.isContextLost());
+
+                        done();
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
Commit c123ebc helps a lot - not only with a significantly reduced (though not yet fully eliminated) memory leak, but also, causes a `stop` for the point picker requestAnimationFrame loop, so the purportedly idempotent `plotNew` function doesn't leave behind an orphaned, CPU eating rAF loop with potentially large arrays.

It may be that part of the residual leakage is related to the rAF acting as a closure with variable capture: even if the rAF is stopped by causing `stop = true` via the intended destroy sequence, maybe some state is still retained. Check this among other things.

Unrelated to the leakage, we identified the rAF based approach as something we might want to improve upon. 

PR is WIP not only because it's not a full fix and it's as yet untested, but also the code will probably need to be more generic (e.g. now it shoots for `_scene2d` but the 3D case may be analogous).