### PR TITLE
add fallback in autobin routine

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -514,6 +514,11 @@ axes.autoBin = function(data, ax, nbins, is2d, calendar) {
                 distinctData.minDiff / msexp, [0.9, 1.9, 4.9, 9.9], true);
         size0 = Math.max(minSize, 2 * Lib.stdev(data) /
             Math.pow(data.length, is2d ? 0.25 : 0.4));
+
+        // fallback if ax.d2c output BADNUMs
+        // e.g. when user try to plot categorical bins
+        // on a layout.xaxis.type: 'linear'
+        if(!isNumeric(size0)) size0 = 0;
     }
 
     // piggyback off autotick code to make "nice" bin sizes

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -518,7 +518,7 @@ axes.autoBin = function(data, ax, nbins, is2d, calendar) {
         // fallback if ax.d2c output BADNUMs
         // e.g. when user try to plot categorical bins
         // on a layout.xaxis.type: 'linear'
-        if(!isNumeric(size0)) size0 = 0;
+        if(!isNumeric(size0)) size0 = 1;
     }
 
     // piggyback off autotick code to make "nice" bin sizes

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1738,4 +1738,95 @@ describe('Test axes', function() {
             ]);
         });
     });
+
+    describe('autoBin', function() {
+
+        function _autoBin(x, ax, nbins) {
+            ax._categories = [];
+            Axes.setConvert(ax);
+
+            var d = ax.makeCalcdata({ x: x }, 'x');
+
+            return Axes.autoBin(d, ax, nbins, false, 'gregorian');
+        }
+
+        it('should auto bin categories', function() {
+            var out = _autoBin(
+                ['apples', 'oranges', 'bananas'],
+                { type: 'category' }
+            );
+
+            expect(out).toEqual({
+                start: -0.5,
+                end: 2.5,
+                size: 1
+            });
+        });
+
+        it('should not error out for categories on linear axis', function() {
+            var out = _autoBin(
+                ['apples', 'oranges', 'bananas'],
+                { type: 'linear' }
+            );
+
+            expect(out).toEqual({
+                start: undefined,
+                end: undefined,
+                size: 2
+            });
+        });
+
+        it('should not error out for categories on log axis', function() {
+            var out = _autoBin(
+                ['apples', 'oranges', 'bananas'],
+                { type: 'log' }
+            );
+
+            expect(out).toEqual({
+                start: undefined,
+                end: undefined,
+                size: 2
+            });
+        });
+
+        it('should not error out for categories on date axis', function() {
+            var out = _autoBin(
+                ['apples', 'oranges', 'bananas'],
+                { type: 'date' }
+            );
+
+            expect(out).toEqual({
+                start: undefined,
+                end: undefined,
+                size: 2
+            });
+        });
+
+        it('should auto bin linear data', function() {
+            var out = _autoBin(
+                [1, 1, 2, 2, 3, 3, 4, 4],
+                { type: 'linear' }
+            );
+
+            expect(out).toEqual({
+                start: -0.5,
+                end: 4.5,
+                size: 1
+            });
+        });
+
+        it('should auto bin linear data with nbins constraint', function() {
+            var out = _autoBin(
+                [1, 1, 2, 2, 3, 3, 4, 4],
+                { type: 'linear' },
+                2
+            );
+
+            expect(out).toEqual({
+                start: -0.5,
+                end: 5.5,
+                size: 2
+            });
+        });
+    });
 });


### PR DESCRIPTION
so that trying to plot a histogram with categorical sample pts on a linear axis result in blank plot instead of `ax.dtick` exception.

For example,

```js
Plotly.plot('graph', [{
  type: 'histogram',
  x: ['orange', 'apple']
}], {
  xaxis: {
     type: 'linear'
  }
}
```

currently lead to:

![image](https://cloud.githubusercontent.com/assets/6675409/21733024/6686025c-d42a-11e6-9ece-3ac2118f7418.png)

with this patch, the above snippet generates a blank graph.
