### PR TITLE
Fix pretest task for require.js test fixture

### DIFF
--- a/tasks/pretest.js
+++ b/tasks/pretest.js
@@ -55,9 +55,13 @@ function makeTestImageFolders() {
 
 // Make script file that define plotly in a RequireJS context
 function makeRequireJSFixture() {
-    var bundle = fs.readFileSync(constants.pathToPlotlyDistMin, 'utf-8'),
-        template = 'define(\'plotly\', function(require, exports, module) { {{bundle}} });',
-        index = template.replace('{{bundle}}', bundle);
+    var bundle = fs.readFileSync(constants.pathToPlotlyDistMin, 'utf-8');
+
+    var index = [
+        'define(\'plotly\', function(require, exports, module) {',
+        bundle,
+        '});'
+    ].join('');
 
     common.writeFile(constants.pathToRequireJSFixture, index);
     logger('make build/requirejs_fixture.js');


### PR DESCRIPTION
`master` is currently broken, but rest assured, there's nothing wrong with `v1.18.0` itself (yet).

In brief,

The `npm run pretest` builds a fixture to test `plotly.min.js` in a Require.js environment in this [suite](https://github.com/plotly/plotly.js/blob/master/test/jasmine/bundle_tests/requirejs_test.js).

To do so, in `master`, `pretest.js` uses a string replace to place the bundle code in a Require.js define statement. This string replace currently breaks the fixture and thus making the Require.js test fail.

In this PR, the Require.js test fixture is built using a more robust arrary `join('')`.