### PR TITLE
Add a requestAnimationFrame polyfill

### DIFF
--- a/dist/extras/request_animation_frame.js
+++ b/dist/extras/request_animation_frame.js
@@ -1,0 +1,42 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+// This code adapted from:
+//
+// http://paulirish.com/2011/requestanimationframe-for-smart-animating/
+// http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
+
+// requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
+
+// MIT license
+
+
+'use strict';
+
+if(!Date.now) {
+    Date.now = function() { return new Date().getTime(); };
+}
+
+var vendors = ['webkit', 'moz'];
+for(var i = 0; i < vendors.length && !window.requestAnimationFrame; ++i) {
+    var vp = vendors[i];
+    window.requestAnimationFrame = window[vp + 'RequestAnimationFrame'];
+    window.cancelAnimationFrame = (window[vp + 'CancelAnimationFrame'] ||
+                                   window[vp + 'CancelRequestAnimationFrame']);
+}
+if(/iP(ad|hone|od).*OS 6/.test(window.navigator.userAgent) || // iOS6 is buggy
+    !window.requestAnimationFrame || !window.cancelAnimationFrame) {
+    var lastTime = 0;
+    window.requestAnimationFrame = function(callback) {
+        var now = Date.now();
+        var nextTime = Math.max(lastTime + 16, now);
+        return setTimeout(function() { callback(lastTime = nextTime); },
+                          nextTime - now);
+    };
+    window.cancelAnimationFrame = clearTimeout;
+}

--- a/src/components/rangeslider/create_slider.js
+++ b/src/components/rangeslider/create_slider.js
@@ -221,16 +221,9 @@ module.exports = function createSlider(gd) {
     }
 
     function setDataRange(dataMin, dataMax) {
-
-        if(window.requestAnimationFrame) {
-            window.requestAnimationFrame(function() {
-                Plotly.relayout(gd, 'xaxis.range', [dataMin, dataMax]);
-            });
-        } else {
-            setTimeout(function() {
-                Plotly.relayout(gd, 'xaxis.range', [dataMin, dataMax]);
-            }, 16);
-        }
+        window.requestAnimationFrame(function() {
+            Plotly.relayout(gd, 'xaxis.range', [dataMin, dataMax]);
+        });
     }
 
 

--- a/tasks/stats.js
+++ b/tasks/stats.js
@@ -52,6 +52,7 @@ function getInfoContent() {
         '',
         '```html',
         '<script>if(typeof window.Int16Array !== \'function\')document.write("<scri"+"pt src=\'extras/typedarray.min.js\'></scr"+"ipt>");</script>',
+        '<script>document.write("<scri"+"pt src=\'extras/request_animation_frame.js\'></scr"+"ipt>");</script>',
         '```',
         '',
         'before the plotly.js script tag.',


### PR DESCRIPTION
This PR adds a proper RAF polyfill based on [this discussion](https://gist.github.com/paulirish/1579671) and [the resulting repo](https://github.com/darius/requestAnimationFrame/blob/master/requestAnimationFrame.js). I debated whether to make this `Lib.requestAnimationFrame` and `Lib.cancelAnimationFrame` or not. The only downside of this approach is that it would *fix* libraries using `requestAnimationFrame` without a polyfill.

As part of this, remove the logic from: https://github.com/plotly/plotly.js/blob/f07a274fe7c215c06d3827f2a589f17421f72ce1/src/components/rangeslider/create_slider.js#L225-L233