### PR TITLE
Animate scatter trace opacity

### DIFF
--- a/src/traces/scatter/plot.js
+++ b/src/traces/scatter/plot.js
@@ -169,6 +169,8 @@ function plotOne(gd, idx, plotinfo, cdscatter, cdscatterAll, element, transition
 
     if(trace.visible !== true) return;
 
+    transition(tr).style('opacity', trace.opacity);
+
     // BUILD LINES AND FILLS
     var ownFillEl3, tonext;
     var ownFillDir = trace.fill.charAt(trace.fill.length - 1);

--- a/test/jasmine/tests/animate_test.js
+++ b/test/jasmine/tests/animate_test.js
@@ -737,3 +737,35 @@ describe('non-animatable fallback', function() {
 
     });
 });
+
+describe('animating scatter traces', function() {
+    'use strict';
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(function() {
+        Plotly.purge(gd);
+        destroyGraphDiv();
+    });
+
+    it('animates trace opacity', function(done) {
+        var trace;
+        Plotly.plot(gd, [{
+            x: [1, 2, 3],
+            y: [4, 5, 6],
+            opacity: 1
+        }]).then(function() {
+            trace = Plotly.d3.selectAll('g.scatter.trace');
+            expect(trace.style('opacity')).toEqual('1');
+
+            return Plotly.animate(gd, [{
+                data: [{opacity: 0.1}]
+            }], {transition: {duration: 0}, frame: {duration: 0, redraw: false}});
+        }).then(function() {
+            expect(trace.style('opacity')).toEqual('0.1');
+        }).catch(fail).then(done);
+    });
+});


### PR DESCRIPTION
This PR adds first a failing test for scatter opacity animation and then a fix. Wasn't so much a bug as just a simple omission.

![ezgif-3077654825](https://cloud.githubusercontent.com/assets/572717/20309744/261e076e-ab17-11e6-9b3a-3f38464577d5.gif)

See #1130 