### PR TITLE
Honor `fixedrange: false` in y-axes anchored to xaxis with range slider

### DIFF
--- a/src/components/rangeslider/defaults.js
+++ b/src/components/rangeslider/defaults.js
@@ -12,7 +12,7 @@ var Lib = require('../../lib');
 var attributes = require('./attributes');
 
 
-module.exports = function handleDefaults(layoutIn, layoutOut, axName, counterAxes) {
+module.exports = function handleDefaults(layoutIn, layoutOut, axName) {
     if(!layoutIn[axName].rangeslider) return;
 
     // not super proud of this (maybe store _ in axis object instead
@@ -45,14 +45,6 @@ module.exports = function handleDefaults(layoutIn, layoutOut, axName, counterAxe
         outRange[1] = axOut.l2r(Math.max(axOut.r2l(outRange[1]), axOut.r2l(axRange[1])));
     } else {
         axOut._needsExpand = true;
-    }
-
-    if(containerOut.visible) {
-        counterAxes.forEach(function(ax) {
-            var opposing = layoutOut[ax] || {};
-            opposing.fixedrange = true;
-            layoutOut[ax] = opposing;
-        });
     }
 
     // to map back range slider (auto) range

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -105,8 +105,6 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
     coerce('range');
     containerOut.cleanRange();
 
-    coerce('fixedrange');
-
     handleTickValueDefaults(containerIn, containerOut, coerce, axType);
     handleTickLabelDefaults(containerIn, containerOut, coerce, axType, options);
     handleTickMarkDefaults(containerIn, containerOut, coerce, options);

--- a/src/plots/cartesian/layout_defaults.js
+++ b/src/plots/cartesian/layout_defaults.js
@@ -179,5 +179,22 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
                 axLayoutOut.calendar
             );
         }
+
+        coerce('fixedrange');
+    });
+
+    yaList.forEach(function(axName) {
+        axLayoutIn = layoutIn[axName];
+        axLayoutOut = layoutOut[axName];
+
+        var anchoredAxis = layoutOut[axisIds.id2name(axLayoutOut.anchor)];
+
+        var fixedRangeDflt = (
+            anchoredAxis &&
+            anchoredAxis.rangeslider &&
+            anchoredAxis.rangeslider.visible
+        );
+
+        coerce('fixedrange', fixedRangeDflt);
     });
 };

--- a/src/plots/cartesian/layout_defaults.js
+++ b/src/plots/cartesian/layout_defaults.js
@@ -115,33 +115,39 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
 
     var bgColor = Color.combine(plot_bgcolor, layoutOut.paper_bgcolor);
 
-    axesList.forEach(function(axName) {
-        var axLetter = axName.charAt(0),
-            axLayoutIn = layoutIn[axName] || {},
-            axLayoutOut = {},
-            defaultOptions = {
-                letter: axLetter,
-                font: layoutOut.font,
-                outerTicks: outerTicks[axName],
-                showGrid: !noGrids[axName],
-                name: axName,
-                data: fullData,
-                bgColor: bgColor,
-                calendar: layoutOut.calendar
-            },
-            positioningOptions = {
-                letter: axLetter,
-                counterAxes: {x: yaList, y: xaList}[axLetter].map(axisIds.name2id),
-                overlayableAxes: {x: xaList, y: yaList}[axLetter].filter(function(axName2) {
-                    return axName2 !== axName && !(layoutIn[axName2] || {}).overlaying;
-                }).map(axisIds.name2id)
-            };
+    var axLayoutIn, axLayoutOut;
 
-        function coerce(attr, dflt) {
-            return Lib.coerce(axLayoutIn, axLayoutOut, layoutAttributes, attr, dflt);
-        }
+    function coerce(attr, dflt) {
+        return Lib.coerce(axLayoutIn, axLayoutOut, layoutAttributes, attr, dflt);
+    }
+
+    axesList.forEach(function(axName) {
+        var axLetter = axName.charAt(0);
+
+        axLayoutIn = layoutIn[axName] || {};
+        axLayoutOut = {};
+
+        var defaultOptions = {
+            letter: axLetter,
+            font: layoutOut.font,
+            outerTicks: outerTicks[axName],
+            showGrid: !noGrids[axName],
+            name: axName,
+            data: fullData,
+            bgColor: bgColor,
+            calendar: layoutOut.calendar
+        };
 
         handleAxisDefaults(axLayoutIn, axLayoutOut, coerce, defaultOptions, layoutOut);
+
+        var positioningOptions = {
+            letter: axLetter,
+            counterAxes: {x: yaList, y: xaList}[axLetter].map(axisIds.name2id),
+            overlayableAxes: {x: xaList, y: yaList}[axLetter].filter(function(axName2) {
+                return axName2 !== axName && !(layoutIn[axName2] || {}).overlaying;
+            }).map(axisIds.name2id)
+        };
+
         handlePositionDefaults(axLayoutIn, axLayoutOut, coerce, positioningOptions);
 
         layoutOut[axName] = axLayoutOut;
@@ -158,17 +164,20 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
     var rangeSliderDefaults = Registry.getComponentMethod('rangeslider', 'handleDefaults'),
         rangeSelectorDefaults = Registry.getComponentMethod('rangeselector', 'handleDefaults');
 
-    axesList.forEach(function(axName) {
-        var axLetter = axName.charAt(0),
-            axLayoutIn = layoutIn[axName],
-            axLayoutOut = layoutOut[axName],
-            counterAxes = {x: yaList, y: xaList}[axLetter];
+    xaList.forEach(function(axName) {
+        axLayoutIn = layoutIn[axName];
+        axLayoutOut = layoutOut[axName];
 
-        rangeSliderDefaults(layoutIn, layoutOut, axName, counterAxes);
+        rangeSliderDefaults(layoutIn, layoutOut, axName);
 
-        if(axLetter === 'x' && axLayoutOut.type === 'date') {
-            rangeSelectorDefaults(axLayoutIn, axLayoutOut, layoutOut, counterAxes,
-                axLayoutOut.calendar);
+        if(axLayoutOut.type === 'date') {
+            rangeSelectorDefaults(
+                axLayoutIn,
+                axLayoutOut,
+                layoutOut,
+                yaList,
+                axLayoutOut.calendar
+            );
         }
     });
 };

--- a/src/plots/gl3d/layout/axis_attributes.js
+++ b/src/plots/gl3d/layout/axis_attributes.js
@@ -76,7 +76,6 @@ module.exports = {
     autorange: axesAttrs.autorange,
     rangemode: axesAttrs.rangemode,
     range: axesAttrs.range,
-    fixedrange: axesAttrs.fixedrange,
     // ticks
     tickmode: axesAttrs.tickmode,
     nticks: axesAttrs.nticks,

--- a/test/jasmine/tests/range_slider_test.js
+++ b/test/jasmine/tests/range_slider_test.js
@@ -1,4 +1,5 @@
 var Plotly = require('@lib/index');
+var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
 var setConvert = require('@src/plots/cartesian/set_convert');
 
@@ -336,34 +337,28 @@ describe('the range slider', function() {
     describe('handleDefaults function', function() {
 
         it('should not coerce anything if rangeslider isn\'t set', function() {
-            var layoutIn = { xaxis: {}, yaxis: {}},
-                layoutOut = { xaxis: {}, yaxis: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis'],
-                expected = { xaxis: {}, yaxis: {}};
+            var layoutIn = { xaxis: {} },
+                layoutOut = { xaxis: {} },
+                expected = { xaxis: {} };
 
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             expect(layoutIn).toEqual(expected);
         });
 
         it('should not mutate layoutIn', function() {
-            var layoutIn = { xaxis: { rangeslider: { visible: true }}, yaxis: {}},
-                layoutOut = { xaxis: { rangeslider: {}}, yaxis: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis'],
-                expected = { xaxis: { rangeslider: { visible: true }}, yaxis: {}};
+            var layoutIn = { xaxis: { rangeslider: { visible: true }} },
+                layoutOut = { xaxis: { rangeslider: {}} },
+                expected = { xaxis: { rangeslider: { visible: true }} };
 
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             expect(layoutIn).toEqual(expected);
         });
 
         it('should set defaults if rangeslider is set to anything truthy', function() {
-            var layoutIn = { xaxis: { rangeslider: {}}, yaxis: {}},
-                layoutOut = { xaxis: {}, yaxis: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis'],
+            var layoutIn = { xaxis: { rangeslider: {} }},
+                layoutOut = { xaxis: {} },
                 expected = {
                     xaxis: {
                         rangeslider: {
@@ -375,22 +370,17 @@ describe('the range slider', function() {
                             _input: layoutIn.xaxis.rangeslider
                         },
                         _needsExpand: true
-                    },
-                    yaxis: {
-                        fixedrange: true
-                    },
+                    }
                 };
 
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             expect(layoutOut).toEqual(expected);
         });
 
         it('should set defaults if rangeslider.visible is true', function() {
-            var layoutIn = { xaxis: { rangeslider: { visible: true }}, yaxis: {}},
-                layoutOut = { xaxis: { rangeslider: {}}, yaxis: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis'],
+            var layoutIn = { xaxis: { rangeslider: { visible: true }} },
+                layoutOut = { xaxis: { rangeslider: {}} },
                 expected = {
                     xaxis: {
                         rangeslider: {
@@ -402,13 +392,10 @@ describe('the range slider', function() {
                             _input: layoutIn.xaxis.rangeslider
                         },
                         _needsExpand: true
-                    },
-                    yaxis: {
-                        fixedrange: true
                     }
                 };
 
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             expect(layoutOut).toEqual(expected);
         });
@@ -420,10 +407,8 @@ describe('the range slider', function() {
                     bgcolor: 42,
                     bordercolor: 42,
                     borderwidth: 'superfat'
-                }}, yaxis: {}},
-                layoutOut = { xaxis: {}, yaxis: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis'],
+                }}},
+                layoutOut = { xaxis: {} },
                 expected = {
                     xaxis: {
                         rangeslider: {
@@ -435,48 +420,17 @@ describe('the range slider', function() {
                             _input: layoutIn.xaxis.rangeslider
                         },
                         _needsExpand: true
-                    },
-                    yaxis: {
-                        fixedrange: true
                     }
                 };
 
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
-
-            expect(layoutOut).toEqual(expected);
-        });
-
-        it('should set all counterAxes to fixedrange', function() {
-            var layoutIn = { xaxis: { rangeslider: true }, yaxis: {}, yaxis2: {}},
-                layoutOut = { xaxis: {}, yaxis: {}, yaxis2: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis', 'yaxis2'],
-                expected = {
-                    xaxis: {
-                        rangeslider: {
-                            visible: true,
-                            thickness: 0.15,
-                            bgcolor: '#fff',
-                            borderwidth: 0,
-                            bordercolor: '#444',
-                            _input: {}
-                        },
-                        _needsExpand: true
-                    },
-                    yaxis: { fixedrange: true},
-                    yaxis2: { fixedrange: true }
-                };
-
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             expect(layoutOut).toEqual(expected);
         });
 
         it('should expand the rangeslider range to axis range', function() {
-            var layoutIn = { xaxis: { rangeslider: { range: [5, 6] } }, yaxis: {}},
-                layoutOut = { xaxis: { range: [1, 10], type: 'linear'}, yaxis: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis'],
+            var layoutIn = { xaxis: { rangeslider: { range: [5, 6] } } },
+                layoutOut = { xaxis: { range: [1, 10], type: 'linear'} },
                 expected = {
                     xaxis: {
                         rangeslider: {
@@ -489,24 +443,21 @@ describe('the range slider', function() {
                             _input: layoutIn.xaxis.rangeslider
                         },
                         range: [1, 10]
-                    },
-                    yaxis: { fixedrange: true }
+                    }
                 };
+
             setConvert(layoutOut.xaxis);
 
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             // don't compare the whole layout, because we had to run setConvert which
             // attaches all sorts of other stuff to xaxis
             expect(layoutOut.xaxis.rangeslider).toEqual(expected.xaxis.rangeslider);
-            expect(layoutOut.yaxis).toEqual(expected.yaxis);
         });
 
         it('should set _needsExpand when an axis range is set', function() {
-            var layoutIn = { xaxis: { rangeslider: true }, yaxis: {}},
-                layoutOut = { xaxis: { range: [2, 40]}, yaxis: {}},
-                axName = 'xaxis',
-                counterAxes = ['yaxis'],
+            var layoutIn = { xaxis: { rangeslider: true } },
+                layoutOut = { xaxis: { range: [2, 40]} },
                 expected = {
                     xaxis: {
                         rangeslider: {
@@ -520,33 +471,67 @@ describe('the range slider', function() {
                         range: [2, 40],
                         _needsExpand: true
                     },
-                    yaxis: { fixedrange: true }
                 };
 
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             expect(layoutOut).toEqual(expected);
         });
 
         it('should default \'bgcolor\' to layout \'plot_bgcolor\'', function() {
             var layoutIn = {
-                xaxis: { rangeslider: true },
-                yaxis: {},
+                xaxis: { rangeslider: true }
             };
 
             var layoutOut = {
                 xaxis: { range: [2, 40]},
-                yaxis: {},
                 plot_bgcolor: 'blue'
             };
 
-            var axName = 'xaxis',
-                counterAxes = ['yaxis'];
-
-            RangeSlider.handleDefaults(layoutIn, layoutOut, axName, counterAxes);
+            RangeSlider.handleDefaults(layoutIn, layoutOut, 'xaxis');
 
             expect(layoutOut.xaxis.rangeslider.bgcolor).toEqual('blue');
         });
+    });
+
+    describe('anchored axes fixedrange', function() {
+
+        it('should default to *true* when range slider is visible', function() {
+            var mock = {
+                layout: {
+                    xaxis: { rangeslider: {} },
+                    yaxis: { anchor: 'x' },
+                    yaxis2: { anchor: 'x' },
+                    yaxis3: { anchor: 'free' }
+                }
+            };
+
+            Plots.supplyDefaults(mock);
+
+            expect(mock._fullLayout.xaxis.rangeslider.visible).toBe(true);
+            expect(mock._fullLayout.yaxis.fixedrange).toBe(true);
+            expect(mock._fullLayout.yaxis2.fixedrange).toBe(true);
+            expect(mock._fullLayout.yaxis3.fixedrange).toBe(false);
+        });
+
+        it('should honor user settings', function() {
+            var mock = {
+                layout: {
+                    xaxis: { rangeslider: {} },
+                    yaxis: { anchor: 'x', fixedrange: false },
+                    yaxis2: { anchor: 'x', fixedrange: false },
+                    yaxis3: { anchor: 'free' }
+                }
+            };
+
+            Plots.supplyDefaults(mock);
+
+            expect(mock._fullLayout.xaxis.rangeslider.visible).toBe(true);
+            expect(mock._fullLayout.yaxis.fixedrange).toBe(false);
+            expect(mock._fullLayout.yaxis2.fixedrange).toBe(false);
+            expect(mock._fullLayout.yaxis3.fixedrange).toBe(false);
+        });
+
     });
 
     describe('in general', function() {


### PR DESCRIPTION
This should make a bunch of folks on https://community.plot.ly/ happy.

Ever since https://github.com/plotly/plotly.js/pull/1017, there's no reason to hard set `fixedrange: true` for all y-axes anchored to a x-axis that has a range slider: the range plot draw [step](https://github.com/plotly/plotly.js/blob/b823573efb1cd910b6f9406502690f4de0c94f6c/src/components/rangeslider/draw.js#L315-L382) can handle y-axis interactions.

To preserve backward compatibility, we must however make sure that y axes anchored to a x-axis with a range slider default to `fixedrange: true`. With this PR, users can now _set back_ `layout.yaxis.fixedrange: false` if they prefer having interactive y-axes along with their range slider plots.