### PR TITLE
Mirror events on an internal event handler

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -89,9 +89,12 @@ var Events = {
      * all handlers for a particular event and returns the return value
      * of the LAST handler. This function also triggers jQuery's
      * triggerHandler for backwards compatibility.
+     *
+     * Note: triggerHandler has been recommended for deprecation in v2.0.0,
+     * so the additional behavior of triggerHandler triggering internal events
+     * is deliberate excluded in order to avoid reinforcing more usage.
      */
     triggerHandler: function(plotObj, event, data) {
-        var i;
         var jQueryHandlerValue;
         var nodeEventHandlerValue;
         /*
@@ -120,22 +123,8 @@ var Events = {
         /*
          * Call all the handlers except the last one.
          */
-        for(i = 0; i < handlers.length; i++) {
+        for(var i = 0; i < handlers.length; i++) {
             handlers[i](data);
-        }
-
-        /* Do the same as for external-facing events, except trigger the same
-         * events on the internal handlers. This does *not* affect the return
-         * value. It simply mirrors triggers internally so that there's no
-         * conflict with external user-defined events when plotly manages
-         * events internally.
-         */
-        var internalHandlers = plotObj._internalEv._events[event];
-        if(internalHandlers) {
-            if(typeof internalHandlers === 'function') internalHandlers = [internalHandlers];
-            for(i = 0; i < internalHandlers.length; i++) {
-                internalHandlers[i](data);
-            }
         }
 
         /*

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -131,7 +131,7 @@ var Events = {
          * events internally.
          */
         var internalHandlers = plotObj._internalEv._events[event];
-        if (internalHandlers) {
+        if(internalHandlers) {
             if(typeof internalHandlers === 'function') internalHandlers = [internalHandlers];
             for(i = 0; i < internalHandlers.length; i++) {
                 internalHandlers[i](data);
@@ -165,7 +165,7 @@ var Events = {
         delete plotObj._internalOn;
         delete plotObj._internalOnce;
         delete plotObj._removeInternalListener;
-        delete plotObj._removeAllInternalListeners;;
+        delete plotObj._removeAllInternalListeners;
 
         return plotObj;
     }

--- a/test/jasmine/tests/events_test.js
+++ b/test/jasmine/tests/events_test.js
@@ -70,6 +70,19 @@ describe('Events', function() {
                 $(plotDiv).trigger('ping', 'pong');
             });
         });
+
+        it('mirrors events on an internal handler', function(done) {
+            Events.init(plotDiv);
+
+            plotDiv._internalOn('ping', function(data) {
+                expect(data).toBe('pong');
+                done();
+            });
+
+            setTimeout(function() {
+                plotDiv.emit('ping', 'pong');
+            });
+        });
     });
 
     describe('triggerHandler', function() {
@@ -97,6 +110,34 @@ describe('Events', function() {
             var result = Events.triggerHandler(plotDiv, 'ping');
 
             expect(eventBaton).toBe(3);
+            expect(result).toBe('pong');
+        });
+
+        it('mirrors events on the internal handler', function() {
+            var eventBaton = 0;
+            var internalEventBaton = 0;
+
+            Events.init(plotDiv);
+
+            plotDiv.on('ping', function() {
+                eventBaton++;
+                return 'ping';
+            });
+
+            plotDiv._internalOn('ping', function() {
+                internalEventBaton++;
+                return 'foo';
+            });
+
+            plotDiv.on('ping', function() {
+                eventBaton++;
+                return 'pong';
+            });
+
+            var result = Events.triggerHandler(plotDiv, 'ping');
+
+            expect(eventBaton).toBe(2);
+            expect(internalEventBaton).toBe(1);
             expect(result).toBe('pong');
         });
 

--- a/test/jasmine/tests/events_test.js
+++ b/test/jasmine/tests/events_test.js
@@ -113,7 +113,7 @@ describe('Events', function() {
             expect(result).toBe('pong');
         });
 
-        it('mirrors events on the internal handler', function() {
+        it('does *not* mirror triggerHandler events on the internal handler', function() {
             var eventBaton = 0;
             var internalEventBaton = 0;
 
@@ -137,7 +137,7 @@ describe('Events', function() {
             var result = Events.triggerHandler(plotDiv, 'ping');
 
             expect(eventBaton).toBe(2);
-            expect(internalEventBaton).toBe(1);
+            expect(internalEventBaton).toBe(0);
             expect(result).toBe('pong');
         });
 

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -301,9 +301,10 @@ describe('Test Plots', function() {
 
         it('should unset everything in the gd except _context', function() {
             var expectedKeys = [
-                '_ev', 'on', 'once', 'removeListener', 'removeAllListeners',
-                'emit', '_context', '_replotPending', '_mouseDownTime',
-                '_hmpixcount', '_hmlumcount'
+                '_ev', '_internalEv', 'on', 'once', 'removeListener', 'removeAllListeners',
+                '_internalOn', '_internalOnce', '_removeInternalListener',
+                '_removeAllInternalListeners', 'emit', '_context', '_replotPending',
+                '_mouseDownTime', '_hmpixcount', '_hmlumcount'
             ];
 
             Plots.purge(gd);


### PR DESCRIPTION
**Problem**: Currently it is the responsibility of the item triggering an event to iterate over all controls and update them. This seems like a rather unmaintainable and tightly coupled pattern.

**Solution**: This PR creates a second event handler which receives a copy of all events emitted on the the regular event handler. It does this so that internal parts of plotly can respond to events without adding events onto the user-facing event handler—which would otherwise break plotly if the user ever executed `plotObj.removeAllListeners()`. 

Note that it mirrors the events so that it's not necessary to *emit* two copies of every event.

This could otherwise be achieved with a flag that differentiates internal vs external event handlers (so that `removeAllListeners` would not break things), but that would be significantly more invasive.

**Possible caveat**: Plotly is designed from the ground up to wipe things out and start over. This PR should be usable when refactoring controls, but we may need to add an extra cleanup phase that detaches events.