### PR TITLE
Use topojson-client

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ dependencies:
     - npm run cibuild
     - npm run pretest
     - eval $(node tasks/docker.js setup)
-    - npm ls
+    - npm prune && npm ls
 
 test:
   override:

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "sane-topojson": "^2.0.0",
     "superscript-text": "^1.0.0",
     "tinycolor2": "^1.3.0",
-    "topojson": "^1.6.20",
+    "topojson-client": "^2.1.0",
     "webgl-context": "^2.2.0"
   },
   "devDependencies": {

--- a/src/lib/topojson_utils.js
+++ b/src/lib/topojson_utils.js
@@ -11,8 +11,8 @@
 
 var topojsonUtils = module.exports = {};
 
-var locationmodeToLayer = require('../plots/geo/constants').locationmodeToLayer,
-    topojsonFeature = require('topojson').feature;
+var locationmodeToLayer = require('../plots/geo/constants').locationmodeToLayer;
+var topojsonFeature = require('topojson-client').feature;
 
 
 topojsonUtils.getTopojsonName = function(geoLayout) {

--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -26,7 +26,7 @@ var constants = require('./constants');
 
 var xmlnsNamespaces = require('../../constants/xmlns_namespaces');
 var topojsonUtils = require('../../lib/topojson_utils');
-var topojsonFeature = require('topojson').feature;
+var topojsonFeature = require('topojson-client').feature;
 
 // add a few projection types to d3.geo
 addProjectionsToD3(d3);


### PR DESCRIPTION
The `topojson` module got split in a geojson to topojson and topojson to geojson version. The latter is what we do in plotly.js.

This PR replaces the `topojson` dependency with [`topojson-client`](https://github.com/topojson/topojson-client). The API hasn't changed, so the change was easy enough. This should lead to a smaller bundle size.