### PR TITLE
Add failling test for coerce

### DIFF
--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -649,6 +649,24 @@ describe('Test lib.js:', function() {
             expect(cOut).toBe(outObj.b.c);
         });
 
+        describe('info_arrays', function () {
+            it('does not filter empty arrays with freeLength: true', function() {
+                var attrs = {
+                    x: {
+                        valType: 'info_array',
+                        freeLength: true,
+                        items: [
+                            { valType: 'any' },
+                            { valType: 'any' },
+                            { valType: 'any' }
+                        ]
+                    }
+                };
+                out = coerce({x: [[], 10]}, {}, attrs, 'x');
+                expect(out).toEqual([[], 10]);
+            });
+        });
+
         describe('string valType', function() {
             var dflt = 'Jabberwock',
                 stringAttrs = {


### PR DESCRIPTION
This PR adds a failing test for `Lib.coerce`. It's pretty short:

```javascript
var attrs = { 
  x: {
    valType: 'info_array',
    freeLength: true,
    items: [
      { valType: 'any' },
      { valType: 'any' },
      { valType: 'any' }
    ]   
  }
};
out = coerce({x: [[], 10]}, {}, attrs, 'x');
expect(out).toEqual([[], 10]);
```
It fails because the output is equal to `[undefined, 10]` instead of `[[], 10]`. 

The error goes away if I remove the third `valType: 'any'`, suggesting that `freeLength` doesn't quite do what it sounds like it does. `freeLength` has no effect either way, but I've included it since I'd expect it to help. It seems it's refusing to set empty arrays, but I'm not sure why.