### PR TITLE
bower best practice: Updating bower.json to reference non-minified file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "plotly.js",
   "description": "The open source javascript graphing library that powers plotly",
-  "main": "./dist/plotly.min.js",
+  "main": "./dist/plotly.js",
   "authors": [
     "Plotly, Inc."
   ],


### PR DESCRIPTION
The minified version of plotly.min.js results in grunt-contrib-uglify
hanging when it hits the minified plotly.min.js
(gruntjs/grunt-contrib-uglify#233)

Best practices captured at bower/bower#393
specify that the main bower file should point to unminified files.