### PR TITLE
fixes 3d thumbnail clone when no xaxis in scene

### DIFF
--- a/src/snapshot/cloneplot.js
+++ b/src/snapshot/cloneplot.js
@@ -113,14 +113,26 @@ module.exports = function clonePlot(graphObj, options) {
             };
         }
         for(i = 0; i < sceneIds.length; i++) {
-            var sceneId = sceneIds[i];
+            var scene = newLayout[sceneIds[i]];
 
-            extendFlat(newLayout[sceneId].xaxis, axesImageOverride);
-            extendFlat(newLayout[sceneId].yaxis, axesImageOverride);
-            extendFlat(newLayout[sceneId].zaxis, axesImageOverride);
+            if(!scene.xaxis) {
+                scene.xaxis = {};
+            }
+
+            if(!scene.yaxis) {
+                scene.yaxis = {};
+            }
+
+            if(!scene.zaxis) {
+                scene.zaxis = {};
+            }
+
+            extendFlat(scene.xaxis, axesImageOverride);
+            extendFlat(scene.yaxis, axesImageOverride);
+            extendFlat(scene.zaxis, axesImageOverride);
 
             // TODO what does this do?
-            newLayout[sceneId]._scene = null;
+            scene._scene = null;
         }
     }
 

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -116,6 +116,42 @@ describe('Plotly.Snapshot', function() {
             expect(thumbTile.layout.annotations).toEqual(THUMBNAIL_DEFAULT_LAYOUT.annotations);
         });
 
+        it('should create a 3D thumbnail with limited attributes', function() {
+
+            var figure = {
+                data: [{
+                    type: 'scatter',
+                    mode: 'markers',
+                    y: [2, 4, 6, 5, 7, 4],
+                    x: [1, 3, 4, 6, 3, 1],
+                    name: 'C'
+                }],
+                layout: {
+                    autosize: true,
+                    scene: {
+                        aspectratio: {y: 1, x: 1, z: 1}
+                    }
+                }};
+
+
+            var thumbnailOptions = {
+                tileClass: 'thumbnail'
+            };
+
+            var AXIS_OVERRIDE = {
+                title: '',
+                showaxeslabels: false,
+                showticklabels: false,
+                linetickenable: false
+            };
+
+            var thumbTile = Plotly.Snapshot.clone(figure, thumbnailOptions);
+            expect(thumbTile.layout.scene.xaxis).toEqual(AXIS_OVERRIDE);
+            expect(thumbTile.layout.scene.yaxis).toEqual(AXIS_OVERRIDE);
+            expect(thumbTile.layout.scene.zaxis).toEqual(AXIS_OVERRIDE);
+        });
+
+
         it('should create a custom sized Tile based on options', function() {
             var customOptions = {
                 tileClass: 'notarealclass',


### PR DESCRIPTION
The test case that now (should) be passing was failing before this fix. This impacted Plotly image server thumbnail generation.
