### PR TITLE
Fix scatter3d marker.line.color inheritance

### DIFF
--- a/src/components/colorscale/calc.js
+++ b/src/components/colorscale/calc.js
@@ -21,7 +21,8 @@ module.exports = function calc(trace, vals, containerStr, cLetter) {
     if(containerStr) {
         container = Lib.nestedProperty(trace, containerStr).get();
         inputContainer = Lib.nestedProperty(trace._input, containerStr).get();
-    } else {
+    }
+    else {
         container = trace;
         inputContainer = trace._input;
     }

--- a/src/traces/scatter/colorscale_calc.js
+++ b/src/traces/scatter/colorscale_calc.js
@@ -15,21 +15,15 @@ var calcColorscale = require('../../components/colorscale/calc');
 var subTypes = require('./subtypes');
 
 
-// common to 'scatter', 'scatter3d' and 'scattergeo'
 module.exports = function calcMarkerColorscale(trace) {
-
-    // auto-z and autocolorscale if applicable
-
     if(subTypes.hasLines(trace) && hasColorscale(trace, 'line')) {
         calcColorscale(trace, trace.line.color, 'line', 'c');
     }
 
     if(subTypes.hasMarkers(trace)) {
-
         if(hasColorscale(trace, 'marker')) {
             calcColorscale(trace, trace.marker.color, 'marker', 'c');
         }
-
         if(hasColorscale(trace, 'marker.line')) {
             calcColorscale(trace, trace.marker.line.color, 'marker.line', 'c');
         }

--- a/src/traces/scatter/line_defaults.js
+++ b/src/traces/scatter/line_defaults.js
@@ -13,21 +13,18 @@ var hasColorscale = require('../../components/colorscale/has_colorscale');
 var colorscaleDefaults = require('../../components/colorscale/defaults');
 
 
-// common to 'scatter', 'scatter3d', 'scattergeo' and 'scattergl'
 module.exports = function lineDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
-
     var markerColor = (traceIn.marker || {}).color;
 
     coerce('line.color', defaultColor);
-    if(hasColorscale(traceIn, 'line')) {
-        colorscaleDefaults(
-            traceIn, traceOut, layout, coerce, {prefix: 'line.', cLetter: 'c'}
-        );
-    } else {
-        coerce('line.color', (Array.isArray(markerColor) ? false : markerColor) ||
-            defaultColor);
-    }
 
+    if(hasColorscale(traceIn, 'line')) {
+        colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: 'line.', cLetter: 'c'});
+    }
+    else {
+        var lineColorDflt = (Array.isArray(markerColor) ? false : markerColor) || defaultColor;
+        coerce('line.color', lineColorDflt);
+    }
 
     coerce('line.width');
     coerce('line.dash');

--- a/src/traces/scatter/marker_defaults.js
+++ b/src/traces/scatter/marker_defaults.js
@@ -16,7 +16,6 @@ var colorscaleDefaults = require('../../components/colorscale/defaults');
 var subTypes = require('./subtypes');
 
 
-// common to 'scatter', 'scatter3d', 'scattergeo' and 'scattergl'
 module.exports = function markerDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
     var isBubble = subTypes.isBubble(traceIn),
         lineColor = !Array.isArray(traceIn.line) ? (traceIn.line || {}).color : undefined,
@@ -30,9 +29,7 @@ module.exports = function markerDefaults(traceIn, traceOut, defaultColor, layout
 
     coerce('marker.color', defaultColor);
     if(hasColorscale(traceIn, 'marker')) {
-        colorscaleDefaults(
-            traceIn, traceOut, layout, coerce, {prefix: 'marker.', cLetter: 'c'}
-        );
+        colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: 'marker.', cLetter: 'c'});
     }
 
     // if there's a line with a different color than the marker, use
@@ -46,9 +43,7 @@ module.exports = function markerDefaults(traceIn, traceOut, defaultColor, layout
 
     coerce('marker.line.color', defaultMLC);
     if(hasColorscale(traceIn, 'marker.line')) {
-        colorscaleDefaults(
-            traceIn, traceOut, layout, coerce, {prefix: 'marker.line.', cLetter: 'c'}
-        );
+        colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: 'marker.line.', cLetter: 'c'});
     }
 
     coerce('marker.line.width', isBubble ? 1 : 0);

--- a/src/traces/scatter/marker_defaults.js
+++ b/src/traces/scatter/marker_defaults.js
@@ -18,9 +18,10 @@ var subTypes = require('./subtypes');
 
 module.exports = function markerDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
     var isBubble = subTypes.isBubble(traceIn),
-        lineColor = !Array.isArray(traceIn.line) ? (traceIn.line || {}).color : undefined,
+        lineColor = (traceIn.line || {}).color,
         defaultMLC;
 
+    // marker.color inherit from line.color (even if line.color is an array)
     if(lineColor) defaultColor = lineColor;
 
     coerce('marker.symbol');
@@ -34,8 +35,9 @@ module.exports = function markerDefaults(traceIn, traceOut, defaultColor, layout
 
     // if there's a line with a different color than the marker, use
     // that line color as the default marker line color
+    // (except when it's an array)
     // mostly this is for transparent markers to behave nicely
-    if(lineColor && (traceOut.marker.color !== lineColor)) {
+    if(lineColor && !Array.isArray(lineColor) && (traceOut.marker.color !== lineColor)) {
         defaultMLC = lineColor;
     }
     else if(isBubble) defaultMLC = Color.background;

--- a/test/jasmine/tests/scatter3d_test.js
+++ b/test/jasmine/tests/scatter3d_test.js
@@ -1,0 +1,68 @@
+var Scatter3D = require('@src/traces/scatter3d');
+var Lib = require('@src/lib');
+var Color = require('@src/components/color');
+
+
+describe('Scatter3D defaults', function() {
+    'use strict';
+
+    var defaultColor = '#d3d3d3';
+
+    function _supply(traceIn) {
+        var traceOut = { visible: true },
+            layout = { _dataLength: 1 };
+
+        Scatter3D.supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        return traceOut;
+    }
+
+    var base = {
+        x: [1, 2, 3],
+        y: [1, 2, 3],
+        z: [1, 2, 1]
+    };
+
+    it('should make marker.color inherit from line.color (scalar case)', function() {
+        var out = _supply(Lib.extendFlat({}, base, {
+            line: { color: 'red' }
+        }));
+
+        expect(out.line.color).toEqual('red');
+        expect(out.marker.color).toEqual('red');
+        expect(out.marker.line.color).toBe(Color.defaultLine, 'but not marker.line.color');
+    });
+
+    it('should make marker.color inherit from line.color (array case)', function() {
+        var color = [1, 2, 3];
+
+        var out = _supply(Lib.extendFlat({}, base, {
+            line: { color: color }
+        }));
+
+        expect(out.line.color).toBe(color);
+        expect(out.marker.color).toBe(color);
+        expect(out.marker.line.color).toBe(Color.defaultLine, 'but not marker.line.color');
+    });
+
+    it('should make line.color inherit from marker.color if scalar)', function() {
+        var out = _supply(Lib.extendFlat({}, base, {
+            marker: { color: 'red' }
+        }));
+
+        expect(out.line.color).toEqual('red');
+        expect(out.marker.color).toEqual('red');
+        expect(out.marker.line.color).toBe(Color.defaultLine);
+    });
+
+    it('should not make line.color inherit from marker.color if array', function() {
+        var color = [1, 2, 3];
+
+        var out = _supply(Lib.extendFlat({}, base, {
+            marker: { color: color }
+        }));
+
+        expect(out.line.color).toBe(defaultColor);
+        expect(out.marker.color).toBe(color);
+        expect(out.marker.line.color).toBe(Color.defaultLine);
+    });
+});


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/750

The :meat_on_bone: of this PR is in https://github.com/plotly/plotly.js/commit/b9a471ebfec5355f9ceadd46903de2cf8016f28d where we now explicitly skip `line.color` --> `marker.line.color` inheritance when `line.color` is an array. 

The errors described in #750 were due to the colorscale calc step complaining about `gd.data[i].marker.line` not being defined. Errors here are fine as `hasColorscale(marker.line)` should be `false` unless the user make `marker.line.color` support a colorscale. The problem was in the default step.