### PR TITLE
Ensure empty candlestick traces don't lead to autotyped 'category' x-axis

### DIFF
--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -205,7 +205,7 @@ function getBoxPosLetter(trace) {
 function isBoxWithoutPositionCoords(trace, axLetter) {
     var posLetter = getBoxPosLetter(trace),
         isBox = Registry.traceIs(trace, 'box'),
-        isCandlestick = isBox && Registry.traceIs(trace._fullInput || {}, 'candlestick');
+        isCandlestick = Registry.traceIs(trace._fullInput || {}, 'candlestick');
 
     return (
         isBox &&

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -207,6 +207,7 @@ function isBoxWithoutPositionCoords(trace, axLetter) {
 
     return (
         Registry.traceIs(trace, 'box') &&
+        trace._fullInput.type === 'box' &&
         axLetter === posLetter &&
         trace[posLetter] === undefined &&
         trace[posLetter + '0'] === undefined

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -203,11 +203,13 @@ function getBoxPosLetter(trace) {
 }
 
 function isBoxWithoutPositionCoords(trace, axLetter) {
-    var posLetter = getBoxPosLetter(trace);
+    var posLetter = getBoxPosLetter(trace),
+        isBox = Registry.traceIs(trace, 'box'),
+        isCandlestick = isBox && Registry.traceIs(trace._fullInput || {}, 'candlestick');
 
     return (
-        Registry.traceIs(trace, 'box') &&
-        trace._fullInput.type === 'box' &&
+        isBox &&
+        !isCandlestick &&
         axLetter === posLetter &&
         trace[posLetter] === undefined &&
         trace[posLetter + '0'] === undefined

--- a/src/traces/candlestick/index.js
+++ b/src/traces/candlestick/index.js
@@ -15,7 +15,7 @@ module.exports = {
     moduleType: 'trace',
     name: 'candlestick',
     basePlotModule: require('../../plots/cartesian'),
-    categories: ['cartesian', 'showLegend'],
+    categories: ['cartesian', 'showLegend', 'candlestick'],
     meta: {
         description: [
             'The candlestick is a style of financial chart describing',

--- a/test/jasmine/tests/finance_test.js
+++ b/test/jasmine/tests/finance_test.js
@@ -367,6 +367,13 @@ describe('finance charts defaults:', function() {
             expect(fullTrace.xcalendar).toBe(i < 2 ? 'hebrew' : 'julian');
         });
     });
+
+    it('should make empty candlestick traces autotype to *linear* (as opposed to real box traces)', function() {
+        var trace0 = { type: 'candlestick' };
+        var out = _supply([trace0], { xaxis: {} });
+
+        expect(out._fullLayout.xaxis.type).toEqual('linear');
+    });
 });
 
 describe('finance charts calc transforms:', function() {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1357

