### PR TITLE
add 'noOpacity' flag to parcoords trace module

### DIFF
--- a/src/traces/parcoords/index.js
+++ b/src/traces/parcoords/index.js
@@ -19,7 +19,7 @@ Parcoords.colorbar = require('./colorbar');
 Parcoords.moduleType = 'trace';
 Parcoords.name = 'parcoords';
 Parcoords.basePlotModule = require('./base_plot');
-Parcoords.categories = ['gl'];
+Parcoords.categories = ['gl', 'noOpacity'];
 Parcoords.meta = {
     description: [
         'Parallel coordinates for multidimensional exploratory data analysis.',

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -28,6 +28,18 @@ describe('parcoords initialization tests', function() {
 
     'use strict';
 
+    describe('parcoords global defaults', function() {
+
+        it('should not coerce trace opacity', function() {
+            var gd = Lib.extendDeep({}, mock1);
+
+            Plots.supplyDefaults(gd);
+
+            expect(gd._fullData[0].opacity).toBeUndefined();
+        });
+
+    });
+
     describe('parcoords defaults', function() {
 
         function _supply(traceIn) {


### PR DESCRIPTION
- so that trace opacity isn't coerced.

cc @bpostlethwaite @monfera 