### PR TITLE
Make null/undefined a noop for addFrames

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2447,6 +2447,10 @@ Plotly.animate = function(gd, frameOrGroupNameOrFrameList, animationOpts) {
 Plotly.addFrames = function(gd, frameList, indices) {
     gd = helpers.getGraphDiv(gd);
 
+    if(frameList === null || frameList === undefined) {
+        return Promise.resolve();
+    }
+
     if(!Lib.isPlotDiv(gd)) {
         throw new Error('This element is not a Plotly plot: ' + gd);
     }

--- a/test/jasmine/tests/frame_api_test.js
+++ b/test/jasmine/tests/frame_api_test.js
@@ -36,6 +36,24 @@ describe('Test frame api', function() {
     });
 
     describe('#addFrames', function() {
+        it('treats an undefined list as a noop', function(done) {
+            Plotly.addFrames(gd, undefined).then(function() {
+                expect(Object.keys(h)).toEqual([]);
+            }).catch(fail).then(done);
+        });
+
+        it('treats a null list as a noop', function(done) {
+            Plotly.addFrames(gd, null).then(function() {
+                expect(Object.keys(h)).toEqual([]);
+            }).catch(fail).then(done);
+        });
+
+        it('treats an empty list as a noop', function(done) {
+            Plotly.addFrames(gd, []).then(function() {
+                expect(Object.keys(h)).toEqual([]);
+            }).catch(fail).then(done);
+        });
+
         it('names an unnamed frame', function(done) {
             Plotly.addFrames(gd, [{}]).then(function() {
                 expect(Object.keys(h)).toEqual(['frame 0']);


### PR DESCRIPTION
This PR makes passing either `null` or `undefined` to `Plotly.addFrames` a no-op. I didn't initially expect this would be a meaningful case, but this allows *all* plots to simply call 

```javascript
Plotly.plot(gd, x.data, x.layout, x.config).then(function () {
  return Plotly.addFrames(gd, x.frames))
});
```

without worrying about whether addFrames *needs* to be called. Ideally in v2.0 frames will be part of the initial `plot` call, but until then, at least you can call addFrames and let the method sort out whether it's a no-op or not.