### PR TITLE
make deleteFrames(gd) delete all frames

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2764,6 +2764,13 @@ Plotly.deleteFrames = function(gd, frameList) {
     var ops = [];
     var revops = [];
 
+    if(!frameList) {
+        frameList = [];
+        for(i = 0; i < _frames.length; i++) {
+            frameList.push(i);
+        }
+    }
+
     frameList = frameList.slice(0);
     frameList.sort();
 

--- a/test/jasmine/tests/frame_api_test.js
+++ b/test/jasmine/tests/frame_api_test.js
@@ -263,5 +263,57 @@ describe('Test frame api', function() {
                 return Plotly.Queue.redo(gd);
             }).then(validate).catch(fail).then(done);
         });
+
+        it('deletes all frames if frameList is falsey', function(done) {
+            var i;
+            var n = 10;
+            var frames = [];
+            for(i = 0; i < n; i++) {
+                frames.push({name: 'frame' + i});
+            }
+
+            function validateCount(n) {
+                return function() {
+                    expect(f.length).toEqual(n);
+                };
+            }
+
+            Plotly.addFrames(gd, frames).then(function() {
+                // Delete with no args:
+                return Plotly.deleteFrames(gd);
+            }).then(validateCount(0)).then(function() {
+                // Restore:
+                return Plotly.Queue.undo(gd);
+            }).then(validateCount(n)).then(function() {
+                // Delete with null arg:
+                return Plotly.deleteFrames(gd, null);
+            }).then(validateCount(0)).then(function() {
+                // Restore:
+                return Plotly.Queue.undo(gd);
+            }).then(validateCount(n)).then(function() {
+                // Delete with undefined:
+                return Plotly.deleteFrames(gd, undefined);
+            }).then(validateCount(0)).catch(fail).then(done);
+        });
+
+        it('deleteFrames is a no-op with empty array', function(done) {
+            var i;
+            var n = 10;
+            var frames = [];
+            for(i = 0; i < n; i++) {
+                frames.push({name: 'frame' + i});
+            }
+
+            function validateCount(n) {
+                return function() {
+                    expect(f.length).toEqual(n);
+                };
+            }
+
+            Plotly.addFrames(gd, frames).then(function() {
+                // Delete with no args:
+                return Plotly.deleteFrames(gd, []);
+            }).then(validateCount(n)).catch(fail).then(done);
+        });
     });
 });


### PR DESCRIPTION
This PR changes the behavior of `deleteFrames(gd)` to delete *all* frames. Previously it threw a slice-null error. Contrast with `deleteTraces(gd)` which throws an error with a meaningful message or `animate(gd)` which animates all frames. In this case I chose to match the behavior of animate.