### PR TITLE
Test SVG image size in test-export

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "fuse.js": "^2.2.0",
     "glob": "^7.0.0",
     "gzip-size": "^3.0.0",
+    "image-size": "^0.5.0",
     "jasmine-core": "^2.4.1",
     "karma": "^1.1.0",
     "karma-browserify": "^5.0.1",

--- a/test/image/assets/get_image_request_options.js
+++ b/test/image/assets/get_image_request_options.js
@@ -23,6 +23,9 @@ module.exports = function getRequestOpts(specs) {
         scale: specs.scale || DEFAULT_SCALE
     };
 
+    if(specs.width) body.width = specs.width;
+    if(specs.height) body.height = specs.height;
+
     return {
         method: 'POST',
         url: constants.testContainerUrl,

--- a/test/image/export_test.js
+++ b/test/image/export_test.js
@@ -9,8 +9,11 @@ var request = require('request');
 var test = require('tape');
 
 // image formats to test
+//
 // N.B. 'png' is tested in `npm run test-image, no need to duplicate here
-// TODO figure why 'jpeg' and 'webp' lead to errors
+//
+// N.B. 'jpeg' and 'webp' lead to errors because of the image server code
+//      is looking for Plotly.Color which isn't exposed anymore
 var FORMATS = ['svg', 'pdf', 'eps'];
 
 // non-exhaustive list of mocks to test


### PR DESCRIPTION
I had a few commits on a local branch that added [`image-size`](https://www.npmjs.com/package/image-size) to our `npm run test-export` routine to test the SVG more robustly check the generated image size (instead of simply looking for a minimum file size) after PR https://github.com/plotly/plotly.js/pull/604

Better late than never.