### PR TITLE
avoid draw buffer -> display buffer copy

### DIFF
--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -84,7 +84,7 @@ proto.makeFramework = function() {
 
             try {
                 STATIC_CONTEXT = STATIC_CANVAS.getContext('webgl', {
-                    preserveDrawingBuffer: true,
+                    preserveDrawingBuffer: false,
                     premultipliedAlpha: true,
                     antialias: true
                 });


### PR DESCRIPTION
General WebGL speedup (currently done for 2D plots only) that can help low-end platforms such as current MacBook and mobile platforms that have large display buffers (high resolution)