### PR TITLE
quick fix - allow relayout array elements

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1959,9 +1959,9 @@ function _relayout(gd, aobj) {
         }
         // alter gd.layout
         else {
+            var pp1 = String(p.parts[1] || '');
             // check whether we can short-circuit a full redraw
             // 3d or geo at this point just needs to redraw.
-            var pp1 = String(p.parts[1] || '');
             if(p.parts[0].indexOf('scene') === 0) flags.doplot = true;
             else if(p.parts[0].indexOf('geo') === 0) flags.doplot = true;
             else if(p.parts[0].indexOf('ternary') === 0) flags.doplot = true;

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1961,6 +1961,7 @@ function _relayout(gd, aobj) {
         else {
             // check whether we can short-circuit a full redraw
             // 3d or geo at this point just needs to redraw.
+            var pp1 = String(p.parts[1] || '');
             if(p.parts[0].indexOf('scene') === 0) flags.doplot = true;
             else if(p.parts[0].indexOf('geo') === 0) flags.doplot = true;
             else if(p.parts[0].indexOf('ternary') === 0) flags.doplot = true;
@@ -1973,17 +1974,17 @@ function _relayout(gd, aobj) {
             else if(ai.indexOf('title') !== -1) flags.doticks = true;
             else if(p.parts[0].indexOf('bgcolor') !== -1) flags.dolayoutstyle = true;
             else if(p.parts.length > 1 &&
-                    Lib.containsAny(p.parts[1], ['tick', 'exponent', 'grid', 'zeroline'])) {
+                    Lib.containsAny(pp1, ['tick', 'exponent', 'grid', 'zeroline'])) {
                 flags.doticks = true;
             }
             else if(ai.indexOf('.linewidth') !== -1 &&
                     ai.indexOf('axis') !== -1) {
                 flags.doticks = flags.dolayoutstyle = true;
             }
-            else if(p.parts.length > 1 && p.parts[1].indexOf('line') !== -1) {
+            else if(p.parts.length > 1 && pp1.indexOf('line') !== -1) {
                 flags.dolayoutstyle = true;
             }
-            else if(p.parts.length > 1 && p.parts[1] === 'mirror') {
+            else if(p.parts.length > 1 && pp1 === 'mirror') {
                 flags.doticks = flags.dolayoutstyle = true;
             }
             else if(ai === 'margin.pad') {

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -148,6 +148,21 @@ describe('Test plot api', function() {
                 })
                 .then(done);
         });
+
+        it('can set items in array objects', function(done) {
+            Plotly.plot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
+                .then(function() {
+                    return Plotly.relayout(gd, {rando: [1, 2, 3]});
+                })
+                .then(function() {
+                    expect(gd.layout.rando).toEqual([1, 2, 3]);
+                    return Plotly.relayout(gd, {'rando[1]': 45});
+                })
+                .then(function() {
+                    expect(gd.layout.rando).toEqual([1, 45, 3]);
+                })
+                .then(done);
+        });
     });
 
     describe('Plotly.restyle', function() {


### PR DESCRIPTION
@bpostlethwaite @etpinard 

@etpinard 's fix https://github.com/plotly/streambed/pull/8378/commits/6a74d87370ef2205cdd4a86eb8c4ab4a1332ecd0 will handle your exact case, but a more general cover for this issue (until we redo this whole mess of code!) is just to make the tests of `p.parts` not fail on integer parts.

```
Plotly.relayout(gd, {rando: [1, 2, 3]})
Plotly.relayout(gd, {'rando[1]': 45})
gd.layout.rando
 [1, 45, 3]
```