### PR TITLE
Non-fancy scattergl to work with dates

### DIFF
--- a/src/plots/cartesian/axis_autotype.js
+++ b/src/plots/cartesian/axis_autotype.js
@@ -1,0 +1,73 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+var isNumeric = require('fast-isnumeric');
+
+var Lib = require('../../lib');
+var cleanDatum = require('./clean_datum');
+
+module.exports = function autoType(array) {
+    if(moreDates(array)) return 'date';
+    if(category(array)) return 'category';
+    if(linearOK(array)) return 'linear';
+    else return '-';
+};
+
+// is there at least one number in array? If not, we should leave
+// ax.type empty so it can be autoset later
+function linearOK(array) {
+    if(!array) return false;
+
+    for(var i = 0; i < array.length; i++) {
+        if(isNumeric(array[i])) return true;
+    }
+
+    return false;
+}
+
+// does the array a have mostly dates rather than numbers?
+// note: some values can be neither (such as blanks, text)
+// 2- or 4-digit integers can be both, so require twice as many
+// dates as non-dates, to exclude cases with mostly 2 & 4 digit
+// numbers and a few dates
+function moreDates(a) {
+    var dcnt = 0,
+        ncnt = 0,
+        // test at most 1000 points, evenly spaced
+        inc = Math.max(1, (a.length - 1) / 1000),
+        ai;
+
+    for(var i = 0; i < a.length; i += inc) {
+        ai = a[Math.round(i)];
+        if(Lib.isDateTime(ai)) dcnt += 1;
+        if(isNumeric(ai)) ncnt += 1;
+    }
+
+    return (dcnt > ncnt * 2);
+}
+
+// are the (x,y)-values in td.data mostly text?
+// require twice as many categories as numbers
+function category(a) {
+    // test at most 1000 points
+    var inc = Math.max(1, (a.length - 1) / 1000),
+        curvenums = 0,
+        curvecats = 0,
+        ai;
+
+    for(var i = 0; i < a.length; i += inc) {
+        ai = cleanDatum(a[Math.round(i)]);
+        if(isNumeric(ai)) curvenums++;
+        else if(typeof ai === 'string' && ai !== '' && ai !== 'None') curvecats++;
+    }
+
+    return curvecats > curvenums * 2;
+}

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -23,9 +23,8 @@ var handleTickLabelDefaults = require('./tick_label_defaults');
 var handleCategoryOrderDefaults = require('./category_order_defaults');
 var setConvert = require('./set_convert');
 var orderedCategories = require('./ordered_categories');
-var cleanDatum = require('./clean_datum');
 var axisIds = require('./axis_ids');
-
+var autoType = require('./axis_autotype');
 
 /**
  * options: object containing:
@@ -207,13 +206,6 @@ function isBoxWithoutPositionCoords(trace, axLetter) {
     );
 }
 
-function autoType(array) {
-    if(moreDates(array)) return 'date';
-    if(category(array)) return 'category';
-    if(linearOK(array)) return 'linear';
-    else return '-';
-}
-
 function getFirstNonEmptyTrace(data, id, axLetter) {
     for(var i = 0; i < data.length; i++) {
         var trace = data[i];
@@ -227,55 +219,4 @@ function getFirstNonEmptyTrace(data, id, axLetter) {
             }
         }
     }
-}
-
-// is there at least one number in array? If not, we should leave
-// ax.type empty so it can be autoset later
-function linearOK(array) {
-    if(!array) return false;
-
-    for(var i = 0; i < array.length; i++) {
-        if(isNumeric(array[i])) return true;
-    }
-
-    return false;
-}
-
-// does the array a have mostly dates rather than numbers?
-// note: some values can be neither (such as blanks, text)
-// 2- or 4-digit integers can be both, so require twice as many
-// dates as non-dates, to exclude cases with mostly 2 & 4 digit
-// numbers and a few dates
-function moreDates(a) {
-    var dcnt = 0,
-        ncnt = 0,
-        // test at most 1000 points, evenly spaced
-        inc = Math.max(1, (a.length - 1) / 1000),
-        ai;
-
-    for(var i = 0; i < a.length; i += inc) {
-        ai = a[Math.round(i)];
-        if(Lib.isDateTime(ai)) dcnt += 1;
-        if(isNumeric(ai)) ncnt += 1;
-    }
-
-    return (dcnt > ncnt * 2);
-}
-
-// are the (x,y)-values in td.data mostly text?
-// require twice as many categories as numbers
-function category(a) {
-    // test at most 1000 points
-    var inc = Math.max(1, (a.length - 1) / 1000),
-        curvenums = 0,
-        curvecats = 0,
-        ai;
-
-    for(var i = 0; i < a.length; i += inc) {
-        ai = cleanDatum(a[Math.round(i)]);
-        if(isNumeric(ai)) curvenums++;
-        else if(typeof ai === 'string' && ai !== '' && ai !== 'None') curvecats++;
-    }
-
-    return curvecats > curvenums * 2;
 }

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -26,6 +26,7 @@ var orderedCategories = require('./ordered_categories');
 var axisIds = require('./axis_ids');
 var autoType = require('./axis_autotype');
 
+
 /**
  * options: object containing:
  *

--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -303,25 +303,28 @@ proto.updateFast = function(options) {
 
     // TODO add 'very fast' mode that bypasses this loop
     // TODO bypass this on modebar +/- zoom
-    for(var i = 0; i < len; ++i) {
-        xx = x[i];
-        yy = y[i];
+    if(fastType || isDateTime) {
 
-        if(isNumeric(yy) && (fastType || isDateTime)) {
+        for(var i = 0; i < len; ++i) {
+            xx = x[i];
+            yy = y[i];
 
-            if(!fastType) {
-                xx = Lib.dateTime2ms(xx);
+            if(isNumeric(yy)) {
+
+                if(!fastType) {
+                    xx = Lib.dateTime2ms(xx);
+                }
+
+                idToIndex[pId++] = i;
+
+                positions[ptr++] = xx;
+                positions[ptr++] = yy;
+
+                bounds[0] = Math.min(bounds[0], xx);
+                bounds[1] = Math.min(bounds[1], yy);
+                bounds[2] = Math.max(bounds[2], xx);
+                bounds[3] = Math.max(bounds[3], yy);
             }
-
-            idToIndex[pId++] = i;
-
-            positions[ptr++] = xx;
-            positions[ptr++] = yy;
-
-            bounds[0] = Math.min(bounds[0], xx);
-            bounds[1] = Math.min(bounds[1], yy);
-            bounds[2] = Math.max(bounds[2], xx);
-            bounds[3] = Math.max(bounds[3], yy);
         }
     }
 

--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -118,7 +118,7 @@ proto.handlePick = function(pickResult) {
         trace: this,
         dataCoord: pickResult.dataCoord,
         traceCoord: [
-            this.pickXData[index],
+            Number(this.pickXData[index]), // non-fancy scattergl has Dates
             this.pickYData[index]
         ],
         textLabel: Array.isArray(this.textLabels) ?

--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -135,7 +135,7 @@ proto.handlePick = function(pickResult) {
 
 // check if trace is fancy
 proto.isFancy = function(options) {
-    if(this.scene.xaxis.type !== 'linear') return true;
+    if(this.scene.xaxis.type !== 'linear' && this.scene.xaxis.type !== 'date') return true;
     if(this.scene.yaxis.type !== 'linear') return true;
 
     if(!options.x || !options.y) return true;
@@ -279,7 +279,8 @@ proto.updateFast = function(options) {
         yy = y[i];
 
         // check for isNaN is faster but doesn't skip over nulls
-        if(!isNumeric(xx) || !isNumeric(yy)) continue;
+        if(!isNumeric(yy)) continue;
+        if(!isNumeric(xx) && !(xx instanceof Date)) continue;
 
         idToIndex[pId++] = i;
 

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -4,6 +4,7 @@ var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
 var Color = require('@src/components/color');
 var tinycolor = require('tinycolor2');
+var hasWebGLSupport = require('../assets/has_webgl_support');
 
 var handleTickValueDefaults = require('@src/plots/cartesian/tick_value_defaults');
 var Axes = PlotlyInternal.Axes;
@@ -385,6 +386,84 @@ describe('Test axes', function() {
             expect(layoutOut.yaxis2.gridcolor)
                 .toEqual(tinycolor.mix('#444', bgColor, frac).toRgbString());
         });
+    });
+
+    describe('date axis', function() {
+
+        if(!hasWebGLSupport('axes_test date axis')) return;
+
+        var gd;
+
+        beforeEach(function() {
+            gd = createGraphDiv();
+        });
+
+        afterEach(destroyGraphDiv);
+
+        it('should use the fancy gl-vis/gl-scatter2d', function() {
+            PlotlyInternal.plot(gd, [{
+                type: 'scattergl',
+                'marker': {
+                    'color': 'rgb(31, 119, 180)',
+                    'size': 18,
+                    'symbol': [
+                        'diamond',
+                        'cross'
+                    ]
+                },
+                x: [new Date('2016-10-10'), new Date('2016-10-12')],
+                y: [15, 16]
+            }]);
+
+            expect(gd._fullLayout.xaxis.type).toBe('date');
+            expect(gd._fullLayout.yaxis.type).toBe('linear');
+            expect(gd._fullData[0].type).toBe('scattergl');
+            expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
+
+            // one way of check which renderer - fancy vs not - we're using
+            expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(0);
+        });
+
+        it('should use the fancy gl-vis/gl-scatter2d once again', function() {
+            PlotlyInternal.plot(gd, [{
+                type: 'scattergl',
+                'marker': {
+                    'color': 'rgb(31, 119, 180)',
+                    'size': 36,
+                    'symbol': [
+                        'circle',
+                        'cross'
+                    ]
+                },
+                x: [new Date('2016-10-10'), new Date('2016-10-11')],
+                y: [15, 16]
+            }]);
+
+            expect(gd._fullLayout.xaxis.type).toBe('date');
+            expect(gd._fullLayout.yaxis.type).toBe('linear');
+            expect(gd._fullData[0].type).toBe('scattergl');
+            expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
+
+            // one way of check which renderer - fancy vs not - we're using
+            expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(0);
+        });
+
+        it('should now use the non-fancy gl-vis/gl-scatter2d', function() {
+            PlotlyInternal.plot(gd, [{
+                type: 'scattergl',
+                mode: 'markers', // important, as otherwise lines are assumed (which needs fancy)
+                x: [new Date('2016-10-10'), new Date('2016-10-11')],
+                y: [15, 16]
+            }]);
+
+            expect(gd._fullLayout.xaxis.type).toBe('date');
+            expect(gd._fullLayout.yaxis.type).toBe('linear');
+            expect(gd._fullData[0].type).toBe('scattergl');
+            expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
+
+            expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(2);
+        });
+
     });
 
     describe('categoryorder', function() {

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -4,7 +4,6 @@ var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
 var Color = require('@src/components/color');
 var tinycolor = require('tinycolor2');
-var hasWebGLSupport = require('../assets/has_webgl_support');
 
 var handleTickValueDefaults = require('@src/plots/cartesian/tick_value_defaults');
 var Axes = PlotlyInternal.Axes;
@@ -386,84 +385,6 @@ describe('Test axes', function() {
             expect(layoutOut.yaxis2.gridcolor)
                 .toEqual(tinycolor.mix('#444', bgColor, frac).toRgbString());
         });
-    });
-
-    describe('date axis', function() {
-
-        if(!hasWebGLSupport('axes_test date axis')) return;
-
-        var gd;
-
-        beforeEach(function() {
-            gd = createGraphDiv();
-        });
-
-        afterEach(destroyGraphDiv);
-
-        it('should use the fancy gl-vis/gl-scatter2d', function() {
-            PlotlyInternal.plot(gd, [{
-                type: 'scattergl',
-                'marker': {
-                    'color': 'rgb(31, 119, 180)',
-                    'size': 18,
-                    'symbol': [
-                        'diamond',
-                        'cross'
-                    ]
-                },
-                x: [new Date('2016-10-10'), new Date('2016-10-12')],
-                y: [15, 16]
-            }]);
-
-            expect(gd._fullLayout.xaxis.type).toBe('date');
-            expect(gd._fullLayout.yaxis.type).toBe('linear');
-            expect(gd._fullData[0].type).toBe('scattergl');
-            expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
-
-            // one way of check which renderer - fancy vs not - we're using
-            expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(0);
-        });
-
-        it('should use the fancy gl-vis/gl-scatter2d once again', function() {
-            PlotlyInternal.plot(gd, [{
-                type: 'scattergl',
-                'marker': {
-                    'color': 'rgb(31, 119, 180)',
-                    'size': 36,
-                    'symbol': [
-                        'circle',
-                        'cross'
-                    ]
-                },
-                x: [new Date('2016-10-10'), new Date('2016-10-11')],
-                y: [15, 16]
-            }]);
-
-            expect(gd._fullLayout.xaxis.type).toBe('date');
-            expect(gd._fullLayout.yaxis.type).toBe('linear');
-            expect(gd._fullData[0].type).toBe('scattergl');
-            expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
-
-            // one way of check which renderer - fancy vs not - we're using
-            expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(0);
-        });
-
-        it('should now use the non-fancy gl-vis/gl-scatter2d', function() {
-            PlotlyInternal.plot(gd, [{
-                type: 'scattergl',
-                mode: 'markers', // important, as otherwise lines are assumed (which needs fancy)
-                x: [new Date('2016-10-10'), new Date('2016-10-11')],
-                y: [15, 16]
-            }]);
-
-            expect(gd._fullLayout.xaxis.type).toBe('date');
-            expect(gd._fullLayout.yaxis.type).toBe('linear');
-            expect(gd._fullData[0].type).toBe('scattergl');
-            expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
-
-            expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(2);
-        });
-
     });
 
     describe('categoryorder', function() {

--- a/test/jasmine/tests/gl2d_date_axis_render_test.js
+++ b/test/jasmine/tests/gl2d_date_axis_render_test.js
@@ -1,0 +1,84 @@
+var PlotlyInternal = require('@src/plotly');
+
+var hasWebGLSupport = require('../assets/has_webgl_support');
+
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+
+describe('date axis', function() {
+
+    if(!hasWebGLSupport('axes_test date axis')) return;
+
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('should use the fancy gl-vis/gl-scatter2d', function() {
+        PlotlyInternal.plot(gd, [{
+            type: 'scattergl',
+            'marker': {
+                'color': 'rgb(31, 119, 180)',
+                'size': 18,
+                'symbol': [
+                    'diamond',
+                    'cross'
+                ]
+            },
+            x: [new Date('2016-10-10'), new Date('2016-10-12')],
+            y: [15, 16]
+        }]);
+
+        expect(gd._fullLayout.xaxis.type).toBe('date');
+        expect(gd._fullLayout.yaxis.type).toBe('linear');
+        expect(gd._fullData[0].type).toBe('scattergl');
+        expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
+
+        // one way of check which renderer - fancy vs not - we're using
+        expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(0);
+    });
+
+    it('should use the fancy gl-vis/gl-scatter2d once again', function() {
+        PlotlyInternal.plot(gd, [{
+            type: 'scattergl',
+            'marker': {
+                'color': 'rgb(31, 119, 180)',
+                'size': 36,
+                'symbol': [
+                    'circle',
+                    'cross'
+                ]
+            },
+            x: [new Date('2016-10-10'), new Date('2016-10-11')],
+            y: [15, 16]
+        }]);
+
+        expect(gd._fullLayout.xaxis.type).toBe('date');
+        expect(gd._fullLayout.yaxis.type).toBe('linear');
+        expect(gd._fullData[0].type).toBe('scattergl');
+        expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
+
+        // one way of check which renderer - fancy vs not - we're using
+        expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(0);
+    });
+
+    it('should now use the non-fancy gl-vis/gl-scatter2d', function() {
+        PlotlyInternal.plot(gd, [{
+            type: 'scattergl',
+            mode: 'markers', // important, as otherwise lines are assumed (which needs fancy)
+            x: [new Date('2016-10-10'), new Date('2016-10-11')],
+            y: [15, 16]
+        }]);
+
+        expect(gd._fullLayout.xaxis.type).toBe('date');
+        expect(gd._fullLayout.yaxis.type).toBe('linear');
+        expect(gd._fullData[0].type).toBe('scattergl');
+        expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
+
+        expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(2);
+    });
+
+});

--- a/test/jasmine/tests/gl2d_date_axis_render_test.js
+++ b/test/jasmine/tests/gl2d_date_axis_render_test.js
@@ -81,4 +81,19 @@ describe('date axis', function() {
         expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(2);
     });
 
+    it('should use the non-fancy gl-vis/gl-scatter2d with string dates', function() {
+        PlotlyInternal.plot(gd, [{
+            type: 'scattergl',
+            mode: 'markers', // important, as otherwise lines are assumed (which needs fancy)
+            x: ['2016-10-10', '2016-10-11'],
+            y: [15, 16]
+        }]);
+
+        expect(gd._fullLayout.xaxis.type).toBe('date');
+        expect(gd._fullLayout.yaxis.type).toBe('linear');
+        expect(gd._fullData[0].type).toBe('scattergl');
+        expect(gd._fullData[0]._module.basePlotModule.name).toBe('gl2d');
+
+        expect(gd._fullLayout._plots.xy._scene2d.glplot.objects[3].pointCount).toBe(2);
+    });
 });


### PR DESCRIPTION
Performance improvement - it avoids the slower fancy `scattergl` that used to be triggered by the presence of the `Date` X axis type.
Fixes issue https://github.com/plotly/plotly.js/issues/413