### PR TITLE
Skip over non-object mapbox layer containers

### DIFF
--- a/src/plots/mapbox/layout_defaults.js
+++ b/src/plots/mapbox/layout_defaults.js
@@ -50,8 +50,10 @@ function handleLayerDefaults(containerIn, containerOut) {
     }
 
     for(var i = 0; i < layersIn.length; i++) {
-        layerIn = layersIn[i] || {};
+        layerIn = layersIn[i];
         layerOut = {};
+
+        if(!Lib.isPlainObject(layerIn)) continue;
 
         var sourceType = coerce('sourcetype');
         coerce('source');
@@ -86,6 +88,7 @@ function handleLayerDefaults(containerIn, containerOut) {
             coerce('symbol.textposition');
         }
 
+        layerOut._index = i;
         layersOut.push(layerOut);
     }
 }

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -80,6 +80,20 @@ describe('mapbox defaults', function() {
         expect(layoutOut.mapbox.layers[1].sourcetype).toEqual('geojson');
     });
 
+    it('should skip over non-object layer containers', function() {
+        layoutIn = {
+            mapbox: {
+                layers: [{}, null, 'remove', {}]
+            }
+        };
+
+        supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+        expect(layoutOut.mapbox.layers[0].sourcetype).toEqual('geojson');
+        expect(layoutOut.mapbox.layers[0]._index).toEqual(0);
+        expect(layoutOut.mapbox.layers[1].sourcetype).toEqual('geojson');
+        expect(layoutOut.mapbox.layers[1]._index).toEqual(3);
+    });
+
     it('should coerce \'sourcelayer\' only for *vector* \'sourcetype\'', function() {
         layoutIn = {
             mapbox: {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/818

I'm starting to really like putting `isPlainObject` checks early in the default step for `isLinkedToArray` containers. Together with adding a ref to the input index with  `_index`, we should think about generalisign this pattern to the older `isLinkedToArray` container `annoations` and `shapes`.