### PR TITLE
Skip over placeholder calc traces in bar set positions

### DIFF
--- a/src/traces/bar/set_positions.js
+++ b/src/traces/bar/set_positions.js
@@ -37,7 +37,8 @@ module.exports = function setPositions(gd, plotinfo) {
             fullTrace.visible === true &&
             Registry.traceIs(fullTrace, 'bar') &&
             fullTrace.xaxis === xa._id &&
-            fullTrace.yaxis === ya._id
+            fullTrace.yaxis === ya._id &&
+            !calcTraces[i][0].placeholder
         ) {
             if(fullTrace.orientation === 'h') {
                 calcTracesHorizontal.push(calcTraces[i]);

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -680,6 +680,23 @@ describe('Bar.setPositions', function() {
         expect(Axes.getAutoRange(xa)).toBeCloseToArray([-0.5, 2.5], undefined, '(xa.range)');
         expect(Axes.getAutoRange(ya)).toBeCloseToArray([-1.11, 1.11], undefined, '(ya.range)');
     });
+
+    it('should skip placeholder trace in position computations', function() {
+        var gd = mockBarPlot([{
+            x: [1, 2, 3],
+            y: [2, 1, 2]
+        }, {
+            x: [null],
+            y: [null]
+        }]);
+
+        expect(gd.calcdata[0][0].t.barwidth).toEqual(0.8);
+
+        expect(gd.calcdata[1][0].x).toBe(false);
+        expect(gd.calcdata[1][0].y).toBe(false);
+        expect(gd.calcdata[1][0].placeholder).toBe(true);
+        expect(gd.calcdata[1][0].t.barwidth).toBeUndefined();
+    });
 });
 
 describe('A bar plot', function() {
@@ -1231,18 +1248,8 @@ function mockBarPlot(dataWithoutTraceType, layout) {
         calcdata: []
     };
 
-    // call Bar.supplyDefaults
     Plots.supplyDefaults(gd);
-
-    // call Bar.calc
-    gd._fullData.forEach(function(fullTrace) {
-        var cd = Bar.calc(gd, fullTrace);
-
-        cd[0].t = {};
-        cd[0].trace = fullTrace;
-
-        gd.calcdata.push(cd);
-    });
+    Plots.doCalcdata(gd);
 
     var plotinfo = {
         xaxis: gd._fullLayout.xaxis,


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1310

In bar calc, bars with non-numeric positions are not included in the resulting `gd.calcdata` ([ref](https://github.com/plotly/plotly.js/blob/32ccae5a5e86bcd8c974fea923436223d6fb723d/src/traces/bar/calc.js#L61-L63)). Later in `Plots.doCalcdata`, those skipped bars are given a placeholder calcdata item ([ref](https://github.com/plotly/plotly.js/blob/32ccae5a5e86bcd8c974fea923436223d6fb723d/src/plots/plots.js#L2046-L2048)) to ensure that all calc traces have as many items their corresponding fullData traces (see https://github.com/plotly/plotly.js/pull/1004/commits/dd05c6ee857ff5e5e537ccf946d715e60f9924e2 for more on `placeholder` calcdata items). 

These placeholder calc items contain `x: false, y: false`, which throws off the bar min-difference [here](https://github.com/plotly/plotly.js/blob/32ccae5a5e86bcd8c974fea923436223d6fb723d/src/traces/bar/sieve.js#L42); hence the :bug: . In details, `false` is coerced to `0` in [`Lib.distinctVals`](https://github.com/plotly/plotly.js/blob/32ccae5a5e86bcd8c974fea923436223d6fb723d/src/lib/search.js#L79) so essentially

```js
data = [{
  x: [1,2,3],
  y: [2,1,2]
}, {
  x: [null],
  y: [/* ... */]
}]
```

was treated essentially the same way as

```js
data = [{
  x: [1,2,3],
  y: [2,1,2]
}, {
  x: [0],
  y: [/* ... */]
}]
```

which leads to large errors especially when `data[0]` has date positions (which are stored in datetimes at the set position step) as reported in #1310.

In brief, the fix is easy, simply skip over `placeholder` calc traces during bar set positions.