### PR TITLE
Fixup for `Axes.expand` in the early return case

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -378,7 +378,11 @@ axes.saveRangeInitial = function(gd, overwrite) {
 //      tozero: (boolean) make sure to include zero if axis is linear,
 //          and make it a tight bound if possible
 axes.expand = function(ax, data, options) {
-    var needsAutorange = (ax.autorange || Lib.nestedProperty(ax, 'rangeslider.autorange'));
+    var needsAutorange = (
+        ax.autorange ||
+        !!Lib.nestedProperty(ax, 'rangeslider.autorange').get()
+    );
+
     if(!needsAutorange || !data) return;
 
     if(!ax._min) ax._min = [];

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1264,11 +1264,11 @@ describe('Test axes', function() {
         // way of getting a new clean copy each time.
         function getDefaultAx() {
             return {
+                autorange: true,
                 c2l: Number,
                 type: 'linear',
                 _length: 100,
-                _m: 1,
-                _needsExpand: true
+                _m: 1
             };
         }
 
@@ -1284,15 +1284,14 @@ describe('Test axes', function() {
 
         it('calls ax.setScale if necessary', function() {
             ax = {
+                autorange: true,
                 c2l: Number,
                 type: 'linear',
-                setScale: function() {},
-                _needsExpand: true
+                setScale: function() {}
             };
             spyOn(ax, 'setScale');
-            data = [1];
 
-            expand(ax, data);
+            expand(ax, [1]);
 
             expect(ax.setScale).toHaveBeenCalled();
         });

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1449,6 +1449,38 @@ describe('Test axes', function() {
             expect(ax._min).toEqual([{val: 0, pad: 0}]);
             expect(ax._max).toEqual([{val: 6, pad: 15}]);
         });
+
+        it('should return early if no data is given', function() {
+            ax = getDefaultAx();
+
+            expand(ax);
+            expect(ax._min).toBeUndefined();
+            expect(ax._max).toBeUndefined();
+        });
+
+        it('should return early if `autorange` is falsy', function() {
+            ax = getDefaultAx();
+            data = [2, 5];
+
+            ax.autorange = false;
+            ax.rangeslider = { autorange: false };
+
+            expand(ax, data, {});
+            expect(ax._min).toBeUndefined();
+            expect(ax._max).toBeUndefined();
+        });
+
+        it('should consider range slider `autorange`', function() {
+            ax = getDefaultAx();
+            data = [2, 5];
+
+            ax.autorange = false;
+            ax.rangeslider = { autorange: true };
+
+            expand(ax, data, {});
+            expect(ax._min).toEqual([{val: 2, pad: 0}]);
+            expect(ax._max).toEqual([{val: 5, pad: 0}]);
+        });
     });
 
     describe('calcTicks and tickText', function() {


### PR DESCRIPTION
Fixup for commit https://github.com/plotly/plotly.js/pull/1355/commits/cebc31c72f20cd0e1426e8d9258f9e09e269817a part of the multiple range slider PR https://github.com/plotly/plotly.js/pull/1355