### PR TITLE
Non-scaling SVG scatter points

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -484,22 +484,30 @@ lib.setScale = function(element, x, y) {
     return transform;
 };
 
-lib.setPointScale = function(selection, x, y) {
+lib.setPointGroupScale = function(selection, x, y) {
+    var t, scale, re;
+
     x = x || 1;
     y = y || 1;
 
-    // The same scale transform for every point:
-    var scale = ' scale(' + x + ',' + y + ')';
+    if(x === 1 && y === 1) {
+        scale = '';
+    } else {
+        // The same scale transform for every point:
+        scale = ' scale(' + x + ',' + y + ')';
+    }
 
     // A regex to strip any existing scale:
-    var re = /sc.*/;
+    re = /\s*sc.*/;
 
     selection.each(function() {
         // Get the transform:
-        var t = this.getAttribute('transform').replace(re, '');
+        t = (this.getAttribute('transform') || '').replace(re, '');
+        t += scale;
+        t = t.trim();
 
         // Append the scale transform
-        this.setAttribute('transform', t + scale);
+        this.setAttribute('transform', t);
     });
 
     return scale;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -484,6 +484,27 @@ lib.setScale = function(element, x, y) {
     return transform;
 };
 
+lib.setPointScale = function(selection, x, y) {
+    x = x || 1;
+    y = y || 1;
+
+    // The same scale transform for every point:
+    var scale = ' scale(' + x + ',' + y + ')';
+
+    // A regex to strip any existing scale:
+    var re = /sc.*/;
+
+    selection.each(function(p) {
+        // Get the transform:
+        var t = this.getAttribute('transform').replace(re,'');
+
+        // Append the scale transform
+        this.setAttribute('transform', t + scale);
+    });
+
+    return scale;
+};
+
 lib.isIE = function() {
     return typeof window.navigator.msSaveBlob !== 'undefined';
 };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -494,9 +494,9 @@ lib.setPointScale = function(selection, x, y) {
     // A regex to strip any existing scale:
     var re = /sc.*/;
 
-    selection.each(function(p) {
+    selection.each(function() {
         // Get the transform:
-        var t = this.getAttribute('transform').replace(re,'');
+        var t = this.getAttribute('transform').replace(re, '');
 
         // Append the scale transform
         this.setAttribute('transform', t + scale);

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -633,7 +633,10 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
             subplot.plot
                 .call(Lib.setTranslate, plotDx, plotDy)
-                .call(Lib.setScale, xScaleFactor, yScaleFactor);
+                .call(Lib.setScale, xScaleFactor, yScaleFactor)
+                .selectAll('.points').selectAll('.point')
+                    .call(Lib.setPointScale, 1 / xScaleFactor, 1 / yScaleFactor);
+
         }
     }
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -634,9 +634,12 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             subplot.plot
                 .call(Lib.setTranslate, plotDx, plotDy)
                 .call(Lib.setScale, xScaleFactor, yScaleFactor)
-                .selectAll('.points').selectAll('.point')
-                    .call(Lib.setPointScale, 1 / xScaleFactor, 1 / yScaleFactor);
 
+                // This is specifically directed at scatter traces, applying an inverse
+                // scale to individual points to counteract the scale of the trace
+                // as a whole:
+                .selectAll('.points').selectAll('.point')
+                    .call(Lib.setPointGroupScale, 1 / xScaleFactor, 1 / yScaleFactor);
         }
     }
 

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -1202,6 +1202,44 @@ describe('Test lib.js:', function() {
         });
     });
 
+    describe('setPointGroupScale', function() {
+        var el, sel;
+
+        beforeEach(function() {
+            el = document.createElement('div');
+            sel = d3.select(el);
+        });
+
+        it('sets the scale of a point', function() {
+            Lib.setPointGroupScale(sel, 2, 2);
+            expect(el.getAttribute('transform')).toBe('scale(2,2)');
+        });
+
+        it('appends the scale of a point', function() {
+            el.setAttribute('transform', 'translate(1,2)');
+            Lib.setPointGroupScale(sel, 2, 2);
+            expect(el.getAttribute('transform')).toBe('translate(1,2) scale(2,2)');
+        });
+
+        it('modifies the scale of a point', function() {
+            el.setAttribute('transform', 'translate(1,2) scale(3,4)');
+            Lib.setPointGroupScale(sel, 2, 2);
+            expect(el.getAttribute('transform')).toBe('translate(1,2) scale(2,2)');
+        });
+
+        it('does not apply the scale of a point if scale (1, 1)', function() {
+            el.setAttribute('transform', 'translate(1,2)');
+            Lib.setPointGroupScale(sel, 1, 1);
+            expect(el.getAttribute('transform')).toBe('translate(1,2)');
+        });
+
+        it('removes the scale of a point if scale (1, 1)', function() {
+            el.setAttribute('transform', 'translate(1,2) scale(3,4)');
+            Lib.setPointGroupScale(sel, 1, 1);
+            expect(el.getAttribute('transform')).toBe('translate(1,2)');
+        });
+    });
+
     describe('pushUnique', function() {
 
         beforeEach(function() {


### PR DESCRIPTION
See issue: #760
See related line scaling PR: #761 
See codepen example (visible on scrollZoom): http://codepen.io/rsreusser/pen/OXvmjR?editors=0010

This PR compensates for point scaling by applying an inverse scale transform. It's simple, but kind of an ugly hack since it requires stripping any existing scale from points before applying a new scale. That may make it prohibitive, but it was a bit easier than expected, so maybe it's not unreasonable. cc @mdtusz 