### PR TITLE
Clear axis types during `Plotly.newPlot`

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -524,6 +524,14 @@ Plotly.redraw = function(gd) {
 Plotly.newPlot = function(gd, data, layout, config) {
     gd = helpers.getGraphDiv(gd);
 
+    // clear 'auto' axis types that could have leaked in user layout
+    // in previous Plotly.plot calls
+    var axList = Plotly.Axes.list({ _fullLayout: layout || {} });
+    for(var i = 0; i < axList.length; i++) {
+        var ax = axList[i];
+        if(ax && ax.type) ax.type = '-';
+    }
+
     // remove gl contexts
     Plots.cleanPlot([], {}, gd._fullData || {}, gd._fullLayout || {});
 


### PR DESCRIPTION
fixes #1231

So that calling `plot` then `newPlot` using the same layout object does not lead to any side-effects.

For example,

```js
var gd = document.getElementById('graph')
var layout = {};

var numberTrace = {
  x: [22000, 22100, 2300],
  type: "histogram"
};

var stringTrace = {
  x: ['apple', 'orange'],
  type: "histogram"
};

Plotly.plot(gd, [numberTrace], layout);

console.log(layout.xaxis.type)  // => 'linear'

// so subsequent `newPlot` will try to plot a categorical histogram
// on  a linear axis.

Plotly.newPlot(gd, [stringTrace], layout);
```

-------------

There are probably other _auto_ attributes (referencing https://github.com/plotly/plotly.js/issues/1282) that could/should get the same treatment in `newPlot`. Obviously, the _real_ way to fix this issue would to **not** mutate the user layout object, but that's a much harder project.