### PR TITLE
Fix date histograms

### DIFF
--- a/src/traces/histogram/calc.js
+++ b/src/traces/histogram/calc.js
@@ -47,8 +47,8 @@ module.exports = function calc(gd, trace) {
     }
 
     var binspec = trace[maindata + 'bins'],
-        allbins = typeof binspec.size === 'string',
-        bins = allbins ? [] : binspec,
+        nonuniformBins = typeof binspec.size === 'string',
+        bins = nonuniformBins ? [] : binspec,
         // make the empty bin array
         i2,
         binend,
@@ -85,11 +85,21 @@ module.exports = function calc(gd, trace) {
         size.push(sizeinit);
         // nonuniform bins (like months) we need to search,
         // rather than straight calculate the bin we're in
-        if(allbins) bins.push(i);
+        if(nonuniformBins) bins.push(i);
         // nonuniform bins also need nonuniform normalization factors
         if(densitynorm) inc.push(1 / (i2 - i));
         if(doavg) counts.push(0);
         i = i2;
+    }
+
+    // for date axes we need bin bounds to be calcdata. For nonuniform bins
+    // we already have this, but uniform with start/end/size they're still strings.
+    if(!nonuniformBins && pa.type === 'date') {
+        bins = {
+            start: pa.r2c(bins.start),
+            end: pa.r2c(bins.end),
+            size: bins.size
+        };
     }
 
     var nMax = size.length;

--- a/test/jasmine/tests/histogram2d_test.js
+++ b/test/jasmine/tests/histogram2d_test.js
@@ -75,8 +75,10 @@ describe('Test histogram2d', function() {
             return out;
         }
 
-        // remove tzOffset when we move to UTC
-        var oneDay = 24 * 3600000;
+        // remove tzJan/tzJuly when we move to UTC
+        var oneDay = 24 * 3600000,
+            tzJan = (new Date(1970, 0, 1)).getTimezoneOffset(),
+            tzJuly = (new Date(1970, 6, 1)).getTimezoneOffset();
 
         it('should handle both uniform and nonuniform date bins', function() {
             var out = _calc({
@@ -95,7 +97,7 @@ describe('Test histogram2d', function() {
             // lets also make it display the bins with nonuniform size,
             // and ensure we don't generate an extra bin on the end (see
             // first row of z below)
-            expect(out.y0).toBe('1969-07-02 15:24');
+            expect(out.y0).toBe(tzJan === tzJuly ? '1969-07-02 14:24' : '1969-07-02 15:24');
             expect(out.dy).toBe(365.2 * oneDay);
 
             expect(out.z).toEqual([

--- a/test/jasmine/tests/histogram2d_test.js
+++ b/test/jasmine/tests/histogram2d_test.js
@@ -1,4 +1,8 @@
+var Plots = require('@src/plots/plots');
+var Lib = require('@src/lib');
+
 var supplyDefaults = require('@src/traces/histogram2d/defaults');
+var calc = require('@src/traces/histogram2d/calc');
 
 
 describe('Test histogram2d', function() {
@@ -56,4 +60,51 @@ describe('Test histogram2d', function() {
 
     });
 
+
+    describe('calc', function() {
+        function _calc(opts) {
+            var base = { type: 'histogram2d' },
+                trace = Lib.extendFlat({}, base, opts),
+                gd = { data: [trace] };
+
+            Plots.supplyDefaults(gd);
+            var fullTrace = gd._fullData[0];
+
+            var out = calc(gd, fullTrace);
+            delete out.trace;
+            return out;
+        }
+
+        // remove tzOffset when we move to UTC
+        var oneDay = 24 * 3600000;
+
+        it('should handle both uniform and nonuniform date bins', function() {
+            var out = _calc({
+                x: ['1970-01-01', '1970-01-01', '1970-01-02', '1970-01-04'],
+                nbinsx: 4,
+                y: ['1970-01-01', '1970-01-01', '1971-01-01', '1973-01-01'],
+                nbinsy: 4
+            });
+
+            expect(out.x0).toBe('1970-01-01');
+            expect(out.dx).toBe(oneDay);
+
+            // TODO: even though the binning is done on non-uniform bins,
+            // the display makes them linear (using only y0 and dy)
+            // when we sort out https://github.com/plotly/plotly.js/issues/1151
+            // lets also make it display the bins with nonuniform size,
+            // and ensure we don't generate an extra bin on the end (see
+            // first row of z below)
+            expect(out.y0).toBe('1969-07-02 15:24');
+            expect(out.dy).toBe(365.2 * oneDay);
+
+            expect(out.z).toEqual([
+                [0, 0, 0, 0],
+                [2, 0, 0, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 0],
+                [0, 0, 0, 1]
+            ]);
+        });
+    });
 });


### PR DESCRIPTION
fixes https://github.com/plotly/streambed/issues/8512 - date histograms with small bins failed. Turns out it was any uniform date bins, ie intervals smaller than 1 month, that were broken.

Note that there are still some issues including and relating to #1151 uncovered in the course of this fix, some TODOs added describing these.

At its root, the issue is that `Lib.findBin` doesn't know anything about the axis it's binning onto, so needs bins specified entirely by numbers, either `{start, end, size}` or `[edge0, edge1, edge2, ... edgeN]`, but in the new date system, `start` and `end` are date strings. For performance it's important that these be turned into numbers only once, so rather than hack date conversion into `findBin` we convert the bins object everywhere it gets called.

In addition to histograms, this routine gets called in:
traces/box/calc.js
traces/heatmap/convert_column_xyz.js
traces/heatmap/hover.js
traces/heatmap/plot.js

But as far as I can tell these callers can only provide numeric data for the bins so they should be safe.