### PR TITLE
use only the calendars we need from 'world-calendars'

### DIFF
--- a/src/components/calendars/calendars.js
+++ b/src/components/calendars/calendars.js
@@ -1,0 +1,30 @@
+/**
+* Copyright 2012-2016, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+// a trimmed down version of:
+// https://github.com/alexcjohnson/world-calendars/blob/master/dist/index.js
+
+module.exports = require('world-calendars/dist/main');
+
+require('world-calendars/dist/plus');
+
+require('world-calendars/dist/calendars/coptic');
+require('world-calendars/dist/calendars/discworld');
+require('world-calendars/dist/calendars/ethiopian');
+require('world-calendars/dist/calendars/hebrew');
+require('world-calendars/dist/calendars/islamic');
+require('world-calendars/dist/calendars/julian');
+require('world-calendars/dist/calendars/mayan');
+require('world-calendars/dist/calendars/nanakshahi');
+require('world-calendars/dist/calendars/nepali');
+require('world-calendars/dist/calendars/persian');
+require('world-calendars/dist/calendars/taiwan');
+require('world-calendars/dist/calendars/thai');
+require('world-calendars/dist/calendars/ummalqura');

--- a/src/components/calendars/index.js
+++ b/src/components/calendars/index.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var calendars = require('world-calendars');
+var calendars = require('./calendars');
 
 var Lib = require('../../lib');
 var constants = require('../../constants/numerical');


### PR DESCRIPTION
.. so that the resulting main plotly.js bundle weighs in at:

![image](https://cloud.githubusercontent.com/assets/6675409/20985455/a2111870-bc92-11e6-94b8-48ee6432ffd6.png)

compared to `567 kB` in https://github.com/plotly/plotly.js/pull/1230
