### PR TITLE
Add support for mapbox style JSON

### DIFF
--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -222,7 +222,7 @@ exports.valObjects = {
     any: {
         description: 'Any type.',
         requiredOpts: [],
-        otherOpts: ['dflt'],
+        otherOpts: ['dflt', 'values'],
         coerceFunction: function(v, propOut, dflt) {
             if(v === undefined) propOut.set(dflt);
             else propOut.set(v);

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -57,13 +57,14 @@ module.exports = {
         ].join(' ')
     },
     style: {
-        valType: 'string',
+        valType: 'any',
         values: ['basic', 'streets', 'outdoors', 'light', 'dark', 'satellite', 'satellite-streets'],
         dflt: 'basic',
         role: 'style',
         description: [
             'Sets the Mapbox map style.',
-            'Either input the defaults Mapbox names or the URL to a custom style.'
+            'Either input one of the default Mapbox style names or the URL to a custom style',
+            'or a valid Mapbox style JSON.'
         ].join(' ')
     },
 

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -55,6 +55,24 @@ describe('mapbox defaults', function() {
         expect(layoutOut.mapbox._input).toBe(mapbox);
     });
 
+    it('should accept both string and object style', function() {
+        var mapboxStyleJSON = {
+            id: 'cdsa213wqdsa',
+            owner: 'johnny'
+        };
+
+        layoutIn = {
+            mapbox: { style: 'light' },
+            mapbox2: { style: mapboxStyleJSON }
+        };
+
+        fullData.push({ type: 'scattermapbox', subplot: 'mapbox2' });
+
+        supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+        expect(layoutOut.mapbox.style).toEqual('light');
+        expect(layoutOut.mapbox2.style).toBe(mapboxStyleJSON);
+    });
+
     it('should fill layer containers', function() {
         layoutIn = {
             mapbox: {


### PR DESCRIPTION
@chriddyp 

This PR add support for mapbox style JSON input in `layout.mapbox.style`. For example,

```js
d3.json(urlToMapboxStyleJSON, function(err, style) {
  Plotly.plot(Tabs.fresh(), [{
    type: 'scattermapbox',
  }], {
    mapbox: {
      style: style
    }
  });
});
```

