### PR TITLE
Update gl3d camera

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "gl-surface3d": "^1.3.0",
     "mapbox-gl": "^0.22.0",
     "mouse-change": "^1.4.0",
+    "mouse-event-offset": "^3.0.2",
     "mouse-wheel": "^1.0.2",
     "ndarray": "^1.0.18",
     "ndarray-fill": "^1.0.2",

--- a/src/plots/gl3d/camera.js
+++ b/src/plots/gl3d/camera.js
@@ -14,6 +14,7 @@ var now = require('right-now');
 var createView = require('3d-view');
 var mouseChange = require('mouse-change');
 var mouseWheel = require('mouse-wheel');
+var mouseOffset = require('mouse-event-offset');
 
 function createCamera(element, options) {
     element = element || document.body;
@@ -179,8 +180,24 @@ function createCamera(element, options) {
         return false;
     });
 
-    var lastX = 0, lastY = 0;
-    mouseChange(element, function(buttons, x, y, mods) {
+    var lastX = 0, lastY = 0, lastMods = {shift: false, control: false, alt: false, meta: false};
+    mouseChange(element, handleInteraction);
+
+    // enable simple touch interactions
+    element.addEventListener('touchstart', function(ev) {
+        var xy = mouseOffset(ev.changedTouches[0], element);
+        handleInteraction(0, xy[0], xy[1], lastMods);
+        handleInteraction(1, xy[0], xy[1], lastMods);
+    });
+    element.addEventListener('touchmove', function(ev) {
+        var xy = mouseOffset(ev.changedTouches[0], element);
+        handleInteraction(1, xy[0], xy[1], lastMods);
+    });
+    element.addEventListener('touchend', function() {
+        handleInteraction(0, lastX, lastY, lastMods);
+    });
+
+    function handleInteraction(buttons, x, y, mods) {
         var keyBindingMode = camera.keyBindingMode;
 
         if(keyBindingMode === false) return;
@@ -225,9 +242,10 @@ function createCamera(element, options) {
 
         lastX = x;
         lastY = y;
+        lastMods = mods;
 
         return true;
-    });
+    }
 
     mouseWheel(element, function(dx, dy) {
         if(camera.keyBindingMode === false) return;


### PR DESCRIPTION
Ok, so here is updated `gl3d/camera`, related to https://github.com/plotly/plotly.js/pull/1424.
Turns out [gl3d/camera](https://github.com/plotly/plotly.js/blob/master/src/plots/gl3d/camera.js) code is 98% the same as [3d-view-controls](https://npmjs.org/package/3d-view-controls), and in some way there is monkey-patching happening rewriting the original 3d-view-controls with the plotly one.
I guess there is optimization possible, but so far that is workable solution.
@etpinard please look at it