### PR TITLE
Fix expect(new Array(1)).toEqual([undefined]) failures on *some* platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "brfs": "^1.4.3",
     "browserify": "^13.0.0",
     "browserify-transform-tools": "^1.5.1",
+    "deep-equal": "^1.0.1",
     "ecstatic": "^1.4.0",
     "eslint": "^3.5.0",
     "falafel": "^1.2.0",

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -8,6 +8,33 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var Plots = PlotlyInternal.Plots;
 
+/* This is a one-off function to fully populate sparse arrays. This arises
+ * because:
+ *
+ *   var x = new Array(2)
+ *   expect(x).toEqual([undefined, undefined])
+ *
+ * will fail assertion even though x[0] === undefined and x[1] === undefined.
+ * This is because the array elements don't exist until assigned.
+ */
+function populateUndefinedArrayEls(x) {
+    var i;
+    if(Array.isArray(x)) {
+        for(i = 0; i < x.length; i++) {
+            x[i] = x[i];
+        }
+    } else if(Lib.isPlainObject(x)) {
+        var keys = Object.keys(x);
+        for(i = 0; i < keys.length; i++) {
+            populateUndefinedArrayEls(x[keys[i]]);
+        }
+    }
+}
+
+function expectLooseDeepEqual(a, b) {
+    expect(populateUndefinedArrayEls(a)).toEqual(populateUndefinedArrayEls(b));
+}
+
 
 describe('Test lib.js:', function() {
     'use strict';
@@ -485,37 +512,37 @@ describe('Test lib.js:', function() {
         it('unpacks top-level paths', function() {
             var input = {'marker.color': 'red', 'marker.size': [1, 2, 3]};
             var expected = {marker: {color: 'red', size: [1, 2, 3]}};
-            expect(Lib.expandObjectPaths(input)).toEqual(expected);
+            expectLooseDeepEqual(Lib.expandObjectPaths(input), expected);
         });
 
         it('unpacks recursively', function() {
             var input = {'marker.color': {'red.certainty': 'definitely'}};
             var expected = {marker: {color: {red: {certainty: 'definitely'}}}};
-            expect(Lib.expandObjectPaths(input)).toEqual(expected);
+            expectLooseDeepEqual(Lib.expandObjectPaths(input), expected);
         });
 
         it('unpacks deep paths', function() {
             var input = {'foo.bar.baz': 'red'};
             var expected = {foo: {bar: {baz: 'red'}}};
-            expect(Lib.expandObjectPaths(input)).toEqual(expected);
+            expectLooseDeepEqual(Lib.expandObjectPaths(input), expected);
         });
 
         it('unpacks non-top-level deep paths', function() {
             var input = {color: {'foo.bar.baz': 'red'}};
             var expected = {color: {foo: {bar: {baz: 'red'}}}};
-            expect(Lib.expandObjectPaths(input)).toEqual(expected);
+            expectLooseDeepEqual(Lib.expandObjectPaths(input), expected);
         });
 
         it('merges dotted properties into objects', function() {
             var input = {marker: {color: 'red'}, 'marker.size': 8};
             var expected = {marker: {color: 'red', size: 8}};
-            expect(Lib.expandObjectPaths(input)).toEqual(expected);
+            expectLooseDeepEqual(Lib.expandObjectPaths(input), expected);
         });
 
         it('merges objects into dotted properties', function() {
             var input = {'marker.size': 8, marker: {color: 'red'}};
             var expected = {marker: {color: 'red', size: 8}};
-            expect(Lib.expandObjectPaths(input)).toEqual(expected);
+            expectLooseDeepEqual(Lib.expandObjectPaths(input), expected);
         });
 
         it('retains the identity of nested objects', function() {
@@ -541,49 +568,49 @@ describe('Test lib.js:', function() {
         it('expands bracketed array notation', function() {
             var input = {'marker[1]': {color: 'red'}};
             var expected = {marker: [undefined, {color: 'red'}]};
-            expect(Lib.expandObjectPaths(input)).toEqual(expected);
+            expectLooseDeepEqual(Lib.expandObjectPaths(input), expected);
         });
 
         it('expands nested arrays', function() {
             var input = {'marker[1].range[1]': 5};
             var expected = {marker: [undefined, {range: [undefined, 5]}]};
             var computed = Lib.expandObjectPaths(input);
-            expect(computed).toEqual(expected);
+            expectLooseDeepEqual(computed, expected);
         });
 
         it('expands bracketed array with more nested attributes', function() {
             var input = {'marker[1]': {'color.alpha': 2}};
             var expected = {marker: [undefined, {color: {alpha: 2}}]};
             var computed = Lib.expandObjectPaths(input);
-            expect(computed).toEqual(expected);
+            expectLooseDeepEqual(computed, expected);
         });
 
         it('expands bracketed array notation without further nesting', function() {
             var input = {'marker[1]': 8};
             var expected = {marker: [undefined, 8]};
             var computed = Lib.expandObjectPaths(input);
-            expect(computed).toEqual(expected);
+            expectLooseDeepEqual(computed, expected);
         });
 
         it('expands bracketed array notation with further nesting', function() {
             var input = {'marker[1].size': 8};
             var expected = {marker: [undefined, {size: 8}]};
             var computed = Lib.expandObjectPaths(input);
-            expect(computed).toEqual(expected);
+            expectLooseDeepEqual(computed, expected);
         });
 
         it('expands bracketed array notation with further nesting', function() {
             var input = {'marker[1].size.magnitude': 8};
             var expected = {marker: [undefined, {size: {magnitude: 8}}]};
             var computed = Lib.expandObjectPaths(input);
-            expect(computed).toEqual(expected);
+            expectLooseDeepEqual(computed, expected);
         });
 
         it('combines changes with single array nesting', function() {
             var input = {'marker[1].foo': 5, 'marker[0].foo': 4};
             var expected = {marker: [{foo: 4}, {foo: 5}]};
             var computed = Lib.expandObjectPaths(input);
-            expect(computed).toEqual(expected);
+            expectLooseDeepEqual(computed, expected);
         });
 
         // TODO: This test is unimplemented since it's a currently-unused corner case.

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -491,7 +491,6 @@ describe('Test lib.js:', function() {
             var expected = {marker: {color: 'red', size: [1, 2, 4]}};
             expect(Lib.expandObjectPaths(input)).toLooseDeepEqual(expected);
         });
-        return;
 
         it('unpacks recursively', function() {
             var input = {'marker.color': {'red.certainty': 'definitely'}};

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -488,7 +488,7 @@ describe('Test lib.js:', function() {
 
         it('unpacks top-level paths', function() {
             var input = {'marker.color': 'red', 'marker.size': [1, 2, 3]};
-            var expected = {marker: {color: 'red', size: [1, 2, 4]}};
+            var expected = {marker: {color: 'red', size: [1, 2, 3]}};
             expect(Lib.expandObjectPaths(input)).toLooseDeepEqual(expected);
         });
 


### PR DESCRIPTION
This test adds a helper function to the lib test in order to loosen the comparison to what we actually care about, which is array **access**, not array **content**.

Gross.