### PR TITLE
Fix minified dist bundles

### DIFF
--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -1,14 +1,6 @@
-var fs = require('fs');
-var path = require('path');
-
-var browserify = require('browserify');
-var UglifyJS = require('uglify-js');
-
 var constants = require('./util/constants');
 var common = require('./util/common');
-var compressAttributes = require('./util/compress_attributes');
-var patchMinified = require('./util/patch_minified');
-var doesFileExist = common.doesFileExist;
+var _bundle = require('./util/browserify_wrapper');
 
 /*
  * This script takes one argument
@@ -26,6 +18,7 @@ var DEV = (arg === 'dev') || (arg === '--dev');
 
 
 // Check if style and font build files are there
+var doesFileExist = common.doesFileExist;
 if(!doesFileExist(constants.pathToCSSBuild) || !doesFileExist(constants.pathToFontSVG)) {
     throw new Error([
         'build/ is missing one or more files',
@@ -59,45 +52,3 @@ constants.partialBundlePaths.forEach(function(pathObj) {
         pathToMinBundle: pathObj.distMin
     });
 });
-
-function _bundle(pathToIndex, pathToBundle, opts) {
-    opts = opts || {};
-
-    // do we output a minified file?
-    var pathToMinBundle = opts.pathToMinBundle,
-        outputMinified = !!pathToMinBundle && !opts.debug;
-
-    var browserifyOpts = {};
-    browserifyOpts.standalone = opts.standalone;
-    browserifyOpts.debug = opts.debug;
-    browserifyOpts.transform = outputMinified ? [compressAttributes] : [];
-
-    var b = browserify(pathToIndex, browserifyOpts),
-        bundleWriteStream = fs.createWriteStream(pathToBundle);
-
-    bundleWriteStream.on('finish', function() {
-        logger(pathToBundle);
-    });
-
-    b.bundle(function(err, buf) {
-        if(err) throw err;
-
-        if(outputMinified) {
-            var minifiedCode = UglifyJS.minify(buf.toString(), constants.uglifyOptions).code;
-            minifiedCode = patchMinified(minifiedCode);
-
-            fs.writeFile(pathToMinBundle, minifiedCode, function(err) {
-                if(err) throw err;
-
-                logger(pathToMinBundle);
-            });
-        }
-    })
-    .pipe(bundleWriteStream);
-}
-
-function logger(pathToOutput) {
-    var log = 'ok ' + path.basename(pathToOutput);
-
-    console.log(log);
-}

--- a/tasks/cibundle.js
+++ b/tasks/cibundle.js
@@ -1,33 +1,24 @@
-var fs = require('fs');
-
-var browserify = require('browserify');
-
 var constants = require('./util/constants');
-var common = require('./util/common');
-var compressAttributes = require('./util/compress_attributes');
+var _bundle = require('./util/browserify_wrapper');
 
 /*
  * Trimmed down version of ./bundle.js for CI testing
  *
- * Outputs plotly.js bundle in build/ and
- * plotly-geo-assets.js bundle in dist/
- * in accordance with test/image/index.html
+ * Outputs:
  *
+ *  - plotly.js bundle in build/
+ *  - plotly-geo-assets.js bundle in dist/ (in accordance with test/image/index.html)
+ *  - plotly.min.js bundle in dist/ (for requirejs test)
  */
 
 
-// Browserify plotly.js
-browserify(constants.pathToPlotlyIndex, {
+// Browserify plotly.js and plotly.min.js
+_bundle(constants.pathToPlotlyIndex, constants.pathToPlotlyBuild, {
     standalone: 'Plotly',
-    transform: [compressAttributes]
-})
-.bundle(common.throwOnError)
-.pipe(fs.createWriteStream(constants.pathToPlotlyBuild));
-
+    pathToMinBundle: constants.pathToPlotlyDistMin,
+});
 
 // Browserify the geo assets
-browserify(constants.pathToPlotlyGeoAssetsSrc, {
+_bundle(constants.pathToPlotlyGeoAssetsSrc, constants.pathToPlotlyGeoAssetsDist, {
     standalone: 'PlotlyGeoAssets'
-})
-.bundle(common.throwOnError)
-.pipe(fs.createWriteStream(constants.pathToPlotlyGeoAssetsDist));
+});

--- a/tasks/util/browserify_wrapper.js
+++ b/tasks/util/browserify_wrapper.js
@@ -1,0 +1,71 @@
+var fs = require('fs');
+var path = require('path');
+
+var browserify = require('browserify');
+var UglifyJS = require('uglify-js');
+
+var constants = require('./constants');
+var compressAttributes = require('./compress_attributes');
+var patchMinified = require('./patch_minified');
+
+/** Convenience browserify wrapper
+ *
+ * @param {string} pathToIndex path to index file to bundle
+ * @param {string} pathToBunlde path to destination bundle
+ *
+ * @param {object} opts
+ *
+ *  Browserify options:
+ *  - standalone {string}
+ *  - debug {boolean} [optional]
+ *
+ *  Additional option:
+ *  - pathToMinBundle {string} path to destination minified bundle
+ *
+ * Outputs one bundle (un-minified) file if opts.pathToMinBundle is omitted
+ * or opts.debug is true. Otherwise outputs two file: one un-minified bundle and
+ * one minified bundle.
+ *
+ * Logs basename of bundle when completed.
+ */
+module.exports = function _bundle(pathToIndex, pathToBundle, opts) {
+    opts = opts || {};
+
+    // do we output a minified file?
+    var pathToMinBundle = opts.pathToMinBundle,
+        outputMinified = !!pathToMinBundle && !opts.debug;
+
+    var browserifyOpts = {};
+    browserifyOpts.standalone = opts.standalone;
+    browserifyOpts.debug = opts.debug;
+    browserifyOpts.transform = outputMinified ? [compressAttributes] : [];
+
+    var b = browserify(pathToIndex, browserifyOpts),
+        bundleWriteStream = fs.createWriteStream(pathToBundle);
+
+    bundleWriteStream.on('finish', function() {
+        logger(pathToBundle);
+    });
+
+    b.bundle(function(err, buf) {
+        if(err) throw err;
+
+        if(outputMinified) {
+            var minifiedCode = UglifyJS.minify(buf.toString(), constants.uglifyOptions).code;
+            minifiedCode = patchMinified(minifiedCode);
+
+            fs.writeFile(pathToMinBundle, minifiedCode, function(err) {
+                if(err) throw err;
+
+                logger(pathToMinBundle);
+            });
+        }
+    })
+    .pipe(bundleWriteStream);
+};
+
+function logger(pathToOutput) {
+    var log = 'ok ' + path.basename(pathToOutput);
+
+    console.log(log);
+}

--- a/tasks/util/patch_minified.js
+++ b/tasks/util/patch_minified.js
@@ -1,5 +1,6 @@
-var STR_TO_REPLACE = 'require("+a(r)+");';
-var STR_NEW = 'require("+ a(r) +");';
+var ALPHABET = 'abcdefghijklmnopqrstuvwxyz'.split('');
+var FRONT = 'require("+';
+var BACK = '+");';
 
 /* Uber hacky in-house fix to
  *
@@ -11,5 +12,20 @@ var STR_NEW = 'require("+ a(r) +");';
  *
  */
 module.exports = function patchMinified(minifiedCode) {
-    return minifiedCode.replace(STR_TO_REPLACE, STR_NEW);
+    for(var i = 0; i < ALPHABET.length; i++) {
+        var li = ALPHABET[i];
+
+        for(var j = 0; j < ALPHABET.length; j++) {
+            var lj = ALPHABET[j];
+
+            var MIDDLE = li + '(' + lj + ')';
+
+            var strOld = FRONT + MIDDLE + BACK,
+                strNew = FRONT + ' ' + MIDDLE + ' ' + BACK;
+
+            minifiedCode = minifiedCode.replace(strOld, strNew);
+        }
+    }
+
+    return minifiedCode;
 };

--- a/tasks/util/patch_minified.js
+++ b/tasks/util/patch_minified.js
@@ -1,6 +1,5 @@
-var ALPHABET = 'abcdefghijklmnopqrstuvwxyz'.split('');
-var FRONT = 'require("+';
-var BACK = '+");';
+var PATTERN = /require\("\+(\w)\((\w)\)\+"\)/;
+var NEW_SUBSTR = 'require("+ $1($2) +")';
 
 /* Uber hacky in-house fix to
  *
@@ -19,20 +18,5 @@ var BACK = '+");';
  *
  */
 module.exports = function patchMinified(minifiedCode) {
-    for(var i = 0; i < ALPHABET.length; i++) {
-        var li = ALPHABET[i];
-
-        for(var j = 0; j < ALPHABET.length; j++) {
-            var lj = ALPHABET[j];
-
-            var MIDDLE = li + '(' + lj + ')';
-
-            var strOld = FRONT + MIDDLE + BACK,
-                strNew = FRONT + ' ' + MIDDLE + ' ' + BACK;
-
-            minifiedCode = minifiedCode.replace(strOld, strNew);
-        }
-    }
-
-    return minifiedCode;
+    return minifiedCode.replace(PATTERN, NEW_SUBSTR);
 };

--- a/tasks/util/patch_minified.js
+++ b/tasks/util/patch_minified.js
@@ -8,7 +8,14 @@ var BACK = '+");';
  *
  * so that plotly.min.js loads in Jupyter NBs, more info here:
  *
- * https://github.com/plotly/plotly.py/pull/545
+ * - https://github.com/plotly/plotly.py/pull/545
+ * - https://github.com/plotly/plotly.js/pull/914
+ * - https://github.com/plotly/plotly.js/pull/1094
+ *
+ * For example, this routine replaces
+ *  'require("+o(s)+")' -> 'require("+ o(s) +")'
+ *
+ * But works for any 1-letter variable that uglify-js may output.
  *
  */
 module.exports = function patchMinified(minifiedCode) {


### PR DESCRIPTION
The ugly `webworkify` + Require.js bug strikes again :ghost: The `1.19.0` dist builds are broken in Require.js. In https://github.com/plotly/plotly.js/pull/914 (more specifically https://github.com/plotly/plotly.js/pull/914#r77898939) I chose to run the plotly.min.js + require.js test only on the main dist bundle because minifying plotly.js takes about 1 minute. That is, it was testing new code only on release builds (like this [one](https://circleci.com/gh/plotly/plotly.js/2887)).

BUT, I should add: _minifying plotly.js take about 1 minute_, that's using node.js v4. Using node.js v6, the minifying time drops to about ~30 seconds. Good enough for me. Let's test this thing on every build!