### PR TITLE
No unwarranted colorscale or related data on parcoords trace/fullTrace

### DIFF
--- a/src/traces/parcoords/calc.js
+++ b/src/traces/parcoords/calc.js
@@ -10,16 +10,9 @@
 
 var hasColorscale = require('../../components/colorscale/has_colorscale');
 var calcColorscale = require('../../components/colorscale/calc');
-var Lib = require('../../lib');
 
 
 module.exports = function calc(gd, trace) {
-    var cs = !!trace.line.colorscale && Lib.isArray(trace.line.color);
-    var color = cs ? trace.line.color : Array.apply(0, Array(trace.dimensions.reduce(function(p, n) {return Math.max(p, n.values.length);}, 0))).map(function() {return 0.5;});
-    var cscale = cs ? trace.line.colorscale : [[0, trace.line.color], [1, trace.line.color]];
-
-    trace.line.color = color;
-    trace.line.colorscale = cscale;
 
     if(hasColorscale(trace, 'line')) {
         calcColorscale(trace, trace.line.color, 'line', 'c');

--- a/src/traces/parcoords/defaults.js
+++ b/src/traces/parcoords/defaults.js
@@ -17,9 +17,9 @@ var maxDimensionCount = require('./constants').maxDimensionCount;
 function handleLineDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
 
     coerce('line.color', defaultColor);
-    coerce('line.colorscale');
 
-    if(hasColorscale(traceIn, 'line')) {
+    if(hasColorscale(traceIn, 'line') && Lib.isArray(traceIn.line.color)) {
+        coerce('line.colorscale');
         colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: 'line.', cLetter: 'c'});
     }
     else {

--- a/src/traces/parcoords/parcoords.js
+++ b/src/traces/parcoords/parcoords.js
@@ -121,8 +121,14 @@ function model(layout, d, i) {
         dimensions = trace.dimensions,
         width = layout.width;
 
+    var cs = !!trace.line.colorscale && Lib.isArray(trace.line.color);
+    var lineColor = cs ?
+        trace.line.color :
+        Array.apply(0, Array(trace.dimensions.reduce(function(p, n) {return Math.max(p, n.values.length);}, 0))).map(function() {return 0.5;});
+    var lineColorScale = cs ? trace.line.colorscale : [[0, trace.line.color], [1, trace.line.color]];
+
     var lines = Lib.extendDeep({}, line, {
-        color: line.color.map(domainToUnitScale({values: line.color, range: [line.cmin, line.cmax]})),
+        color: lineColor.map(domainToUnitScale({values: lineColor, range: [line.cmin, line.cmax]})),
         blockLineCount: c.blockLineCount,
         canvasOverdrag: c.overdrag * c.canvasPixelRatio
     });
@@ -139,7 +145,7 @@ function model(layout, d, i) {
         colCount: dimensions.filter(visible).length,
         dimensions: dimensions,
         tickDistance: c.tickDistance,
-        unitToColor: unitToColorScale(line.colorscale),
+        unitToColor: unitToColorScale(lineColorScale),
         lines: lines,
         translateX: domain.x[0] * width,
         translateY: layout.height - domain.y[1] * layout.height,

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -197,14 +197,11 @@ describe('parcoords initialization tests', function() {
             }));
 
             expect(fullTrace.line).toEqual({
-                color: [0.5, 0.5, 0.5, 0.5],
-                colorscale: [[0, '#444'], [1, '#444']],
-                cmin: 0,
-                cmax: 1
+                color: '#444'
             });
         });
 
-        it('use a singular \'color\' even if a \'colorscale\' is supplied', function() {
+        it('use a singular \'color\' even if a \'colorscale\' is supplied as \'color\' is not an array', function() {
 
             var fullTrace = _calc(Lib.extendDeep({}, base, {
                 line: {
@@ -218,14 +215,7 @@ describe('parcoords initialization tests', function() {
             }));
 
             expect(fullTrace.line).toEqual({
-                color: [0.5, 0.5, 0.5, 0.5],
-                colorscale: [[0, '#444'], [1, '#444']],
-                autocolorscale: false,
-                showscale: false,
-                reversescale: false,
-                cauto: true,
-                cmin: 0,
-                cmax: 1
+                color: '#444'
             });
         });
     });


### PR DESCRIPTION
Avoid color scale persistence on trace / fullTrace if the user hasn't specified one (as interpreted by [has_colorscale.js](https://github.com/plotly/plotly.js/blob/master/src/components/colorscale/has_colorscale.js#L36-L42))

Before this PR, `colorscale` related details populated `data` and `fullData`, as seen by these test case changes.