### PR TITLE
Sanitise gl2d double-click interactions

### DIFF
--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -137,6 +137,11 @@ proto.makeFramework = function() {
     canvas.style.left = '0px';
     canvas.style['pointer-events'] = 'none';
 
+    // disabling user select on the canvas
+    // sanitizes double-clicks interactions
+    // ref: https://github.com/plotly/plotly.js/issues/744
+    canvas.className += 'user-select-none';
+
     // create SVG container for hover text
     var svgContainer = this.svgContainer = document.createElementNS(
         'http://www.w3.org/2000/svg',


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/744

Off this branch, double-clicking on the canvas now no longer puts the select-box in a weird state.

This solution was discovered by @dfcreative , I made a PR here to potential make this fix part of the `1.17.3` patch release.