### PR TITLE
[concept] Queue length limit

### DIFF
--- a/src/lib/queue.js
+++ b/src/lib/queue.js
@@ -93,8 +93,6 @@ queue.add = function(gd, undoFunc, undoArgs, redoFunc, redoArgs) {
         gd.undoQueue.queue.shift();
         gd.undoQueue.index--;
     }
-
-    console.log('QUEUE length: ', gd.undoQueue.queue.length)
 };
 
 /**

--- a/src/lib/queue.js
+++ b/src/lib/queue.js
@@ -45,6 +45,8 @@ function copyArgArray(gd, args) {
 
 var queue = {};
 
+var maxElementCount = 10;
+
 // TODO: disable/enable undo and redo buttons appropriately
 
 /**
@@ -87,6 +89,12 @@ queue.add = function(gd, undoFunc, undoArgs, redoFunc, redoArgs) {
     queueObj.redo.calls.push(redoFunc);
     queueObj.redo.args.push(redoArgs);
 
+    if(gd.undoQueue.queue.length > maxElementCount) {
+        gd.undoQueue.queue.shift();
+        gd.undoQueue.index--;
+    }
+
+    console.log('QUEUE length: ', gd.undoQueue.queue.length)
 };
 
 /**


### PR DESCRIPTION
Client bug report on seemingly unjustified memory growth lead to, among other things, the retainment of data in the undo/redo queue. As I'm not too familiar with this feature, I can only suggest that there be a default (overridable) limit to the queue, or at least an optional configuration for the maximum queue length. So I'd be glad to pass the baton on this one, due to numerous WebGL improvement requirements I still need to do.