### PR TITLE
Fix broken non-animatable transition fallback

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1673,11 +1673,15 @@ plots.transition = function(gd, data, layout, traces, frameOpts, transitionOpts)
             var trace = gd._fullData[traceIdx];
             var module = trace._module;
 
-            if(!module || !module.animatable) {
-                continue;
-            }
+            // There's nothing to do if this module is not defined:
+            if(!module) continue;
 
-            transitionedTraces.push(traceIdx);
+            // Don't register the trace as transitioned if it doens't know what to do.
+            // If it *is* registered, it will receive a callback that it's responsible
+            // for calling in order to register the transition as having completed.
+            if(module.animatable) {
+                transitionedTraces.push(traceIdx);
+            }
 
             gd.data[traceIndices[i]] = plots.extendTrace(gd.data[traceIndices[i]], data[i]);
         }

--- a/test/jasmine/tests/animate_test.js
+++ b/test/jasmine/tests/animate_test.js
@@ -706,3 +706,34 @@ describe('Animate API details', function() {
         }).catch(fail).then(done);
     });
 });
+
+describe('non-animatable fallback', function() {
+    'use strict';
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(function() {
+        Plotly.purge(gd);
+        destroyGraphDiv();
+    });
+
+    it('falls back to a simple update for bar graphs', function(done) {
+        Plotly.plot(gd, [{
+            x: [1, 2, 3],
+            y: [4, 5, 6],
+            type: 'bar'
+        }]).then(function() {
+            expect(gd.data[0].y).toEqual([4, 5, 6]);
+
+            return Plotly.animate(gd, [{
+                data: [{y: [6, 4, 5]}]
+            }], {frame: {duration: 0}});
+        }).then(function() {
+            expect(gd.data[0].y).toEqual([6, 4, 5]);
+        }).catch(fail).then(done);
+
+    });
+});


### PR DESCRIPTION
This PR adds a previously-failing test and corresponding bug-fix for animating bar graphs. Since it was not previously tested, a regression snuck in in the logic that skips non-animatable traces. The updates aren't pretty, but at least now modules that have `module.animatable !== true` will update.