### PR TITLE
Try out visibility:inherit default for text

### DIFF
--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -91,7 +91,7 @@ exports.convertToTspans = function(_context, _callback) {
         }
         _context.text('')
             .style({
-                visibility: 'visible',
+                visibility: 'inherit',
                 'white-space': 'pre'
             });
 

--- a/src/snapshot/tosvg.js
+++ b/src/snapshot/tosvg.js
@@ -71,11 +71,18 @@ module.exports = function toSVG(gd, format) {
     svg.selectAll('text')
         .attr('data-unformatted', null)
         .each(function() {
-            // hidden text is pre-formatting mathjax, the browser ignores it but it can still confuse batik
             var txt = d3.select(this);
+
+            // hidden text is pre-formatting mathjax,
+            // the browser ignores it but it can still confuse batik
             if(txt.style('visibility') === 'hidden') {
                 txt.remove();
                 return;
+            }
+            else {
+                // force other visibility value to export as visible
+                // to not potentially confuse non-browser SVG implementations
+                txt.style('visibility', 'visible');
             }
 
             // Font family styles break things because of quotation marks,

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -1,6 +1,9 @@
 var Plotly = require('@lib/index');
+
+var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
+
 var subplotMock = require('../../image/mocks/multiple_subplots.json');
 var annotationMock = require('../../image/mocks/annotations.json');
 
@@ -180,6 +183,29 @@ describe('Plotly.Snapshot', function() {
 
                 expect(svgElements.length).toBe(1);
             }).then(done);
+        });
+
+        it('should force *visibility: visible* for text elements with *visibility: inherit*', function(done) {
+            d3.select(gd).style('visibility', 'inherit');
+
+            Plotly.plot(gd, subplotMock.data, subplotMock.layout).then(function() {
+
+                d3.select(gd).selectAll('text').each(function() {
+                    expect(d3.select(this).style('visibility')).toEqual('visible');
+                });
+
+                return Plotly.Snapshot.toSVG(gd);
+            })
+            .then(function(svg) {
+                var svgDOM = parser.parseFromString(svg, 'image/svg+xml'),
+                    textElements = svgDOM.getElementsByTagName('text');
+
+                for(var i = 0; i < textElements.length; i++) {
+                    expect(textElements[i].style.visibility).toEqual('visible');
+                }
+
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
See #984 

The goal of this PR is to get circle-ci to see what happens if the visibility default on text is `visibility: inherit` instead of `visibility: visible`. `visible` hard-codes it and is difficult to override. I had an ominous feeling about this change leading to a rabbit hole of related fixes and compensations, but let's see what happens…