### PR TITLE
Don't use `child_process.exec` to setup docker container on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,10 @@ dependencies:
   pre:
     - docker pull plotly/testbed:latest
   post:
+    - eval $(node tasks/run_docker.js)
     - npm run cibuild
     - npm run pretest
+    - eval $(node tasks/setup_docker.js)
 
 test:
   override:

--- a/tasks/pretest.js
+++ b/tasks/pretest.js
@@ -2,14 +2,11 @@ var fs = require('fs');
 
 var constants = require('./util/constants');
 var common = require('./util/common');
-var containerCommands = require('./util/container_commands');
-var isCI = process.env.CIRCLECI;
 
 // main
 makeCredentialsFile();
 makeSetPlotConfigFile();
 makeTestImageFolders();
-if(isCI) runAndSetupImageTestContainer();
 
 // Create a credentials json file,
 // to be required in jasmine test suites and test dashboard
@@ -53,30 +50,6 @@ function makeTestImageFolders() {
 
     makeOne(constants.pathToTestImages, 'test image folder');
     makeOne(constants.pathToTestImagesDiff, 'test image diff folder');
-}
-
-// On CircleCI, run and setup image test container once an for all
-function runAndSetupImageTestContainer() {
-
-    function run() {
-        var cmd = containerCommands.dockerRun;
-        common.execCmd(cmd, function() {
-            logger('run docker container');
-
-            setTimeout(setup, 500);
-        });
-    }
-
-    function setup() {
-        var cmd = containerCommands.getRunCmd(isCI, [
-            containerCommands.setup
-        ]);
-        common.execCmd(cmd, function() {
-            logger('setup docker container');
-        });
-    }
-
-    run();
 }
 
 function logger(task) {

--- a/tasks/run_docker.js
+++ b/tasks/run_docker.js
@@ -1,0 +1,18 @@
+var constants = require('./util/constants');
+var common = require('./util/common');
+var containerCommands = require('./util/container_commands');
+var isCI = process.env.CIRCLECI;
+
+var msg = 'Booting up ' + constants.testContainerName + ' docker container';
+var cmd = containerCommands.dockerRun;
+
+// Log command string on CircleCI,
+//  because node's `child_process.exec()` is having issues there
+
+if(isCI) {
+    console.log(cmd);
+}
+else {
+    console.log(msg);
+    common.execCmd(cmd);
+}

--- a/tasks/setup_docker.js
+++ b/tasks/setup_docker.js
@@ -1,0 +1,20 @@
+var constants = require('./util/constants');
+var common = require('./util/common');
+var containerCommands = require('./util/container_commands');
+var isCI = process.env.CIRCLECI;
+
+var msg = 'Setting up ' + constants.testContainerName + ' docker container for testing';
+var cmd = containerCommands.getRunCmd(process.env.CIRCLECI, [
+    containerCommands.setup
+]);
+
+// Log command string on CircleCI,
+//  because node's `child_process.exec()` is having issues there
+
+if(isCI) {
+    console.log(cmd);
+}
+else {
+    console.log(msg);
+    common.execCmd(cmd);
+}


### PR DESCRIPTION
We've seen a lot of intermittent test failure on CircleCI during the `npm run pretest` test ever since #821 got merged and https://github.com/plotly/plotly.js/pull/849 does not seem to help much.

So I decided to dumb down the pretest step. Instead of having one node script that does it all, this PR split the docker container tasks in two steps. These tasks are call using the shell `eval`.

cc @rreusser 