### PR TITLE
Prevent uncaught exception in plot_api _relayout()

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1870,7 +1870,7 @@ function _relayout(gd, aobj) {
 
         // toggling log without autorange: need to also recalculate ranges
         // logical XOR (ie are we toggling log)
-        if(pleaf === 'type' && ((parentFull.type === 'log') !== (vi === 'log'))) {
+        if(pleaf === 'type' && ((parentFull && parentFull.type === 'log') !== (vi === 'log'))) {
             var ax = parentIn;
 
             if(!ax || !ax.range) {


### PR DESCRIPTION
Happens when `fixedrange` is set to true of a line chart's `yaxis`
