### PR TITLE
Clear cartesian axis titles when deleting subplots

### DIFF
--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -166,9 +166,14 @@ exports.clean = function(newFullData, newFullLayout, oldFullData, oldFullLayout)
 
     if(hadCartesian && !hasCartesian) {
         var subplotLayers = oldFullLayout._cartesianlayer.selectAll('.subplot');
+        var axIds = Axes.listIds({ _fullLayout: oldFullLayout });
 
         subplotLayers.call(purgeSubplotLayers, oldFullLayout);
         oldFullLayout._defs.selectAll('.axesclip').remove();
+
+        for(i = 0; i < axIds.length; i++) {
+            oldFullLayout._infolayer.select('.' + axIds[i] + 'title').remove();
+        }
     }
 };
 

--- a/test/jasmine/tests/cartesian_test.js
+++ b/test/jasmine/tests/cartesian_test.js
@@ -306,3 +306,40 @@ describe('relayout', function() {
     });
 
 });
+
+describe('subplot creation / deletion:', function() {
+
+    afterEach(destroyGraphDiv);
+
+    it('should clear orphan subplot when adding traces to blank graph', function(done) {
+
+        function assertCartesianSubplot(len) {
+            expect(d3.select('.subplot.xy').size()).toEqual(len);
+            expect(d3.select('.subplot.x2y2').size()).toEqual(len);
+            expect(d3.select('.x2title').size()).toEqual(len);
+            expect(d3.select('.x2title').size()).toEqual(len);
+            expect(d3.select('.ytitle').size()).toEqual(len);
+            expect(d3.select('.ytitle').size()).toEqual(len);
+        }
+
+        Plotly.plot(createGraphDiv(), [], {
+            xaxis: { title: 'X' },
+            yaxis: { title: 'Y' },
+            xaxis2: { title: 'X2', anchor: 'y2' },
+            yaxis2: { title: 'Y2', anchor: 'x2' }
+        })
+        .then(function(gd) {
+            assertCartesianSubplot(1);
+
+            return Plotly.addTraces(gd, [{
+                type: 'scattergeo',
+                lon: [10, 20, 30],
+                lat: [20, 30, 10]
+            }]);
+        })
+        .then(function() {
+            assertCartesianSubplot(0);
+        })
+        .then(done);
+    });
+});

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -363,6 +363,28 @@ describe('Test gl plot interactions', function() {
             })
             .then(done);
         });
+
+        it('should clear orphan cartesian subplots on addTraces', function(done) {
+
+            Plotly.newPlot(gd, [], {
+                xaxis: { title: 'X' },
+                yaxis: { title: 'Y' }
+            })
+            .then(function() {
+                return Plotly.addTraces(gd, [{
+                    type: 'scattergl',
+                    x: [1, 2, 3, 4, 5, 6, 7],
+                    y: [0, 5, 8, 9, 8, 5, 0]
+                }]);
+            })
+            .then(function() {
+                expect(d3.select('.subplot.xy').size()).toEqual(0);
+                expect(d3.select('.xtitle').size()).toEqual(0);
+                expect(d3.select('.ytitle').size()).toEqual(0);
+            })
+            .then(done);
+
+        });
     });
 
     describe('gl3d event handlers', function() {


### PR DESCRIPTION
Previously,

```js
var newPlotLayout = {
  "xaxis":{ "title":"xAxis Name" },
  "yaxis":{ "title":"yAxis Name" }
}

var traces = [ {
  "type":"scattergl",  // or any other non-cartesian type
  "x":[1,2,3,4,5,6,7],
  "y":[0,5,8,9,8,5,0]
}]

Plotly.newPlot('graph', [], newPlotLayout).then(function(){
  Plotly.addTraces('graph', traces);
})
```

yielded

![image](https://cloud.githubusercontent.com/assets/6675409/23084329/c602cd34-f52f-11e6-908d-af03420f46f6.png)


After this fix, we get:

![image](https://cloud.githubusercontent.com/assets/6675409/23084322/bae6232e-f52f-11e6-9510-0542e295a332.png)


as desired.