### PR TITLE
Ensure axis autorange is computed after transform operations

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1984,10 +1984,11 @@ plots.doCalcdata = function(gd, traces) {
         }
     }
 
-    // clear stuff ...
+    // clear stuff that should recomputed in 'regular' loop
     for(i = 0; i < axList.length; i++) {
         axList[i]._min = [];
         axList[i]._max = [];
+        axList[i]._categories = [];
     }
 
     // 'regular' loop

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1961,6 +1961,8 @@ plots.doCalcdata = function(gd, traces) {
         }
     }
 
+    var hasCalcTransform = false;
+
     // transform loop
     for(i = 0; i < fullData.length; i++) {
         trace = fullData[i];
@@ -1978,6 +1980,7 @@ plots.doCalcdata = function(gd, traces) {
 
                 _module = transformsRegistry[transform.type];
                 if(_module && _module.calcTransform) {
+                    hasCalcTransform = true;
                     _module.calcTransform(gd, trace, transform);
                 }
             }
@@ -1985,10 +1988,12 @@ plots.doCalcdata = function(gd, traces) {
     }
 
     // clear stuff that should recomputed in 'regular' loop
-    for(i = 0; i < axList.length; i++) {
-        axList[i]._min = [];
-        axList[i]._max = [];
-        axList[i]._categories = [];
+    if(hasCalcTransform) {
+        for(i = 0; i < axList.length; i++) {
+            axList[i]._min = [];
+            axList[i]._max = [];
+            axList[i]._categories = [];
+        }
     }
 
     // 'regular' loop

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1921,8 +1921,9 @@ plots.transition = function(gd, data, layout, traces, frameOpts, transitionOpts)
 plots.doCalcdata = function(gd, traces) {
     var axList = Plotly.Axes.list(gd),
         fullData = gd._fullData,
-        fullLayout = gd._fullLayout,
-        i, j;
+        fullLayout = gd._fullLayout;
+
+    var trace, _module, i, j;
 
     // XXX: Is this correct? Needs a closer look so that *some* traces can be recomputed without
     // *all* needing doCalcdata:
@@ -1951,46 +1952,45 @@ plots.doCalcdata = function(gd, traces) {
         axList[i]._categories = axList[i]._initialCategories.slice();
     }
 
+    // If traces were specified and this trace was not included,
+    // then transfer it over from the old calcdata:
     for(i = 0; i < fullData.length; i++) {
-        // If traces were specified and this trace was not included, then transfer it over from
-        // the old calcdata:
         if(Array.isArray(traces) && traces.indexOf(i) === -1) {
             calcdata[i] = oldCalcdata[i];
             continue;
         }
+    }
 
-        var trace = fullData[i],
-            cd = [];
+    // transform loop
+    for(i = 0; i < fullData.length; i++) {
+        trace = fullData[i];
 
-        // If traces were specified and this trace was not included, then transfer it over from
-        // the old calcdata:
-        if(Array.isArray(traces) && traces.indexOf(i) === -1) {
-            calcdata[i] = oldCalcdata[i];
-            continue;
-        }
+        if(trace.visible === true && trace.transforms) {
+            _module = trace._module;
 
-        var _module;
-        if(trace.visible === true) {
+            // we need one round of trace module calc before
+            // the calc transform to 'fill in' the categories list
+            // used for example in the data-to-coordinate method
+            if(_module && _module.calc) _module.calc(gd, trace);
 
-            // call calcTransform method if any
-            if(trace.transforms) {
+            for(j = 0; j < trace.transforms.length; j++) {
+                var transform = trace.transforms[j];
 
-                // we need one round of trace module calc before
-                // the calc transform to 'fill in' the categories list
-                // used for example in the data-to-coordinate method
-                _module = trace._module;
-                if(_module && _module.calc) _module.calc(gd, trace);
-
-                for(j = 0; j < trace.transforms.length; j++) {
-                    var transform = trace.transforms[j];
-
-                    _module = transformsRegistry[transform.type];
-                    if(_module && _module.calcTransform) {
-                        _module.calcTransform(gd, trace, transform);
-                    }
+                _module = transformsRegistry[transform.type];
+                if(_module && _module.calcTransform) {
+                    _module.calcTransform(gd, trace, transform);
                 }
             }
+        }
+    }
 
+    // 'regular' loop
+    for(i = 0; i < fullData.length; i++) {
+        var cd = [];
+
+        trace = fullData[i];
+
+        if(trace.visible === true) {
             _module = trace._module;
             if(_module && _module.calc) cd = _module.calc(gd, trace);
         }

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1984,6 +1984,12 @@ plots.doCalcdata = function(gd, traces) {
         }
     }
 
+    // clear stuff ...
+    for(i = 0; i < axList.length; i++) {
+        axList[i]._min = [];
+        axList[i]._max = [];
+    }
+
     // 'regular' loop
     for(i = 0; i < fullData.length; i++) {
         var cd = [];

--- a/test/jasmine/tests/transform_filter_test.js
+++ b/test/jasmine/tests/transform_filter_test.js
@@ -8,6 +8,7 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var assertDims = require('../assets/assert_dims');
 var assertStyle = require('../assets/assert_style');
+var customMatchers = require('../assets/custom_matchers');
 
 describe('filter transforms defaults:', function() {
 
@@ -844,6 +845,10 @@ describe('filter transforms calc:', function() {
 describe('filter transforms interactions', function() {
     'use strict';
 
+    beforeAll(function() {
+        jasmine.addMatchers(customMatchers);
+    });
+
     var mockData0 = [{
         x: [-2, -1, -2, 0, 1, 2, 3],
         y: [1, 2, 3, 1, 2, 3, 1],
@@ -898,6 +903,9 @@ describe('filter transforms interactions', function() {
             assertUid(gd);
             assertStyle(dims, ['rgb(255, 0, 0)'], [1]);
 
+            expect(gd._fullLayout.xaxis.range).toBeCloseToArray([0.87, 3.13]);
+            expect(gd._fullLayout.yaxis.range).toBeCloseToArray([0.85, 3.15]);
+
             return Plotly.restyle(gd, 'marker.color', 'blue');
         }).then(function() {
             expect(gd._fullData[0].marker.color).toEqual('blue');
@@ -914,6 +922,9 @@ describe('filter transforms interactions', function() {
         }).then(function() {
             assertUid(gd);
             assertStyle([1], ['rgb(255, 0, 0)'], [1]);
+
+            expect(gd._fullLayout.xaxis.range).toBeCloseToArray([2, 4]);
+            expect(gd._fullLayout.yaxis.range).toBeCloseToArray([0, 2]);
 
             done();
         });

--- a/test/jasmine/tests/transform_filter_test.js
+++ b/test/jasmine/tests/transform_filter_test.js
@@ -999,4 +999,48 @@ describe('filter transforms interactions', function() {
             done();
         });
     });
+
+    it('should update axie categories', function(done) {
+        var data = [{
+            type: 'bar',
+            x: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+            y: [1, 10, 100, 25, 50, -25, 100],
+            transforms: [{
+                type: 'filter',
+                operation: '<',
+                value: 10,
+                target: [1, 10, 100, 25, 50, -25, 100]
+            }]
+        }];
+
+        var gd = createGraphDiv();
+
+        Plotly.plot(gd, data).then(function() {
+            expect(gd._fullLayout.xaxis._categories).toEqual(['a', 'f']);
+            expect(gd._fullLayout.yaxis._categories).toEqual([]);
+
+            return Plotly.addTraces(gd, [{
+                type: 'bar',
+                x: ['h', 'i'],
+                y: [2, 1],
+                transforms: [{
+                    type: 'filter',
+                    operation: '=',
+                    value: 'i'
+                }]
+            }]);
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis._categories).toEqual(['a', 'f', 'i']);
+            expect(gd._fullLayout.yaxis._categories).toEqual([]);
+
+            return Plotly.deleteTraces(gd, [0]);
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis._categories).toEqual(['i']);
+            expect(gd._fullLayout.yaxis._categories).toEqual([]);
+
+        })
+        .then(done);
+    });
 });


### PR DESCRIPTION
To fix the bug, we need to _clear_ the `ax._min` and `_ax._max` arrays (generated in `Axes.expand` done in the `_module.calc` call before the `calcTransform` loop) before the _final_ `module.calc` call.

To do so in the least _intrusive_ way possible, this PR splits `Plots.doCalcdata` operations into separate loops - which hopefully will also help readability. 