### PR TITLE
Bypassing most of the heavy lifting in the rAF for when there's no interaction

### DIFF
--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -483,13 +483,13 @@ proto.draw = function() {
 
             if(nextSelection && (
                 !this.lastPickResult ||
-                this.lastPickResult.trace !== nextSelection.trace ||
+                this.lastPickResult.traceUid !== nextSelection.trace.uid ||
                 this.lastPickResult.dataCoord[0] !== nextSelection.dataCoord[0] ||
                 this.lastPickResult.dataCoord[1] !== nextSelection.dataCoord[1])
             ) {
                 var selection = nextSelection;
                 this.lastPickResult = {
-                    trace: nextSelection.trace, // could we just retain/compare the trace uid?
+                    traceUid: nextSelection.trace ? nextSelection.trace.uid : null,
                     dataCoord: nextSelection.dataCoord.slice()
                 };
                 this.spikes.update({ center: result.dataCoord });

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -487,7 +487,11 @@ proto.draw = function() {
                 this.lastPickResult.dataCoord[0] !== nextSelection.dataCoord[0] ||
                 this.lastPickResult.dataCoord[1] !== nextSelection.dataCoord[1])
             ) {
-                var selection = this.lastPickResult = nextSelection;
+                var selection = nextSelection;
+                this.lastPickResult = {
+                    trace: nextSelection.trace, // could we just retain/compare the trace uid?
+                    dataCoord: nextSelection.dataCoord.slice()
+                };
                 this.spikes.update({ center: result.dataCoord });
 
                 selection.screenCoord = [
@@ -523,8 +527,6 @@ proto.draw = function() {
                 }, {
                     container: this.svgContainer
                 });
-
-                this.lastPickResult = { dataCoord: result.dataCoord };
             }
         }
         else if(!result && this.lastPickResult) {


### PR DESCRIPTION
Solves the symptoms of https://github.com/plotly/plotly.js/issues/730 in that it reduces idle CPU utilization from 100% to around 5% at 500k-1m data points (as measured even for non-fancy 2d WebGL scatterplot)