### PR TITLE
Fix mapbox visible false first draw

### DIFF
--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -212,7 +212,7 @@ proto.updateData = function(calcData) {
         traceObj = traceHash[trace.uid];
 
         if(traceObj) traceObj.update(calcTrace);
-        else {
+        else if(trace._module) {
             traceHash[trace.uid] = trace._module.plot(this, calcTrace);
         }
     }

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -295,6 +295,12 @@ describe('mapbox plots', function() {
         }).then(function() {
             expect(countVisibleTraces(gd, modes)).toEqual(2);
 
+            mock.data[0].visible = false;
+
+            return Plotly.newPlot(gd, mock.data, mock.layout);
+        }).then(function() {
+            expect(countVisibleTraces(gd, modes)).toEqual(1);
+
             done();
         });
     });


### PR DESCRIPTION
Passing in `scattermapbox` trace with `visible: false` to `Plotly.plot` resulted in plot code exceptions (updates with `visible: false` worked and work fine).
