### PR TITLE
add streaming maxpoints max and dflt

### DIFF
--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -94,6 +94,8 @@ module.exports = {
         maxpoints: {
             valType: 'number',
             min: 0,
+            max: 10000,
+            dflt: 500,
             role: 'info',
             description: [
                 'Sets the maximum number of points to keep on the plots from an',


### PR DESCRIPTION
Add max and default vals for `maxpoint` attribute for streams
so the values shown [here](https://github.com/plotly/streambed/blob/f95f3303b3600451902efa6d86bada58b9f727ee/shelly/streaming/streamingviews.py#L97) make it into the reference pages