### PR TITLE
Ensure that extendDeepNoArrays includes typed arrays by reference

### DIFF
--- a/test/jasmine/.eslintrc
+++ b/test/jasmine/.eslintrc
@@ -5,6 +5,10 @@
     "jasmine": true
   },
   "globals": {
-    "Promise": true
+    "Promise": true,
+    "Float32Array": true,
+    "Float64Array": true,
+    "Int16Array": true,
+    "Int32Array": true
   }
 }

--- a/test/jasmine/tests/extend_test.js
+++ b/test/jasmine/tests/extend_test.js
@@ -505,4 +505,20 @@ describe('array by reference vs deep-copy', function() {
         expect(ext.foo.bop).toBe(tar.foo.bop);
     });
 
+    it('extendDeep ALSO includes by reference typed arrays from source', function() {
+        var src = {foo: {bar: new Int32Array([1, 2, 3]), baz: new Float32Array([5, 4, 3])}};
+        var tar = {foo: {bar: new Int16Array([4, 5, 6]), bop: new Float64Array([8, 2, 1])}};
+        var ext = extendDeep(tar, src);
+
+        expect(ext).not.toBe(src);
+        expect(ext).toBe(tar);
+
+        expect(ext.foo).not.toBe(src.foo);
+        expect(ext.foo).toBe(tar.foo);
+
+        expect(ext.foo.bar).toBe(src.foo.bar);
+        expect(ext.foo.baz).toBe(src.foo.baz);
+        expect(ext.foo.bop).toBe(tar.foo.bop);
+    });
+
 });

--- a/test/jasmine/tests/extend_test.js
+++ b/test/jasmine/tests/extend_test.js
@@ -454,10 +454,26 @@ describe('extendDeepAll', function() {
     });
 });
 
-describe('extendDeepNoArrays', function() {
+describe('array by reference vs deep-copy', function() {
     'use strict';
 
-    it('does not copy arrays', function() {
+    it('extendDeep DOES deep-copy untyped source arrays', function() {
+        var src = {foo: {bar: [1, 2, 3], baz: [5, 4, 3]}};
+        var tar = {foo: {bar: [4, 5, 6], bop: [8, 2, 1]}};
+        var ext = extendDeep(tar, src);
+
+        expect(ext).not.toBe(src);
+        expect(ext).toBe(tar);
+
+        expect(ext.foo).not.toBe(src.foo);
+        expect(ext.foo).toBe(tar.foo);
+
+        expect(ext.foo.bar).not.toBe(src.foo.bar);
+        expect(ext.foo.baz).not.toBe(src.foo.baz);
+        expect(ext.foo.bop).toBe(tar.foo.bop); // what comes from the target isn't deep copied
+    });
+
+    it('extendDeepNoArrays includes by reference untyped arrays from source', function() {
         var src = {foo: {bar: [1, 2, 3], baz: [5, 4, 3]}};
         var tar = {foo: {bar: [4, 5, 6], bop: [8, 2, 1]}};
         var ext = extendDeepNoArrays(tar, src);
@@ -472,4 +488,21 @@ describe('extendDeepNoArrays', function() {
         expect(ext.foo.baz).toBe(src.foo.baz);
         expect(ext.foo.bop).toBe(tar.foo.bop);
     });
+
+    it('extendDeepNoArrays includes by reference typed arrays from source', function() {
+        var src = {foo: {bar: new Int32Array([1, 2, 3]), baz: new Float32Array([5, 4, 3])}};
+        var tar = {foo: {bar: new Int16Array([4, 5, 6]), bop: new Float64Array([8, 2, 1])}};
+        var ext = extendDeepNoArrays(tar, src);
+
+        expect(ext).not.toBe(src);
+        expect(ext).toBe(tar);
+
+        expect(ext.foo).not.toBe(src.foo);
+        expect(ext.foo).toBe(tar.foo);
+
+        expect(ext.foo.bar).toBe(src.foo.bar);
+        expect(ext.foo.baz).toBe(src.foo.baz);
+        expect(ext.foo.bop).toBe(tar.foo.bop);
+    });
+
 });

--- a/test/jasmine/tests/extend_test.js
+++ b/test/jasmine/tests/extend_test.js
@@ -1,3 +1,5 @@
+/*global Float32Array, Float64Array, Int16Array, Int32Array */
+
 var extendModule = require('@src/lib/extend.js');
 var extendFlat = extendModule.extendFlat;
 var extendDeep = extendModule.extendDeep;

--- a/test/jasmine/tests/extend_test.js
+++ b/test/jasmine/tests/extend_test.js
@@ -1,5 +1,3 @@
-/*global Float32Array, Float64Array, Int16Array, Int32Array */
-
 var extendModule = require('@src/lib/extend.js');
 var extendFlat = extendModule.extendFlat;
 var extendDeep = extendModule.extendDeep;


### PR DESCRIPTION
These changes ensure that `extendDeepNoArrays` includes by reference (i.e. does NOT deep-copy) typed arrays. Initially it looked as though the [definition](https://github.com/plotly/plotly.js/blob/master/src/lib/extend.js#L13) of `isArray` needs to be changed to
```
var isArray = function(a) {
    return ArrayBuffer.isView(a) || Array.isArray(a);
};
``` 
because `Array.isArray` returns `false` for typed arrays.

But it turned out that even the plain `extendDeep` already didn't deep-copy TYPED arrays. Therefore it was sufficient to add test coverage to ensure that `extendDeepNoArrays` doesn't deep-copy the typed arrays.

An additional commit locks in the current, untested `extendDeep` behavior with typed arrays. However it's contentious because maybe the reason for this `extendDeep` behavior is that perhaps the `plotly.js` doesn't use expect typed arrays (expects UNtyped arrays expressly or by implication). There are some good arguments for the benefits of the current `extendDeep` behavior when it comes to handling user-supplied typed-array input - e.g. typed arrays generally indicate performance awareness, therefore the user can reasonably expect structure sharing internally. It would make sense to treat typed arrays as atomic values, which is the current `extendDeep` behavior. It means that for performance critical code sections that would use typed array, the `plotly.js` contributor has to bear in mind that typed arrays are included by reference.

If the second commit isn't timely, I'm glad to reset it, but even in that case it's useful to ensure that `extendDeepNoArrays` doesn't deep copy typed arrays (first commit) as there's a WebGL plot performance improvement that hinges on it.