### PR TITLE
Fix scattermapbox and scattergeo handling of '' text items

### DIFF
--- a/src/traces/scattergeo/hover.js
+++ b/src/traces/scattergeo/hover.js
@@ -102,7 +102,10 @@ function getExtraText(trace, pt, axis) {
     else if(hasLon) text.push('lon: ' + format(pt.lonlat[0]));
     else if(hasLat) text.push('lat: ' + format(pt.lonlat[1]));
 
-    if(hasText) text.push(pt.tx || trace.text);
+    if(hasText) {
+        var tx = pt.tx || trace.text;
+        if(!Array.isArray(tx)) text.push(tx);
+    }
 
     return text.join('<br>');
 }

--- a/src/traces/scattermapbox/hover.js
+++ b/src/traces/scattermapbox/hover.js
@@ -86,7 +86,8 @@ function getExtraText(trace, di) {
     else if(hasLat) text.push('lat: ' + format(lonlat[1]));
 
     if(isAll || hoverinfo.indexOf('text') !== -1) {
-        text.push(di.tx || trace.text);
+        var tx = di.tx || trace.text;
+        if(!Array.isArray(tx)) text.push(tx);
     }
 
     return text.join('<br>');

--- a/test/jasmine/tests/geo_test.js
+++ b/test/jasmine/tests/geo_test.js
@@ -420,24 +420,53 @@ describe('Test geo interactions', function() {
         });
 
         describe('scattergeo hover labels', function() {
-            beforeEach(function() {
-                mouseEventScatterGeo('mousemove');
-            });
-
             it('should show one hover text group', function() {
+                mouseEventScatterGeo('mousemove');
                 expect(d3.selectAll('g.hovertext').size()).toEqual(1);
             });
 
             it('should show longitude and latitude values', function() {
-                var node = d3.selectAll('g.hovertext').selectAll('tspan')[0][0];
+                mouseEventScatterGeo('mousemove');
 
+                var node = d3.selectAll('g.hovertext').selectAll('tspan')[0][0];
                 expect(node.innerHTML).toEqual('(0°, 0°)');
             });
 
             it('should show the trace name', function() {
-                var node = d3.selectAll('g.hovertext').selectAll('text')[0][0];
+                mouseEventScatterGeo('mousemove');
 
+                var node = d3.selectAll('g.hovertext').selectAll('text')[0][0];
                 expect(node.innerHTML).toEqual('trace 0');
+            });
+
+            it('should show *text* (case 1)', function(done) {
+                Plotly.restyle(gd, 'text', [['A', 'B']]).then(function() {
+                    mouseEventScatterGeo('mousemove');
+
+                    var node = d3.selectAll('g.hovertext').selectAll('tspan')[0][1];
+                    expect(node.innerHTML).toEqual('A');
+                })
+                .then(done);
+            });
+
+            it('should show *text* (case 2)', function(done) {
+                Plotly.restyle(gd, 'text', [[null, 'B']]).then(function() {
+                    mouseEventScatterGeo('mousemove');
+
+                    var node = d3.selectAll('g.hovertext').selectAll('tspan')[0][1];
+                    expect(node).toBeUndefined();
+                })
+                .then(done);
+            });
+
+            it('should show *text* (case 3)', function(done) {
+                Plotly.restyle(gd, 'text', [['', 'B']]).then(function() {
+                    mouseEventScatterGeo('mousemove');
+
+                    var node = d3.selectAll('g.hovertext').selectAll('tspan')[0][1];
+                    expect(node).toBeUndefined();
+                })
+                .then(done);
             });
         });
 

--- a/test/jasmine/tests/scattermapbox_test.js
+++ b/test/jasmine/tests/scattermapbox_test.js
@@ -494,6 +494,36 @@ describe('scattermapbox hover', function() {
         expect(out.color).toEqual('#1f77b4');
     });
 
+    it('should skip over blank and non-string text items', function(done) {
+        var xval = 11,
+            yval = 11,
+            out;
+
+        Plotly.restyle(gd, 'text', [['', 'B', 'C']]).then(function() {
+            out = hoverPoints(getPointData(gd), xval, yval)[0];
+            expect(out.extraText).toEqual('(10°, 10°)');
+
+            return Plotly.restyle(gd, 'text', [[null, 'B', 'C']]);
+        })
+        .then(function() {
+            out = hoverPoints(getPointData(gd), xval, yval)[0];
+            expect(out.extraText).toEqual('(10°, 10°)');
+
+            return Plotly.restyle(gd, 'text', [[false, 'B', 'C']]);
+        })
+        .then(function() {
+            out = hoverPoints(getPointData(gd), xval, yval)[0];
+            expect(out.extraText).toEqual('(10°, 10°)');
+
+            return Plotly.restyle(gd, 'text', [['A', 'B', 'C']]);
+        })
+        .then(function() {
+            out = hoverPoints(getPointData(gd), xval, yval)[0];
+            expect(out.extraText).toEqual('(10°, 10°)<br>A');
+        })
+        .then(done);
+    });
+
     it('should generate hover label info (positive winding case)', function() {
         var xval = 11 + 720,
             yval = 11;


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1278

I opted for a strategy similar to what's currently done in [`Drawing.textPointStyle`](https://github.com/plotly/plotly.js/blob/1ef50b91e97e3bfc53a856329649c858e7f0d9ec/src/components/drawing/index.js#L319-L321) to handle all valid `text` input combinations.

cc @alexcjohnson @chriddyp  