### PR TITLE
Improve gl2d interactions

### DIFF
--- a/src/plots/gl2d/camera.js
+++ b/src/plots/gl2d/camera.js
@@ -32,6 +32,11 @@ function createCamera(scene) {
         plot = scene.glplot,
         result = new Camera2D(element, plot);
 
+    function unSetAutoRange() {
+        scene.xaxis.autorange = false;
+        scene.yaxis.autorange = false;
+    }
+
     result.mouseListener = mouseChange(element, function(buttons, x, y) {
         var xrange = scene.xaxis.range,
             yrange = scene.yaxis.range,
@@ -84,7 +89,7 @@ function createCamera(scene) {
                 else if(result.boxEnabled) {
                     updateRange(xrange, result.boxStart[0], result.boxEnd[0]);
                     updateRange(yrange, result.boxStart[1], result.boxEnd[1]);
-
+                    unSetAutoRange();
                     result.boxEnabled = false;
                 }
                 break;
@@ -104,7 +109,7 @@ function createCamera(scene) {
                     yrange[1] += dy;
 
                     result.lastInputTime = Date.now();
-
+                    unSetAutoRange();
                     scene.cameraChanged();
                 }
                 break;
@@ -142,6 +147,7 @@ function createCamera(scene) {
                 yrange[1] = (yrange[1] - cy) * scale + cy;
 
                 result.lastInputTime = Date.now();
+                unSetAutoRange();
                 scene.cameraChanged();
                 break;
         }

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -275,7 +275,9 @@ var relayoutCallback = function(scene) {
         yrange = scene.yaxis.range;
 
     // Update the layout on the DIV
+    scene.graphDiv.layout.xaxis.autorange = scene.xaxis.autorange;
     scene.graphDiv.layout.xaxis.range = xrange.slice(0);
+    scene.graphDiv.layout.yaxis.autorange = scene.yaxis.autorange;
     scene.graphDiv.layout.yaxis.range = yrange.slice(0);
 
     // Make a meaningful value to be passed on to the possible 'plotly_relayout' subscriber(s)

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -335,8 +335,6 @@ proto.plot = function(fullData, calcData, fullLayout) {
     var glplot = this.glplot,
         pixelRatio = this.pixelRatio;
 
-    var i;
-
     this.fullLayout = fullLayout;
     this.updateAxes(fullLayout);
     this.updateTraces(fullData, calcData);
@@ -379,6 +377,8 @@ proto.plot = function(fullData, calcData, fullLayout) {
     bounds[2] = bounds[3] = -Infinity;
 
     var traceIds = Object.keys(this.traces);
+    var ax, i;
+
     for(i = 0; i < traceIds.length; ++i) {
         var traceObj = this.traces[traceIds[i]];
 
@@ -388,7 +388,6 @@ proto.plot = function(fullData, calcData, fullLayout) {
         }
     }
 
-    var ax;
     for(i = 0; i < 2; ++i) {
         if(bounds[i] > bounds[i + 2]) {
             bounds[i] = -1;

--- a/src/traces/contourgl/convert.js
+++ b/src/traces/contourgl/convert.js
@@ -20,6 +20,7 @@ var str2RGBArray = require('../../lib/str2rgbarray');
 function Contour(scene, uid) {
     this.scene = scene;
     this.uid = uid;
+    this.type = 'contourgl';
 
     this.name = '';
     this.hoverinfo = 'all';

--- a/src/traces/contourgl/convert.js
+++ b/src/traces/contourgl/convert.js
@@ -12,6 +12,7 @@
 var createContour2D = require('gl-contour2d');
 var createHeatmap2D = require('gl-heatmap2d');
 
+var Axes = require('../../plots/cartesian/axes');
 var makeColorMap = require('../contour/make_color_map');
 var str2RGBArray = require('../../lib/str2rgbarray');
 
@@ -96,7 +97,6 @@ proto.update = function(fullTrace, calcTrace) {
     this.contourOptions.x = this.heatmapOptions.x = calcPt.x;
     this.contourOptions.y = this.heatmapOptions.y = calcPt.y;
 
-
     // pass on fill information
     if(fullTrace.contours.coloring === 'fill') {
         colorOptions = convertColorScale(fullTrace, {fill: true});
@@ -118,6 +118,10 @@ proto.update = function(fullTrace, calcTrace) {
 
     this.contour.update(this.contourOptions);
     this.heatmap.update(this.heatmapOptions);
+
+    // expand axes
+    Axes.expand(this.scene.xaxis, calcPt.x);
+    Axes.expand(this.scene.yaxis, calcPt.y);
 };
 
 proto.dispose = function() {

--- a/src/traces/heatmap/calc.js
+++ b/src/traces/heatmap/calc.js
@@ -29,6 +29,7 @@ module.exports = function calc(gd, trace) {
         ya = Axes.getFromId(gd, trace.yaxis || 'y'),
         isContour = Plots.traceIs(trace, 'contour'),
         isHist = Plots.traceIs(trace, 'histogram'),
+        isGL2D = Plots.traceIs(trace, 'gl2d'),
         zsmooth = isContour ? 'best' : trace.zsmooth,
         x,
         x0,
@@ -112,8 +113,11 @@ module.exports = function calc(gd, trace) {
         yIn = trace.ytype === 'scaled' ? '' : trace.y,
         yArray = makeBoundArray(trace, yIn, y0, dy, z.length, ya);
 
-    Axes.expand(xa, xArray);
-    Axes.expand(ya, yArray);
+    // handler in gl2d convert step
+    if(!isGL2D) {
+        Axes.expand(xa, xArray);
+        Axes.expand(ya, yArray);
+    }
 
     var cd0 = {x: xArray, y: yArray, z: z};
 

--- a/src/traces/heatmap/calc.js
+++ b/src/traces/heatmap/calc.js
@@ -113,7 +113,7 @@ module.exports = function calc(gd, trace) {
         yIn = trace.ytype === 'scaled' ? '' : trace.y,
         yArray = makeBoundArray(trace, yIn, y0, dy, z.length, ya);
 
-    // handler in gl2d convert step
+    // handled in gl2d convert step
     if(!isGL2D) {
         Axes.expand(xa, xArray);
         Axes.expand(ya, yArray);

--- a/src/traces/heatmapgl/convert.js
+++ b/src/traces/heatmapgl/convert.js
@@ -10,7 +10,7 @@
 'use strict';
 
 var createHeatmap2D = require('gl-heatmap2d');
-
+var Axes = require('../../plots/cartesian/axes');
 var str2RGBArray = require('../../lib/str2rgbarray');
 
 
@@ -87,6 +87,9 @@ proto.update = function(fullTrace, calcTrace) {
     this.textLabels = [].concat.apply([], fullTrace.text);
 
     this.heatmap.update(this.options);
+
+    Axes.expand(this.scene.xaxis, calcPt.x);
+    Axes.expand(this.scene.yaxis, calcPt.y);
 };
 
 proto.dispose = function() {

--- a/src/traces/heatmapgl/convert.js
+++ b/src/traces/heatmapgl/convert.js
@@ -17,6 +17,7 @@ var str2RGBArray = require('../../lib/str2rgbarray');
 function Heatmap(scene, uid) {
     this.scene = scene;
     this.uid = uid;
+    this.type = 'heatmapgl';
 
     this.name = '';
     this.hoverinfo = 'all';

--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -32,6 +32,7 @@ var AXES = ['xaxis', 'yaxis'];
 function LineWithMarkers(scene, uid) {
     this.scene = scene;
     this.uid = uid;
+    this.type = 'scattergl';
 
     this.pickXData = [];
     this.pickYData = [];

--- a/test/jasmine/tests/gl2d_scatterplot_contour_test.js
+++ b/test/jasmine/tests/gl2d_scatterplot_contour_test.js
@@ -4,8 +4,9 @@ var Plotly = require('@lib/index');
 var Lib = require('@src/lib');
 var d3 = require('d3');
 
-// contourgl is not part of the dist plotly.js bundle initially
+// heatmapgl & contourgl is not part of the dist plotly.js bundle initially
 Plotly.register(
+    require('@lib/heatmapgl'),
     require('@lib/contourgl')
 );
 
@@ -207,5 +208,46 @@ describe('contourgl plots', function() {
         mock.data[0].contours.coloring = 'fill'; // 'fill' is the default
         mock.data[0].line = {smoothing: 0};
         makePlot(gd, mock, done);
+    });
+
+    it('should update properly', function(done) {
+        var mock = plotDataElliptical(0);
+        var scene2d;
+
+        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+            scene2d = gd._fullLayout._plots.xy._scene2d;
+
+            expect(scene2d.traces[mock.data[0].uid].type).toEqual('contourgl');
+            expect(scene2d.xaxis._min).toEqual([{ val: -1, pad: 0}]);
+            expect(scene2d.xaxis._max).toEqual([{ val: 1, pad: 0}]);
+
+            return Plotly.relayout(gd, 'xaxis.range', [0, -10]);
+        }).then(function() {
+            expect(scene2d.xaxis._min).toEqual([]);
+            expect(scene2d.xaxis._max).toEqual([]);
+
+            return Plotly.relayout(gd, 'xaxis.autorange', true);
+        }).then(function() {
+            expect(scene2d.xaxis._min).toEqual([{ val: -1, pad: 0}]);
+            expect(scene2d.xaxis._max).toEqual([{ val: 1, pad: 0}]);
+
+            return Plotly.restyle(gd, 'type', 'heatmapgl');
+        }).then(function() {
+            expect(scene2d.traces[mock.data[0].uid].type).toEqual('heatmapgl');
+            expect(scene2d.xaxis._min).toEqual([{ val: -1, pad: 0}]);
+            expect(scene2d.xaxis._max).toEqual([{ val: 1, pad: 0}]);
+
+            return Plotly.relayout(gd, 'xaxis.range', [0, -10]);
+        }).then(function() {
+            expect(scene2d.xaxis._min).toEqual([]);
+            expect(scene2d.xaxis._max).toEqual([]);
+
+            return Plotly.relayout(gd, 'xaxis.autorange', true);
+        }).then(function() {
+            expect(scene2d.xaxis._min).toEqual([{ val: -1, pad: 0}]);
+            expect(scene2d.xaxis._max).toEqual([{ val: 1, pad: 0}]);
+
+            done();
+        });
     });
 });

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -248,6 +248,8 @@ describe('Test gl plot interactions', function() {
             var newX = [-0.23224043715846995, 4.811895754518705];
             var newY = [-1.2962655110623016, 4.768255474123081];
 
+            expect(gd.layout.xaxis.autorange).toBe(true);
+            expect(gd.layout.yaxis.autorange).toBe(true);
             expect(gd.layout.xaxis.range).toBeCloseToArray(originalX, precision);
             expect(gd.layout.yaxis.range).toBeCloseToArray(originalY, precision);
 
@@ -269,6 +271,9 @@ describe('Test gl plot interactions', function() {
                 // Drag scene along the X axis
 
                 mouseEvent('mousemove', 220, 200, {buttons: 1});
+
+                expect(gd.layout.xaxis.autorange).toBe(false);
+                expect(gd.layout.yaxis.autorange).toBe(false);
 
                 expect(gd.layout.xaxis.range).toBeCloseToArray(newX, precision);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(originalY, precision);


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/830 and https://github.com/plotly/plotly.js/issues/545

In brief

- `heatmapgl` and `contourgl` traces rescale properly when click on the reset axes and autoscale modebar button via https://github.com/plotly/plotly.js/commit/330c5f3cd1aaccad9fa1c9607006f5891dd78c69
- toggling gl2d trace via the legend preserves the current axis range (post interactions) via https://github.com/plotly/plotly.js/commit/e0d05f6265c6ccf91d34dc2d1fde3e51abce075e