### PR TITLE
don't auto-run `git push && git push --tags` on version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "baseline": "node tasks/baseline.js",
     "preversion": "npm-link-check && npm dedupe && npm ls",
     "version": "npm run build && git add -A dist src build",
-    "postversion": "git push && git push --tags"
+    "postversion": "node -e \"console.log('Version bumped and committed. If ok, run: git push && git push --tags')\""
   },
   "dependencies": {
     "3d-view": "^2.0.0",


### PR DESCRIPTION
as discussed privately with @alexcjohnson , the auto `git push && git push --tags` postversion hook is probably too magical. Adding one step to our publishing tasks will allow us to inspect `dist/` bundles and `dist/npm-ls.json` before pushing to the origin.

For example,  the failed `v1.19.0` could have been avoided if this hook wasn't present.

TODO:

- [ ]  update dev-docs once merged