### PR TITLE
Speed up Lib.extendDeep (_extend) for arrays that have no object, array elements

### DIFF
--- a/src/lib/extend.js
+++ b/src/lib/extend.js
@@ -12,6 +12,20 @@
 var isPlainObject = require('./is_plain_object.js');
 var isArray = Array.isArray;
 
+function primitivesLoopSplice(source, target) {
+    var i, value;
+    for(i = 0; i < source.length; i++) {
+        value = source[i];
+        if(value !== null && typeof(value) === 'object') {
+            return false;
+        }
+        if(value !== void(0)) {
+            target[i] = value;
+        }
+    }
+    return true;
+}
+
 exports.extendFlat = function() {
     return _extend(arguments, false, false);
 };
@@ -45,7 +59,18 @@ function _extend(inputs, isDeep, keepAllKeys) {
     var target = inputs[0],
         length = inputs.length;
 
-    var input, key, src, copy, copyIsArray, clone;
+    var input, key, src, copy, copyIsArray, clone, allPrimitives;
+
+    if(length === 2 && isArray(target) && isArray(inputs[1]) && target.length === 0) {
+
+        allPrimitives = primitivesLoopSplice(inputs[1], target);
+
+        if(allPrimitives) {
+            return target;
+        } else {
+            target.splice(0, target.length); // reset target and continue to next block
+        }
+    }
 
     for(var i = 1; i < length; i++) {
         input = inputs[i];


### PR DESCRIPTION
This PR has the same effect on speed as the suggestion in https://github.com/plotly/plotly.js/pull/726#issuecomment-231656623

The referred suggestion isn't obsoleted by this PR, because `deepExtend`, by its nature, is still expensive: with large datasets, `Plotly.restyle` will still allocate and populate very large arrays (though much faster if this PR is merged). 

Similarly, this PR can be useful even outside the original speed problem, as it generally speeds up structure extension when large, simple arrays are present.