### PR TITLE
Fix linting in lib/filter.js

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -6,4 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
 module.exports = require('../src/transforms/filter');


### PR DESCRIPTION
making `eslint .` pass again on `master`

cherry-picked https://github.com/plotly/plotly.js/pull/978/commits/6309837f46ddca9369d9d5624a9d7e1918899dcf from https://github.com/plotly/plotly.js/pull/978