### PR TITLE
Use package to obtain webgl context

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "sane-topojson": "^1.2.0",
     "superscript-text": "^1.0.0",
     "tinycolor2": "^1.3.0",
-    "topojson": "^1.6.20"
+    "topojson": "^1.6.20",
+    "webgl-context": "^2.2.0"
   },
   "devDependencies": {
     "brfs": "^1.4.3",

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -15,6 +15,7 @@ var Fx = require('../../plots/cartesian/graph_interact');
 var createPlot2D = require('gl-plot2d');
 var createSpikes = require('gl-spikes2d');
 var createSelectBox = require('gl-select-box');
+var getContext = require('webgl-context');
 
 var createOptions = require('./convert');
 var createCamera = require('./camera');
@@ -82,16 +83,15 @@ proto.makeFramework = function() {
         if(!STATIC_CONTEXT) {
             STATIC_CANVAS = document.createElement('canvas');
 
-            try {
-                STATIC_CONTEXT = STATIC_CANVAS.getContext('webgl', {
-                    preserveDrawingBuffer: false,
-                    premultipliedAlpha: true,
-                    antialias: true
-                });
-            } catch(e) {
-                throw new Error([
-                    'Error creating static canvas/context for image server'
-                ].join(' '));
+            STATIC_CONTEXT = getContext({
+                canvas: STATIC_CANVAS,
+                preserveDrawingBuffer: false,
+                premultipliedAlpha: true,
+                antialias: true
+            });
+
+            if(!STATIC_CONTEXT) {
+                throw new Error('Error creating static canvas/context for image server');
             }
         }
 
@@ -99,23 +99,12 @@ proto.makeFramework = function() {
         this.gl = STATIC_CONTEXT;
     }
     else {
-        var liveCanvas = document.createElement('canvas'),
-            glOpts = { premultipliedAlpha: true };
-        var gl;
+        var liveCanvas = document.createElement('canvas');
 
-        try {
-            gl = liveCanvas.getContext('webgl', glOpts);
-        } catch(e) {
-            //
-        }
-
-        if(!gl) {
-            try {
-                gl = liveCanvas.getContext('experimental-webgl', glOpts);
-            } catch(e) {
-                //
-            }
-        }
+        var gl = getContext({
+            canvas: liveCanvas,
+            premultipliedAlpha: true
+        });
 
         if(!gl) showNoWebGlMsg(this);
 

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -10,6 +10,7 @@
 'use strict';
 
 var createPlot = require('gl-plot3d');
+var getContext = require('webgl-context');
 
 var Lib = require('../../lib');
 
@@ -143,13 +144,13 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
     if(scene.staticMode) {
         if(!STATIC_CONTEXT) {
             STATIC_CANVAS = document.createElement('canvas');
-            try {
-                STATIC_CONTEXT = STATIC_CANVAS.getContext('webgl', {
-                    preserveDrawingBuffer: true,
-                    premultipliedAlpha: true,
-                    antialias: true
-                });
-            } catch(e) {
+            STATIC_CONTEXT = getContext({
+                canvas: STATIC_CANVAS,
+                preserveDrawingBuffer: true,
+                premultipliedAlpha: true,
+                antialias: true
+            });
+            if(!STATIC_CONTEXT) {
                 throw new Error('error creating static canvas/context for image server');
             }
         }

--- a/test/jasmine/assets/has_webgl_support.js
+++ b/test/jasmine/assets/has_webgl_support.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getContext = require('webgl-context')
+var getContext = require('webgl-context');
 
 module.exports = function hasWebGLSupport(testName) {
     var gl, canvas;

--- a/test/jasmine/assets/has_webgl_support.js
+++ b/test/jasmine/assets/has_webgl_support.js
@@ -1,16 +1,12 @@
 'use strict';
 
+var getContext = require('webgl-context')
 
 module.exports = function hasWebGLSupport(testName) {
     var gl, canvas;
 
-    try {
-        canvas = document.createElement('canvas');
-        gl = canvas.getContext('webgl');
-    }
-    catch(err) {
-        gl = null;
-    }
+    canvas = document.createElement('canvas');
+    gl = getContext({canvas: canvas});
 
     var hasSupport = !!gl;
 


### PR DESCRIPTION
Replace every entry of `canvas.getContext('webgl')` with more reliable context getter [webgl-context](https://github.com/mattdesl/webgl-context) (it handles errors and returns null if no context available).

May be related to the karma cases where context is unavailable.