### PR TITLE
Add grouping property to traces

### DIFF
--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -28,6 +28,14 @@ module.exports = {
             '(provided that the legend itself is visible).'
         ].join(' ')
     },
+    groups: {
+        valType: 'data_array',
+        description: [
+            'An array of strings corresponding to each respective datum. These strings are not' +
+            'inherently used by plotly for any purpose but may be used, for example, with transforms' +
+            'in order to filter or group points by an auxilliary property.'
+        ].join(' ')
+    },
     showlegend: {
         valType: 'boolean',
         role: 'info',

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -742,6 +742,7 @@ plots.supplyTraceDefaults = function(traceIn, traceIndex, layout) {
     coerce('type');
     coerce('uid');
     coerce('name', 'trace ' + traceIndex);
+    coerce('groups');
 
     // coerce subplot attributes of all registered subplot types
     var subplotTypes = Object.keys(subplotsRegistry);

--- a/src/traces/scatter/attributes.js
+++ b/src/traces/scatter/attributes.js
@@ -73,14 +73,6 @@ module.exports = {
             'occur if ids are not unique. *ids* is equivalent to a *key* in d3.'
         ].join(' ')
     },
-    grouping: {
-        valType: 'data_array',
-        description: [
-            'An array of strings corresponding to each respective point. These strings are not' +
-            'inherently used by plotly for any purpose but may be used, for example, with transforms' +
-            'in order to filter or group points by an auxilliary property'
-        ].join(' ')
-    },
     text: {
         valType: 'string',
         role: 'info',

--- a/src/traces/scatter/attributes.js
+++ b/src/traces/scatter/attributes.js
@@ -67,7 +67,19 @@ module.exports = {
     },
     ids: {
         valType: 'data_array',
-        description: 'A list of keys for object constancy of data points during animation'
+        description: [
+            'A list of unique string ids for object constancy of data points during animation.' +
+            'For efficiency, the uniqueness of ids is not validated, but unexpected results may' +
+            'occur if ids are not unique. *ids* is equivalent to a *key* in d3.'
+        ].join(' ')
+    },
+    grouping: {
+        valType: 'data_array',
+        description: [
+            'An array of strings corresponding to each respective point. These strings are not' +
+            'inherently used by plotly for any purpose but may be used, for example, with transforms' +
+            'in order to filter or group points by an auxilliary property'
+        ].join(' ')
     },
     text: {
         valType: 'string',

--- a/src/traces/scatter/calc.js
+++ b/src/traces/scatter/calc.js
@@ -121,12 +121,6 @@ module.exports = function calc(gd, trace) {
                 cd[i].id = String(trace.ids[i]);
             }
         }
-
-        if(trace.grouping) {
-            if(trace.grouping[i] !== undefined && trace.grouping[i] !== null) {
-                cd[i].grouping = String(trace.grouping[i]);
-            }
-        }
     }
 
     // this has migrated up from arraysToCalcdata as we have a reference to 's' here

--- a/src/traces/scatter/calc.js
+++ b/src/traces/scatter/calc.js
@@ -117,7 +117,15 @@ module.exports = function calc(gd, trace) {
             {x: x[i], y: y[i]} : {x: false, y: false};
 
         if(trace.ids) {
-            cd[i].id = String(trace.ids[i]);
+            if(trace.ids[i] !== undefined && trace.ids[i] !== null) {
+                cd[i].id = String(trace.ids[i]);
+            }
+        }
+
+        if(trace.grouping) {
+            if(trace.grouping[i] !== undefined && trace.grouping[i] !== null) {
+                cd[i].grouping = String(trace.grouping[i]);
+            }
         }
     }
 

--- a/src/traces/scatter/defaults.js
+++ b/src/traces/scatter/defaults.js
@@ -39,6 +39,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     coerce('text');
     coerce('mode', defaultMode);
     coerce('ids');
+    coerce('grouping');
 
     if(subTypes.hasLines(traceOut)) {
         handleLineDefaults(traceIn, traceOut, defaultColor, layout, coerce);

--- a/src/traces/scatter/defaults.js
+++ b/src/traces/scatter/defaults.js
@@ -39,7 +39,6 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     coerce('text');
     coerce('mode', defaultMode);
     coerce('ids');
-    coerce('grouping');
 
     if(subTypes.hasLines(traceOut)) {
         handleLineDefaults(traceIn, traceOut, defaultColor, layout, coerce);

--- a/src/transforms/filter.js
+++ b/src/transforms/filter.js
@@ -166,9 +166,11 @@ function getDataToCoordFunc(gd, trace, filtersrc) {
 
     // special case for 'ids' or 'grouping'
     // -> cast to String
-    if(['ids', 'grouping'].indexOf(filtersrc) !== -1) return function(v) {
-        return v === undefined ? undefined : String(v);
-    };
+    if(['ids', 'grouping'].indexOf(filtersrc) !== -1) {
+        return function(v) {
+            return v === undefined ? undefined : String(v);
+        };
+    }
 
     // otherwise
     // -> cast to Number

--- a/src/transforms/filter.js
+++ b/src/transforms/filter.js
@@ -164,9 +164,9 @@ function getDataToCoordFunc(gd, trace, filtersrc) {
     // -> use setConvert method
     if(ax) return ax.d2c;
 
-    // special case for 'ids' or 'grouping'
+    // special case for 'ids' or 'groups'
     // -> cast to String
-    if(['ids', 'grouping'].indexOf(filtersrc) !== -1) {
+    if(['ids', 'groups'].indexOf(filtersrc) !== -1) {
         return function(v) {
             return v === undefined ? undefined : String(v);
         };

--- a/src/transforms/filter.js
+++ b/src/transforms/filter.js
@@ -164,9 +164,11 @@ function getDataToCoordFunc(gd, trace, filtersrc) {
     // -> use setConvert method
     if(ax) return ax.d2c;
 
-    // special case for 'ids'
+    // special case for 'ids' or 'grouping'
     // -> cast to String
-    if(filtersrc === 'ids') return function(v) { return String(v); };
+    if(['ids', 'grouping'].indexOf(filtersrc) !== -1) return function(v) {
+        return v === undefined ? undefined : String(v);
+    };
 
     // otherwise
     // -> cast to Number

--- a/test/jasmine/tests/calcdata_test.js
+++ b/test/jasmine/tests/calcdata_test.js
@@ -30,6 +30,28 @@ describe('calculated data and points', function() {
         });
     });
 
+    describe('ids', function() {
+        it('should assign ids to points and cast them to strings in the process', function() {
+            Plotly.plot(gd, [{ x: [1, 2, 3, 5], y: [1, null, 3, 5], ids: [1, 'a', 'b', undefined]}], {});
+
+            expect(gd.calcdata[0][0]).toEqual(jasmine.objectContaining({ x: 1, y: 1, id: '1'}));
+            expect(gd.calcdata[0][1]).toEqual(jasmine.objectContaining({ x: false, y: false, id: 'a'}));
+            expect(gd.calcdata[0][2]).toEqual(jasmine.objectContaining({ x: 3, y: 3, id: 'b'}));
+            expect(gd.calcdata[0][3]).toEqual(jasmine.objectContaining({ x: 5, y: 5}));
+        });
+    });
+
+    describe('grouping', function() {
+        it('should assign grouping to points and cast them to strings in the process', function() {
+            Plotly.plot(gd, [{ x: [1, 2, 3, 5], y: [1, null, 3, 5], grouping: [1, 'a', 'b', undefined]}], {});
+
+            expect(gd.calcdata[0][0]).toEqual(jasmine.objectContaining({ x: 1, y: 1, grouping: '1'}));
+            expect(gd.calcdata[0][1]).toEqual(jasmine.objectContaining({ x: false, y: false, grouping: 'a'}));
+            expect(gd.calcdata[0][2]).toEqual(jasmine.objectContaining({ x: 3, y: 3, grouping: 'b'}));
+            expect(gd.calcdata[0][3]).toEqual(jasmine.objectContaining({ x: 5, y: 5}));
+        });
+    });
+
     describe('category ordering', function() {
 
         describe('default category ordering reified', function() {

--- a/test/jasmine/tests/calcdata_test.js
+++ b/test/jasmine/tests/calcdata_test.js
@@ -41,17 +41,6 @@ describe('calculated data and points', function() {
         });
     });
 
-    describe('grouping', function() {
-        it('should assign grouping to points and cast them to strings in the process', function() {
-            Plotly.plot(gd, [{ x: [1, 2, 3, 5], y: [1, null, 3, 5], grouping: [1, 'a', 'b', undefined]}], {});
-
-            expect(gd.calcdata[0][0]).toEqual(jasmine.objectContaining({ x: 1, y: 1, grouping: '1'}));
-            expect(gd.calcdata[0][1]).toEqual(jasmine.objectContaining({ x: false, y: false, grouping: 'a'}));
-            expect(gd.calcdata[0][2]).toEqual(jasmine.objectContaining({ x: 3, y: 3, grouping: 'b'}));
-            expect(gd.calcdata[0][3]).toEqual(jasmine.objectContaining({ x: 5, y: 5}));
-        });
-    });
-
     describe('category ordering', function() {
 
         describe('default category ordering reified', function() {


### PR DESCRIPTION
It's become clear that the `ids` field is insufficient. It's needed for object constancy while animating, but  duplicate `ids` result in disappearing markers. This is the expected behavior; it just precludes overloading the `ids` field for something like a filter transform, where duplicate data is perfectly reasonable.

This PR:
- [x] adds a `grouping` property to traces and explicitly notes that it has no inherent effect
- [x] notes in the docs that duplicate `ids` are invalid or at least have likely-unintended consequences
- [x] adds `calcdata` tests for casting `ids`

Feedback on naming and functionality is welcome. I don't like adding attributes, but this is very lightweight, seems necessary, and explicitly notes that it does not have any effect unless hooked up elsewhere by the user (e.g. transforms).

See also: #1027 
cc: @chriddyp @etpinard @alexcjohnson 