### PR TITLE
Finance trace editable legend fix

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -384,7 +384,7 @@ function drawTexts(g, gd) {
                     var transforms = legendItem.trace.transforms,
                         direction = transforms[transforms.length - 1].direction;
 
-                    astr = direction + '.legenditem.name';
+                    astr = direction + '.name';
                 }
                 else astr = 'name';
 

--- a/test/jasmine/tests/finance_test.js
+++ b/test/jasmine/tests/finance_test.js
@@ -963,3 +963,79 @@ describe('finance charts updates:', function() {
         });
     });
 });
+
+describe('finance charts *special* handlers:', function() {
+
+    afterEach(destroyGraphDiv);
+
+    it('`editable: true` handles should work', function(done) {
+
+        function editText(itemNumber, newText) {
+            var textNode = d3.selectAll('text.legendtext')
+                .filter(function(_, i) { return i === itemNumber; }).node();
+            textNode.dispatchEvent(new window.MouseEvent('click'));
+
+            var editNode = d3.select('.plugin-editable.editable').node();
+            editNode.dispatchEvent(new window.FocusEvent('focus'));
+
+            editNode.textContent = newText;
+            editNode.dispatchEvent(new window.FocusEvent('focus'));
+            editNode.dispatchEvent(new window.FocusEvent('blur'));
+
+            editNode.remove();
+        }
+
+        Plotly.plot(createGraphDiv(), [
+            Lib.extendDeep({}, mock0, { type: 'ohlc' }),
+            Lib.extendDeep({}, mock0, { type: 'candlestick' })
+        ], {}, {
+            editable: true
+        })
+        .then(function(gd) {
+            return new Promise(function(resolve) {
+                gd.once('plotly_restyle', function(eventData) {
+                    expect(eventData[0]['increasing.name']).toEqual('0');
+                    expect(eventData[1]).toEqual([0]);
+                    resolve(gd);
+                });
+
+                editText(0, '0');
+            });
+        })
+        .then(function(gd) {
+            return new Promise(function(resolve) {
+                gd.once('plotly_restyle', function(eventData) {
+                    expect(eventData[0]['decreasing.name']).toEqual('1');
+                    expect(eventData[1]).toEqual([0]);
+                    resolve(gd);
+                });
+
+                editText(1, '1');
+            });
+        })
+        .then(function(gd) {
+            return new Promise(function(resolve) {
+                gd.once('plotly_restyle', function(eventData) {
+                    expect(eventData[0]['decreasing.name']).toEqual('2');
+                    expect(eventData[1]).toEqual([1]);
+                    resolve(gd);
+                });
+
+                editText(3, '2');
+            });
+        })
+        .then(function(gd) {
+            return new Promise(function(resolve) {
+                gd.once('plotly_restyle', function(eventData) {
+                    expect(eventData[0]['increasing.name']).toEqual('3');
+                    expect(eventData[1]).toEqual([1]);
+                    resolve(gd);
+                });
+
+                editText(2, '3');
+            });
+        })
+        .then(done);
+    });
+
+});

--- a/test/jasmine/tests/finance_test.js
+++ b/test/jasmine/tests/finance_test.js
@@ -968,7 +968,9 @@ describe('finance charts *special* handlers:', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('`editable: true` handles should work', function(done) {
+    it('`editable: true` handlers should work', function(done) {
+
+        var gd = createGraphDiv();
 
         function editText(itemNumber, newText) {
             var textNode = d3.selectAll('text.legendtext')
@@ -981,11 +983,17 @@ describe('finance charts *special* handlers:', function() {
             editNode.textContent = newText;
             editNode.dispatchEvent(new window.FocusEvent('focus'));
             editNode.dispatchEvent(new window.FocusEvent('blur'));
-
-            editNode.remove();
         }
 
-        Plotly.plot(createGraphDiv(), [
+        // makeEditable in svg_text_utils clears the edit <div> in
+        // a 0-second transition, so push the resolve call at the back
+        // of the rendering queue to make sure the edit <div> is properly
+        // cleared after each mocked text edits.
+        function delayedResolve(resolve) {
+            setTimeout(function() { return resolve(gd); }, 0);
+        }
+
+        Plotly.plot(gd, [
             Lib.extendDeep({}, mock0, { type: 'ohlc' }),
             Lib.extendDeep({}, mock0, { type: 'candlestick' })
         ], {}, {
@@ -996,7 +1004,7 @@ describe('finance charts *special* handlers:', function() {
                 gd.once('plotly_restyle', function(eventData) {
                     expect(eventData[0]['increasing.name']).toEqual('0');
                     expect(eventData[1]).toEqual([0]);
-                    resolve(gd);
+                    delayedResolve(resolve);
                 });
 
                 editText(0, '0');
@@ -1007,7 +1015,7 @@ describe('finance charts *special* handlers:', function() {
                 gd.once('plotly_restyle', function(eventData) {
                     expect(eventData[0]['decreasing.name']).toEqual('1');
                     expect(eventData[1]).toEqual([0]);
-                    resolve(gd);
+                    delayedResolve(resolve);
                 });
 
                 editText(1, '1');
@@ -1018,7 +1026,7 @@ describe('finance charts *special* handlers:', function() {
                 gd.once('plotly_restyle', function(eventData) {
                     expect(eventData[0]['decreasing.name']).toEqual('2');
                     expect(eventData[1]).toEqual([1]);
-                    resolve(gd);
+                    delayedResolve(resolve);
                 });
 
                 editText(3, '2');
@@ -1029,7 +1037,7 @@ describe('finance charts *special* handlers:', function() {
                 gd.once('plotly_restyle', function(eventData) {
                     expect(eventData[0]['increasing.name']).toEqual('3');
                     expect(eventData[1]).toEqual([1]);
-                    resolve(gd);
+                    delayedResolve(resolve);
                 });
 
                 editText(2, '3');


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1329

In https://github.com/plotly/plotly.js/pull/1020 (more precisely in https://github.com/plotly/plotly.js/pull/1020/commits/fbb299b145d0ed1c16e4802a4a25120938ff4e16) a custom finance trace `editable: true` legend item handler was added to ensure that editing legend text would propagate to the correct finance trace. Unfortunately, the relevant attribute name changed since then, breaking the behavior. Testing this particular `editable: true` isn't trivial hence why I left it out of #1020. 

In this PR, I make sure to :lock: this behavior down.