### PR TITLE
Skip gl3d hover and click test on CI

### DIFF
--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -78,7 +78,7 @@ describe('Test gl3d plots', function() {
         destroyGraphDiv();
     });
 
-    it('should display correct hover labels and emit correct event data', function(done) {
+    it('@noCI should display correct hover labels and emit correct event data', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
 
         function _hover() {
@@ -136,7 +136,7 @@ describe('Test gl3d plots', function() {
 
     });
 
-    it('should emit correct event data on click', function(done) {
+    it('@noCI should emit correct event data on click', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
 
         // N.B. gl3d click events are 'mouseover' events


### PR DESCRIPTION
... for now. It's been a rough day on CI for those two tests. 

I could not find a way to make these tests more robust. Even translating the technique of [`gl2d_click_test.js`](https://github.com/plotly/plotly.js/blob/master/test/jasmine/tests/gl2d_click_test.js#L61) didn't work. I think we're not mocking the mouse events that trigger hover in the 3d [code](https://github.com/plotly/plotly.js/blob/b1b525ee042fd423a11801c2cca8a83c10e04da4/src/plots/gl3d/scene.js#L67-L124) correctly. At the moment we're simply triggering a [mouseover](https://github.com/plotly/plotly.js/blob/b1b525ee042fd423a11801c2cca8a83c10e04da4/test/jasmine/tests/gl_plot_interact_test.js#L45) event. So, let's skip them for now.