### PR TITLE
Implement Axis boundaries

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1771,7 +1771,8 @@ function _relayout(gd, aobj) {
         doplot: false,
         docalc: false,
         domodebar: false,
-        layoutReplot: false
+        layoutReplot: false,
+        overBounds: false
     };
 
     // copies of the change (and previous values of anything affected)
@@ -1819,6 +1820,19 @@ function _relayout(gd, aobj) {
             parentFull = Lib.nestedProperty(fullLayout, ptrunk).get();
 
         if(vi === undefined) continue;
+
+        if(pleaf === 'range' && parentIn.bound) {
+            var boundIdx = p.parts[2];
+            var val = vi;
+            var bound = parentIn.bound[boundIdx];
+            if(parentFull.type === 'date') {
+                val = +new Date(val);
+                bound = +new Date(bound);
+            }
+            if(boundIdx === 0 ? vi < bound : vi > bound) {
+                flags.overBounds = true;
+            }
+        }
 
         redoit[ai] = vi;
 
@@ -2018,6 +2032,12 @@ function _relayout(gd, aobj) {
 
             p.set(vi);
         }
+    }
+
+    if(flags.overBounds) {
+        // TODO: Handle per xaxis & yaxis / Set range to max bound
+        flags.docalc = false;
+        redoit = {};
     }
 
     var oldWidth = gd._fullLayout.width,

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -93,6 +93,14 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
         color: dfltFontColor
     });
 
+    var validBound = (
+        (containerIn.bound || []).length === 2 &&
+        isNumeric(containerOut.r2l(containerIn.bound[0])) &&
+        isNumeric(containerOut.r2l(containerIn.bound[1]))
+    );
+    var autoBound = coerce('autorange', !validBound);
+    if(autoBound) coerce('bound');
+
     var validRange = (
         (containerIn.range || []).length === 2 &&
         isNumeric(containerOut.r2l(containerIn.range[0])) &&

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -52,6 +52,35 @@ module.exports = {
             'the axis in question.'
         ].join(' ')
     },
+    autobound: {
+        valType: 'boolean',
+        dflt: true,
+        role: 'style',
+        description: [
+            'Determines the bound of this axis for layout',
+            'If `bound` is provided, then `autobound` is set to *false*.'
+        ].join(' ')
+    },
+    bound: {
+        valType: 'info_array',
+        role: 'info',
+        items: [
+            {valType: 'any'},
+            {valType: 'any'}
+        ],
+        description: [
+            'Sets the bound of this axis.',
+            'If the axis `type` is *log*, then you must take the log of your',
+            'desired bound (e.g. to set the bound from 1 to 100,',
+            'set the bound from 0 to 2).',
+            'If the axis `type` is *date*, it should be date strings,',
+            'like date data, though Date objects and unix milliseconds',
+            'will be accepted and converted to strings.',
+            'If the axis `type` is *category*, it should be numbers,',
+            'using the scale where each category is assigned a serial',
+            'number from zero in the order it appears.'
+        ].join(' ')
+    },
     autorange: {
         valType: 'enumerated',
         values: [true, false, 'reversed'],


### PR DESCRIPTION
Added two options in layout: `bound` and `autobound` for control the axis boundaries.

@etpinard I would like to know is there a list of functions I need to modify in order to add this feature?
As there're different actions to trigger relayout: click buttons at displayModeBar, scrollZoom at axis, etc.
My draft commit only can handle axis change by drag but not scroll.

Also is there any convenient ways to undo drag / zoom?

Related issues: #887 #400