### PR TITLE
Fix range selector position logic for overlaying axes

### DIFF
--- a/src/components/rangeselector/defaults.js
+++ b/src/components/rangeselector/defaults.js
@@ -83,7 +83,8 @@ function getPosDflt(containerOut, layout, counterAxes) {
 
     var posY = 0;
     for(var i = 0; i < anchoredList.length; i++) {
-        posY = Math.max(layout[anchoredList[i]].domain[1], posY);
+        var domain = layout[anchoredList[i]].domain;
+        if(domain) posY = Math.max(domain[1], posY);
     }
 
     return [containerOut.domain[0], posY + constants.yPad];

--- a/test/jasmine/tests/range_selector_test.js
+++ b/test/jasmine/tests/range_selector_test.js
@@ -161,7 +161,7 @@ describe('range selector defaults:', function() {
             },
             yaxis2: {
                 anchor: 'x',
-                domain: [0.3, 0.55]
+                overlaying: 'y'
             },
             yaxis3: {
                 anchor: 'x',


### PR DESCRIPTION
fixes bug reported on this forum [post](http://community.plot.ly/t/range-selector-on-x-axis-seems-to-break-when-using-multiple-y-axes/1904/3).

To note, overlaying axes don't get coerced domain (logic [here](https://github.com/plotly/plotly.js/blob/c837359532dac161d157eadde7277406757736d5/src/plots/cartesian/position_defaults.js#L52-L60)).