### PR TITLE
Make mapbox access token configurable via layout attribute

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -328,6 +328,7 @@ Plotly.plot = function(gd, data, layout, config) {
         return gd;
     }, function() {
         // clear the promise queue if one of them got rejected
+        Lib.log('Clearing previous rejected promises from queue.');
         gd._promises = [];
     });
 };

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -326,6 +326,9 @@ Plotly.plot = function(gd, data, layout, config) {
     // so that the caller doesn't care which route we took
     return Promise.all(gd._promises).then(function() {
         return gd;
+    }, function() {
+        // clear the promise queue if one of them got rejected
+        gd._promises = [];
     });
 };
 

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -45,6 +45,16 @@ module.exports = {
         }
     },
 
+    accesstoken: {
+        valType: 'string',
+        noBlank: true,
+        strict: true,
+        role: 'info',
+        description: [
+            'Sets the mapbox access token to be set or as a configuration option',
+            'under `mapboxAccessToken`.'
+        ].join(' ')
+    },
     style: {
         valType: 'string',
         values: ['basic', 'streets', 'outdoors', 'light', 'dark', 'satellite', 'satellite-streets'],
@@ -55,6 +65,7 @@ module.exports = {
             'Either input the defaults Mapbox names or the URL to a custom style.'
         ].join(' ')
     },
+
     center: {
         lon: {
             valType: 'number',

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -51,8 +51,9 @@ module.exports = {
         strict: true,
         role: 'info',
         description: [
-            'Sets the mapbox access token to be set or as a configuration option',
-            'under `mapboxAccessToken`.'
+            'Sets the mapbox access token to be used for this mapbox map.',
+            'Alternatively, the mapbox access token can be set in the',
+            'configuration options under `mapboxAccessToken`.'
         ].join(' ')
     },
     style: {

--- a/src/plots/mapbox/layout_defaults.js
+++ b/src/plots/mapbox/layout_defaults.js
@@ -25,6 +25,7 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
 };
 
 function handleDefaults(containerIn, containerOut, coerce) {
+    coerce('accesstoken');
     coerce('style');
     coerce('center.lon');
     coerce('center.lat');

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -40,6 +40,7 @@ function Mapbox(opts) {
 
     // state variables used to infer how and what to update
     this.map = null;
+    this.accessToken = null;
     this.styleUrl = null;
     this.traceHash = {};
     this.layerList = [];
@@ -57,7 +58,16 @@ proto.plot = function(calcData, fullLayout, promises) {
     var self = this;
 
     // feed in new mapbox options
-    self.opts = fullLayout[this.id];
+    var opts = self.opts = fullLayout[this.id];
+
+    // remove map and create a new map if access token has change
+    if(self.map && (opts.accesstoken !== self.accessToken)) {
+        self.map.remove();
+        self.map = null;
+        self.styleUrl = null;
+        self.traceHash = [];
+        self.layerList = {};
+    }
 
     var promise;
 
@@ -82,6 +92,9 @@ proto.createMap = function(calcData, fullLayout, resolve, reject) {
 
     // mapbox doesn't have a way to get the current style URL; do it ourselves
     var styleUrl = self.styleUrl = convertStyleUrl(opts.style);
+
+    // store access token associated with this map
+    self.accessToken = opts.accesstoken;
 
     var map = self.map = new mapboxgl.Map({
         container: self.div,
@@ -334,7 +347,7 @@ proto.updateLayers = function() {
 };
 
 proto.destroy = function() {
-    this.map.remove();
+    if(this.map) this.map.remove();
     this.container.removeChild(this.div);
 };
 

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -188,6 +188,22 @@ describe('mapbox credentials', function() {
             mapboxAccessToken: dummyToken
         }).catch(function(err) {
             expect(err).toEqual(new Error(constants.mapOnErrorMsg));
+        }).then(done);
+    });
+
+    it('should use access token in mapbox layout options if present', function(done) {
+        Plotly.plot(gd, [{
+            type: 'scattermapbox',
+            lon: [10, 20, 30],
+            lat: [10, 20, 30]
+        }], {
+            mapbox: {
+                accesstoken: MAPBOX_ACCESS_TOKEN
+            }
+        }, {
+            mapboxAccessToken: dummyToken
+        }).then(function() {
+            expect(gd._fullLayout.mapbox.accesstoken).toEqual(MAPBOX_ACCESS_TOKEN);
             done();
         });
     });
@@ -475,6 +491,22 @@ describe('mapbox plots', function() {
             done();
         });
     });
+
+    it('should be able to update the access token', function(done) {
+        var promise = Plotly.relayout(gd, 'mapbox.accesstoken', 'wont-work');
+
+        promise.catch(function(err) {
+            expect(gd._fullLayout.mapbox.accesstoken).toEqual('wont-work');
+            expect(err).toEqual(new Error(constants.mapOnErrorMsg));
+        });
+
+        promise.then(function() {
+            return Plotly.relayout(gd, 'mapbox.accesstoken', MAPBOX_ACCESS_TOKEN);
+        }).then(function() {
+            expect(gd._fullLayout.mapbox.accesstoken).toEqual(MAPBOX_ACCESS_TOKEN);
+        }).then(done);
+    });
+
 
     it('should be able to update traces', function(done) {
         function assertDataPts(lengths) {

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -13,6 +13,7 @@ var customMatchers = require('../assets/custom_matchers');
 
 var MAPBOX_ACCESS_TOKEN = require('@build/credentials.json').MAPBOX_ACCESS_TOKEN;
 var TRANSITION_DELAY = 500;
+var MOUSE_DELAY = 100;
 
 var noop = function() {};
 
@@ -763,15 +764,13 @@ describe('mapbox plots', function() {
     }
 
     function _mouseEvent(type, pos, cb) {
-        var DELAY = 100;
-
         return new Promise(function(resolve) {
             mouseEvent(type, pos[0], pos[1]);
 
             setTimeout(function() {
                 cb();
                 resolve();
-            }, DELAY);
+            }, MOUSE_DELAY);
         });
     }
 


### PR DESCRIPTION
@chriddyp 

### In brief

Users can now register their mapbox access token via `layout.mapbox.accesstoken`:

```js
var layout = {
  mapbox: {
    accesstoken: 'pk.124faEdgfsar2wsasdfsdgradgafdgasd'
  }
};
```

This is especially important for users wanting to use a custom map style - where setting the access token in `layout` guarantee that the map will look the same regardless of the specified `config` options.

If `mapbox.accesstoken` isn't specify, the config `mapboxAccessToken` is used.


