### PR TITLE
Batch image export tests

### DIFF
--- a/tasks/ci_test.sh
+++ b/tasks/ci_test.sh
@@ -7,7 +7,7 @@ case $CIRCLE_NODE_INDEX in
     0)
         npm run test-image      || EXIT_STATE=$?
         npm run test-image-gl2d || EXIT_STATE=$?
-        npm run test-export     || EXIT_STATE=$?
+        npm run test-bundle     || EXIT_STATE=$?
         npm run test-syntax     || EXIT_STATE=$?
         npm run lint            || EXIT_STATE=$?
         exit $EXIT_STATE
@@ -15,7 +15,7 @@ case $CIRCLE_NODE_INDEX in
 
     1)
         npm run test-jasmine || EXIT_STATE=$?
-        npm run test-bundle    || EXIT_STATE=$?
+        npm run test-export  || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;
 


### PR DESCRIPTION
Previously, image export [tests](https://github.com/plotly/plotly.js/blob/master/test/image/export_test.js) were simply firing requests to our image server all at once. 

We currently (only) generate 21 images in this export test, so most machines can handle that fairly easily. But looks like (from all the intermittent failures) CI has a harder time getting through those 21 requests. So the solution is easy, simply batch and throttle the image export requests as we do already in the image comparison tests.

As a bonus, I moved the export test to container 1 after the jasmine tests which should reduce the total test time.