### PR TITLE
Add mouse event to `plotly_click`, `plotly_hover` and `plotly_unhover`

### DIFF
--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -140,8 +140,22 @@ dragElement.init = function init(options) {
         if(options.doneFn) options.doneFn(gd._dragged, numClicks, e);
 
         if(!gd._dragged) {
-            var e2 = document.createEvent('MouseEvents');
-            e2.initEvent('click', true, true);
+            var e2;
+
+            try {
+                e2 = new MouseEvent('click', e);
+            }
+            catch(err) {
+                e2 = document.createEvent('MouseEvents');
+                e2.initMouseEvent('click',
+                    e.bubbles, e.cancelable,
+                    e.view, e.detail,
+                    e.screenX, e.screenY,
+                    e.clientX, e.clientY,
+                    e.ctrlKey, e.altKey, e.shiftKey, e.metaKey,
+                    e.button, e.relatedTarget);
+            }
+
             initialTarget.dispatchEvent(e2);
         }
 

--- a/src/components/dragelement/unhover.js
+++ b/src/components/dragelement/unhover.js
@@ -44,6 +44,9 @@ unhover.raw = function unhoverRaw(gd, evt) {
     gd._hoverdata = undefined;
 
     if(evt.target && oldhoverdata) {
-        gd.emit('plotly_unhover', {points: oldhoverdata});
+        gd.emit('plotly_unhover', {
+            event: evt,
+            points: oldhoverdata
+        });
     }
 };

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -305,7 +305,7 @@ fx.hover = function(gd, evt, subplot) {
 function hover(gd, evt, subplot) {
     if(subplot === 'pie') {
         gd.emit('plotly_hover', {
-            event: evt,
+            event: evt.originalEvent,
             points: [evt]
         });
         return;

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -414,12 +414,17 @@ function hover(gd, evt, subplot) {
 
         // [x|y]px: the pixels (from top left) of the mouse location
         // on the currently selected plot area
-        var xpx, ypx;
+        var hasUserCalledHover = ('xpx' in evt || 'ypx' in evt),
+            xpx, ypx;
 
-        // mouse event? ie is there a target element with
-        // clientX and clientY values?
-        if(evt.target && ('clientX' in evt) && ('clientY' in evt)) {
+        if(hasUserCalledHover) {
+            if('xpx' in evt) xpx = evt.xpx;
+            else xpx = xaArray[0]._length / 2;
 
+            if('ypx' in evt) ypx = evt.ypx;
+            else ypx = yaArray[0]._length / 2;
+        }
+        else {
             // fire the beforehover event and quit if it returns false
             // note that we're only calling this on real mouse events, so
             // manual calls to fx.hover will always run.
@@ -437,13 +442,6 @@ function hover(gd, evt, subplot) {
             if(xpx < 0 || xpx > dbb.width || ypx < 0 || ypx > dbb.height) {
                 return dragElement.unhoverRaw(gd, evt);
             }
-        }
-        else {
-            if('xpx' in evt) xpx = evt.xpx;
-            else xpx = xaArray[0]._length / 2;
-
-            if('ypx' in evt) ypx = evt.ypx;
-            else ypx = yaArray[0]._length / 2;
         }
 
         if('xval' in evt) xvalArray = flat(subplots, evt.xval);

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -414,7 +414,7 @@ function hover(gd, evt, subplot) {
 
         // [x|y]px: the pixels (from top left) of the mouse location
         // on the currently selected plot area
-        var hasUserCalledHover = ('xpx' in evt || 'ypx' in evt),
+        var hasUserCalledHover = !evt.target,
             xpx, ypx;
 
         if(hasUserCalledHover) {

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -305,6 +305,7 @@ fx.hover = function(gd, evt, subplot) {
 function hover(gd, evt, subplot) {
     if(subplot === 'pie') {
         gd.emit('plotly_hover', {
+            event: evt,
             points: [evt]
         });
         return;
@@ -624,10 +625,14 @@ function hover(gd, evt, subplot) {
     if(!hoverChanged(gd, evt, oldhoverdata)) return;
 
     if(oldhoverdata) {
-        gd.emit('plotly_unhover', { points: oldhoverdata });
+        gd.emit('plotly_unhover', {
+            event: evt,
+            points: oldhoverdata
+        });
     }
 
     gd.emit('plotly_hover', {
+        event: evt,
         points: gd._hoverdata,
         xaxes: xaArray,
         yaxes: yaArray,
@@ -1350,7 +1355,7 @@ function hoverChanged(gd, evt, oldhoverdata) {
 fx.click = function(gd, evt) {
     var annotationsDone = Registry.getComponentMethod('annotations', 'onClick')(gd, gd._hoverdata);
 
-    function emitClick() { gd.emit('plotly_click', {points: gd._hoverdata}); }
+    function emitClick() { gd.emit('plotly_click', {points: gd._hoverdata, event: evt}); }
 
     if(gd._hoverdata && evt && evt.target) {
         if(annotationsDone && annotationsDone.then) {

--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -91,11 +91,9 @@ proto.plot = function(geoCalcData, fullLayout, promises) {
 
         if(!lonlat || isNaN(lonlat[0]) || isNaN(lonlat[1])) return;
 
-        var evt = {
-            target: true,
-            xpx: mouse[0],
-            ypx: mouse[1]
-        };
+        var evt = d3.event;
+        evt.xpx = mouse[0];
+        evt.ypx = mouse[1];
 
         _this.xaxis.c2p = function() { return mouse[0]; };
         _this.xaxis.p2c = function() { return lonlat[0]; };
@@ -110,7 +108,7 @@ proto.plot = function(geoCalcData, fullLayout, promises) {
     });
 
     _this.framework.on('click', function() {
-        Fx.click(_this.graphDiv, { target: true });
+        Fx.click(_this.graphDiv, d3.event);
     });
 
     topojsonNameNew = topojsonUtils.getTopojsonName(geoLayout);

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -166,8 +166,8 @@ proto.createMap = function(calcData, fullLayout, resolve, reject) {
         Fx.hover(gd, evt, self.id);
     });
 
-    map.on('click', function() {
-        Fx.click(gd, { target: true });
+    map.on('click', function(evt) {
+        Fx.click(gd, evt.originalEvent);
     });
 
     function unhover() {

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -86,6 +86,8 @@ module.exports = function plot(gd, cdpie) {
                     hasHoverData = false;
 
                 function handleMouseOver(evt) {
+                    evt.originalEvent = d3.event;
+
                     // in case fullLayout or fullData has changed without a replot
                     var fullLayout2 = gd._fullLayout,
                         trace2 = gd._fullData[trace.index],
@@ -97,6 +99,7 @@ module.exports = function plot(gd, cdpie) {
                     // or if hover is turned off
                     if(gd._dragging || fullLayout2.hovermode === false ||
                             hoverinfo === 'none' || hoverinfo === 'skip' || !hoverinfo) {
+                        Fx.hover(gd, evt, 'pie');
                         return;
                     }
 
@@ -126,7 +129,6 @@ module.exports = function plot(gd, cdpie) {
                         outerContainer: fullLayout2._paper.node()
                     });
 
-                    evt.originalEvent = d3.event;
                     Fx.hover(gd, evt, 'pie');
 
                     hasHoverData = true;

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -149,7 +149,7 @@ module.exports = function plot(gd, cdpie) {
 
                 function handleClick() {
                     gd._hoverdata = [pt];
-                    gd._hoverdata.trace = cd.trace;
+                    gd._hoverdata.trace = cd0.trace;
                     Fx.click(gd, d3.event);
                 }
 

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -85,9 +85,7 @@ module.exports = function plot(gd, cdpie) {
                     slicePath = sliceTop.selectAll('path.surface').data([pt]),
                     hasHoverData = false;
 
-                function handleMouseOver() {
-                    var evt = d3.event;
-
+                function handleMouseOver(evt) {
                     // in case fullLayout or fullData has changed without a replot
                     var fullLayout2 = gd._fullLayout,
                         trace2 = gd._fullData[trace.index],
@@ -128,16 +126,16 @@ module.exports = function plot(gd, cdpie) {
                         outerContainer: fullLayout2._paper.node()
                     });
 
+                    evt.originalEvent = d3.event;
                     Fx.hover(gd, evt, 'pie');
 
                     hasHoverData = true;
                 }
 
-                function handleMouseOut() {
-                    var evt = d3.event;
-
+                function handleMouseOut(evt) {
+                    evt.originalEvent = d3.event;
                     gd.emit('plotly_unhover', {
-                        event: evt,
+                        event: d3.event,
                         points: [evt]
                     });
 

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -85,7 +85,9 @@ module.exports = function plot(gd, cdpie) {
                     slicePath = sliceTop.selectAll('path.surface').data([pt]),
                     hasHoverData = false;
 
-                function handleMouseOver(evt) {
+                function handleMouseOver() {
+                    var evt = d3.event;
+
                     // in case fullLayout or fullData has changed without a replot
                     var fullLayout2 = gd._fullLayout,
                         trace2 = gd._fullData[trace.index],
@@ -131,8 +133,11 @@ module.exports = function plot(gd, cdpie) {
                     hasHoverData = true;
                 }
 
-                function handleMouseOut(evt) {
+                function handleMouseOut() {
+                    var evt = d3.event;
+
                     gd.emit('plotly_unhover', {
+                        event: evt,
                         points: [evt]
                     });
 
@@ -145,7 +150,7 @@ module.exports = function plot(gd, cdpie) {
                 function handleClick() {
                     gd._hoverdata = [pt];
                     gd._hoverdata.trace = cd.trace;
-                    Fx.click(gd, { target: true });
+                    Fx.click(gd, d3.event);
                 }
 
                 slicePath.enter().append('path')

--- a/test/jasmine/assets/click.js
+++ b/test/jasmine/assets/click.js
@@ -1,7 +1,8 @@
 var mouseEvent = require('./mouse_event');
 
-module.exports = function click(x, y) {
-    mouseEvent('mousemove', x, y);
-    mouseEvent('mousedown', x, y);
-    mouseEvent('mouseup', x, y);
+module.exports = function click(x, y, opts) {
+    mouseEvent('mousemove', x, y, opts);
+    mouseEvent('mousedown', x, y, opts);
+    mouseEvent('mouseup', x, y, opts);
+    mouseEvent('click', x, y, opts);
 };

--- a/test/jasmine/assets/get_client_position.js
+++ b/test/jasmine/assets/get_client_position.js
@@ -1,0 +1,10 @@
+module.exports = function getClientPosition(selector, index) {
+    index = index || 0;
+
+    var selection = document.querySelectorAll(selector),
+        clientPos = selection[index].getBoundingClientRect(),
+        x = Math.floor((clientPos.left + clientPos.right) / 2),
+        y = Math.floor((clientPos.top + clientPos.bottom) / 2);
+
+    return [x, y];
+};

--- a/test/jasmine/assets/mouse_event.js
+++ b/test/jasmine/assets/mouse_event.js
@@ -9,6 +9,18 @@ module.exports = function(type, x, y, opts) {
     if(opts && opts.buttons) {
         fullOpts.buttons = opts.buttons;
     }
+    if(opts && opts.altKey) {
+        fullOpts.altKey = opts.altKey;
+    }
+    if(opts && opts.ctrlKey) {
+        fullOpts.ctrlKey = opts.ctrlKey;
+    }
+    if(opts && opts.metaKey) {
+        fullOpts.metaKey = opts.metaKey;
+    }
+    if(opts && opts.shiftKey) {
+        fullOpts.shiftKey = opts.shiftKey;
+    }
 
     var el = (opts && opts.element) || document.elementFromPoint(x, y),
         ev;

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -16,6 +16,30 @@ var customMatchers = require('../assets/custom_matchers');
 var click = require('../assets/click');
 var doubleClickRaw = require('../assets/double_click');
 
+function move(fromX, fromY, toX, toY, delay) {
+    return new Promise(function(resolve) {
+        mouseEvent('mousemove', fromX, fromY);
+
+        setTimeout(function() {
+            mouseEvent('mousemove', toX, toY);
+            resolve();
+        }, delay || DBLCLICKDELAY / 4);
+    });
+}
+
+function drag(fromX, fromY, toX, toY, delay) {
+    return new Promise(function(resolve) {
+        mouseEvent('mousemove', fromX, fromY);
+        mouseEvent('mousedown', fromX, fromY);
+        mouseEvent('mousemove', toX, toY);
+
+        setTimeout(function() {
+            mouseEvent('mouseup', toX, toY);
+            resolve();
+        }, delay || DBLCLICKDELAY / 4);
+    });
+}
+
 
 describe('Test click interactions:', function() {
     var mock = require('@mocks/14.json');
@@ -38,19 +62,6 @@ describe('Test click interactions:', function() {
     });
 
     afterEach(destroyGraphDiv);
-
-    function drag(fromX, fromY, toX, toY, delay) {
-        return new Promise(function(resolve) {
-            mouseEvent('mousemove', fromX, fromY);
-            mouseEvent('mousedown', fromX, fromY);
-            mouseEvent('mousemove', toX, toY);
-
-            setTimeout(function() {
-                mouseEvent('mouseup', toX, toY);
-                resolve();
-            }, delay || DBLCLICKDELAY / 4);
-        });
-    }
 
     function doubleClick(x, y) {
         return doubleClickRaw(x, y).then(function() {
@@ -87,6 +98,55 @@ describe('Test click interactions:', function() {
             expect(pt.pointNumber).toEqual(11);
             expect(pt.x).toEqual(0.125);
             expect(pt.y).toEqual(2.125);
+
+            var evt = futureData.event;
+            expect(evt.clientX).toEqual(pointPos[0]);
+            expect(evt.clientY).toEqual(pointPos[1]);
+        });
+    });
+
+    describe('modified click events', function() {
+        var clickOpts = {
+                altKey: true,
+                ctrlKey: true,
+                metaKey: true,
+                shiftKey: true
+            },
+            futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_click', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should not be trigged when not on data points', function() {
+            click(blankPos[0], blankPos[1], clickOpts);
+            expect(futureData).toBe(undefined);
+        });
+
+        it('should contain the correct fields', function() {
+            click(pointPos[0], pointPos[1], clickOpts);
+            expect(futureData.points.length).toEqual(1);
+
+            var pt = futureData.points[0];
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber',
+                'x', 'y', 'xaxis', 'yaxis'
+            ]);
+            expect(pt.curveNumber).toEqual(0);
+            expect(pt.pointNumber).toEqual(11);
+            expect(pt.x).toEqual(0.125);
+            expect(pt.y).toEqual(2.125);
+
+            var evt = futureData.event;
+            expect(evt.clientX).toEqual(pointPos[0]);
+            expect(evt.clientY).toEqual(pointPos[1]);
+            Object.getOwnPropertyNames(clickOpts).forEach(function(opt) {
+                expect(evt[opt]).toEqual(clickOpts[opt], opt);
+            });
         });
     });
 
@@ -191,6 +251,46 @@ describe('Test click interactions:', function() {
             expect(pt.pointNumber).toEqual(11);
             expect(pt.x).toEqual(0.125);
             expect(pt.y).toEqual(2.125);
+
+            var evt = futureData.event;
+            expect(evt.clientX).toEqual(pointPos[0]);
+            expect(evt.clientY).toEqual(pointPos[1]);
+        });
+    });
+
+    describe('plotly_unhover event with hoverinfo set to none', function() {
+        var futureData;
+
+        beforeEach(function(done) {
+
+            var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
+            modifiedMockCopy.data[0].hoverinfo = 'none';
+            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+                .then(done);
+
+            gd.on('plotly_unhover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should contain the correct fields despite hoverinfo: "none"', function(done) {
+            move(pointPos[0], pointPos[1], blankPos[0], blankPos[1]).then(function() {
+                expect(futureData.points.length).toEqual(1);
+
+                var pt = futureData.points[0];
+                expect(Object.keys(pt)).toEqual([
+                    'data', 'fullData', 'curveNumber', 'pointNumber',
+                    'x', 'y', 'xaxis', 'yaxis'
+                ]);
+                expect(pt.curveNumber).toEqual(0);
+                expect(pt.pointNumber).toEqual(11);
+                expect(pt.x).toEqual(0.125);
+                expect(pt.y).toEqual(2.125);
+
+                var evt = futureData.event;
+                expect(evt.clientX).toEqual(blankPos[0]);
+                expect(evt.clientY).toEqual(blankPos[1]);
+            }).then(done);
         });
     });
 
@@ -816,6 +916,7 @@ describe('Test click interactions:', function() {
         });
     });
 });
+
 
 describe('dragbox', function() {
 

--- a/test/jasmine/tests/geo_test.js
+++ b/test/jasmine/tests/geo_test.js
@@ -11,9 +11,33 @@ var topojsonUtils = require('@src/lib/topojson_utils');
 var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
+var customMatchers = require('../assets/custom_matchers');
 var mouseEvent = require('../assets/mouse_event');
+var click = require('../assets/click');
 
+var DBLCLICKDELAY = require('@src/constants/interactions').DBLCLICKDELAY;
 var HOVERMINTIME = require('@src/plots/cartesian/constants').HOVERMINTIME;
+
+
+function getClientPosition(selector, index) {
+    index = index || 0;
+    var selection = document.querySelectorAll(selector),
+        clientPos = selection[index].getBoundingClientRect(),
+        x = Math.floor((clientPos.left + clientPos.right) / 2),
+        y = Math.floor((clientPos.top + clientPos.bottom) / 2);
+    return [x, y];
+}
+
+function move(fromX, fromY, toX, toY, delay) {
+    return new Promise(function(resolve) {
+        mouseEvent('mousemove', fromX, fromY);
+
+        setTimeout(function() {
+            mouseEvent('mousemove', toX, toY);
+            resolve();
+        }, delay || DBLCLICKDELAY / 4);
+    });
+}
 
 
 describe('Test geoaxes', function() {
@@ -1012,6 +1036,197 @@ describe('Test geo interactions', function() {
                 });
             });
 
+        });
+    });
+});
+
+
+describe('Test event property of interactions on a geo plot:', function() {
+    var mock = require('@mocks/geo_scattergeo-locations.json');
+
+    var mockCopy, gd;
+
+    var blankPos = [10, 10],
+        pointPos,
+        nearPos;
+
+    beforeAll(function(done) {
+        jasmine.addMatchers(customMatchers);
+
+        gd = createGraphDiv();
+        mockCopy = Lib.extendDeep({}, mock);
+        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            pointPos = getClientPosition('path.point');
+            nearPos = [pointPos[0] - 30, pointPos[1] - 30];
+            destroyGraphDiv();
+            done();
+        });
+    });
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+        mockCopy = Lib.extendDeep({}, mock);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    describe('click events', function() {
+        var futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_click', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should not be trigged when not on data points', function() {
+            click(blankPos[0], blankPos[1]);
+            expect(futureData).toBe(undefined);
+        });
+
+        it('should contain the correct fields', function() {
+            click(pointPos[0], pointPos[1]);
+
+            var pt = futureData.points[0],
+                evt = futureData.event;
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'lon', 'lat',
+                'location'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.lat).toEqual(-101.57, 'points[0].lat');
+            expect(pt.lon).toEqual(57.75, 'points[0].lon');
+            expect(pt.location).toEqual(57.75, 'points[0].location');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+
+            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
+            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
+        });
+    });
+
+    describe('modified click events', function() {
+        var clickOpts = {
+                altKey: true,
+                ctrlKey: true,
+                metaKey: true,
+                shiftKey: true
+            },
+            futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_click', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should not be trigged when not on data points', function() {
+            click(blankPos[0], blankPos[1], clickOpts);
+            expect(futureData).toBe(undefined);
+        });
+
+        it('should contain the correct fields', function() {
+            click(pointPos[0], pointPos[1], clickOpts);
+
+            var pt = futureData.points[0],
+                evt = futureData.event;
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'lon', 'lat',
+                'location'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.lat).toEqual(-101.57, 'points[0].lat');
+            expect(pt.lon).toEqual(57.75, 'points[0].lon');
+            expect(pt.location).toEqual(57.75, 'points[0].location');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+
+            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
+            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
+            Object.getOwnPropertyNames(clickOpts).forEach(function(opt) {
+                expect(evt[opt]).toEqual(clickOpts[opt], 'event.' + opt);
+            });
+        });
+    });
+
+    describe('hover events', function() {
+        var futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_hover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should contain the correct fields', function() {
+            mouseEvent('mousemove', blankPos[0], blankPos[1]);
+            mouseEvent('mousemove', pointPos[0], pointPos[1]);
+
+            var pt = futureData.points[0],
+                evt = futureData.event;
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'lon', 'lat',
+                'location'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.lat).toEqual(-101.57, 'points[0].lat');
+            expect(pt.lon).toEqual(57.75, 'points[0].lon');
+            expect(pt.location).toEqual(57.75, 'points[0].location');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+
+            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
+            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
+        });
+    });
+
+    describe('unhover events', function() {
+        var futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_unhover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should contain the correct fields', function(done) {
+            move(pointPos[0], pointPos[1], nearPos[0], nearPos[1], HOVERMINTIME + 10).then(function() {
+                var pt = futureData.points[0],
+                    evt = futureData.event;
+
+                expect(Object.keys(pt)).toEqual([
+                    'data', 'fullData', 'curveNumber', 'pointNumber', 'lon', 'lat',
+                    'location'
+                ]);
+
+                expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+                expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+                expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+                expect(pt.lat).toEqual(-101.57, 'points[0].lat');
+                expect(pt.lon).toEqual(57.75, 'points[0].lon');
+                expect(pt.location).toEqual(57.75, 'points[0].location');
+                expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+
+                expect(evt.clientX).toEqual(nearPos[0], 'event.clientX');
+                expect(evt.clientY).toEqual(nearPos[1], 'event.clientY');
+            }).then(done);
         });
     });
 });

--- a/test/jasmine/tests/geo_test.js
+++ b/test/jasmine/tests/geo_test.js
@@ -12,21 +12,13 @@ var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var customMatchers = require('../assets/custom_matchers');
+var getClientPosition = require('../assets/get_client_position');
 var mouseEvent = require('../assets/mouse_event');
 var click = require('../assets/click');
 
 var DBLCLICKDELAY = require('@src/constants/interactions').DBLCLICKDELAY;
 var HOVERMINTIME = require('@src/plots/cartesian/constants').HOVERMINTIME;
 
-
-function getClientPosition(selector, index) {
-    index = index || 0;
-    var selection = document.querySelectorAll(selector),
-        clientPos = selection[index].getBoundingClientRect(),
-        x = Math.floor((clientPos.left + clientPos.right) / 2),
-        y = Math.floor((clientPos.top + clientPos.bottom) / 2);
-    return [x, y];
-}
 
 function move(fromX, fromY, toX, toY, delay) {
     return new Promise(function(resolve) {

--- a/test/jasmine/tests/hover_pie_test.js
+++ b/test/jasmine/tests/hover_pie_test.js
@@ -23,6 +23,60 @@ function getClientPosition(selector, index) {
 describe('pie hovering', function() {
     var mock = require('@mocks/pie_simple.json');
 
+    describe('with hoverinfo set to none', function() {
+        var mockCopy = Lib.extendDeep({}, mock),
+            gd;
+
+        mockCopy.data[0].hoverinfo = 'none';
+
+        beforeEach(function(done) {
+            gd = createGraphDiv();
+
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+                .then(done);
+        });
+
+        afterEach(destroyGraphDiv);
+
+        it('should fire hover event when moving from one slice to another', function(done) {
+            var count = 0,
+                hoverData = [];
+
+            gd.on('plotly_hover', function(data) {
+                count++;
+                hoverData.push(data);
+            });
+
+            mouseEvent('mouseover', 173, 133);
+            setTimeout(function() {
+                mouseEvent('mouseover', 233, 193);
+                expect(count).toEqual(2);
+                expect(hoverData[0]).not.toEqual(hoverData[1]);
+                done();
+            }, 100);
+        });
+
+        it('should fire unhover event when the mouse moves off the graph', function(done) {
+            var count = 0,
+                unhoverData = [];
+
+            gd.on('plotly_unhover', function(data) {
+                count++;
+                unhoverData.push(data);
+            });
+
+            mouseEvent('mouseover', 173, 133);
+            mouseEvent('mouseout', 173, 133);
+            setTimeout(function() {
+                mouseEvent('mouseover', 233, 193);
+                mouseEvent('mouseout', 233, 193);
+                expect(count).toEqual(2);
+                expect(unhoverData[0]).not.toEqual(unhoverData[1]);
+                done();
+            }, 100);
+        });
+    });
+
     describe('event data', function() {
         var mockCopy = Lib.extendDeep({}, mock),
             width = mockCopy.layout.width,

--- a/test/jasmine/tests/hover_pie_test.js
+++ b/test/jasmine/tests/hover_pie_test.js
@@ -285,6 +285,9 @@ describe('Test event property of interactions on a pie plot:', function() {
             click(pointPos[0], pointPos[1]);
             expect(futureData.points.length).toEqual(1);
 
+            var trace = futureData.points.trace;
+            expect(typeof trace).toEqual(typeof {}, 'points.trace');
+
             var pt = futureData.points[0];
             expect(Object.keys(pt)).toEqual([
                 'v', 'label', 'color', 'i', 'hidden', 'vTotal', 'text', 't',
@@ -342,6 +345,9 @@ describe('Test event property of interactions on a pie plot:', function() {
         it('should contain the correct fields', function() {
             click(pointPos[0], pointPos[1], clickOpts);
             expect(futureData.points.length).toEqual(1);
+
+            var trace = futureData.points.trace;
+            expect(typeof trace).toEqual(typeof {}, 'points.trace');
 
             var pt = futureData.points[0];
             expect(Object.keys(pt)).toEqual([

--- a/test/jasmine/tests/hover_pie_test.js
+++ b/test/jasmine/tests/hover_pie_test.js
@@ -7,17 +7,8 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 
 var click = require('../assets/click');
+var getClientPosition = require('../assets/get_client_position');
 var mouseEvent = require('../assets/mouse_event');
-
-
-function getClientPosition(selector, index) {
-    index = index || 0;
-    var selection = document.querySelectorAll(selector),
-        clientPos = selection[index].getBoundingClientRect(),
-        x = Math.floor((clientPos.left + clientPos.right) / 2),
-        y = Math.floor((clientPos.top + clientPos.bottom) / 2);
-    return [x, y];
-}
 
 
 describe('pie hovering', function() {

--- a/test/jasmine/tests/ternary_test.js
+++ b/test/jasmine/tests/ternary_test.js
@@ -12,6 +12,16 @@ var doubleClick = require('../assets/double_click');
 var customMatchers = require('../assets/custom_matchers');
 
 
+function getClientPosition(selector, index) {
+    index = index || 0;
+    var selection = document.querySelectorAll(selector),
+        clientPos = selection[index].getBoundingClientRect(),
+        x = Math.floor((clientPos.left + clientPos.right) / 2),
+        y = Math.floor((clientPos.top + clientPos.bottom) / 2);
+    return [x, y];
+}
+
+
 describe('ternary plots', function() {
     'use strict';
 
@@ -332,5 +342,209 @@ describe('ternary defaults', function() {
         expect(layoutOut.ternary.aaxis.gridcolor).toEqual('rgb(102, 0, 153)');
         expect(layoutOut.ternary.baxis.gridcolor).toEqual('rgb(27, 27, 180)');
         expect(layoutOut.ternary.caxis.gridcolor).toEqual('black');
+    });
+});
+
+
+describe('Test event property of interactions on a ternary plot:', function() {
+    var mock = require('@mocks/ternary_simple.json');
+
+    var mockCopy, gd;
+
+    var blankPos = [10, 10],
+        pointPos;
+
+    beforeAll(function(done) {
+        jasmine.addMatchers(customMatchers);
+
+        gd = createGraphDiv();
+        mockCopy = Lib.extendDeep({}, mock);
+        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            pointPos = getClientPosition('path.point');
+            destroyGraphDiv();
+            done();
+        });
+    });
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+        mockCopy = Lib.extendDeep({}, mock);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    describe('click events', function() {
+        var futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_click', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should not be trigged when not on data points', function() {
+            click(blankPos[0], blankPos[1]);
+            expect(futureData).toBe(undefined);
+        });
+
+        it('should contain the correct fields', function() {
+            click(pointPos[0], pointPos[1]);
+
+            var pt = futureData.points[0],
+                evt = futureData.event;
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'x', 'y',
+                'xaxis', 'yaxis'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+            expect(pt.x).toEqual(undefined, 'points[0].x');
+            expect(pt.y).toEqual(undefined, 'points[0].y');
+            expect(typeof pt.xaxis).toEqual(typeof {}, 'points[0].xaxis');
+            expect(typeof pt.yaxis).toEqual(typeof {}, 'points[0].yaxis');
+
+            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
+            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
+        });
+    });
+
+    describe('modified click events', function() {
+        var clickOpts = {
+                altKey: true,
+                ctrlKey: true,
+                metaKey: true,
+                shiftKey: true
+            },
+            futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_click', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should not be trigged when not on data points', function() {
+            click(blankPos[0], blankPos[1], clickOpts);
+            expect(futureData).toBe(undefined);
+        });
+
+        it('should contain the correct fields', function() {
+            click(pointPos[0], pointPos[1], clickOpts);
+
+            var pt = futureData.points[0],
+                evt = futureData.event;
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'x', 'y',
+                'xaxis', 'yaxis'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+            expect(pt.x).toEqual(undefined, 'points[0].x');
+            expect(pt.y).toEqual(undefined, 'points[0].y');
+            expect(typeof pt.xaxis).toEqual(typeof {}, 'points[0].xaxis');
+            expect(typeof pt.yaxis).toEqual(typeof {}, 'points[0].yaxis');
+
+            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
+            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
+            Object.getOwnPropertyNames(clickOpts).forEach(function(opt) {
+                expect(evt[opt]).toEqual(clickOpts[opt], 'event.' + opt);
+            });
+        });
+    });
+
+    describe('hover events', function() {
+        var futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_hover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should contain the correct fields', function() {
+            mouseEvent('mousemove', blankPos[0], blankPos[1]);
+            mouseEvent('mousemove', pointPos[0], pointPos[1]);
+
+            var pt = futureData.points[0],
+                evt = futureData.event,
+                xaxes0 = futureData.xaxes[0],
+                xvals0 = futureData.xvals[0],
+                yaxes0 = futureData.yaxes[0],
+                yvals0 = futureData.yvals[0];
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'x', 'y',
+                'xaxis', 'yaxis'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+            expect(pt.x).toEqual(undefined, 'points[0].x');
+            expect(pt.y).toEqual(undefined, 'points[0].y');
+            expect(typeof pt.xaxis).toEqual(typeof {}, 'points[0].xaxis');
+            expect(typeof pt.yaxis).toEqual(typeof {}, 'points[0].yaxis');
+
+            expect(xaxes0).toEqual(pt.xaxis, 'xaxes[0]');
+            expect(xvals0).toEqual(-0.0016654247744483342, 'xaxes[0]');
+            expect(yaxes0).toEqual(pt.yaxis, 'yaxes[0]');
+            expect(yvals0).toEqual(0.5013, 'xaxes[0]');
+
+            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
+            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
+        });
+    });
+
+    describe('unhover events', function() {
+        var futureData;
+
+        beforeEach(function(done) {
+            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+
+            gd.on('plotly_unhover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('should contain the correct fields', function() {
+            mouseEvent('mousemove', blankPos[0], blankPos[1]);
+            mouseEvent('mousemove', pointPos[0], pointPos[1]);
+            mouseEvent('mouseout', pointPos[0], pointPos[1]);
+
+            var pt = futureData.points[0],
+                evt = futureData.event;
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'x', 'y',
+                'xaxis', 'yaxis'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+            expect(pt.x).toEqual(undefined, 'points[0].x');
+            expect(pt.y).toEqual(undefined, 'points[0].y');
+            expect(typeof pt.xaxis).toEqual(typeof {}, 'points[0].xaxis');
+            expect(typeof pt.yaxis).toEqual(typeof {}, 'points[0].yaxis');
+
+            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
+            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
+        });
     });
 });

--- a/test/jasmine/tests/ternary_test.js
+++ b/test/jasmine/tests/ternary_test.js
@@ -10,16 +10,7 @@ var mouseEvent = require('../assets/mouse_event');
 var click = require('../assets/click');
 var doubleClick = require('../assets/double_click');
 var customMatchers = require('../assets/custom_matchers');
-
-
-function getClientPosition(selector, index) {
-    index = index || 0;
-    var selection = document.querySelectorAll(selector),
-        clientPos = selection[index].getBoundingClientRect(),
-        x = Math.floor((clientPos.left + clientPos.right) / 2),
-        y = Math.floor((clientPos.top + clientPos.bottom) / 2);
-    return [x, y];
-}
+var getClientPosition = require('../assets/get_client_position');
 
 
 describe('ternary plots', function() {


### PR DESCRIPTION
With this PR, listeners to `plotly_click`, `plotly_hover` and `plotly_unhover` receive the original mouse event (that triggered the event) in `data.event`.

Implements #988 for scatter (@etpinard **edit:** cartesian), pie, ternary, geo and mapbox plots.

Fixes #1456 and #902 