### PR TITLE
Bump server repsonse retry limit to 20

### DIFF
--- a/tasks/util/container_commands.js
+++ b/tasks/util/container_commands.js
@@ -8,7 +8,7 @@ var containerCommands = {
 
 containerCommands.ping = [
     'wget',
-    '--server-response --spider --tries=10 --retry-connrefused',
+    '--server-response --spider --tries=20 --retry-connrefused',
     constants.testContainerUrl + 'ping'
 ].join(' ');
 


### PR DESCRIPTION
Intermittent failures at the `pretest` step have more common ever since  https://github.com/plotly/plotly.js/pull/821 get merged.

This PR attempts to solve the problem by bumping the `wget` server response command from 10 to 20.