### PR TITLE
Implement `scene.dragmode: false`

### DIFF
--- a/src/plots/gl3d/camera.js
+++ b/src/plots/gl3d/camera.js
@@ -181,9 +181,13 @@ function createCamera(element, options) {
 
     var lastX = 0, lastY = 0;
     mouseChange(element, function(buttons, x, y, mods) {
-        var rotate = camera.keyBindingMode === 'rotate';
-        var pan = camera.keyBindingMode === 'pan';
-        var zoom = camera.keyBindingMode === 'zoom';
+        var keyBindingMode = camera.keyBindingMode;
+
+        if(keyBindingMode === false) return;
+
+        var rotate = keyBindingMode === 'rotate';
+        var pan = keyBindingMode === 'pan';
+        var zoom = keyBindingMode === 'zoom';
 
         var ctrl = !!mods.control;
         var alt = !!mods.alt;
@@ -226,6 +230,8 @@ function createCamera(element, options) {
     });
 
     mouseWheel(element, function(dx, dy) {
+        if(camera.keyBindingMode === false) return;
+
         var flipX = camera.flipX ? 1 : -1;
         var flipY = camera.flipY ? 1 : -1;
         var t = now();

--- a/src/plots/gl3d/layout/defaults.js
+++ b/src/plots/gl3d/layout/defaults.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+var Lib = require('../../../lib');
 var Color = require('../../../components/color');
 
 var handleSubplotDefaults = require('../../subplot_defaults');
@@ -17,20 +18,14 @@ var supplyGl3dAxisLayoutDefaults = require('./axis_defaults');
 
 
 module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
-    var hasNon3D = (
-        layoutOut._has('cartesian') ||
-        layoutOut._has('geo') ||
-        layoutOut._has('gl2d') ||
-        layoutOut._has('pie') ||
-        layoutOut._has('ternary')
-    );
+    var hasNon3D = layoutOut._basePlotModules.length > 1;
 
     // some layout-wide attribute are used in all scenes
     // if 3D is the only visible plot type
     function getDfltFromLayout(attr) {
         if(hasNon3D) return;
 
-        var isValid = layoutAttributes[attr].values.indexOf(layoutIn[attr]) !== -1;
+        var isValid = Lib.validate(layoutIn[attr], layoutAttributes[attr]);
         if(isValid) return layoutIn[attr];
     }
 

--- a/src/plots/gl3d/layout/layout_attributes.js
+++ b/src/plots/gl3d/layout/layout_attributes.js
@@ -142,7 +142,7 @@ module.exports = {
     dragmode: {
         valType: 'enumerated',
         role: 'info',
-        values: ['orbit', 'turntable', 'zoom', 'pan'],
+        values: ['orbit', 'turntable', 'zoom', 'pan', false],
         dflt: 'turntable',
         description: [
             'Determines the mode of drag interactions for this scene.'

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -173,6 +173,8 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
     }
 
     var relayoutCallback = function(scene) {
+        if(scene.fullSceneLayout.dragmode === false) return;
+
         var update = {};
         update[scene.id] = getLayoutCamera(scene.camera);
         scene.saveCamera(scene.graphDiv.layout);

--- a/test/jasmine/tests/gl3dlayout_test.js
+++ b/test/jasmine/tests/gl3dlayout_test.js
@@ -1,5 +1,4 @@
 var Gl3d = require('@src/plots/gl3d');
-var Plots = require('@src/plots/plots');
 
 var tinycolor = require('tinycolor2');
 var Color = require('@src/components/color');
@@ -14,9 +13,7 @@ describe('Test Gl3d layout defaults', function() {
         var supplyLayoutDefaults = Gl3d.supplyLayoutDefaults;
 
         beforeEach(function() {
-            layoutOut = {
-                _has: Plots._hasPlotType
-            };
+            layoutOut = { _basePlotModules: ['gl3d'] };
 
             // needs a scene-ref in a trace in order to be detected
             fullData = [ { type: 'scatter3d', scene: 'scene' }];
@@ -174,8 +171,13 @@ describe('Test Gl3d layout defaults', function() {
             expect(layoutOut.scene.dragmode)
                 .toBe('orbit', 'to user layout val if valid and 3d only');
 
+            layoutIn = { scene: {}, dragmode: 'invalid' };
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut.scene.dragmode)
+                .toBe('turntable', 'to turntable if invalid and 3d only');
+
             layoutIn = { scene: {}, dragmode: 'orbit' };
-            layoutOut._basePlotModules = [{ name: 'cartesian' }];
+            layoutOut._basePlotModules.push({ name: 'cartesian' });
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.dragmode)
                 .toBe('turntable', 'to default if not 3d only');
@@ -202,8 +204,13 @@ describe('Test Gl3d layout defaults', function() {
             expect(layoutOut.scene.hovermode)
                 .toBe(false, 'to user layout val if valid and 3d only');
 
+            layoutIn = { scene: {}, hovermode: 'invalid' };
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut.scene.hovermode)
+                .toBe('closest', 'to closest if invalid and 3d only');
+
             layoutIn = { scene: {}, hovermode: false };
-            layoutOut._basePlotModules = [{ name: 'cartesian' }];
+            layoutOut._basePlotModules.push({ name: 'cartesian' });
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
             expect(layoutOut.scene.hovermode)
                 .toBe('closest', 'to default if not 3d only');


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/456

for users that want to lock the camera position ... 

and to make our gl3d test more robust in preparation for https://github.com/plotly/plotly.js/issues/751