### PR TITLE
add id to location href w/o hashes when setting clip paths urls

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -568,6 +568,10 @@ drawing.setClipUrl = function(s, localId) {
     var url = '#' + localId,
         base = d3.select('base');
 
-    if(base.size() && base.attr('href')) url = window.location.href + url;
+    // add id to location href w/o hashes if any)
+    if(base.size() && base.attr('href')) {
+        url = window.location.href.split('#')[0] + url;
+    }
+
     s.attr('clip-path', 'url(' + url + ')');
 };

--- a/test/jasmine/tests/drawing_test.js
+++ b/test/jasmine/tests/drawing_test.js
@@ -49,4 +49,21 @@ describe('Drawing.setClipUrl', function() {
 
         base.remove();
     });
+
+    it('should append window URL w/o hash to clip-path if <base> is present', function() {
+        var base = d3.select('body')
+            .append('base')
+            .attr('href', 'https://plot.ly/#hash');
+
+        window.location.hash = 'hash';
+
+        Drawing.setClipUrl(this.g, 'id4');
+
+        var expected = 'url(' + window.location.href.split('#')[0] + '#id4)';
+
+        expect(this.g.attr('clip-path')).toEqual(expected);
+
+        base.remove();
+        window.location.hash = '';
+    });
 });

--- a/test/jasmine/tests/plot_interact_test.js
+++ b/test/jasmine/tests/plot_interact_test.js
@@ -657,7 +657,7 @@ describe('plot svg clip paths', function() {
             .attr('href', 'https://plot.ly');
 
         // grab window URL
-        var href = window.location.href;
+        var href = window.location.href.split('#')[0];
 
         plot().then(function() {
 


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/558 (hopefully :smile:)

See https://github.com/plotly/plotly.js/issues/558#issuecomment-262853476 for rationale.