### PR TITLE
Fix leak of global vars in polyfill

### DIFF
--- a/dist/extras/request_animation_frame.js
+++ b/dist/extras/request_animation_frame.js
@@ -15,28 +15,41 @@
 
 // MIT license
 
+(function(){
+    
+    'use strict';
 
-'use strict';
+    if(!Date.now) {
+        Date.now = function() { return (new Date()).getTime(); };
+    }
 
-if(!Date.now) {
-    Date.now = function() { return new Date().getTime(); };
-}
-
-var vendors = ['webkit', 'moz'];
-for(var i = 0; i < vendors.length && !window.requestAnimationFrame; ++i) {
-    var vp = vendors[i];
-    window.requestAnimationFrame = window[vp + 'RequestAnimationFrame'];
-    window.cancelAnimationFrame = (window[vp + 'CancelAnimationFrame'] ||
-                                   window[vp + 'CancelRequestAnimationFrame']);
-}
-if(/iP(ad|hone|od).*OS 6/.test(window.navigator.userAgent) || // iOS6 is buggy
-    !window.requestAnimationFrame || !window.cancelAnimationFrame) {
+    var vendors = ['webkit', 'moz'];
+    var i = 0;
+    var l = vendors.length;
+    var vp;
     var lastTime = 0;
-    window.requestAnimationFrame = function(callback) {
-        var now = Date.now();
-        var nextTime = Math.max(lastTime + 16, now);
-        return setTimeout(function() { callback(lastTime = nextTime); },
-                          nextTime - now);
-    };
-    window.cancelAnimationFrame = clearTimeout;
-}
+
+    for(; i < l && !window.requestAnimationFrame; ++i) {
+        vp = vendors[i];
+        window.requestAnimationFrame = window[vp + 'RequestAnimationFrame'];
+        window.cancelAnimationFrame = (window[vp + 'CancelAnimationFrame'] ||
+                                       window[vp + 'CancelRequestAnimationFrame']);
+    }
+
+    if(/iP(ad|hone|od).*OS 6/.test(window.navigator.userAgent) || // iOS6 is buggy
+        !window.requestAnimationFrame || !window.cancelAnimationFrame) {
+        window.requestAnimationFrame = function(callback) {
+            var now = Date.now();
+            var nextTime = Math.max(lastTime + 16, now);
+            return setTimeout(function() { callback(lastTime = nextTime); },
+                              nextTime - now);
+        };
+        window.cancelAnimationFrame = clearTimeout;
+    }
+
+    vendors = null;
+    i = null;
+    l = null;
+    vp = null;
+
+}());


### PR DESCRIPTION
After looking at the requestAnimationFrame polyfill I noticed that it would be leaking global vars as it's not wrapped in an IIFE. As the closure will be around for the life of the page, I have also nulled out the temporary vars.