### PR TITLE
Clean data & layout on Plotly.redraw

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -473,6 +473,9 @@ Plotly.redraw = function(gd) {
         throw new Error('This element is not a Plotly plot: ' + gd);
     }
 
+    helpers.cleanData(gd.data, gd.data);
+    helpers.cleanLayout(gd.layout);
+
     gd.calcdata = undefined;
     return Plotly.plot(gd).then(function() {
         gd.emit('plotly_redraw');

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -8,6 +8,7 @@ var Legend = require('@src/components/legend');
 var pkg = require('../../../package.json');
 var subroutines = require('@src/plot_api/subroutines');
 
+var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 
@@ -776,6 +777,43 @@ describe('Test plot api', function() {
 
                 done();
             });
+        });
+    });
+
+    describe('Plotly.redraw', function() {
+
+        afterEach(destroyGraphDiv);
+
+        it('', function(done) {
+            var gd = createGraphDiv(),
+                initialData = [],
+                layout = { title: 'Redraw' };
+
+            Plotly.newPlot(gd, initialData, layout);
+
+            var trace1 = {
+                x: [1, 2, 3, 4],
+                y: [4, 1, 5, 3],
+                name: 'First Trace'
+            };
+            var trace2 = {
+                x: [1, 2, 3, 4],
+                y: [14, 11, 15, 13],
+                name: 'Second Trace'
+            };
+            var trace3 = {
+                x: [1, 2, 3, 4],
+                y: [5, 3, 7, 1],
+                name: 'Third Trace'
+            };
+
+            var newData = [trace1, trace2, trace3];
+            gd.data = newData;
+
+            Plotly.redraw(gd).then(function() {
+                expect(d3.selectAll('g.trace.scatter').size()).toEqual(3);
+            })
+            .then(done);
         });
     });
 


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/942

... which turned out to be an easy fix. All we had to do was to make `Plotly.redraw` go through the `cleanData` to make sure the newly (if any) added traces have a `uid` field - which is now used in the key function in the scatter plot method since @rreusser 's animation PR #802 