### PR TITLE
Non-scaling SVG scatter lines

### DIFF
--- a/src/traces/scatter/plot.js
+++ b/src/traces/scatter/plot.js
@@ -161,7 +161,10 @@ module.exports = function plot(gd, plotinfo, cdscatter) {
                     revpath = thisrevpath + 'Z' + revpath;
                 }
                 if(subTypes.hasLines(trace) && pts.length > 1) {
-                    tr.append('path').classed('js-line', true).attr('d', thispath);
+                    tr.append('path')
+                        .classed('js-line', true)
+                        .style('vector-effect', 'non-scaling-stroke')
+                        .attr('d', thispath);
                 }
             }
             if(ownFillEl3) {


### PR DESCRIPTION
See: #760 
See related point scaling PR: #762
See codepen example (includes point scaling PR, visible on scrollZoom): http://codepen.io/rsreusser/pen/OXvmjR?editors=0010

This is basically a one-line commit that disables scaling on scatter paths. It can be applied in `lineGroupStyle`, but since it has no effect in the other places where it's used (except for contours, where this could also be applied), it seems more targeted to just apply it to scatter lines directly.

This does not solve the point scaling problem. See example at: http://rickyreusser.com/plotly-expression-transform/ (which actually applies it in the drawing component, but for the sake of illustration, the effect is the same while scrollzoooming)

cc: @mdtusz 