### PR TITLE
Add identity _fullInput refs to fullTrace

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -642,6 +642,11 @@ plots.supplyDataDefaults = function(dataIn, dataOut, layout, fullLayout) {
             }
         }
         else {
+
+            // add identify refs for consistency with transformed traces
+            fullTrace._fullInput = fullTrace;
+            fullTrace._expandedInput = fullTrace;
+
             pushModule(fullTrace);
         }
     }

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -64,6 +64,33 @@ describe('Test Plots', function() {
             expect(gd._fullLayout.yaxis._m)
                 .not.toBe(oldFullLayout.yaxis._m, '(set during ax.setScale');
         });
+
+        it('should include the correct reference to user data', function() {
+            var trace0 = { y: [1, 2, 3] };
+            var trace1 = { y: [5, 2, 3] };
+
+            var data = [trace0, trace1];
+            var gd = { data: data };
+
+            Plots.supplyDefaults(gd);
+
+            expect(gd.data).toBe(data);
+
+            expect(gd._fullData[0].index).toEqual(0);
+            expect(gd._fullData[1].index).toEqual(1);
+
+            expect(gd._fullData[0]._expandedIndex).toEqual(0);
+            expect(gd._fullData[1]._expandedIndex).toEqual(1);
+
+            expect(gd._fullData[0]._input).toBe(trace0);
+            expect(gd._fullData[1]._input).toBe(trace1);
+
+            expect(gd._fullData[0]._fullInput).toBe(gd._fullData[0]);
+            expect(gd._fullData[1]._fullInput).toBe(gd._fullData[1]);
+
+            expect(gd._fullData[0]._expandedInput).toBe(gd._fullData[0]);
+            expect(gd._fullData[1]._expandedInput).toBe(gd._fullData[1]);
+        });
     });
 
     describe('Plots.supplyLayoutGlobalDefaults should', function() {


### PR DESCRIPTION
... so that `gd._fullData[i]._fullInput` and `gd._fullData[i]._expandedTrace` are **always** defined, that is, inside transform traces and non-transforms traces.

This, I believe, will make @VeraZab's live a lot easier for building UI buttons for `ohlc` and `candlestick` traces.

@bpostlethwaite can you think of a potential problem here?