### PR TITLE
Fix range slider svg / eps / pdf exports

### DIFF
--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -377,7 +377,9 @@ function drawRangePlot(rangeSlider, gd, axisOpts, opts) {
 
         Cartesian.rangePlot(gd, plotinfo, filterRangePlotCalcData(calcData, id));
 
-        if(isMainPlot) plotinfo.bg.call(Color.fill, opts.bgcolor);
+        // no need for the bg layer,
+        // drawBg handles coloring the background
+        if(isMainPlot) plotinfo.bg.remove();
     });
 }
 

--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -406,10 +406,9 @@ function drawMasks(rangeSlider, gd, axisOpts, opts) {
         .classed(constants.maskMinClassName, true)
         .attr({ x: 0, y: 0 });
 
-    maskMin.attr({
-        height: opts._height,
-        fill: constants.maskColor
-    });
+    maskMin
+        .attr('height', opts._height)
+        .call(Color.fill, constants.maskColor);
 
     var maskMax = rangeSlider.selectAll('rect.' + constants.maskMaxClassName)
         .data([0]);
@@ -418,10 +417,9 @@ function drawMasks(rangeSlider, gd, axisOpts, opts) {
         .classed(constants.maskMaxClassName, true)
         .attr('y', 0);
 
-    maskMax.attr({
-        height: opts._height,
-        fill: constants.maskColor
-    });
+    maskMax
+        .attr('height', opts._height)
+        .call(Color.fill, constants.maskColor);
 }
 
 function drawSlideBox(rangeSlider, gd, axisOpts, opts) {

--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -423,6 +423,8 @@ function drawMasks(rangeSlider, gd, axisOpts, opts) {
 }
 
 function drawSlideBox(rangeSlider, gd, axisOpts, opts) {
+    if(gd._context.staticPlot) return;
+
     var slideBox = rangeSlider.selectAll('rect.' + constants.slideBoxClassName)
         .data([0]);
 
@@ -482,6 +484,8 @@ function drawGrabbers(rangeSlider, gd, axisOpts, opts) {
     handleMax.attr(handleDynamicAttrs);
 
     // <g grabarea />
+
+    if(gd._context.staticPlot) return;
 
     var grabAreaFixAttrs = {
         width: constants.grabAreaWidth,

--- a/test/image/export_test.js
+++ b/test/image/export_test.js
@@ -19,7 +19,8 @@ var FORMATS = ['svg', 'pdf', 'eps'];
 
 // non-exhaustive list of mocks to test
 var DEFAULT_LIST = [
-    '0', 'geo_first', 'gl3d_z-range', 'text_export', 'layout_image', 'gl2d_12'
+    '0', 'geo_first', 'gl3d_z-range', 'text_export', 'layout_image', 'gl2d_12',
+    'range_slider_initial_valid'
 ];
 
 // return dimensions [in px]


### PR DESCRIPTION
Range slider svg / eps / pdf exports are currently failing on plot.ly. 

This PR ensures that

- all range slider `<rect>` elements have set x/y/width/height attributes (no setting those makes the SVG invalid)
- RGBA color are set via `fill` + `fill-opacity` attributes (Batik doesn't like `fill: ${rgba}`)
- all `fill: 'transparent` elements are not drawn on static plots (Batik doesn't like `fill: 'transparent'`)