### PR TITLE
make Plots.graphJson serialize frames too

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1338,7 +1338,8 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults) {
     }
 
     var data = (useDefaults) ? gd._fullData : gd.data,
-        layout = (useDefaults) ? gd._fullLayout : gd.layout;
+        layout = (useDefaults) ? gd._fullLayout : gd.layout,
+        frames = (gd._transitionData || {})._frames;
 
     function stripObj(d) {
         if(typeof d === 'function') {
@@ -1410,6 +1411,8 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults) {
     if(!dataonly) { obj.layout = stripObj(layout); }
 
     if(gd.framework && gd.framework.isPolar) obj = gd.framework.getConfig();
+
+    if(frames) obj.frames = stripObj(frames);
 
     return (output === 'object') ? obj : JSON.stringify(obj);
 };

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -494,4 +494,46 @@ describe('Test Plots', function() {
             assert(dest, src, expected);
         });
     });
+
+    describe('Plots.graphJson', function() {
+
+        it('should serialize data, layout and frames', function(done) {
+            var mock = {
+                data: [{
+                    x: [1, 2, 3],
+                    y: [2, 1, 2]
+                }],
+                layout: {
+                    title: 'base'
+                },
+                frames: [{
+                    data: [{
+                        y: [1, 2, 1],
+                    }],
+                    layout: {
+                        title: 'frame A'
+                    },
+                    name: 'A'
+                }, {
+                    data: [{
+                        y: [1, 2, 3],
+                    }],
+                    layout: {
+                        title: 'frame B'
+                    },
+                    name: 'B'
+                }]
+            };
+
+            Plotly.plot(createGraphDiv(), mock).then(function(gd) {
+                var str = Plots.graphJson(gd, false, 'keepdata');
+                var obj = JSON.parse(str);
+
+                expect(obj.data).toEqual(mock.data);
+                expect(obj.layout).toEqual(mock.layout);
+                expect(obj.frames).toEqual(mock.frames);
+            })
+            .then(done);
+        });
+    });
 });

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -514,9 +514,7 @@ describe('Test Plots', function() {
                         title: 'frame A'
                     },
                     name: 'A'
-                },
-                    null,
-                {
+                }, null, {
                     data: [{
                         y: [1, 2, 3],
                     }],
@@ -524,6 +522,10 @@ describe('Test Plots', function() {
                         title: 'frame B'
                     },
                     name: 'B'
+                }, {
+                    data: [null, false, undefined],
+                    layout: 'garbage',
+                    name: 'garbage'
                 }]
             };
 
@@ -535,6 +537,11 @@ describe('Test Plots', function() {
                 expect(obj.layout).toEqual(mock.layout);
                 expect(obj.frames[0]).toEqual(mock.frames[0]);
                 expect(obj.frames[1]).toEqual(mock.frames[2]);
+                expect(obj.frames[2]).toEqual({
+                    data: [null, false, null],
+                    layout: 'garbage',
+                    name: 'garbage'
+                });
             })
             .then(function() {
                 destroyGraphDiv();

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -514,7 +514,9 @@ describe('Test Plots', function() {
                         title: 'frame A'
                     },
                     name: 'A'
-                }, {
+                },
+                    null,
+                {
                     data: [{
                         y: [1, 2, 3],
                     }],
@@ -531,7 +533,8 @@ describe('Test Plots', function() {
 
                 expect(obj.data).toEqual(mock.data);
                 expect(obj.layout).toEqual(mock.layout);
-                expect(obj.frames).toEqual(mock.frames);
+                expect(obj.frames[0]).toEqual(mock.frames[0]);
+                expect(obj.frames[1]).toEqual(mock.frames[2]);
             })
             .then(function() {
                 destroyGraphDiv();

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -533,7 +533,10 @@ describe('Test Plots', function() {
                 expect(obj.layout).toEqual(mock.layout);
                 expect(obj.frames).toEqual(mock.frames);
             })
-            .then(done);
+            .then(function() {
+                destroyGraphDiv();
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
@rreusser @alexcjohnson 

`Plots.graphJson` is called in the [`Plots.sendDataToCloud`](https://github.com/plotly/plotly.js/blob/7e9fc1d37cbfaa6c7371121f57a1c330b0bec52f/src/plots/plots.js#L317) to serialize the graph data. 

Now, this routine also serializes `frames`.