### PR TITLE
lock gl-scatter2d-sdf to 1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "gl-plot3d": "^1.5.4",
     "gl-pointcloud2d": "^1.0.0",
     "gl-scatter2d": "^1.2.2",
-    "gl-scatter2d-sdf": "^1.3.4",
+    "gl-scatter2d-sdf": "1.3.4",
     "gl-scatter3d": "^1.0.4",
     "gl-select-box": "^1.0.1",
     "gl-shader": "4.2.0",


### PR DESCRIPTION
Temporary fix for https://github.com/gl-vis/gl-scatter2d-sdf/commit/263078a7206d40dbadfb350613bb4701171fbb23#commitcomment-21683726

cc @dfcreative 