### PR TITLE
Modify Plotly.plot to accept frames #1014

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -345,8 +345,8 @@ Plotly.plot = function(gd, data, layout, config) {
 
     Lib.syncOrAsync([
         Plots.previousPromises,
-        drawFramework,
         addFrames,
+        drawFramework,
         marginPushers,
         marginPushersAgain,
         positionAndAutorange,

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -47,10 +47,20 @@ var subroutines = require('./subroutines');
  *
  */
 Plotly.plot = function(gd, data, layout, config) {
+    var frames;
+
     gd = helpers.getGraphDiv(gd);
 
     // Events.init is idempotent and bails early if gd has already been init'd
     Events.init(gd);
+
+    if(Lib.isPlainObject(data)) {
+        var obj = data;
+        data = obj.data;
+        layout = obj.layout;
+        config = obj.config;
+        frames = obj.frames;
+    }
 
     var okToPlot = Events.triggerHandler(gd, 'plotly_beforeplot', [data, layout, config]);
     if(okToPlot === false) return Promise.reject();
@@ -60,6 +70,12 @@ Plotly.plot = function(gd, data, layout, config) {
     if(!data && !layout && !Lib.isPlotDiv(gd)) {
         Lib.warn('Calling Plotly.plot as if redrawing ' +
             'but this container doesn\'t yet have a plot.', gd);
+    }
+
+    function addFrames() {
+        if(frames) {
+            return Plotly.addFrames(gd, frames);
+        }
     }
 
     // transfer configuration options to gd until we move over to
@@ -330,6 +346,7 @@ Plotly.plot = function(gd, data, layout, config) {
     Lib.syncOrAsync([
         Plots.previousPromises,
         drawFramework,
+        addFrames,
         marginPushers,
         marginPushersAgain,
         positionAndAutorange,

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -11,6 +11,7 @@ var subroutines = require('@src/plot_api/subroutines');
 var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
+var fail = require('../assets/fail_test');
 
 
 describe('Test plot api', function() {
@@ -19,6 +20,44 @@ describe('Test plot api', function() {
     describe('Plotly.version', function() {
         it('should be the same as in the package.json', function() {
             expect(Plotly.version).toEqual(pkg.version);
+        });
+    });
+
+    describe('Plotly.plot', function() {
+        var gd;
+
+        beforeEach(function() {
+            gd = createGraphDiv();
+        });
+
+        afterEach(destroyGraphDiv);
+
+        it('accepts gd, data, layout, and config as args', function(done) {
+            Plotly.plot(gd,
+                [{x: [1, 2, 3], y: [1, 2, 3]}],
+                {width: 500, height: 500},
+                {editable: true}
+            ).then(function() {
+                expect(gd.layout.width).toEqual(500);
+                expect(gd.layout.height).toEqual(500);
+                expect(gd.data.length).toEqual(1);
+                expect(gd._context.editable).toBe(true);
+            }).catch(fail).then(done);
+        });
+
+        it('accepts gd and an object as args', function(done) {
+            Plotly.plot(gd, {
+                data: [{x: [1, 2, 3], y: [1, 2, 3]}],
+                layout: {width: 500, height: 500},
+                config: {editable: true},
+                frames: [{y: [2, 1, 0], name: 'frame1'}]
+            }).then(function() {
+                expect(gd.layout.width).toEqual(500);
+                expect(gd.layout.height).toEqual(500);
+                expect(gd.data.length).toEqual(1);
+                expect(gd._transitionData._frames.length).toEqual(1);
+                expect(gd._context.editable).toBe(true);
+            }).catch(fail).then(done);
         });
     });
 

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -59,6 +59,31 @@ describe('Test plot api', function() {
                 expect(gd._context.editable).toBe(true);
             }).catch(fail).then(done);
         });
+
+        it('allows adding more frames to the initial set', function(done) {
+            Plotly.plot(gd, {
+                data: [{x: [1, 2, 3], y: [1, 2, 3]}],
+                layout: {width: 500, height: 500},
+                config: {editable: true},
+                frames: [{y: [7, 7, 7], name: 'frame1'}]
+            }).then(function() {
+                expect(gd.layout.width).toEqual(500);
+                expect(gd.layout.height).toEqual(500);
+                expect(gd.data.length).toEqual(1);
+                expect(gd._transitionData._frames.length).toEqual(1);
+                expect(gd._context.editable).toBe(true);
+
+                return Plotly.addFrames(gd, [
+                    {y: [8, 8, 8], name: 'frame2'},
+                    {y: [9, 9, 9], name: 'frame3'}
+                ]);
+            }).then(function() {
+                expect(gd._transitionData._frames.length).toEqual(3);
+                expect(gd._transitionData._frames[0].name).toEqual('frame1');
+                expect(gd._transitionData._frames[1].name).toEqual('frame2');
+                expect(gd._transitionData._frames[2].name).toEqual('frame3');
+            }).catch(fail).then(done);
+        });
     });
 
     describe('Plotly.relayout', function() {


### PR DESCRIPTION
This PR overloads `Plotly.plot` so that loading frames isn't a second, promise-chained step.

### Original

```javascript
Plotly.plot(gd, data, layout, config)
```

### Variation

```javascript
Plotly.plot(gd, {
  data: [...]
  layout: {...}
  config: {...}
  frames: [...]
});
```

### Now unnecessary

```javascript
Plotly.plot(gd, data, layout, config).then(function () {
  return Plotly.addFrames(gd, frames);
});
```
