### PR TITLE
make paper bgcolor relayout update legend and updatemenu accordingly

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1948,6 +1948,7 @@ function _relayout(gd, aobj) {
             if(p.parts[0].indexOf('scene') === 0) flags.doplot = true;
             else if(p.parts[0].indexOf('geo') === 0) flags.doplot = true;
             else if(p.parts[0].indexOf('ternary') === 0) flags.doplot = true;
+            else if(ai === 'paper_bgcolor') flags.doplot = true;
             else if(fullLayout._has('gl2d') &&
                 (ai.indexOf('axis') !== -1 || p.parts[0] === 'plot_bgcolor')
             ) flags.doplot = true;

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -537,6 +537,14 @@ describe('legend relayout update', function() {
         }).then(function() {
             assertLegendStyle('rgb(0, 0, 255)', 'rgb(255, 0, 0)', 10);
 
+            return Plotly.relayout(gd, 'legend.bgcolor', null);
+        }).then(function() {
+            assertLegendStyle('rgb(255, 255, 255)', 'rgb(255, 0, 0)', 10);
+
+            return Plotly.relayout(gd, 'paper_bgcolor', 'blue');
+        }).then(function() {
+            assertLegendStyle('rgb(0, 0, 255)', 'rgb(255, 0, 0)', 10);
+
             done();
         });
     });

--- a/test/jasmine/tests/updatemenus_test.js
+++ b/test/jasmine/tests/updatemenus_test.js
@@ -348,6 +348,14 @@ describe('update menus interactions', function() {
             // fold up buttons whenever new menus are added
             assertMenus([0, 0]);
 
+            return Plotly.relayout(gd, {
+                'updatemenus[0].bgcolor': null,
+                'paper_bgcolor': 'black'
+            });
+        }).then(function() {
+            assertItemColor(selectHeader(0), 'rgb(0, 0, 0)');
+            assertItemColor(selectHeader(1), 'rgb(0, 0, 0)');
+
             done();
         });
     });


### PR DESCRIPTION
Both legend and updatemenus `bgcolor` are defaulted to the `layout.paper_bgcolor` value. Previously, relayout calls that included `paper_bgcolor` bypassed component updates, but in general, we can't do so in order to correctly update the legend and updatemenu `bgcolor`.