### PR TITLE
annotation hover text

### DIFF
--- a/build/plotcss.js
+++ b/build/plotcss.js
@@ -14,6 +14,7 @@ var rules = {
     "X svg a:hover": "fill:#3c6dc5;",
     "X .main-svg": "position:absolute;top:0;left:0;pointer-events:none;",
     "X .main-svg .draglayer": "pointer-events:all;",
+    "X .cursor-default": "cursor:default;",
     "X .cursor-pointer": "cursor:pointer;",
     "X .cursor-crosshair": "cursor:crosshair;",
     "X .cursor-move": "cursor:move;",

--- a/src/components/annotations/annotation_defaults.js
+++ b/src/components/annotations/annotation_defaults.js
@@ -120,6 +120,7 @@ module.exports = function handleAnnotationDefaults(annIn, annOut, fullLayout, op
             color: hoverBorder
         });
     }
+    coerce('captureevents', !!hoverText);
 
     return annOut;
 };

--- a/src/components/annotations/annotation_defaults.js
+++ b/src/components/annotations/annotation_defaults.js
@@ -12,6 +12,7 @@
 var Lib = require('../../lib');
 var Color = require('../color');
 var Axes = require('../../plots/cartesian/axes');
+var constants = require('../../plots/cartesian/constants');
 
 var attributes = require('./attributes');
 
@@ -30,7 +31,7 @@ module.exports = function handleAnnotationDefaults(annIn, annOut, fullLayout, op
     if(!(visible || clickToShow)) return annOut;
 
     coerce('opacity');
-    coerce('bgcolor');
+    var bgColor = coerce('bgcolor');
 
     var borderColor = coerce('bordercolor'),
         borderOpacity = Color.opacity(borderColor);
@@ -106,6 +107,18 @@ module.exports = function handleAnnotationDefaults(annIn, annOut, fullLayout, op
         // so we don't have to do this little bit of logic on every hover event
         annOut._xclick = (xClick === undefined) ? annOut.x : xClick;
         annOut._yclick = (yClick === undefined) ? annOut.y : yClick;
+    }
+
+    var hoverText = coerce('hovertext');
+    if(hoverText) {
+        var hoverBG = coerce('hoverlabel.bgcolor',
+            Color.opacity(bgColor) ? Color.rgb(bgColor) : Color.defaultLine);
+        var hoverBorder = coerce('hoverlabel.bordercolor', Color.contrast(hoverBG));
+        Lib.coerceFont(coerce, 'hoverlabel.font', {
+            family: constants.HOVERFONT,
+            size: constants.HOVERFONTSIZE,
+            color: hoverBorder
+        });
     }
 
     return annOut;

--- a/src/components/annotations/attributes.js
+++ b/src/components/annotations/attributes.js
@@ -378,6 +378,41 @@ module.exports = {
             'is `yclick` rather than the annotation\'s `y` value.'
         ].join(' ')
     },
+    hovertext: {
+        valType: 'string',
+        role: 'info',
+        description: [
+            'Sets text to appear when hovering over this annotation.',
+            'If omitted or blank, no hover label will appear.'
+        ].join(' ')
+    },
+    hoverlabel: {
+        bgcolor: {
+            valType: 'color',
+            role: 'style',
+            description: [
+                'Sets the background color of the hover label.',
+                'By default uses the annotation\'s `bgcolor` made opaque,',
+                'or white if it was transparent.'
+            ].join(' ')
+        },
+        bordercolor: {
+            valType: 'color',
+            role: 'style',
+            description: [
+                'Sets the border color of the hover label.',
+                'By default uses either dark grey or white, for maximum',
+                'contrast with `hoverlabel.bgcolor`.'
+            ].join(' ')
+        },
+        font: extendFlat({}, fontAttrs, {
+            description: [
+                'Sets the hover label text font.',
+                'By default uses the global hover font and size,',
+                'with color from `hoverlabel.bordercolor`.'
+            ].join(' ')
+        })
+    },
 
     _deprecated: {
         ref: {

--- a/src/components/annotations/attributes.js
+++ b/src/components/annotations/attributes.js
@@ -413,6 +413,18 @@ module.exports = {
             ].join(' ')
         })
     },
+    captureevents: {
+        valType: 'boolean',
+        role: 'info',
+        description: [
+            'Determines whether the annotation text box captures mouse move',
+            'and click events, or allows those events to pass through to data',
+            'points in the plot that may be behind the annotation. By default',
+            '`captureevents` is *false* unless `hovertext` is provided.',
+            'If you use the event `plotly_clickannotation` without `hovertext`',
+            'you must explicitly enable `captureevents`.'
+        ].join(' ')
+    },
 
     _deprecated: {
         ref: {

--- a/src/components/annotations/draw.js
+++ b/src/components/annotations/draw.js
@@ -105,7 +105,7 @@ function drawOne(gd, index) {
         .attr('data-index', String(index));
 
     var annTextGroupInner = annTextGroup.append('g')
-        .style('pointer-events', 'all')
+        .style('pointer-events', options.captureevents ? 'all' : null)
         .call(setCursor, 'default')
         .on('click', function() {
             gd._dragging = false;

--- a/src/components/color/index.js
+++ b/src/components/color/index.js
@@ -20,6 +20,10 @@ color.defaultLine = colorAttrs.defaultLine;
 color.lightLine = colorAttrs.lightLine;
 color.background = colorAttrs.background;
 
+/*
+ * tinyRGB: turn a tinycolor into an rgb string, but
+ * unlike the built-in tinycolor.toRgbString this never includes alpha
+ */
 color.tinyRGB = function(tc) {
     var c = tc.toRgb();
     return 'rgb(' + Math.round(c.r) + ', ' +
@@ -57,12 +61,23 @@ color.combine = function(front, back) {
     return tinycolor(fcflat).toRgbString();
 };
 
+/*
+ * Create a color that contrasts with cstr.
+ *
+ * If cstr is a dark color, we lighten it; if it's light, we darken.
+ *
+ * If lightAmount / darkAmount are used, we adjust by these percentages,
+ * otherwise we go all the way to white or black.
+ * TODO: black is what we've always done for hover, but should it be #444 instead?
+ */
 color.contrast = function(cstr, lightAmount, darkAmount) {
     var tc = tinycolor(cstr);
 
-    var newColor = tc.isLight() ?
-        tc.darken(darkAmount) :
-        tc.lighten(lightAmount);
+    if(tc.getAlpha() !== 1) tc = tinycolor(color.combine(cstr, '#fff'));
+
+    var newColor = tc.isDark() ?
+        (lightAmount ? tc.lighten(lightAmount) : '#fff') :
+        (darkAmount ? tc.darken(darkAmount) : '#000');
 
     return newColor.toString();
 };

--- a/src/components/color/index.js
+++ b/src/components/color/index.js
@@ -16,9 +16,9 @@ var color = module.exports = {};
 
 var colorAttrs = require('./attributes');
 color.defaults = colorAttrs.defaults;
-color.defaultLine = colorAttrs.defaultLine;
+var defaultLine = color.defaultLine = colorAttrs.defaultLine;
 color.lightLine = colorAttrs.lightLine;
-color.background = colorAttrs.background;
+var background = color.background = colorAttrs.background;
 
 /*
  * tinyRGB: turn a tinycolor into an rgb string, but
@@ -47,7 +47,7 @@ color.combine = function(front, back) {
     var fc = tinycolor(front).toRgb();
     if(fc.a === 1) return tinycolor(front).toRgbString();
 
-    var bc = tinycolor(back || color.background).toRgb(),
+    var bc = tinycolor(back || background).toRgb(),
         bcflat = bc.a === 1 ? bc : {
             r: 255 * (1 - bc.a) + bc.r * bc.a,
             g: 255 * (1 - bc.a) + bc.g * bc.a,
@@ -68,16 +68,15 @@ color.combine = function(front, back) {
  *
  * If lightAmount / darkAmount are used, we adjust by these percentages,
  * otherwise we go all the way to white or black.
- * TODO: black is what we've always done for hover, but should it be #444 instead?
  */
 color.contrast = function(cstr, lightAmount, darkAmount) {
     var tc = tinycolor(cstr);
 
-    if(tc.getAlpha() !== 1) tc = tinycolor(color.combine(cstr, '#fff'));
+    if(tc.getAlpha() !== 1) tc = tinycolor(color.combine(cstr, background));
 
     var newColor = tc.isDark() ?
-        (lightAmount ? tc.lighten(lightAmount) : '#fff') :
-        (darkAmount ? tc.darken(darkAmount) : '#000');
+        (lightAmount ? tc.lighten(lightAmount) : background) :
+        (darkAmount ? tc.darken(darkAmount) : defaultLine);
 
     return newColor.toString();
 };

--- a/src/css/_cursor.scss
+++ b/src/css/_cursor.scss
@@ -1,3 +1,4 @@
+.cursor-default { cursor: default; }
 .cursor-pointer { cursor: pointer; }
 .cursor-crosshair { cursor: crosshair; }
 .cursor-move { cursor: move; }

--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -776,10 +776,10 @@ function cleanPoint(d, hovermode) {
  *      the background color this is against, used if the trace is
  *      non-opaque, and for the name, which goes outside the box
  *    - container:
- *      a dom <svg> element - must be big enough to contain the whole
- *      hover label
+ *      a <svg> or <g> element to add the hover label to
  *    - outerContainer:
- *      TODO: what exactly is container vs outerContainer?
+ *      normally a parent of `container`, sets the bounding box to use to
+ *      constrain the hover label and determine whether to show it on the left or right
  */
 fx.loneHover = function(hoverItem, opts) {
     var pointData = {

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -826,26 +826,6 @@ describe('annotation effects', function() {
         jasmine.addMatchers(customMatchers);
     });
 
-    // beforeEach(function(done) {
-    //     gd = createGraphDiv();
-
-    //     // we've already tested autorange with relayout, so fix the geometry
-    //     // completely so we know exactly what we're dealing with
-    //     // plot area is 300x300, and covers data range 100x100
-    //     Plotly.plot(gd,
-    //         [{x: [0, 100], y: [0, 100], mode: 'markers'}],
-    //         {
-    //             xaxis: {range: [0, 100]},
-    //             yaxis: {range: [0, 100]},
-    //             width: 500,
-    //             height: 500,
-    //             margin: {l: 100, r: 100, t: 100, b: 100, pad: 0}
-    //         },
-    //         {editable: true}
-    //     )
-    //     .then(done);
-    // });
-
     function makePlot(annotations, config) {
         gd = createGraphDiv();
 
@@ -869,13 +849,6 @@ describe('annotation effects', function() {
     }
 
     afterEach(destroyGraphDiv);
-
-    function initAnnotation(annotation) {
-        return Plotly.relayout(gd, {annotations: [annotation]})
-        .then(function() {
-            return Plots.previousPromises(gd);
-        });
-    }
 
     function dragAndReplot(node, dx, dy, edge) {
         return drag(node, dx, dy, edge).then(function() {

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -1127,9 +1127,9 @@ describe('annotation effects', function() {
         }
 
         makePlot([
-            {x: 50, y: 50, text: 'hi', width: 50, ax: 0, ay: -20},
+            {x: 50, y: 50, text: 'hi', width: 50, ax: 0, ay: -40},
             {x: 20, y: 20, text: 'bye', height: 40, showarrow: false},
-            {x: 80, y: 80, text: 'why?', ax: 0, ay: -20}
+            {x: 80, y: 80, text: 'why?', ax: 0, ay: -40}
         ], {}) // turn off the default editable: true
         .then(function() {
             clickData = [];
@@ -1137,13 +1137,26 @@ describe('annotation effects', function() {
 
             gdBB = gd.getBoundingClientRect();
             pos0Head = [gdBB.left + 250, gdBB.top + 250];
-            pos0 = [pos0Head[0], pos0Head[1] - 20];
+            pos0 = [pos0Head[0], pos0Head[1] - 40];
             pos1 = [gdBB.left + 160, gdBB.top + 340];
             pos2Head = [gdBB.left + 340, gdBB.top + 160];
-            pos2 = [pos2Head[0], pos2Head[1] - 20];
+            pos2 = [pos2Head[0], pos2Head[1] - 40];
 
             return assertHoverLabels([[pos0, ''], [pos1, ''], [pos2, '']]);
         })
+        // not going to register either of these because captureevents is off
+        .then(function() { return _click(pos1); })
+        .then(function() { return _click(pos2Head); })
+        .then(function() {
+            assertClickData([]);
+
+            return Plotly.relayout(gd, {
+                'annotations[1].captureevents': true,
+                'annotations[2].captureevents': true
+            });
+        })
+        // now we'll register the click on #1, but still not on #2
+        // because we're clicking the head, not the text box
         .then(function() { return _click(pos1); })
         .then(function() { return _click(pos2Head); })
         .then(function() {
@@ -1168,6 +1181,7 @@ describe('annotation effects', function() {
                 '0 only');
         })
         // click and hover work together?
+        // this also tests that hover turns on annotation.captureevents
         .then(function() { return _click(pos0); })
         .then(function() {
             assertClickData([{

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -5,6 +5,7 @@ var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
 var Loggers = require('@src/lib/loggers');
 var Axes = require('@src/plots/cartesian/axes');
+var constants = require('@src/plots/cartesian/constants');
 
 var d3 = require('d3');
 var customMatchers = require('../assets/custom_matchers');
@@ -12,6 +13,8 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var failTest = require('../assets/fail_test');
 var drag = require('../assets/drag');
+var mouseEvent = require('../assets/mouse_event');
+var click = require('../assets/click');
 
 
 describe('Test annotations', function() {
@@ -812,7 +815,7 @@ describe('annotation clicktoshow', function() {
     });
 });
 
-describe('annotation dragging', function() {
+describe('annotation effects', function() {
     var gd;
 
     function textDrag() { return gd.querySelector('.annotation-text-g>g'); }
@@ -823,25 +826,47 @@ describe('annotation dragging', function() {
         jasmine.addMatchers(customMatchers);
     });
 
-    beforeEach(function(done) {
+    // beforeEach(function(done) {
+    //     gd = createGraphDiv();
+
+    //     // we've already tested autorange with relayout, so fix the geometry
+    //     // completely so we know exactly what we're dealing with
+    //     // plot area is 300x300, and covers data range 100x100
+    //     Plotly.plot(gd,
+    //         [{x: [0, 100], y: [0, 100], mode: 'markers'}],
+    //         {
+    //             xaxis: {range: [0, 100]},
+    //             yaxis: {range: [0, 100]},
+    //             width: 500,
+    //             height: 500,
+    //             margin: {l: 100, r: 100, t: 100, b: 100, pad: 0}
+    //         },
+    //         {editable: true}
+    //     )
+    //     .then(done);
+    // });
+
+    function makePlot(annotations, config) {
         gd = createGraphDiv();
+
+        if(!config) config = {editable: true};
 
         // we've already tested autorange with relayout, so fix the geometry
         // completely so we know exactly what we're dealing with
         // plot area is 300x300, and covers data range 100x100
-        Plotly.plot(gd,
+        return Plotly.plot(gd,
             [{x: [0, 100], y: [0, 100], mode: 'markers'}],
             {
                 xaxis: {range: [0, 100]},
                 yaxis: {range: [0, 100]},
                 width: 500,
                 height: 500,
-                margin: {l: 100, r: 100, t: 100, b: 100, pad: 0}
+                margin: {l: 100, r: 100, t: 100, b: 100, pad: 0},
+                annotations: annotations
             },
-            {editable: true}
-        )
-        .then(done);
-    });
+            config
+        );
+    }
 
     afterEach(destroyGraphDiv);
 
@@ -957,14 +982,14 @@ describe('annotation dragging', function() {
     }
 
     it('respects anchor: auto when paper-referenced without arrow', function(done) {
-        initAnnotation({
+        makePlot([{
             x: 0,
             y: 0,
             showarrow: false,
             text: 'blah<br>blah blah',
             xref: 'paper',
             yref: 'paper'
-        })
+        }])
         .then(function() {
             var bbox = textBox().getBoundingClientRect();
 
@@ -975,7 +1000,7 @@ describe('annotation dragging', function() {
     });
 
     it('also works paper-referenced with explicit anchors and no arrow', function(done) {
-        initAnnotation({
+        makePlot([{
             x: 0,
             y: 0,
             showarrow: false,
@@ -984,7 +1009,7 @@ describe('annotation dragging', function() {
             yref: 'paper',
             xanchor: 'left',
             yanchor: 'top'
-        })
+        }])
         .then(function() {
             // with offsets 0, 0 because the anchor doesn't change now
             return checkDragging(textDrag, 0, 0, 1);
@@ -994,7 +1019,7 @@ describe('annotation dragging', function() {
     });
 
     it('works paper-referenced with arrows', function(done) {
-        initAnnotation({
+        makePlot([{
             x: 0,
             y: 0,
             text: 'blah<br>blah blah',
@@ -1002,7 +1027,7 @@ describe('annotation dragging', function() {
             yref: 'paper',
             ax: 30,
             ay: 30
-        })
+        }])
         .then(function() {
             return checkDragging(arrowDrag, 0, 0, 1);
         })
@@ -1012,12 +1037,12 @@ describe('annotation dragging', function() {
     });
 
     it('works data-referenced with no arrow', function(done) {
-        initAnnotation({
+        makePlot([{
             x: 0,
             y: 0,
             showarrow: false,
             text: 'blah<br>blah blah'
-        })
+        }])
         .then(function() {
             return checkDragging(textDrag, 0, 0, 100);
         })
@@ -1026,13 +1051,13 @@ describe('annotation dragging', function() {
     });
 
     it('works data-referenced with arrow', function(done) {
-        initAnnotation({
+        makePlot([{
             x: 0,
             y: 0,
             text: 'blah<br>blah blah',
             ax: 30,
             ay: -30
-        })
+        }])
         .then(function() {
             return checkDragging(arrowDrag, 0, 0, 100);
         })
@@ -1040,33 +1065,17 @@ describe('annotation dragging', function() {
         .catch(failTest)
         .then(done);
     });
-});
-
-describe('annotation clip paths', function() {
-    var gd;
-
-    beforeEach(function(done) {
-        gd = createGraphDiv();
-
-        // we've already tested autorange with relayout, so fix the geometry
-        // completely so we know exactly what we're dealing with
-        // plot area is 300x300, and covers data range 100x100
-        Plotly.plot(gd, [{x: [0, 100], y: [0, 100]}], {
-            annotations: [
-                {x: 50, y: 50, text: 'hi', width: 50},
-                {x: 20, y: 20, text: 'bye', height: 40},
-                {x: 80, y: 80, text: 'why?'}
-            ]
-        })
-        .then(done);
-    });
-
-    afterEach(destroyGraphDiv);
 
     it('should only make the clippaths it needs and delete others', function(done) {
-        expect(d3.select(gd).selectAll('.annclip').size()).toBe(2);
+        makePlot([
+            {x: 50, y: 50, text: 'hi', width: 50, ax: 0, ay: -20},
+            {x: 20, y: 20, text: 'bye', height: 40, showarrow: false},
+            {x: 80, y: 80, text: 'why?', ax: 0, ay: -20}
+        ]).then(function() {
+            expect(d3.select(gd).selectAll('.annclip').size()).toBe(2);
 
-        Plotly.relayout(gd, {'annotations[0].visible': false})
+            return Plotly.relayout(gd, {'annotations[0].visible': false});
+        })
         .then(function() {
             expect(d3.select(gd).selectAll('.annclip').size()).toBe(1);
 
@@ -1084,6 +1093,134 @@ describe('annotation clip paths', function() {
         })
         .then(function() {
             expect(d3.select(gd).selectAll('.annclip').size()).toBe(0);
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('should register clicks and show hover effects on the text box only', function(done) {
+        var gdBB, pos0Head, pos0, pos1, pos2Head, pos2, clickData;
+
+        function assertHoverLabel(pos, text, msg) {
+            return new Promise(function(resolve) {
+                mouseEvent('mousemove', pos[0], pos[1]);
+                mouseEvent('mouseover', pos[0], pos[1]);
+
+                setTimeout(function() {
+                    var hoverText = d3.selectAll('g.hovertext');
+                    expect(hoverText.size()).toEqual(text ? 1 : 0, msg);
+
+                    if(text && hoverText.size()) {
+                        expect(hoverText.text()).toEqual(text, msg);
+                    }
+
+                    mouseEvent('mouseout', pos[0], pos[1]);
+                    mouseEvent('mousemove', 0, 0);
+
+                    setTimeout(resolve, constants.HOVERMINTIME);
+                }, constants.HOVERMINTIME);
+            });
+        }
+
+        function assertHoverLabels(spec, msg) {
+            // spec is an array of [pos, text]
+            // always check that the heads don't have hover effects
+            // so we only have to explicitly include pos0-2
+            spec.push([pos0Head, '']);
+            spec.push([pos2Head, '']);
+            var p = Promise.resolve();
+            spec.forEach(function(speci, i) {
+                p = p.then(function() {
+                    return assertHoverLabel(speci[0], speci[1],
+                        msg ? msg + ' (' + i + ')' : i);
+                });
+            });
+            return p;
+        }
+
+        function _click(pos) {
+            return new Promise(function(resolve) {
+                click(pos[0], pos[1]);
+
+                setTimeout(function() {
+                    resolve();
+                }, constants.HOVERMINTIME);
+            });
+        }
+
+        function assertClickData(data) {
+            expect(clickData).toEqual(data);
+            clickData.splice(0, clickData.length);
+        }
+
+        makePlot([
+            {x: 50, y: 50, text: 'hi', width: 50, ax: 0, ay: -20},
+            {x: 20, y: 20, text: 'bye', height: 40, showarrow: false},
+            {x: 80, y: 80, text: 'why?', ax: 0, ay: -20}
+        ], {}) // turn off the default editable: true
+        .then(function() {
+            clickData = [];
+            gd.on('plotly_clickannotation', function(evt) { clickData.push(evt); });
+
+            gdBB = gd.getBoundingClientRect();
+            pos0Head = [gdBB.left + 250, gdBB.top + 250];
+            pos0 = [pos0Head[0], pos0Head[1] - 20];
+            pos1 = [gdBB.left + 160, gdBB.top + 340];
+            pos2Head = [gdBB.left + 340, gdBB.top + 160];
+            pos2 = [pos2Head[0], pos2Head[1] - 20];
+
+            return assertHoverLabels([[pos0, ''], [pos1, ''], [pos2, '']]);
+        })
+        .then(function() { return _click(pos1); })
+        .then(function() { return _click(pos2Head); })
+        .then(function() {
+            assertClickData([{
+                index: 1,
+                annotation: gd.layout.annotations[1],
+                fullAnnotation: gd._fullLayout.annotations[1]
+            }]);
+
+            expect(gd._fullLayout.annotations[0].hoverlabel).toBeUndefined();
+
+            return Plotly.relayout(gd, {'annotations[0].hovertext': 'bananas'});
+        })
+        .then(function() {
+            expect(gd._fullLayout.annotations[0].hoverlabel).toEqual({
+                bgcolor: '#444',
+                bordercolor: '#fff',
+                font: {family: 'Arial, sans-serif', size: 13, color: '#fff'}
+            });
+
+            return assertHoverLabels([[pos0, 'bananas'], [pos1, ''], [pos2, '']],
+                '0 only');
+        })
+        // click and hover work together?
+        .then(function() { return _click(pos0); })
+        .then(function() {
+            assertClickData([{
+                index: 0,
+                annotation: gd.layout.annotations[0],
+                fullAnnotation: gd._fullLayout.annotations[0]
+            }]);
+
+            return Plotly.relayout(gd, {
+                'annotations[0].hoverlabel': {
+                    bgcolor: '#800',
+                    bordercolor: '#008',
+                    font: {family: 'courier', size: 50, color: '#080'}
+                },
+                'annotations[1].hovertext': 'chicken'
+            });
+        })
+        .then(function() {
+            expect(gd._fullLayout.annotations[0].hoverlabel).toEqual({
+                bgcolor: '#800',
+                bordercolor: '#008',
+                font: {family: 'courier', size: 50, color: '#080'}
+            });
+
+            return assertHoverLabels([[pos0, 'bananas'], [pos1, 'chicken'], [pos2, '']],
+                '0 and 1');
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
Provides hover text for annotations, using the existing hover label framework so you get stuff like automatic left/right flipping built in. Because this is a bit of a custom scenario anyway, and it's not always clear what style these hover labels should get, I included explicit styling. @etpinard and I iterated on this separately to come up with a structure that should work for styling trace hover items as well:

```js
{
  annotations: [
    {
      ...,
      hovertext: "hello!",
      hoverlabel: {
        font: {
          family: "courier",
          size: 20,
          color: "#f00"
        },
        bgcolor: "#0ff",
        bordercolor: "#080"
      }
    }
  ]
}
```
![screen shot 2017-04-10 at 10 28 21 am](https://cloud.githubusercontent.com/assets/2678795/24866556/778656f4-1dd8-11e7-83ac-47a89c360337.png)
