### PR TITLE
Make gl2d snapshot non-blurry

### DIFF
--- a/src/plots/gl2d/index.js
+++ b/src/plots/gl2d/index.js
@@ -86,8 +86,7 @@ exports.clean = function(newFullData, newFullLayout, oldFullData, oldFullLayout)
 
 exports.toSVG = function(gd) {
     var fullLayout = gd._fullLayout,
-        subplotIds = Plots.getSubplotIds(fullLayout, 'gl2d'),
-        size = fullLayout._size;
+        subplotIds = Plots.getSubplotIds(fullLayout, 'gl2d');
 
     for(var i = 0; i < subplotIds.length; i++) {
         var subplot = fullLayout._plots[subplotIds[i]],
@@ -99,10 +98,10 @@ exports.toSVG = function(gd) {
         image.attr({
             xmlns: xmlnsNamespaces.svg,
             'xlink:href': imageData,
-            x: size.l,
-            y: size.t,
-            width: size.w,
-            height: size.h,
+            x: 0,
+            y: 0,
+            width: '100%',
+            height: '100%',
             preserveAspectRatio: 'none'
         });
 

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -184,7 +184,7 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
 
     if(!scene.staticMode) {
         scene.glplot.canvas.addEventListener('webglcontextlost', function(ev) {
-			Lib.warn('Lost WebGL context.');
+            Lib.warn('Lost WebGL context.');
             ev.preventDefault();
         });
     }

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -147,7 +147,8 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
             try {
                 STATIC_CONTEXT = STATIC_CANVAS.getContext('webgl', {
                     preserveDrawingBuffer: true,
-                    premultipliedAlpha: true
+                    premultipliedAlpha: true,
+                    antialias: true
                 });
             } catch(e) {
                 throw new Error('error creating static canvas/context for image server');
@@ -183,7 +184,7 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
 
     if(!scene.staticMode) {
         scene.glplot.canvas.addEventListener('webglcontextlost', function(ev) {
-            Lib.warn('Lost WebGL context.');
+			Lib.warn('Lost WebGL context.');
             ev.preventDefault();
         });
     }


### PR DESCRIPTION
Cherry-picking @mikolalysenko 's commit 778560bb85dff1bd3dfebb5416f8d23801ec8ab8 off PR https://github.com/plotly/plotly.js/pull/572 and fixing the merge conflict to make gl2d images non-blurry. Example:

before

![image](https://cloud.githubusercontent.com/assets/6675409/16741426/367edd4a-4771-11e6-99b6-a414aa200640.png)

after

![image](https://cloud.githubusercontent.com/assets/6675409/16741430/3b97bff4-4771-11e6-85de-ca91a9b46735.png)


**Note:** this PR does not fix all our gl2d images trouble namely the lack of image test support. See  https://github.com/plotly/plotly.js/pull/572#issuecomment-222178770 for more info.