### PR TITLE
Add hoverinfo skip

### DIFF
--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -72,7 +72,7 @@ module.exports = {
         valType: 'flaglist',
         role: 'info',
         flags: ['x', 'y', 'z', 'text', 'name'],
-        extras: ['all', 'none'],
+        extras: ['all', 'none', 'skip'],
         dflt: 'all',
         description: 'Determines which trace information appear on hover.'
     },

--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -74,7 +74,11 @@ module.exports = {
         flags: ['x', 'y', 'z', 'text', 'name'],
         extras: ['all', 'none', 'skip'],
         dflt: 'all',
-        description: 'Determines which trace information appear on hover.'
+        description: [
+            'Determines which trace information appear on hover.',
+            'If `none` or `skip` are set, no information is displayed upon hovering.',
+            'But, if `none` is set, click and hover events are still fired.'
+        ].join(' ')
     },
     stream: {
         token: {

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -394,14 +394,16 @@ function hover(gd, evt, subplot) {
         hovermode = 'array';
         for(itemnum = 0; itemnum < evt.length; itemnum++) {
             cd = gd.calcdata[evt[itemnum].curveNumber||0];
-            searchData.push(cd);
+            if(cd[0].trace.hoverinfo !== 'skip') {
+                searchData.push(cd);
+            }
         }
     }
     else {
         for(curvenum = 0; curvenum < gd.calcdata.length; curvenum++) {
             cd = gd.calcdata[curvenum];
             trace = cd[0].trace;
-            if(subplots.indexOf(getSubplot(trace)) !== -1) {
+            if(trace.hoverinfo !== 'skip' && subplots.indexOf(getSubplot(trace)) !== -1) {
                 searchData.push(cd);
             }
         }

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -478,7 +478,7 @@ proto.draw = function() {
             (y / glplot.pixelRatio) - (size.t + (1 - domainY[1]) * size.h)
         );
 
-        if(result && fullLayout.hovermode) {
+        if(result && result.object._trace.hoverinfo !== 'skip' && fullLayout.hovermode) {
             var nextSelection = result.object._trace.handlePick(result);
 
             if(nextSelection && (
@@ -488,6 +488,7 @@ proto.draw = function() {
                 this.lastPickResult.dataCoord[1] !== nextSelection.dataCoord[1])
             ) {
                 var selection = nextSelection;
+
                 this.lastPickResult = {
                     traceUid: nextSelection.trace ? nextSelection.trace.uid : null,
                     dataCoord: nextSelection.dataCoord.slice()

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -50,7 +50,7 @@ function render(scene) {
     var selection = scene.glplot.selection;
     for(var i = 0; i < keys.length; ++i) {
         trace = scene.traces[keys[i]];
-        if(trace.handlePick(selection)) {
+        if(trace.data.hoverinfo !== 'skip' && trace.handlePick(selection)) {
             lastPicked = trace;
         }
 

--- a/src/traces/choropleth/plot.js
+++ b/src/traces/choropleth/plot.js
@@ -165,7 +165,7 @@ plotChoropleth.style = function(geo) {
 function makeCleanHoverLabelsFunc(geo, trace) {
     var hoverinfo = trace.hoverinfo;
 
-    if(hoverinfo === 'none') {
+    if(hoverinfo === 'none' || hoverinfo === 'skip') {
         return function cleanHoverLabelsFunc(pt) {
             delete pt.nameLabel;
             delete pt.textLabel;

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -96,7 +96,7 @@ module.exports = function plot(gd, cdpie) {
                     // in case we dragged over the pie from another subplot,
                     // or if hover is turned off
                     if(gd._dragging || fullLayout2.hovermode === false ||
-                            hoverinfo === 'none' || !hoverinfo) {
+                            hoverinfo === 'none' || hoverinfo === 'skip' || !hoverinfo) {
                         return;
                     }
 

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -82,6 +82,48 @@ describe('Test click interactions:', function() {
         });
     });
 
+    describe('click event with hoverinfo set to skip - plotly_click', function() {
+        var futureData = null;
+
+        beforeEach(function(done) {
+
+            var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
+            modifiedMockCopy.data[0].hoverinfo = 'skip';
+            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+                .then(done);
+
+            gd.on('plotly_click', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should not register the click', function() {
+            click(pointPos[0], pointPos[1]);
+            expect(futureData).toEqual(null);
+        });
+    });
+
+    describe('click events with hoverinfo set to skip - plotly_hover', function() {
+        var futureData = null;
+
+        beforeEach(function(done) {
+
+            var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
+            modifiedMockCopy.data[0].hoverinfo = 'skip';
+            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+                .then(done);
+
+            gd.on('plotly_hover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should not register the hover', function() {
+            click(pointPos[0], pointPos[1]);
+            expect(futureData).toEqual(null);
+        });
+    });
+
     describe('click event with hoverinfo set to none - plotly_click', function() {
         var futureData;
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -300,6 +300,23 @@ describe('hover info', function() {
         });
     });
 
+    describe('hover info skip', function() {
+        var mockCopy = Lib.extendDeep({}, mock);
+
+        mockCopy.data[0].hoverinfo = 'skip';
+
+        beforeEach(function(done) {
+            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+        });
+
+        it('does not hover if hover info is set to skip', function() {
+            var gd = document.getElementById('graph');
+            Fx.hover('graph', evt, 'xy');
+
+            expect(gd._hoverdata, undefined);
+        });
+    });
+
     describe('hover info none', function() {
         var mockCopy = Lib.extendDeep({}, mock);
 


### PR DESCRIPTION
Add a new hoverinfo flag 'skip'. This prevents a trace from being considered for hovering or clicking. Addresses #678.