### PR TITLE
Range slider data update fix

### DIFF
--- a/src/components/rangeslider/defaults.js
+++ b/src/components/rangeslider/defaults.js
@@ -36,7 +36,7 @@ module.exports = function handleDefaults(layoutIn, layoutOut, axName) {
     coerce('range');
 
     // Expand slider range to the axis range
-    if(containerOut.range && !axOut.autorange) {
+    if(containerOut.range) {
         // TODO: what if the ranges are reversed?
         var outRange = containerOut.range,
             axRange = axOut.range;

--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -82,7 +82,7 @@ module.exports = function(gd) {
         // compute new slider range using axis autorange if necessary
         // copy back range to input range slider container to skip
         // this step in subsequent draw calls
-        if(!opts.range) {
+        if(axisOpts._needsExpand && axisOpts._min.length && axisOpts._max.length) {
             opts._input.range = opts.range = Axes.getAutoRange(axisOpts);
         }
 

--- a/test/jasmine/tests/range_slider_test.js
+++ b/test/jasmine/tests/range_slider_test.js
@@ -536,6 +536,9 @@ describe('the range slider', function() {
 
     describe('in general', function() {
 
+        // lower toBeCloseToArray precision for FF38 on CI
+        var precision = 1e-2;
+
         beforeAll(function() {
             jasmine.addMatchers(customMatchers);
         });
@@ -569,8 +572,8 @@ describe('the range slider', function() {
         it('should expand its range in accordance with new data arrays', function(done) {
 
             function assertRange(expected) {
-                expect(gd.layout.xaxis.range).toBeCloseToArray(expected);
-                expect(gd.layout.xaxis.rangeslider.range).toBeCloseToArray(expected);
+                expect(gd.layout.xaxis.range).toBeCloseToArray(expected, precision);
+                expect(gd.layout.xaxis.rangeslider.range).toBeCloseToArray(expected, precision);
             }
 
             Plotly.plot(gd, [{
@@ -608,8 +611,8 @@ describe('the range slider', function() {
             var rangeSliderRange = [-1, 11];
 
             function assertRange(expected) {
-                expect(gd.layout.xaxis.range).toBeCloseToArray(expected);
-                expect(gd.layout.xaxis.rangeslider.range).toEqual(rangeSliderRange);
+                expect(gd.layout.xaxis.range).toBeCloseToArray(expected, precision);
+                expect(gd.layout.xaxis.rangeslider.range).toEqual(rangeSliderRange, precision);
             }
 
             Plotly.plot(gd, [{

--- a/test/jasmine/tests/range_slider_test.js
+++ b/test/jasmine/tests/range_slider_test.js
@@ -536,6 +536,10 @@ describe('the range slider', function() {
 
     describe('in general', function() {
 
+        beforeAll(function() {
+            jasmine.addMatchers(customMatchers);
+        });
+
         beforeEach(function() {
             gd = createGraphDiv();
         });
@@ -560,6 +564,83 @@ describe('the range slider', function() {
                     expect(rangeSlider).toBeDefined();
                 })
                 .then(done);
+        });
+
+        it('should expand its range in accordance with new data arrays', function(done) {
+
+            function assertRange(expected) {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(expected);
+                expect(gd.layout.xaxis.rangeslider.range).toBeCloseToArray(expected);
+            }
+
+            Plotly.plot(gd, [{
+                y: [2, 1, 2]
+            }], {
+                xaxis: { rangeslider: {} }
+            })
+            .then(function() {
+                assertRange([-0.13, 2.13]);
+
+                return Plotly.restyle(gd, 'y', [[2, 1, 2, 1]]);
+            })
+            .then(function() {
+                assertRange([-0.19, 3.19]);
+
+                return Plotly.extendTraces(gd, { y: [[2, 1]] }, [0]);
+            })
+            .then(function() {
+                assertRange([-0.32, 5.32]);
+
+                return Plotly.addTraces(gd, { x: [0, 10], y: [2, 1] });
+            })
+            .then(function() {
+                assertRange([-0.68, 10.68]);
+
+                return Plotly.deleteTraces(gd, [1]);
+            })
+            .then(function() {
+                assertRange([-0.31, 5.31]);
+            })
+            .then(done);
+        });
+
+        it('should not expand its range when range slider range is set', function(done) {
+            var rangeSliderRange = [-1, 11];
+
+            function assertRange(expected) {
+                expect(gd.layout.xaxis.range).toBeCloseToArray(expected);
+                expect(gd.layout.xaxis.rangeslider.range).toEqual(rangeSliderRange);
+            }
+
+            Plotly.plot(gd, [{
+                y: [2, 1, 2]
+            }], {
+                xaxis: { rangeslider: { range: [-1, 11]} }
+            })
+            .then(function() {
+                assertRange([-0.13, 2.13]);
+
+                return Plotly.restyle(gd, 'y', [[2, 1, 2, 1]]);
+            })
+            .then(function() {
+                assertRange([-0.19, 3.19]);
+
+                return Plotly.extendTraces(gd, { y: [[2, 1]] }, [0]);
+            })
+            .then(function() {
+                assertRange([-0.32, 5.32]);
+
+                return Plotly.addTraces(gd, { x: [0, 10], y: [2, 1] });
+            })
+            .then(function() {
+                assertRange([-0.68, 10.68]);
+
+                return Plotly.deleteTraces(gd, [1]);
+            })
+            .then(function() {
+                assertRange([-0.31, 5.31]);
+            })
+            .then(done);
         });
     });
 });


### PR DESCRIPTION
fixes https://github.com/plotly/streambed/issues/9088

A very subtle change that ensures that new range slider ranges are computed under data array restyle/addTraces/expandTrace/deleteTraces updates. 