### PR TITLE
Add extendDeepNoArrays variant

### DIFF
--- a/src/lib/extend.js
+++ b/src/lib/extend.js
@@ -27,15 +27,19 @@ function primitivesLoopSplice(source, target) {
 }
 
 exports.extendFlat = function() {
-    return _extend(arguments, false, false);
+    return _extend(arguments, false, false, false);
 };
 
 exports.extendDeep = function() {
-    return _extend(arguments, true, false);
+    return _extend(arguments, true, false, false);
 };
 
 exports.extendDeepAll = function() {
-    return _extend(arguments, true, true);
+    return _extend(arguments, true, true, false);
+};
+
+exports.extendDeepNoArrays = function() {
+    return _extend(arguments, true, false, true);
 };
 
 /*
@@ -55,7 +59,7 @@ exports.extendDeepAll = function() {
  *   Warning: this might result in infinite loops.
  *
  */
-function _extend(inputs, isDeep, keepAllKeys) {
+function _extend(inputs, isDeep, keepAllKeys, noArrayCopies) {
     var target = inputs[0],
         length = inputs.length;
 
@@ -79,8 +83,13 @@ function _extend(inputs, isDeep, keepAllKeys) {
             src = target[key];
             copy = input[key];
 
+            // Stop early and just transfer the array if array copies are disallowed:
+            if(noArrayCopies && isArray(copy)) {
+                target[key] = copy;
+            }
+
             // recurse if we're merging plain objects or arrays
-            if(isDeep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
+            else if(isDeep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
                 if(copyIsArray) {
                     copyIsArray = false;
                     clone = src && isArray(src) ? src : [];
@@ -89,7 +98,7 @@ function _extend(inputs, isDeep, keepAllKeys) {
                 }
 
                 // never move original objects, clone them
-                target[key] = _extend([clone, copy], isDeep, keepAllKeys);
+                target[key] = _extend([clone, copy], isDeep, keepAllKeys, noArrayCopies);
             }
 
             // don't bring in undefined values, except for extendDeepAll

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -58,6 +58,7 @@ var extendModule = require('./extend');
 lib.extendFlat = extendModule.extendFlat;
 lib.extendDeep = extendModule.extendDeep;
 lib.extendDeepAll = extendModule.extendDeepAll;
+lib.extendDeepNoArrays = extendModule.extendDeepNoArrays;
 
 var loggersModule = require('./loggers');
 lib.log = loggersModule.log;

--- a/test/jasmine/tests/extend_test.js
+++ b/test/jasmine/tests/extend_test.js
@@ -2,6 +2,7 @@ var extendModule = require('@src/lib/extend.js');
 var extendFlat = extendModule.extendFlat;
 var extendDeep = extendModule.extendDeep;
 var extendDeepAll = extendModule.extendDeepAll;
+var extendDeepNoArrays = extendModule.extendDeepNoArrays;
 
 var str = 'me a test',
     integer = 10,
@@ -450,5 +451,25 @@ describe('extendDeepAll', function() {
         expect(ori.str).toBe(undefined);
         expect(ori.layer.date).toBe(undefined);
         expect(ori.arr[2]).toBe(undefined);
+    });
+});
+
+describe('extendDeepNoArrays', function() {
+    'use strict';
+
+    it('does not copy arrays', function() {
+        var src = {foo: {bar: [1, 2, 3], baz: [5, 4, 3]}};
+        var tar = {foo: {bar: [4, 5, 6], bop: [8, 2, 1]}};
+        var ext = extendDeepNoArrays(tar, src);
+
+        expect(ext).not.toBe(src);
+        expect(ext).toBe(tar);
+
+        expect(ext.foo).not.toBe(src.foo);
+        expect(ext.foo).toBe(tar.foo);
+
+        expect(ext.foo.bar).toBe(src.foo.bar);
+        expect(ext.foo.baz).toBe(src.foo.baz);
+        expect(ext.foo.bop).toBe(tar.foo.bop);
     });
 });


### PR DESCRIPTION
This PR implements the `extendDeepNoArrays` library function that does a regular deep extend except transferring arrays and not recursing instead of also duplicating arrays. It includes tests but not any use so that @monfera can use it in his code right away.