### PR TITLE
Reifies not yet covered, preexisting behavior of Lib.extendDeep

### DIFF
--- a/test/jasmine/tests/extend_test.js
+++ b/test/jasmine/tests/extend_test.js
@@ -44,6 +44,14 @@ var undef = {
     arr: [1, 2, undefined]
 };
 
+var undef2 = {
+    str: undefined,
+    layer: {
+        date: undefined
+    },
+    arr: [1, undefined, 2]
+};
+
 
 describe('extendFlat', function() {
     'use strict';
@@ -376,7 +384,7 @@ describe('extendDeep', function() {
 
         expect(ori).toEqual({
             layer: { },
-            arr: [1, 2 ]
+            arr: [1, 2]
         });
         expect(undef).toEqual({
             str: undefined,
@@ -387,7 +395,33 @@ describe('extendDeep', function() {
         });
         expect(target).toEqual({
             layer: { },
-            arr: [1, 2 ]
+            arr: [1, 2]
+        });
+    });
+
+    it('leaves a gap in the array for undefined of lower index than that of the highest defined value', function() {
+        ori = {};
+        target = extendDeep(ori, undef2);
+
+        var compare = [];
+        compare[0] = 1;
+        // compare[1] left undefined
+        compare[2] = 2;
+
+        expect(ori).toEqual({
+            layer: { },
+            arr: compare
+        });
+        expect(undef2).toEqual({
+            str: undefined,
+            layer: {
+                date: undefined
+            },
+            arr: [1, undefined, 2]
+        });
+        expect(target).toEqual({
+            layer: { },
+            arr: compare
         });
     });
 


### PR DESCRIPTION
I made a separate PR out of it b/c it can be merged irrespective of the speedup (https://github.com/plotly/plotly.js/pull/732) or discussed here if it's not desirable to lock in this specific behavior. Once it gets the green light, then the speedup just needs to comply with whatever tests.