### PR TITLE
Lock mouse-change@1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gl-spikes2d": "^1.0.1",
     "gl-surface3d": "^1.3.0",
     "mapbox-gl": "^0.22.0",
-    "mouse-change": "^1.1.1",
+    "mouse-change": "1.3.0",
     "mouse-wheel": "^1.0.2",
     "ndarray": "^1.0.16",
     "ndarray-fill": "^1.0.1",


### PR DESCRIPTION
... so that users on `v1.21.x` can see 3D hover labels after a fresh `npm i`.

This PR **does not fix** https://github.com/plotly/plotly.js/issues/1268. Making 3D hover labels work with `mouse-change@^1.4.0` will require a patch that I don't want to make on a patch release.