### PR TITLE
Fix legend width calculation

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -630,7 +630,7 @@ function computeLegendDimensions(gd, groups, traces) {
                 (borderwidth + offsetX),
                 (5 + borderwidth + legendItem.height / 2) + rowHeight);
 
-            opts.width += traceGap + traceWidth;
+            opts.width = Math.max(opts.width, borderwidth + offsetX + traceWidth)
             opts.height = Math.max(opts.height, legendItem.height);
 
             // keep track of tallest trace in group


### PR DESCRIPTION
The legend width calculation was not taking columns into account. This
should allow it to correctly reflect the width after the traces have
been wrapped.