### PR TITLE
Add frames accept null

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2566,7 +2566,7 @@ Plotly.addFrames = function(gd, frameList, indices) {
 
     var insertions = [];
     for(i = frameList.length - 1; i >= 0; i--) {
-        if (!frameList[i]) continue;
+        if(!frameList[i]) continue;
 
         var name = (_hash[frameList[i].name] || {}).name;
         var newName = frameList[i].name;

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2566,6 +2566,8 @@ Plotly.addFrames = function(gd, frameList, indices) {
 
     var insertions = [];
     for(i = frameList.length - 1; i >= 0; i--) {
+        if (!frameList[i]) continue;
+
         var name = (_hash[frameList[i].name] || {}).name;
         var newName = frameList[i].name;
 

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2566,7 +2566,7 @@ Plotly.addFrames = function(gd, frameList, indices) {
 
     var insertions = [];
     for(i = frameList.length - 1; i >= 0; i--) {
-        if(!frameList[i]) continue;
+        if(!Lib.isPlainObject(frameList[i])) continue;
 
         var name = (_hash[frameList[i].name] || {}).name;
         var newName = frameList[i].name;

--- a/test/jasmine/tests/frame_api_test.js
+++ b/test/jasmine/tests/frame_api_test.js
@@ -43,8 +43,8 @@ describe('Test frame api', function() {
             }).catch(fail).then(done);
         });
 
-        it('compresses nulls when adding frames', function (done) {
-            Plotly.addFrames(gd, [null, {name: 'test'}, null]).then(function () {
+        it('compresses nulls when adding frames', function(done) {
+            Plotly.addFrames(gd, [null, {name: 'test'}, null]).then(function() {
                 expect(Object.keys(h)).toEqual(['test']);
                 expect(f).toEqual([{name: 'test'}]);
             }).catch(fail).then(done);

--- a/test/jasmine/tests/frame_api_test.js
+++ b/test/jasmine/tests/frame_api_test.js
@@ -43,6 +43,13 @@ describe('Test frame api', function() {
             }).catch(fail).then(done);
         });
 
+        it('compresses nulls when adding frames', function (done) {
+            Plotly.addFrames(gd, [null, {name: 'test'}, null]).then(function () {
+                expect(Object.keys(h)).toEqual(['test']);
+                expect(f).toEqual([{name: 'test'}]);
+            }).catch(fail).then(done);
+        });
+
         it('treats a null list as a noop', function(done) {
             Plotly.addFrames(gd, null).then(function() {
                 expect(Object.keys(h)).toEqual([]);

--- a/test/jasmine/tests/frame_api_test.js
+++ b/test/jasmine/tests/frame_api_test.js
@@ -43,8 +43,8 @@ describe('Test frame api', function() {
             }).catch(fail).then(done);
         });
 
-        it('compresses nulls when adding frames', function(done) {
-            Plotly.addFrames(gd, [null, {name: 'test'}, null]).then(function() {
+        it('compresses garbage when adding frames', function(done) {
+            Plotly.addFrames(gd, [null, 'garbage', 14, true, false, {name: 'test'}, null]).then(function() {
                 expect(Object.keys(h)).toEqual(['test']);
                 expect(f).toEqual([{name: 'test'}]);
             }).catch(fail).then(done);


### PR DESCRIPTION
cc: @bpostlethwaite 

I've added the capability to ignore null frames in `addFrames`. I *think* it's good, but honestly I find the index-based addFrames a bit fragile and undesirable in the first place, so I hate to push 'fixes' through too quickly. All it does is continue to the next frame if the input is null.