### PR TITLE
bump mouse-change dep to ^1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gl-spikes2d": "^1.0.1",
     "gl-surface3d": "^1.3.0",
     "mapbox-gl": "^0.22.0",
-    "mouse-change": "1.3.0",
+    "mouse-change": "^1.4.0",
     "mouse-wheel": "^1.0.2",
     "ndarray": "^1.0.16",
     "ndarray-fill": "^1.0.1",

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -201,7 +201,6 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
         });
     }
 
-    scene.glplot.mouseListener.enabled = false;
     scene.glplot.camera = scene.camera;
 
     scene.glplot.oncontextloss = function() {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1268

... and makes 3D hover labels compatible with it.