### PR TITLE
Hotfix: clean up visible false scatter trace

### DIFF
--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -110,3 +110,39 @@ exports.plot = function(gd, traces, transitionOpts, makeOnCompleteCallback) {
         }
     }
 };
+
+exports.clean = function(newFullData, newFullLayout, oldFullData, oldFullLayout) {
+    var oldModules = oldFullLayout._modules || [],
+        newModules = newFullLayout._modules || [];
+
+    var hadScatter, hasScatter, i;
+
+    for(i = 0; i < oldModules.length; i++) {
+        if(oldModules[i].name === 'scatter') {
+            hadScatter = true;
+            break;
+        }
+    }
+
+    for(i = 0; i < newModules.length; i++) {
+        if(newModules[i].name === 'scatter') {
+            hasScatter = true;
+            break;
+        }
+    }
+
+    if(hadScatter && !hasScatter) {
+        var oldPlots = oldFullLayout._plots,
+            ids = Object.keys(oldPlots || {});
+
+        for(i = 0; i < ids.length; i++) {
+            var subplotInfo = oldPlots[ids[i]];
+
+            if(subplotInfo.plot) {
+                subplotInfo.plot.select('g.scatterlayer')
+                    .selectAll('g.trace')
+                    .remove();
+            }
+        }
+    }
+};

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -707,6 +707,7 @@ plots.supplyTraceDefaults = function(traceIn, traceIndex, layout) {
 
     coerce('type');
     coerce('uid');
+    coerce('name', 'trace ' + traceIndex);
 
     // coerce subplot attributes of all registered subplot types
     var subplotTypes = Object.keys(subplotsRegistry);
@@ -732,8 +733,6 @@ plots.supplyTraceDefaults = function(traceIn, traceIndex, layout) {
         // TODO add per-base-plot-module trace defaults step
 
         if(_module) _module.supplyDefaults(traceIn, traceOut, defaultColor, layout);
-
-        coerce('name', 'trace ' + traceIndex);
 
         if(!plots.traceIs(traceOut, 'noOpacity')) coerce('opacity');
 

--- a/test/jasmine/tests/cartesian_test.js
+++ b/test/jasmine/tests/cartesian_test.js
@@ -105,6 +105,11 @@ describe('restyle', function() {
 
                 // The second has been recreated so is different:
                 expect(firstToNext).not.toBe(secondToNext);
+
+                return Plotly.restyle(gd, 'visible', false);
+            }).then(function() {
+                expect(d3.selectAll('g.trace.scatter').size()).toEqual(0);
+
             }).then(done);
         });
 


### PR DESCRIPTION
Setting **all** scatter traces to `visible: false` on a given graph at once (e.g. by `Plotly.restyle(gd, 'visible', false);` is currently broken in `master` and `v1.17.0` ever since commit https://github.com/plotly/plotly.js/commit/57892edf00c497a447b3e9e32847c6e7d08dd5ac of PR #802. By broken, I meant the `visible: false` traces remain visible on the graph after the update.

As of https://github.com/plotly/plotly.js/commit/57892edf00c497a447b3e9e32847c6e7d08dd5ac, scatter traces aren't purged in the cartesian subplot plot step (see [here](https://github.com/plotly/plotly.js/blob/ab51c36edeb629ab73bdc542cdb89d430491c71e/src/plots/cartesian/index.js#L88)), meaning that the `Scatter` trace module takes the responsibility of cleaning up `visible: false` traces - which works fine **except** when all scatter traces are simultaneously gone. In this case, `fullLayout._modules` does not contain the `Scatter` module [here](https://github.com/plotly/plotly.js/blob/ab51c36edeb629ab73bdc542cdb89d430491c71e/src/plots/cartesian/index.js#L36) and `Scatter.plot` is not called [here](https://github.com/plotly/plotly.js/blob/ab51c36edeb629ab73bdc542cdb89d430491c71e/src/plots/cartesian/index.js#L109).

I'm starting to think that we are not correctly handling `visible: false` starting from the trace [`supplyDefaults`](https://github.com/plotly/plotly.js/blob/ab51c36edeb629ab73bdc542cdb89d430491c71e/src/plots/plots.js#L725). Changing that will be a bigger project that I'd call too ambitious for a patch release. So, I propose this fix that uses the `plots.cleanPlot` step.

@rreusser 