### PR TITLE
Add fallbacks for manual manipulation of slider/frames

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1546,6 +1546,23 @@ plots.computeFrame = function(gd, frameName) {
     return result;
 };
 
+/*
+ * Recompute the lookup table that maps frame name -> frame object. addFrames/
+ * deleteFrames already manages this data one at a time, so the only time this
+ * is necessary is if you poke around manually in `gd._transitionData_frames`
+ * and create and haven't updated the lookup table.
+ */
+plots.recomputeFrameHash = function(gd) {
+    var hash = gd._transitionData._frameHash = {};
+    var frames = gd._transitionData._frames;
+    for(var i = 0; i < frames.length; i++) {
+        var frame = frames[i];
+        if(frame && frame.name) {
+            hash[frame.name] = frame;
+        }
+    }
+};
+
 /**
  * Extend an object, treating container arrays very differently by extracting
  * their contents and merging them separately.

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1549,7 +1549,7 @@ plots.computeFrame = function(gd, frameName) {
 /*
  * Recompute the lookup table that maps frame name -> frame object. addFrames/
  * deleteFrames already manages this data one at a time, so the only time this
- * is necessary is if you poke around manually in `gd._transitionData_frames`
+ * is necessary is if you poke around manually in `gd._transitionData._frames`
  * and create and haven't updated the lookup table.
  */
 plots.recomputeFrameHash = function(gd) {


### PR DESCRIPTION
cc @bpostlethwaite @etpinard 

This PR fixes two cases:

1. When slider options are added, it needs to *refetch* the slider steps from the d3 data. The mouse events are in a closure, so it was previously using outdated data in callbacks.
1. When slider options are removed, it checks whether the active index is invalid. If it is, it just moves the slider to the first position.

This PR does not fix:

- It does not search for a matching option after the update has occurred. Like if you remove the thid option, it will not fix the active index from 5 -> 4. That can be added, but I did not yet address that case in the interest of stopping blocking @bpostlethwaite ASAP.

This PR also sneaks in `Plot.recomputeFrameHash(gd)` which does what it says. I should add tests for that; it's just a small bonus to prevent @bpostlethwaite from needing to do it manually.