### PR TITLE
Cast to empty array

### DIFF
--- a/src/components/errorbars/index.js
+++ b/src/components/errorbars/index.js
@@ -19,7 +19,7 @@ errorBars.calc = require('./calc');
 
 errorBars.calcFromTrace = function(trace, layout) {
     var x = trace.x || [],
-        y = trace.y,
+        y = trace.y || [],
         len = x.length || y.length;
 
     var calcdataMock = new Array(len);

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -968,6 +968,20 @@ describe('Test gl2d plots', function() {
         .catch(fail)
         .then(done);
     });
+
+    it('should reversibly change plot type with incomplete data', function(done) {
+        Plotly.plot(gd, [{}]);
+
+        expect(function() {
+            Plotly.restyle(gd, {type: 'scattergl', x: [[1]]}, 0);
+        }).not.toThrow();
+
+        expect(function() {
+            Plotly.restyle(gd, {y: [[1]]}, 0);
+        }).not.toThrow();
+
+        done();
+    });
 });
 
 describe('Test removal of gl contexts', function() {

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -969,7 +969,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should reversibly change plot type with incomplete data', function(done) {
+    it('should change plot type with incomplete data', function(done) {
         Plotly.plot(gd, [{}]);
 
         expect(function() {


### PR DESCRIPTION
Tiny fix for https://github.com/plotly/plotly.js/issues/1139
No idea why it was done for `x` but was not for `y`.