### PR TITLE
Special mapboxAccessToken case for Atlas users

### DIFF
--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -90,6 +90,8 @@ module.exports = {
     topojsonURL: 'https://cdn.plot.ly/',
 
     // Mapbox access token (required to plot mapbox trace types)
+    // If using an Mapbox Atlas server, set this option to '',
+    // so that plotly.js won't attempt to authenticate to the public Mapbox server.
     mapboxAccessToken: null,
 
     // Turn all console logging on or off (errors will be thrown)

--- a/src/plots/mapbox/index.js
+++ b/src/plots/mapbox/index.js
@@ -135,6 +135,9 @@ function findAccessToken(gd, mapboxIds) {
     var fullLayout = gd._fullLayout,
         context = gd._context;
 
+    // special case for Mapbox Atlas users
+    if(context.mapboxAccessToken === '') return '';
+
     // first look for access token in context
     var accessToken = context.mapboxAccessToken;
 

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -245,6 +245,32 @@ describe('mapbox credentials', function() {
             done();
         });
     });
+
+    it('should bypass access token in mapbox layout options when config points to an Atlas server', function(done) {
+        var cnt = 0;
+        var msg = [
+            'An API access token is required to use Mapbox GL.',
+            'See https://www.mapbox.com/developers/api/#access-tokens'
+        ].join(' ');
+
+        Plotly.plot(gd, [{
+            type: 'scattermapbox',
+            lon: [10, 20, 30],
+            lat: [10, 20, 30]
+        }], {
+            mapbox: {
+                accesstoken: MAPBOX_ACCESS_TOKEN
+            }
+        }, {
+            mapboxAccessToken: ''
+        }).catch(function(err) {
+            cnt++;
+            expect(err).toEqual(new Error(msg));
+        }).then(function() {
+            expect(cnt).toEqual(1);
+            done();
+        });
+    });
 });
 
 describe('mapbox plots', function() {


### PR DESCRIPTION
This PR makes sure that plotly.js does not attempt to reach the mapbox public server when users are connected to a Mapbox Atlas server.