### PR TITLE
Remove HTML entity decoding from convertToSVG

### DIFF
--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -252,8 +252,7 @@ function encodeForHTML(_str) {
 }
 
 function convertToSVG(_str) {
-    var htmlEntitiesDecoded = Plotly.util.html_entity_decode(_str);
-    var result = htmlEntitiesDecoded
+    var result = _str
         .split(/(<[^<>]*>)/).map(function(d) {
             var match = d.match(/<(\/?)([^ >]*)\s*(.*)>/i),
                 tag = match && match[2].toLowerCase(),

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1053,7 +1053,8 @@ function formatLinear(ax, out, hover, extraPrecision, hideexp) {
 // new, more reliable procedure than d3.round or similar:
 // add half the rounding increment, then stringify and truncate
 // also automatically switch to sci. notation
-var SIPREFIXES = ['f', 'p', 'n', '&mu;', 'm', '', 'k', 'M', 'G', 'T'];
+var SIPREFIXES = ['f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T'];
+
 function numFormat(v, ax, fmtoverride, hover) {
         // negative?
     var isNeg = v < 0,
@@ -1144,7 +1145,7 @@ function numFormat(v, ax, fmtoverride, hover) {
             v += 'E' + signedExponent;
         }
         else if(exponentFormat === 'power') {
-            v += '&times;10<sup>' + signedExponent + '</sup>';
+            v += '×10<sup>' + signedExponent + '</sup>';
         }
         else if(exponentFormat === 'B' && exponent === 9) {
             v += 'B';

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -695,7 +695,7 @@ function cleanPoint(d, hovermode) {
             d.xLabel += ' +' + xeText + ' / -' +
                 Axes.tickText(d.xa, d.xa.c2l(d.xerrneg), 'hover').text;
         }
-        else d.xLabel += ' &plusmn; ' + xeText;
+        else d.xLabel += ' ± ' + xeText;
 
         // small distance penalty for error bars, so that if there are
         // traces with errors and some without, the error bar label will
@@ -708,7 +708,7 @@ function cleanPoint(d, hovermode) {
             d.yLabel += ' +' + yeText + ' / -' +
                 Axes.tickText(d.ya, d.ya.c2l(d.yerrneg), 'hover').text;
         }
-        else d.yLabel += ' &plusmn; ' + yeText;
+        else d.yLabel += ' ± ' + yeText;
 
         if(hovermode === 'y') d.distance += 1;
     }

--- a/test/image/mocks/axes_enumerated_ticks.json
+++ b/test/image/mocks/axes_enumerated_ticks.json
@@ -33,7 +33,7 @@
         "xaxis": {
             "ticktext": [
                 "<span style=\"fill:green\">green</span> eggs",
-                "&amp; ham",
+                "& ham",
                 "H<sub>2</sub>O",
                 "Gorgonzola"
             ],

--- a/test/jasmine/tests/svg_text_utils_test.js
+++ b/test/jasmine/tests/svg_text_utils_test.js
@@ -121,33 +121,34 @@ describe('svg+text utils', function() {
         });
 
         it('wrap XSS attacks in href', function() {
-            var textCases = [
-                '<a href="XSS\" onmouseover=&quot;alert(1)\" style=&quot;font-size:300px">Subtitle</a>',
+            var node = mockTextSVGElement(
+                '<a href="XSS" onmouseover="alert(1)" style="font-size:300px">Subtitle</a>'
+            );
+
+            expect(node.text()).toEqual('Subtitle');
+            assertAnchorAttrs(node);
+            assertAnchorLink(node, 'XSS onmouseover=alert(1) style=font-size:300px');
+        });
+
+        it('wrap XSS attacks with quoted entities in href', function() {
+            var node = mockTextSVGElement(
                 '<a href="XSS&quot; onmouseover=&quot;alert(1)&quot; style=&quot;font-size:300px">Subtitle</a>'
-            ];
+            );
 
-            textCases.forEach(function(textCase) {
-                var node = mockTextSVGElement(textCase);
-
-                expect(node.text()).toEqual('Subtitle');
-                assertAnchorAttrs(node);
-                assertAnchorLink(node, 'XSS onmouseover=alert(1) style=font-size:300px');
-            });
+            console.log(node.select('a').attr('xlink:href'));
+            expect(node.text()).toEqual('Subtitle');
+            assertAnchorAttrs(node);
+            assertAnchorLink(node, 'XSS&quot; onmouseover=&quot;alert(1)&quot; style=&quot;font-size:300px');
         });
 
         it('should keep query parameters in href', function() {
-            var textCases = [
-                '<a href="https://abc.com/myFeature.jsp?name=abc&pwd=def">abc.com?shared-key</a>',
-                '<a href="https://abc.com/myFeature.jsp?name=abc&amp;pwd=def">abc.com?shared-key</a>'
-            ];
+            var node = mockTextSVGElement(
+                '<a href="https://abc.com/myFeature.jsp?name=abc&pwd=def">abc.com?shared-key</a>'
+            );
 
-            textCases.forEach(function(textCase) {
-                var node = mockTextSVGElement(textCase);
-
-                assertAnchorAttrs(node);
-                expect(node.text()).toEqual('abc.com?shared-key');
-                assertAnchorLink(node, 'https://abc.com/myFeature.jsp?name=abc&pwd=def');
-            });
+            assertAnchorAttrs(node);
+            expect(node.text()).toEqual('abc.com?shared-key');
+            assertAnchorLink(node, 'https://abc.com/myFeature.jsp?name=abc&pwd=def');
         });
 
         it('allow basic spans', function() {


### PR DESCRIPTION
Remove HTML entity decoding from convertToSVG - this is unnecessary and imposes a performance hit on long strings.