### PR TITLE
Additional notes on verbose karma reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,13 @@ To run a specific suite, use:
 npm run test-jasmine -- tests/<suite>.js
 ```
 
-where the `<suite>` corresponds to the suite's file name as found in [`test/jasmine/tests/`](https://github.com/plotly/plotly.js/tree/master/test/jasmine/tests).
+where the `<suite>` corresponds to the suite's file name as found in [`test/jasmine/tests/`](https://github.com/plotly/plotly.js/tree/master/test/jasmine/tests). In certain situations, you may find that the default reporting is not verbose enough to pin down the source of the failing test. In this situation, you may wish to use [karma-verbose-reporter](https://www.npmjs.com/package/karma-verbose-reporter). You can use it without adding as a dev dependency by running:
+
+```
+npm install karma-verbose-reporter
+```
+
+and adding `reporters: ['verbose']` to the corresponding karma configuration file. (You should disable the `progress` reporter when using `verbose`.)
 
 
 Image pixel comparison tests are run in a docker container. For more

--- a/test/jasmine/karma.ciconf.js
+++ b/test/jasmine/karma.ciconf.js
@@ -6,6 +6,11 @@ function func(config) {
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     func.defaultConfig.logLevel = config.LOG_INFO;
 
+    // Note: config.LOG_DEBUG may not be verbose enough to pin down the source of failed tests.
+    // See the note in CONTRIBUTING.md about karma-verbose-reporter:
+    // func.defaultConfig.reporters = ['verbose'];
+
+
     // Continuous Integration mode
 
     /*

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -26,6 +26,9 @@ function func(config) {
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    //
+    // NB: if you try config.LOG_DEBUG, you may actually be looking for karma-verbose-reporter.
+    //     See CONTRIBUTING.md for additional notes on reporting.
     func.defaultConfig.logLevel = config.LOG_INFO;
 
     config.set(func.defaultConfig);
@@ -56,6 +59,10 @@ func.defaultConfig = {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    //
+    // See note in CONTRIBUTING.md about more verbose reporting via karma-verbose-reporter:
+    // https://www.npmjs.com/package/karma-verbose-reporter ('verbose')
+    //
     reporters: ['progress'],
 
     // web server port


### PR DESCRIPTION
This PR adds additional notes on `karma-verbose-reporter`, which is definitely what I was actually looking for when I tried `config.LOG_DEBUG`—which I found verbose without adding any useful information. The comments are intended to serve as a signpost toward what, in hindsight, would have helped me locate messy test failures much faster.