### PR TITLE
Do not log in clearPromiseQueue is _promises is empty

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -353,7 +353,10 @@ function getGraphDiv(gd) {
 
 // clear the promise queue if one of them got rejected
 function clearPromiseQueue(gd) {
-    Lib.log('Clearing previous rejected promises from queue.');
+    if(Array.isArray(gd._promises) && gd._promises.length > 0) {
+        Lib.log('Clearing previous rejected promises from queue.');
+    }
+
     gd._promises = [];
 }
 


### PR DESCRIPTION
fixup of https://github.com/plotly/plotly.js/pull/776/commits/8f4e11e01e6a2794c5fe97802018ce74a099e0f3 merged via https://github.com/plotly/plotly.js/pull/776
 