### PR TITLE
Faster relink private keys

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -610,9 +610,9 @@ function relinkPrivateKeys(toContainer, fromContainer) {
 
             toContainer[k] = fromVal;
         }
-        else if(isArray(fromVal) && isArray(toVal)) {
+        else if(isArray(fromVal) && isArray(toVal) && isPlainObject(fromVal[0])) {
 
-            // recurse into arrays
+            // recurse into arrays containers
             for(var j = 0; j < fromVal.length; j++) {
                 if(isPlainObject(fromVal[j]) && isPlainObject(toVal[j])) {
                     relinkPrivateKeys(toVal[j], fromVal[j]);

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -50,6 +50,8 @@ describe('Test Plots', function() {
 
             Plots.supplyDefaults(gd);
 
+            expect(gd._fullData[0].z).toBe(newData[0].z);
+            expect(gd._fullData[1].z).toBe(newData[1].z);
             expect(gd._fullData[1]._empties).toBe(oldFullData[1]._empties);
             expect(gd._fullLayout.scene._scene).toBe(oldFullLayout.scene._scene);
             expect(gd._fullLayout._plots).toBe(oldFullLayout._plots);


### PR DESCRIPTION
The `relinkPrivateKeys` step was refactor in https://github.com/plotly/plotly.js/pull/499/commits/37e291b0439f5c5baa7df52895bdc22aa2c255d5, to accommodate transform operation they may change the side of array containers.

In doing so, it made the `Plots.supplyDefaults` step dive into all arrays present in `"data"` / `"layout"` - not just array container (e.g. annotations, images, etc as originally intended. My mistake.