### PR TITLE
supplyTransformDefaults to fill in missing transformModules

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -832,6 +832,7 @@ plots.supplyTraceDefaults = function(traceIn, traceOutIndex, layout, traceInInde
 
 function supplyTransformDefaults(traceIn, traceOut, layout) {
     var globalTransforms = layout._globalTransforms || [];
+    var transformModules = layout._transformModules || [];
 
     if(!Array.isArray(traceIn.transforms) && globalTransforms.length === 0) return;
 
@@ -852,7 +853,7 @@ function supplyTransformDefaults(traceIn, traceOut, layout) {
             transformOut.type = type;
             transformOut._module = _module;
 
-            Lib.pushUnique(layout._transformModules, _module);
+            Lib.pushUnique(transformModules, _module);
         }
         else {
             transformOut = Lib.extendFlat({}, transformIn);

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -824,13 +824,13 @@ plots.supplyTraceDefaults = function(traceIn, traceOutIndex, layout, traceInInde
             coerce('legendgroup');
         }
 
-        supplyTransformDefaults(traceIn, traceOut, layout);
+        plots.supplyTransformDefaults(traceIn, traceOut, layout);
     }
 
     return traceOut;
 };
 
-function supplyTransformDefaults(traceIn, traceOut, layout) {
+plots.supplyTransformDefaults = function(traceIn, traceOut, layout) {
     var globalTransforms = layout._globalTransforms || [];
     var transformModules = layout._transformModules || [];
 
@@ -861,7 +861,7 @@ function supplyTransformDefaults(traceIn, traceOut, layout) {
 
         containerOut.push(transformOut);
     }
-}
+};
 
 function applyTransforms(fullTrace, fullData, layout, fullLayout) {
     var container = fullTrace.transforms,

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -240,6 +240,20 @@ describe('Test Plots', function() {
         });
     });
 
+    describe('Plots.supplyTransformDefaults', function() {
+        it('should accept an empty layout when transforms present', function() {
+            var traceOut = {};
+            Plots.supplyTransformDefaults({}, traceOut, {
+                _globalTransforms: [{ type: 'filter'}]
+            });
+
+            // This isn't particularly interseting. More relevant is that
+            // the above supplyTransformDefaults call didn't fail due to
+            // missing transformModules data.
+            expect(traceOut.transforms.length).toEqual(1);
+        });
+    });
+
     describe('Plots.getSubplotIds', function() {
         var getSubplotIds = Plots.getSubplotIds;
 


### PR DESCRIPTION
fullLayout is sometimes an empty object. This fixes an assumption that layout._transformModules is definitely defined.