### PR TITLE
Add npm ls check and dist log file

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start-image_viewer": "node devtools/image_viewer/server.js",
     "start": "npm run start-test_dashboard",
     "baseline": "node tasks/baseline.js",
-    "preversion": "npm-link-check && npm dedupe",
+    "preversion": "npm-link-check && && npm dedupe && npm ls",
     "version": "npm run build && git add -A dist src build",
     "postversion": "git push && git push --tags"
   },

--- a/tasks/stats.js
+++ b/tasks/stats.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+var spawn = require('child_process').spawn;
 
 var falafel = require('falafel');
 var gzipSize = require('gzip-size');
@@ -10,6 +11,7 @@ var constants = require('./util/constants');
 var pkg = require('../package.json');
 
 var pathDistREADME = path.join(constants.pathToDist, 'README.md');
+var pathDistNpmLs = path.join(constants.pathToDist, 'npm-ls.json');
 var cdnRoot = 'https://cdn.plot.ly/plotly-';
 var coreModules = ['scatter'];
 
@@ -18,15 +20,25 @@ var JS = '.js';
 var MINJS = '.min.js';
 
 // main
-var content = getContent();
-common.writeFile(pathDistREADME, content.join('\n'));
+writeNpmLs();
+common.writeFile(pathDistREADME, getReadMeContent());
 
-function getContent() {
+function writeNpmLs() {
+    if(common.doesFileExist(pathDistNpmLs)) fs.unlinkSync(pathDistNpmLs);
+
+    var ws = fs.createWriteStream(pathDistNpmLs, { flags: 'a' });
+    var proc = spawn('npm', ['ls', '--json', '--only', 'prod']);
+
+    proc.stdout.pipe(ws);
+}
+
+function getReadMeContent() {
     return []
         .concat(getInfoContent())
         .concat(getMainBundleInfo())
         .concat(getPartialBundleInfo())
-        .concat(getFooter());
+        .concat(getFooter())
+        .join('\n');
 }
 
 // general info about distributed files


### PR DESCRIPTION
The most recent minor version bump (`v1.19.0`) featured many dependency bumps. To make sure that I had the correct `node_modules` tree I ran [`npm ls`](https://docs.npmjs.com/cli/ls). That's when I realised that `npm ls` completes with exit code `1` whenever unmet dependencies are present in the local `node_module`. So, why not use this as a preversion check? That way we'll enforce whoever bumps the version to have the correct `node_modules` tree. 

Moreover, I'm thinking that we should log the `node_modules` tree structure in `dist/` whenever for produce new dist bundles. That way troubleshooting possible `master` and `dist` bundle mismatch should be a lot easier. This is especially important with the recent and planned short-term gl2d development where a lot of gl-vis module were patched.
