### PR TITLE
Let the regl object tree be garbage collected on `Plotly.restyle`

### DIFF
--- a/src/traces/parcoords/base_plot.js
+++ b/src/traces/parcoords/base_plot.js
@@ -61,7 +61,6 @@ exports.toSVG = function(gd) {
         });
     }
 
-    imageRoot.selectAll('*').remove();
     canvases.each(canvasToImage);
 
     // Chrome / Safari bug workaround - browser apparently loses connection to the defined pattern

--- a/src/traces/parcoords/parcoords.js
+++ b/src/traces/parcoords/parcoords.js
@@ -278,10 +278,10 @@ module.exports = function(root, svg, styledData, layout, callbacks) {
         .map(model.bind(0, layout))
         .map(viewModel);
 
+    root.selectAll('.parcoords-line-layers').remove();
+
     var parcoordsLineLayers = root.selectAll('.parcoords-line-layers')
         .data(vm, keyFun);
-
-    parcoordsLineLayers.exit().remove();
 
     parcoordsLineLayers.enter()
         .insert('div', '.' + svg.attr('class').split(' ').join(' .')) // not hardcoding .main-svg


### PR DESCRIPTION
Having tried more verbose approaches such as keeping around both the `<canvas>` element and the `regl` object, or just the `<canvas>` element, the simple and effective route from a memory and object lifecycle point of view was to let the previously created `regl` object be garbage collected. This is achieved by ensuring a fresh `<canvas>` is created and the previous one gets garbage collected (again, after trying some alternatives), including its attached `gl` context and `regl` object.

Also, the snapshot making code should no longer remove the canvas as it's not kept around on rerendering.