### PR TITLE
Enforce is-plain-object

### DIFF
--- a/src/components/colorbar/has_colorbar.js
+++ b/src/components/colorbar/has_colorbar.js
@@ -9,10 +9,9 @@
 
 'use strict';
 
+var Lib = require('../../lib');
+
 
 module.exports = function hasColorbar(container) {
-    return (
-        typeof container.colorbar === 'object' &&
-        container.colorbar !== null
-    );
+    return Lib.isPlainObject(container.colorbar);
 };

--- a/src/components/colorscale/has_colorscale.js
+++ b/src/components/colorscale/has_colorscale.js
@@ -33,12 +33,12 @@ module.exports = function hasColorscale(trace, containerStr) {
     }
 
     return (
-        (typeof container === 'object' && container !== null) && (
+        Lib.isPlainObject(container) && (
             isArrayWithOneNumber ||
             container.showscale === true ||
             (isNumeric(container.cmin) && isNumeric(container.cmax)) ||
             isValidScale(container.colorscale) ||
-            (typeof container.colorbar === 'object' && container.colorbar !== null)
+            Lib.isPlainObject(container.colorbar)
         )
     );
 };

--- a/src/components/rangeslider/defaults.js
+++ b/src/components/rangeslider/defaults.js
@@ -13,10 +13,9 @@ var attributes = require('./attributes');
 
 
 module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, axName, counterAxes) {
-
     if(!layoutIn[axName].rangeslider) return;
 
-    var containerIn = typeof layoutIn[axName].rangeslider === 'object' ?
+    var containerIn = Lib.isPlainObject(layoutIn[axName].rangeslider) ?
             layoutIn[axName].rangeslider : {},
         containerOut = layoutOut[axName].rangeslider = {};
 

--- a/src/lib/is_plain_object.js
+++ b/src/lib/is_plain_object.js
@@ -11,6 +11,15 @@
 
 // more info: http://stackoverflow.com/questions/18531624/isplainobject-thing
 module.exports = function isPlainObject(obj) {
+
+    // We need to be a little less strict in the `imagetest` container because
+    // of how async image requests are handled.
+    //
+    // N.B. isPlainObject(new Constructor()) will return true in `imagetest`
+    if(window && window.process && window.process.versions) {
+        return Object.prototype.toString.call(obj) === '[object Object]';
+    }
+
     return (
         Object.prototype.toString.call(obj) === '[object Object]' &&
         Object.getPrototypeOf(obj) === Object.prototype

--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -131,11 +131,8 @@ proto.dispose = function dispose() {
 function isVisible(opts) {
     var source = opts.source;
 
-    // For some weird reason Lib.isPlainObject fails
-    // to detect `source` as a plain object in nw.js 0.12.
-
     return (
-        typeof source === 'object' ||
+        Lib.isPlainObject(source) ||
         (typeof source === 'string' && source.length > 0)
     );
 }

--- a/src/traces/scatter/subtypes.js
+++ b/src/traces/scatter/subtypes.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+var Lib = require('../../lib');
+
 module.exports = {
     hasLines: function(trace) {
         return trace.visible && trace.mode &&
@@ -26,7 +28,7 @@ module.exports = {
     },
 
     isBubble: function(trace) {
-        return (typeof trace.marker === 'object' &&
-                    Array.isArray(trace.marker.size));
+        return Lib.isPlainObject(trace.marker) &&
+            Array.isArray(trace.marker.size);
     }
 };


### PR DESCRIPTION
`Lib.isPlainObject` fails in our `imagetest` docker image test container at the moment.

More specifically, 

```js
Object.getPrototypeOf(obj) === Object.prototype
```

is `false` for _plain_ objects in `imagetest`. This behaviour is due to how the async utility [`lash`](https://github.com/bpostlethwaite/lash) applies functions to objects. Making a fix `lash` and/or the `imagetest` would have been arduous, so I decided to patch `Lib.isPlainObject` instead.

The patch in  https://github.com/plotly/plotly.js/commit/c09cbb3f2d53fe30126e1c233a5a8ea11dd79d35 makes `Lib.isPlainObject` only check for 

```js
Object.prototype.toString.call(obj) === '[object Object]'
```

in `nw.js` environments. This lead to 

```js
function A() {}

Lib.isPlainObject(new A());
```

to return `true`. I'd argue that this is fine in `imagetest` where request bodies are JSON stringified and JSON parsed before plotting - note that `JSON.parse(JSON.stringify(new A())` returns `{}`.

Commit https://github.com/plotly/plotly.js/commit/e1f6818acb1d9873187afe00de1130155bade3f4 enforces `Lib.isPlainObject` is the source files.
