### PR TITLE
Force redraw on updateSize

### DIFF
--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -233,6 +233,9 @@ proto.updateSize = function(canvas) {
         canvas.height = pixelHeight;
     }
 
+    // make sure plots rendered right thing
+    if (this.redraw) this.redraw()
+
     return canvas;
 };
 

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -233,8 +233,8 @@ proto.updateSize = function(canvas) {
         canvas.height = pixelHeight;
     }
 
-    // make sure plots rendered right thing
-    if (this.redraw) this.redraw()
+    // make sure plots render right thing
+    if(this.redraw) this.redraw();
 
     return canvas;
 };


### PR DESCRIPTION
Fixes loosing axes/scale in sequence of `toImage`.

Test setup:
```js
let list = [
	'gl2d_10',
	'gl2d_12'
]


list.forEach(mock => {
	let div = document.body.appendChild(document.createElement('div'))

	Tabs.getMock(mock, (err, fig) => {

		Plotly.plot(div, fig).then((div) => {
			return Plotly.toImage(div).then(dataUrl => {
				let img = document.body.appendChild(document.createElement('img'))
				img.src = dataUrl
			})
		})

	})
})
```

Allows to get rid of delay [here](https://github.com/plotly/plotly.js/blob/master/src/snapshot/helpers.js#L18) to speed up serializing.

Reminiscent of https://github.com/plotly/streambed/issues/6307.

@etpinard please take a look, should go well with https://github.com/gl-vis/gl-scatter2d-fancy/pull/5.