### PR TITLE
Clear axis types on some restyle calls

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -133,14 +133,15 @@ axes.coercePosition = function(containerOut, gd, coerce, axRef, attr, dflt) {
 // empty out types for all axes containing these traces
 // so we auto-set them again
 axes.clearTypes = function(gd, traces) {
-    if(!Array.isArray(traces) || !traces.length) {
-        traces = (gd._fullData).map(function(d, i) { return i; });
+    var fullData = gd._fullData;
+    var mockGd = { _fullLayout: gd.layout };
+
+    for(var i = 0; i < traces.length; i++) {
+        var trace = fullData[traces[i]];
+
+        (axes.getFromId(mockGd, trace.xaxis) || {}).type = '-';
+        (axes.getFromId(mockGd, trace.xaxis) || {}).type = '-';
     }
-    traces.forEach(function(tracenum) {
-        var trace = gd.data[tracenum];
-        delete (axes.getFromId(gd, trace.xaxis) || {}).type;
-        delete (axes.getFromId(gd, trace.yaxis) || {}).type;
-    });
 };
 
 // get counteraxis letter for this axis (name or id)


### PR DESCRIPTION
which allows for example to restyle histogram `x` from one axis type to another:

![gifrecord_2017-01-11_175650](https://cloud.githubusercontent.com/assets/6675409/21869857/90b37d88-d827-11e6-9132-9b281402853b.gif)

In detail, `Axes.clearTypes` is called during `restyle` in this [block](https://github.com/plotly/plotly.js/blob/6ebf221f16b7dde558fa8e17d78321e6e3cf6be3/src/plot_api/plot_api.js#L1584-L1587). At the moment, the [attributes](https://github.com/plotly/plotly.js/blob/6ebf221f16b7dde558fa8e17d78321e6e3cf6be3/src/plot_api/plot_api.js#L1334-L1338) that trigger an `Axes.clearTypes` call are the following:

```js
[ 'type', 'x', 'y', 'x0', 'y0', 'orientation', 'xaxis', 'yaxis' ]
```

anything missing?