### PR TITLE
Clone input trace

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
     "no-trailing-spaces": [2],
     "no-multiple-empty-lines": [2, {"max": 2, "maxEOF": 0}],
     "eol-last": [2],
-    "linebreak-style": [2, "unix"],
     "indent": [2, 4, {"SwitchCase": 1}],
     "max-len": [0, 80],
     "brace-style": [0, "stroustrup", {"allowSingleLine": true}],

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -957,7 +957,7 @@ Plotly.addTraces = function addTraces(gd, traces, newIndices) {
         traces = [traces];
     }
 
-    // make sure traces does not repeat existing ones
+    // make sure traces do not repeat existing ones
     traces = traces.map(function(trace) {
         return Lib.extendFlat({}, trace);
     });

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -956,6 +956,12 @@ Plotly.addTraces = function addTraces(gd, traces, newIndices) {
     if(!Array.isArray(traces)) {
         traces = [traces];
     }
+
+    // make sure traces does not repeat existing ones
+    traces = traces.map(function(trace) {
+        return Lib.extendFlat({}, trace);
+    });
+
     helpers.cleanData(traces, gd.data);
 
     // add the traces to gd.data (no redrawing yet!)


### PR DESCRIPTION
This fixes https://github.com/plotly/plotly.js/issues/1083.
I guess making sure that input trace data for `addTraces` is cloned, at least in shallow fashion, is a good move.