### PR TITLE
Fix repeated val case in scattermapbox convert step

### DIFF
--- a/src/traces/scattermapbox/convert.js
+++ b/src/traces/scattermapbox/convert.js
@@ -184,7 +184,7 @@ function makeCircleGeoJSON(calcTrace, hash) {
     // Translate vals in trace arrayOk containers
     // into a val-to-index hash object
     function translate(props, key, val, index) {
-        if(!hash[key][val]) hash[key][val] = index;
+        if(hash[key][val] === undefined) hash[key][val] = index;
 
         props[key] = hash[key][val];
     }

--- a/test/jasmine/tests/scattermapbox_test.js
+++ b/test/jasmine/tests/scattermapbox_test.js
@@ -243,6 +243,10 @@ describe('scattermapbox calc', function() {
 describe('scattermapbox convert', function() {
     'use strict';
 
+    beforeAll(function() {
+        jasmine.addMatchers(customMatchers);
+    });
+
     function _convert(trace) {
         var gd = { data: [trace] };
 
@@ -395,6 +399,23 @@ describe('scattermapbox convert', function() {
                 opts.symbol.layout['text-offset']
             ]).toEqual(spec, '(case ' + k + ')');
         });
+    });
+
+    it('for markers + circle bubbles traces with repeated values, should', function() {
+        var opts = _convert(Lib.extendFlat({}, base, {
+            lon: ['-96.796988', '-81.379236', '-85.311819', ''],
+            lat: ['32.776664', '28.538335', '35.047157', '' ],
+            marker: { size: ['5', '49', '5', ''] }
+        }));
+
+        expect(opts.circle.paint['circle-radius'].stops)
+            .toBeCloseTo2DArray([[0, 2.5], [1, 24.5]], 'not replicate stops');
+
+        var radii = opts.circle.geojson.features.map(function(f) {
+            return f.properties['circle-radius'];
+        });
+
+        expect(radii).toBeCloseToArray([0, 1, 0], 'link features to correct stops');
     });
 
     function assertVisibility(opts, expectations) {


### PR DESCRIPTION
### In brief

The `mapbox-gl` API for `arrayOk` attributes (they call it [data-driven](https://www.mapbox.com/blog/data-driven-styling/) :smiley: ) links values in the features geojson `properties` field to a set of `stops`. These stops map the geojson properties values to mapbox-gl paint settings per feature (as opposed to a source-wide setting). Note that the stop values must be unique.
