### PR TITLE
Throw an error when redraw called on invalid gd

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -823,8 +823,7 @@ Plotly.redraw = function(gd) {
     gd = getGraphDiv(gd);
 
     if(!Lib.isPlotDiv(gd)) {
-        Lib.warn('This element is not a Plotly plot.', gd);
-        return;
+        throw new Error('This element is not a Plotly plot: ' + gd);
     }
 
     gd.calcdata = undefined;


### PR DESCRIPTION
As discussed, this replaces a warning + early return on invalid gd with throwing an error. Related to but **does not** address the fact that `Lib.isPlotDiv(Plotly.purge(gd)) === true` if `gd` was ever a plot.