### PR TITLE
Fix `Plotly.validate` for colorscale attributes

### DIFF
--- a/src/plot_api/validate.js
+++ b/src/plot_api/validate.js
@@ -164,7 +164,8 @@ function crawl(objIn, objOut, schema, list, base, path) {
             valOut = objOut[k];
 
         var nestedSchema = getNestedSchema(schema, k),
-            isInfoArray = (nestedSchema || {}).valType === 'info_array';
+            isInfoArray = (nestedSchema || {}).valType === 'info_array',
+            isColorscale = (nestedSchema || {}).valType === 'colorscale';
 
         if(!isInSchema(schema, k)) {
             list.push(format('schema', base, p));
@@ -209,7 +210,7 @@ function crawl(objIn, objOut, schema, list, base, path) {
         else if(!isPlainObject(valIn) && isPlainObject(valOut)) {
             list.push(format('object', base, p, valIn));
         }
-        else if(!isArray(valIn) && isArray(valOut) && !isInfoArray) {
+        else if(!isArray(valIn) && isArray(valOut) && !isInfoArray && !isColorscale) {
             list.push(format('array', base, p, valIn));
         }
         else if(!(k in objOut)) {

--- a/test/jasmine/tests/validate_test.js
+++ b/test/jasmine/tests/validate_test.js
@@ -148,6 +148,34 @@ describe('Plotly.validate', function() {
         );
     });
 
+    it('should work with colorscale attributes', function() {
+        var out = Plotly.validate([{
+            x: [1, 2, 3],
+            marker: {
+                color: [20, 10, 30],
+                colorscale: 'Reds'
+            }
+        }, {
+            x: [1, 2, 3],
+            marker: {
+                color: [20, 10, 30],
+                colorscale: 'not-gonna-work'
+            }
+        }, {
+            x: [1, 2, 3],
+            marker: {
+                color: [20, 10, 30],
+                colorscale: [[0, 'red'], [1, 'blue']]
+            }
+        }]);
+
+        expect(out.length).toEqual(1);
+        assertErrorContent(
+            out[0], 'value', 'data', 1, ['marker', 'colorscale'], 'marker.colorscale',
+            'In data trace 1, key marker.colorscale is set to an invalid value (not-gonna-work)'
+        );
+    });
+
     it('should work with isLinkedToArray attributes', function() {
         var out = Plotly.validate([], {
             annotations: [{


### PR DESCRIPTION
Something I noticed while reviewing @monfera's `parcoords` PR. Easy late Friday Fixin' :beers: 