### PR TITLE
Fix register call in gl2d test suite

### DIFF
--- a/test/jasmine/tests/gl2d_scatterplot_contour_test.js
+++ b/test/jasmine/tests/gl2d_scatterplot_contour_test.js
@@ -5,10 +5,10 @@ var Lib = require('@src/lib');
 var d3 = require('d3');
 
 // heatmapgl & contourgl is not part of the dist plotly.js bundle initially
-Plotly.register(
+Plotly.register([
     require('@lib/heatmapgl'),
     require('@lib/contourgl')
-);
+]);
 
 // Test utilities
 var createGraphDiv = require('../assets/create_graph_div');


### PR DESCRIPTION
PR https://github.com/plotly/plotly.js/pull/855 added a few test cases in `gl_plot_interact_test.js` but messed up the `Plotly.register` call. This PR fixes it.