### PR TITLE
Persist the current test dashboard mock on page reload

### DIFF
--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -175,6 +175,14 @@ var plotArea = document.getElementById('plots');
 
 searchBar.addEventListener('keyup', debounce(searchMocks, 250));
 
+window.onload = function() {
+    var initialMock = window.location.hash.replace(/^#/, '');
+
+    if(initialMock.length > 0) {
+        Tabs.plotMock(initialMock);
+    }
+};
+
 function debounce(func, wait, immediate) {
     var timeout;
     return function() {
@@ -206,10 +214,12 @@ function searchMocks(e) {
         result.innerText = r.name;
 
         result.addEventListener('click', function() {
+            var mockName = r.file.slice(0, -5);
+            window.location.hash = mockName;
 
             // Clear plots and plot selected.
             Tabs.purge();
-            Tabs.plotMock(r.file.slice(0, -5));
+            Tabs.plotMock(mockName);
         });
 
         mocksList.appendChild(result);


### PR DESCRIPTION
A tiny PR to set and load the currently selected mock via a hash fragment. `Tabs.reload()` and `Tabs.plotMock(...)` is able to replot the mock, but command-R is my natural instinct and always requires me to re-locate the mock.

An easy nice-to-have, so let me know if there's a better way or any side effects I'm not aware of.

<img width="455" alt="screen shot 2016-07-21 at 2 27 27 pm" src="https://cloud.githubusercontent.com/assets/572717/17034172/7ca3db82-4f4f-11e6-879d-fd7a1d6caf41.png">
