### PR TITLE
Handle actual zero values as other numbers rather than as unsupplied

### DIFF
--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -322,7 +322,7 @@ exports.coerce2 = function(containerIn, containerOut, attributes, attribute, dfl
     var propIn = nestedProperty(containerIn, attribute),
         propOut = exports.coerce(containerIn, containerOut, attributes, attribute, dflt);
 
-    return propIn.get() ? propOut : false;
+    return propIn.get() !== undefined ? propOut : false;
 };
 
 /*

--- a/src/traces/contour/defaults.js
+++ b/src/traces/contour/defaults.js
@@ -33,7 +33,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
 
     var contourStart = Lib.coerce2(traceIn, traceOut, attributes, 'contours.start'),
         contourEnd = Lib.coerce2(traceIn, traceOut, attributes, 'contours.end'),
-        autocontour = coerce('autocontour', !(contourStart && contourEnd));
+        autocontour = coerce('autocontour', contourStart === false || contourEnd === false);
 
     if(autocontour) coerce('ncontours');
     else coerce('contours.size');


### PR DESCRIPTION
Lib.coerce2 to return original value for 0, "", NaN, null rather than false
Perform logic such that a specified zero value doesn't mean false in the `contour` logic
