### PR TITLE
Correct check for undefined variable

### DIFF
--- a/src/traces/scatter/calc.js
+++ b/src/traces/scatter/calc.js
@@ -122,7 +122,7 @@ module.exports = function calc(gd, trace) {
     }
 
     // this has migrated up from arraysToCalcdata as we have a reference to 's' here
-    if(typeof s !== undefined) Lib.mergeArray(s, cd, 'ms');
+    if(typeof s !== 'undefined') Lib.mergeArray(s, cd, 'ms');
 
     gd.firstscatter = false;
     return cd;

--- a/src/traces/scatterternary/calc.js
+++ b/src/traces/scatterternary/calc.js
@@ -91,7 +91,7 @@ module.exports = function calc(gd, trace) {
     calcColorscale(trace);
 
     // this has migrated up from arraysToCalcdata as we have a reference to 's' here
-    if(typeof s !== undefined) Lib.mergeArray(s, cd, 'ms');
+    if(typeof s !== 'undefined') Lib.mergeArray(s, cd, 'ms');
 
     return cd;
 };


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`.

As typeof returns a string it should compare to `'undefined'`