### PR TITLE
Remove the performance overhead of showLink property

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -257,7 +257,7 @@ plots.previousPromises = function(gd) {
  * Add source links to your graph inside the 'showSources' config argument.
  */
 plots.addLinks = function(gd) {
-    if(gd._context.showLink === false) return;
+    if(!gd._context.showLink || !gd._context.showSources) return;
 
     var fullLayout = gd._fullLayout;
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -257,6 +257,7 @@ plots.previousPromises = function(gd) {
  * Add source links to your graph inside the 'showSources' config argument.
  */
 plots.addLinks = function(gd) {
+    // Do not do anything if showLink and showSources are not set to true in config
     if(!gd._context.showLink && !gd._context.showSources) return;
 
     var fullLayout = gd._fullLayout;

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -257,6 +257,8 @@ plots.previousPromises = function(gd) {
  * Add source links to your graph inside the 'showSources' config argument.
  */
 plots.addLinks = function(gd) {
+    if(gd._context.showLink === false) return;
+    
     var fullLayout = gd._fullLayout;
 
     var linkContainer = fullLayout._paper

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -258,7 +258,7 @@ plots.previousPromises = function(gd) {
  */
 plots.addLinks = function(gd) {
     if(gd._context.showLink === false) return;
-    
+
     var fullLayout = gd._fullLayout;
 
     var linkContainer = fullLayout._paper

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -257,7 +257,7 @@ plots.previousPromises = function(gd) {
  * Add source links to your graph inside the 'showSources' config argument.
  */
 plots.addLinks = function(gd) {
-    if(!gd._context.showLink || !gd._context.showSources) return;
+    if(!gd._context.showLink && !gd._context.showSources) return;
 
     var fullLayout = gd._fullLayout;
 

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -160,11 +160,7 @@ describe('config argument', function() {
 
             var link = document.getElementsByClassName('js-plot-link-container')[0];
 
-            expect(link.textContent).toBe('');
-
-            var bBox = link.getBoundingClientRect();
-            expect(bBox.width).toBe(0);
-            expect(bBox.height).toBe(0);
+            expect(link).toBeUndefined();
         });
 
         it('should display a link when true', function() {


### PR DESCRIPTION
A fix for: https://github.com/plotly/plotly.js/issues/1554. Do nothing if showLink is set to be false, to avoid performance overhead caused by measuring and reflows.