### PR TITLE
Fixing a few maintenance issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,15 @@
   "env": {
     "commonjs": true
   },
+  "globals": {
+    "Promise": true,
+    "Float32Array": true,
+    "Float64Array": true,
+    "Uint8Array": true,
+    "Int16Array": true,
+    "Int32Array": true,
+    "ArrayBuffer": true
+  },
   "rules": {
     "no-trailing-spaces": [2],
     "no-multiple-empty-lines": [2, {"max": 2, "maxEOF": 0}],

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,15 @@
 node_modules
-*.sublime*
 
 build/*
-
 !build/plotcss.js
 !build/ploticon.js
 !build/README.md
 
 npm-debug.log*
+*.sublime*
 
 .*
-!/.gitignore
-!/.npmignore
-!/.eslintrc
-!/.eslintignore
+!.gitignore
+!.npmignore
+!.eslintrc
+!.eslintignore

--- a/devtools/.eslintrc
+++ b/devtools/.eslintrc
@@ -3,8 +3,5 @@
   "env": {
     "node": true,
     "browser": true
-  },
-  "globals": {
-    "Promise": true
   }
 }

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../src/.eslintrc"
+}

--- a/lib/bar.js
+++ b/lib/bar.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/bar');

--- a/lib/box.js
+++ b/lib/box.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/box');

--- a/lib/choropleth.js
+++ b/lib/choropleth.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/choropleth');

--- a/lib/contour.js
+++ b/lib/contour.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/contour');

--- a/lib/contourgl.js
+++ b/lib/contourgl.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/contourgl');

--- a/lib/core.js
+++ b/lib/core.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/core');

--- a/lib/heatmap.js
+++ b/lib/heatmap.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/heatmap');

--- a/lib/heatmapgl.js
+++ b/lib/heatmapgl.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/heatmapgl');

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/histogram');

--- a/lib/histogram2d.js
+++ b/lib/histogram2d.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/histogram2d');

--- a/lib/histogram2dcontour.js
+++ b/lib/histogram2dcontour.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/histogram2dcontour');

--- a/lib/mesh3d.js
+++ b/lib/mesh3d.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/mesh3d');

--- a/lib/pie.js
+++ b/lib/pie.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/pie');

--- a/lib/pointcloud.js
+++ b/lib/pointcloud.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/pointcloud');

--- a/lib/scatter.js
+++ b/lib/scatter.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/scatter');

--- a/lib/scatter3d.js
+++ b/lib/scatter3d.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/scatter3d');

--- a/lib/scattergeo.js
+++ b/lib/scattergeo.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/scattergeo');

--- a/lib/scattergl.js
+++ b/lib/scattergl.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/scattergl');

--- a/lib/scattermapbox.js
+++ b/lib/scattermapbox.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/scattermapbox');

--- a/lib/scatterternary.js
+++ b/lib/scatterternary.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/scatterternary');

--- a/lib/surface.js
+++ b/lib/surface.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/traces/surface');

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -3,13 +3,6 @@
   "env": {
     "browser": true
   },
-  "globals": {
-    "Promise": true,
-    "Float32Array": true,
-    "Uint8Array": true,
-    "Int32Array": true,
-    "ArrayBuffer": true
-  },
   "rules": {
     "strict": [2, "global"],
     "no-console": [2]

--- a/test/jasmine/.eslintrc
+++ b/test/jasmine/.eslintrc
@@ -3,12 +3,5 @@
   "env": {
     "browser": true,
     "jasmine": true
-  },
-  "globals": {
-    "Promise": true,
-    "Float32Array": true,
-    "Float64Array": true,
-    "Int16Array": true,
-    "Int32Array": true
   }
 }


### PR DESCRIPTION
This PR:

- defines one set of globals in the root `.eslintrc` for simplicity
- enforce `src/` linting rules in `lib/` (e.g. if ever we add `console.log` in `lib/<trace>.js`)