### PR TITLE
Fix badly chosen default positioning for sliders

### DIFF
--- a/src/components/sliders/attributes.js
+++ b/src/components/sliders/attributes.js
@@ -105,7 +105,7 @@ module.exports = {
         valType: 'number',
         min: -2,
         max: 3,
-        dflt: -0.05,
+        dflt: 0,
         role: 'style',
         description: 'Sets the x position (in normalized coordinates) of the slider.'
     },

--- a/src/components/sliders/attributes.js
+++ b/src/components/sliders/attributes.js
@@ -11,6 +11,7 @@
 var fontAttrs = require('../../plots/font_attributes');
 var padAttrs = require('../../plots/pad_attributes');
 var extendFlat = require('../../lib/extend').extendFlat;
+var extendDeep = require('../../lib/extend').extendDeep;
 var animationAttrs = require('../../plots/animation_attributes');
 var constants = require('./constants');
 
@@ -109,9 +110,9 @@ module.exports = {
         role: 'style',
         description: 'Sets the x position (in normalized coordinates) of the slider.'
     },
-    pad: extendFlat({}, padAttrs, {
+    pad: extendDeep({}, padAttrs, {
         description: 'Set the padding of the slider component along each side.'
-    }),
+    }, {t: {dflt: 20}}),
     xanchor: {
         valType: 'enumerated',
         values: ['auto', 'left', 'center', 'right'],
@@ -127,14 +128,14 @@ module.exports = {
         valType: 'number',
         min: -2,
         max: 3,
-        dflt: 1,
+        dflt: 0,
         role: 'style',
         description: 'Sets the y position (in normalized coordinates) of the slider.'
     },
     yanchor: {
         valType: 'enumerated',
         values: ['auto', 'top', 'middle', 'bottom'],
-        dflt: 'bottom',
+        dflt: 'top',
         role: 'info',
         description: [
             'Sets the slider\'s vertical position anchor',


### PR DESCRIPTION
This is a trivial PR that fixes poorly chosen defaults for sliders. It should look *nice* by default, not by configuration. This PR sets:

```javascript
{
  x: 0,
  y: 0,
  xanchor: 'left',
  yanchor: 'top',
  pad: {t: 20}
}
```

In many cases, this will hopefully just make it unnecessary to do much with the appearance. The result for an otherwise unstyled slider now looks like:

<img width="680" alt="screen shot 2016-10-11 at 17 36 31" src="https://cloud.githubusercontent.com/assets/572717/19289568/5bcc29c6-8fd9-11e6-9042-c696e9f5e5ab.png">
