### PR TITLE
Combine geo and ternary genaral update pattern

### DIFF
--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -15,6 +15,7 @@ var d3 = require('d3');
 
 var Color = require('../../components/color');
 var Drawing = require('../../components/drawing');
+var Plots = require('../plots');
 var Axes = require('../cartesian/axes');
 var Fx = require('../cartesian/graph_interact');
 
@@ -170,65 +171,12 @@ proto.plot = function(geoCalcData, fullLayout, promises) {
 };
 
 proto.onceTopojsonIsLoaded = function(geoCalcData, geoLayout) {
-    var i;
-
     this.drawLayout(geoLayout);
 
-    var traceHashOld = this.traceHash;
-    var traceHash = {};
-
-    for(i = 0; i < geoCalcData.length; i++) {
-        var calcData = geoCalcData[i],
-            trace = calcData[0].trace;
-
-        traceHash[trace.type] = traceHash[trace.type] || [];
-        traceHash[trace.type].push(calcData);
-    }
-
-    var moduleNamesOld = Object.keys(traceHashOld);
-    var moduleNames = Object.keys(traceHash);
-
-    // when a trace gets deleted, make sure that its module's
-    // plot method is called so that it is properly
-    // removed from the DOM.
-    for(i = 0; i < moduleNamesOld.length; i++) {
-        var moduleName = moduleNamesOld[i];
-
-        if(moduleNames.indexOf(moduleName) === -1) {
-            var fakeCalcTrace = traceHashOld[moduleName][0],
-                fakeTrace = fakeCalcTrace[0].trace;
-
-            fakeTrace.visible = false;
-            traceHash[moduleName] = [fakeCalcTrace];
-        }
-    }
-
-    moduleNames = Object.keys(traceHash);
-
-    for(i = 0; i < moduleNames.length; i++) {
-        var moduleCalcData = traceHash[moduleNames[i]],
-            _module = moduleCalcData[0][0].trace._module;
-
-        _module.plot(this, filterVisible(moduleCalcData), geoLayout);
-    }
-
-    this.traceHash = traceHash;
+    Plots.generalUpdatePerTraceModule(this, geoCalcData, geoLayout);
 
     this.render();
 };
-
-function filterVisible(calcDataIn) {
-    var calcDataOut = [];
-
-    for(var i = 0; i < calcDataIn.length; i++) {
-        var calcTrace = calcDataIn[i],
-            trace = calcTrace[0].trace;
-
-        if(trace.visible === true) calcDataOut.push(calcTrace);
-    }
-
-    return calcDataOut;
-}
 
 proto.updateFx = function(hovermode) {
     this.showHover = (hovermode !== false);

--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -15,8 +15,8 @@ var d3 = require('d3');
 
 var Color = require('../../components/color');
 var Drawing = require('../../components/drawing');
-var Axes = require('../../plots/cartesian/axes');
-var Fx = require('../../plots/cartesian/graph_interact');
+var Axes = require('../cartesian/axes');
+var Fx = require('../cartesian/graph_interact');
 
 var addProjectionsToD3 = require('./projections');
 var createGeoScale = require('./set_scale');

--- a/src/plots/geo/index.js
+++ b/src/plots/geo/index.js
@@ -45,7 +45,7 @@ exports.plot = function plotGeo(gd) {
 
     for(var i = 0; i < geoIds.length; i++) {
         var geoId = geoIds[i],
-            geoCalcData = getSubplotCalcData(calcData, geoId),
+            geoCalcData = Plots.getSubplotCalcData(calcData, 'geo', geoId),
             geo = fullLayout[geoId]._subplot;
 
         // If geo is not instantiated, create one!
@@ -102,16 +102,3 @@ exports.toSVG = function(gd) {
             .appendChild(geoFramework.node());
     }
 };
-
-function getSubplotCalcData(calcData, id) {
-    var subplotCalcData = [];
-
-    for(var i = 0; i < calcData.length; i++) {
-        var calcTrace = calcData[i],
-            trace = calcTrace[0].trace;
-
-        if(trace.geo === id) subplotCalcData.push(calcTrace);
-    }
-
-    return subplotCalcData;
-}

--- a/src/plots/geo/index.js
+++ b/src/plots/geo/index.js
@@ -49,7 +49,7 @@ exports.plot = function plotGeo(gd) {
             geo = fullLayout[geoId]._subplot;
 
         // If geo is not instantiated, create one!
-        if(geo === undefined) {
+        if(!geo) {
             geo = new Geo({
                 id: geoId,
                 graphDiv: gd,

--- a/src/plots/mapbox/index.js
+++ b/src/plots/mapbox/index.js
@@ -56,7 +56,7 @@ exports.plot = function plotMapbox(gd) {
 
     for(var i = 0; i < mapboxIds.length; i++) {
         var id = mapboxIds[i],
-            subplotCalcData = getSubplotCalcData(calcData, id),
+            subplotCalcData = Plots.getSubplotCalcData(calcData, 'mapbox', id),
             opts = fullLayout[id],
             mapbox = opts._subplot;
 
@@ -117,19 +117,6 @@ exports.toSVG = function(gd) {
         mapbox.destroy();
     }
 };
-
-function getSubplotCalcData(calcData, id) {
-    var subplotCalcData = [];
-
-    for(var i = 0; i < calcData.length; i++) {
-        var calcTrace = calcData[i],
-            trace = calcTrace[0].trace;
-
-        if(trace.subplot === id) subplotCalcData.push(calcTrace);
-    }
-
-    return subplotCalcData;
-}
 
 function findAccessToken(gd, mapboxIds) {
     var fullLayout = gd._fullLayout,

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -124,8 +124,8 @@ plots.getSubplotIds = function getSubplotIds(layout, type) {
  * Get the data trace(s) associated with a given subplot.
  *
  * @param {array} data  plotly full data array.
- * @param {object} layout plotly full layout object.
- * @param {string} subplotId subplot ids to look for.
+ * @param {string} type subplot type to look for.
+ * @param {string} subplotId subplot id to look for.
  *
  * @return {array} list of trace objects.
  *

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -157,6 +157,31 @@ plots.getSubplotData = function getSubplotData(data, type, subplotId) {
     return subplotData;
 };
 
+/**
+ * Get calcdata traces(s) associated with a given subplot
+ *
+ * @param {array} calcData (as in gd.calcdata)
+ * @param {string} type subplot type
+ * @param {string} subplotId subplot id to look for
+ *
+ * @return {array} array of calcdata traces
+ */
+plots.getSubplotCalcData = function(calcData, type, subplotId) {
+    if(plots.subplotsRegistry[type] === undefined) return [];
+
+    var attr = plots.subplotsRegistry[type].attr;
+    var subplotCalcData = [];
+
+    for(var i = 0; i < calcData.length; i++) {
+        var calcTrace = calcData[i],
+            trace = calcTrace[0].trace;
+
+        if(trace[attr] === subplotId) subplotCalcData.push(calcTrace);
+    }
+
+    return subplotCalcData;
+};
+
 // in some cases the browser doesn't seem to know how big
 // the text is at first, so it needs to draw it,
 // then wait a little, then draw it again

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -63,7 +63,7 @@ plots.hasSimpleAPICommandBindings = commandModule.hasSimpleAPICommandBindings;
 plots.findSubplotIds = function findSubplotIds(data, type) {
     var subplotIds = [];
 
-    if(plots.subplotsRegistry[type] === undefined) return subplotIds;
+    if(!plots.subplotsRegistry[type]) return subplotIds;
 
     var attr = plots.subplotsRegistry[type].attr;
 
@@ -90,7 +90,7 @@ plots.findSubplotIds = function findSubplotIds(data, type) {
 plots.getSubplotIds = function getSubplotIds(layout, type) {
     var _module = plots.subplotsRegistry[type];
 
-    if(_module === undefined) return [];
+    if(!_module) return [];
 
     // layout must be 'fullLayout' here
     if(type === 'cartesian' && (!layout._has || !layout._has('cartesian'))) return [];
@@ -131,7 +131,7 @@ plots.getSubplotIds = function getSubplotIds(layout, type) {
  *
  */
 plots.getSubplotData = function getSubplotData(data, type, subplotId) {
-    if(plots.subplotsRegistry[type] === undefined) return [];
+    if(!plots.subplotsRegistry[type]) return [];
 
     var attr = plots.subplotsRegistry[type].attr,
         subplotData = [],
@@ -167,7 +167,7 @@ plots.getSubplotData = function getSubplotData(data, type, subplotId) {
  * @return {array} array of calcdata traces
  */
 plots.getSubplotCalcData = function(calcData, type, subplotId) {
-    if(plots.subplotsRegistry[type] === undefined) return [];
+    if(!plots.subplotsRegistry[type]) return [];
 
     var attr = plots.subplotsRegistry[type].attr;
     var subplotCalcData = [];

--- a/src/plots/ternary/index.js
+++ b/src/plots/ternary/index.js
@@ -32,12 +32,12 @@ exports.supplyLayoutDefaults = require('./layout/defaults');
 
 exports.plot = function plotTernary(gd) {
     var fullLayout = gd._fullLayout,
-        fullData = gd._fullData,
+        calcData = gd.calcdata,
         ternaryIds = Plots.getSubplotIds(fullLayout, 'ternary');
 
     for(var i = 0; i < ternaryIds.length; i++) {
         var ternaryId = ternaryIds[i],
-            fullTernaryData = Plots.getSubplotData(fullData, 'ternary', ternaryId),
+            ternaryCalcData = Plots.getSubplotCalcData(calcData, 'ternary', ternaryId),
             ternary = fullLayout[ternaryId]._subplot;
 
         // If ternary is not instantiated, create one!
@@ -53,7 +53,7 @@ exports.plot = function plotTernary(gd) {
             fullLayout[ternaryId]._subplot = ternary;
         }
 
-        ternary.plot(fullTernaryData, fullLayout, gd._promises);
+        ternary.plot(ternaryCalcData, fullLayout, gd._promises);
     }
 };
 

--- a/src/plots/ternary/index.js
+++ b/src/plots/ternary/index.js
@@ -41,7 +41,7 @@ exports.plot = function plotTernary(gd) {
             ternary = fullLayout[ternaryId]._subplot;
 
         // If ternary is not instantiated, create one!
-        if(ternary === undefined) {
+        if(!ternary) {
             ternary = new Ternary({
                 id: ternaryId,
                 graphDiv: gd,

--- a/src/plots/ternary/ternary.js
+++ b/src/plots/ternary/ternary.js
@@ -50,14 +50,6 @@ proto.plot = function(ternaryData, fullLayout) {
         graphSize = fullLayout._size,
         i;
 
-    if(Lib.getPlotDiv(_this.plotContainer.node()) !== _this.graphDiv) {
-        // someone deleted the framework - remake it
-        // TODO: this is getting deleted in (cartesian) makePlotFramework
-        // turn that into idiomatic d3 (enter/exit, the piece I didn't know
-        // before was ordering selections) so we don't need this.
-        _this.init(_this.graphDiv._fullLayout);
-        _this.makeFramework();
-    }
 
     _this.adjustLayout(ternaryLayout, graphSize);
 

--- a/src/plots/ternary/ternary.js
+++ b/src/plots/ternary/ternary.js
@@ -18,6 +18,7 @@ var Color = require('../../components/color');
 var Drawing = require('../../components/drawing');
 var setConvert = require('../cartesian/set_convert');
 var extendFlat = require('../../lib/extend').extendFlat;
+var Plots = require('../plots');
 var Axes = require('../cartesian/axes');
 var dragElement = require('../../components/dragelement');
 var Titles = require('../../components/titles');
@@ -44,51 +45,14 @@ proto.init = function(fullLayout) {
     this.traceHash = {};
 };
 
-proto.plot = function(ternaryData, fullLayout) {
+proto.plot = function(ternaryCalcData, fullLayout) {
     var _this = this,
         ternaryLayout = fullLayout[_this.id],
-        graphSize = fullLayout._size,
-        i;
-
+        graphSize = fullLayout._size;
 
     _this.adjustLayout(ternaryLayout, graphSize);
 
-    var traceHashOld = _this.traceHash;
-    var traceHash = {};
-
-    for(i = 0; i < ternaryData.length; i++) {
-        var trace = ternaryData[i];
-
-        traceHash[trace.type] = traceHash[trace.type] || [];
-        traceHash[trace.type].push(trace);
-    }
-
-    var moduleNamesOld = Object.keys(traceHashOld);
-    var moduleNames = Object.keys(traceHash);
-
-    // when a trace gets deleted, make sure that its module's
-    // plot method is called so that it is properly
-    // removed from the DOM.
-    for(i = 0; i < moduleNamesOld.length; i++) {
-        var moduleName = moduleNamesOld[i];
-
-        if(moduleNames.indexOf(moduleName) === -1) {
-            var fakeModule = traceHashOld[moduleName][0];
-            fakeModule.visible = false;
-            traceHash[moduleName] = [fakeModule];
-        }
-    }
-
-    moduleNames = Object.keys(traceHash);
-
-    for(i = 0; i < moduleNames.length; i++) {
-        var moduleData = traceHash[moduleNames[i]];
-        var _module = moduleData[0]._module;
-
-        _module.plot(_this, Lib.filterVisible(moduleData), ternaryLayout);
-    }
-
-    _this.traceHash = traceHash;
+    Plots.generalUpdatePerTraceModule(_this, ternaryCalcData, ternaryLayout);
 
     _this.layers.plotbg.select('path').call(Color.fill, ternaryLayout.bgcolor);
 };

--- a/src/traces/scatterternary/plot.js
+++ b/src/traces/scatterternary/plot.js
@@ -12,7 +12,7 @@
 var scatterPlot = require('../scatter/plot');
 
 
-module.exports = function plot(ternary, data) {
+module.exports = function plot(ternary, moduleCalcData) {
     var plotContainer = ternary.plotContainer;
 
     // remove all nodes inside the scatter layer
@@ -25,20 +25,10 @@ module.exports = function plot(ternary, data) {
         plot: plotContainer
     };
 
-    var calcdata = new Array(data.length),
-        fullCalcdata = ternary.graphDiv.calcdata;
-
-    for(var i = 0; i < fullCalcdata.length; i++) {
-        var j = data.indexOf(fullCalcdata[i][0].trace);
-
-        if(j === -1) continue;
-
-        calcdata[j] = fullCalcdata[i];
-
-        // while we're here and have references to both the Ternary object
-        // and fullData, connect the two (for use by hover)
-        data[j]._ternary = ternary;
+    // add ref to ternary subplot object in fullData traces
+    for(var i = 0; i < moduleCalcData.length; i++) {
+        moduleCalcData[i][0].trace._ternary = ternary;
     }
 
-    scatterPlot(ternary.graphDiv, plotinfo, calcdata);
+    scatterPlot(ternary.graphDiv, plotinfo, moduleCalcData);
 };

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -1,5 +1,7 @@
 var Plotly = require('@lib/index');
 var Plots = require('@src/plots/plots');
+
+var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 
@@ -691,5 +693,23 @@ describe('Test Plots', function() {
             });
         });
 
+        it('should handle cases when module plot is not set (ternary case)', function(done) {
+            Plotly.plot(createGraphDiv(), [{
+                type: 'scatterternary',
+                visible: false,
+                a: [0.1, 0.2],
+                b: [0.2, 0.1]
+            }, {
+                type: 'scatterternary',
+                a: [0.1, 0.2],
+                b: [0.2, 0.1]
+            }])
+            .then(function() {
+                expect(d3.selectAll('g.trace.scatter').size()).toEqual(1);
+
+                destroyGraphDiv();
+                done();
+            });
+        });
     });
 });

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -549,4 +549,37 @@ describe('Test Plots', function() {
             });
         });
     });
+
+    describe('Plots.getSubplotCalcData', function() {
+        var trace0 = { geo: 'geo2' };
+        var trace1 = { subplot: 'ternary10' };
+        var trace2 = { subplot: 'ternary10' };
+
+        var cd = [
+            [{ trace: trace0 }],
+            [{ trace: trace1 }],
+            [{ trace: trace2}]
+        ];
+
+        it('should extract calcdata traces associated with subplot (1)', function() {
+            var out = Plots.getSubplotCalcData(cd, 'geo', 'geo2');
+            expect(out).toEqual([[{ trace: trace0 }]]);
+        });
+
+        it('should extract calcdata traces associated with subplot (2)', function() {
+            var out = Plots.getSubplotCalcData(cd, 'ternary', 'ternary10');
+            expect(out).toEqual([[{ trace: trace1 }], [{ trace: trace2 }]]);
+        });
+
+        it('should return [] when no calcdata traces where found', function() {
+            var out = Plots.getSubplotCalcData(cd, 'geo', 'geo');
+            expect(out).toEqual([]);
+        });
+
+        it('should return [] when subplot type is invalid', function() {
+            var out = Plots.getSubplotCalcData(cd, 'non-sense', 'geo2');
+            expect(out).toEqual([]);
+        });
+    });
+
 });


### PR DESCRIPTION
Cartesian, geo and ternary subplots (i.e. all SVG/d3 subplots) draw traces using the trace modules' `plot` method which expects as input the `calcdata` traces corresponding to all traces of a given trace type on a given subplot.

Previously, geo and ternary subplot used similar but not-exactly-equivalent logic to handle add/remove/modify updates. This PR - mainly by making ternary subplot use `gd.calcdata` instead of `gd._fullData` traces - unifies the geo and ternary logic into `Plots.generalUpdatePerTraceModule` (I hope you like the name). Cartesian subplots on the other hand are (still) in a world of their own - unifying all SVG/d3 subplots will have to wait.

By doing so, this PR also fixes a bug where:

```js
Plotly.plot('graph', [{
  type: 'scattergeo',   // or 'scatterternary'
  visible: false,
  lon: [/* ... */],
  lat: [/* ... */]
}, {
  type: 'scattergeo',   // or 'scatterternary'
  lon: [/* ... */],
  lat: [/* ... */]
}])
```

would lead to exception and fail to render. See commit  in particular this [line](https://github.com/plotly/plotly.js/commit/fc0af0c9a759decb6f1102dad83bfd5873b99457#diff-ad4f76ccd6044ed16514297078e13b84R2081) for more details.