### PR TITLE
Expand values into arrays as needed when setting with nestedProperty

### DIFF
--- a/src/lib/nested_property.js
+++ b/src/lib/nested_property.js
@@ -243,8 +243,13 @@ function checkNewContainer(container, part, nextPart, toDelete) {
     if(container[part] === undefined) {
         if(toDelete) return false;
 
-        if(typeof nextPart === 'number') container[part] = [];
-        else container[part] = {};
+        if(typeof nextPart === 'number') {
+            container[part] = [];
+        } else {
+            container[part] = {};
+        }
+    } else if(!isPlainObject(container[part]) && !isArray(container[part]) && typeof nextPart === 'number') {
+        container[part] = [container[part]];
     }
     return true;
 }

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -434,6 +434,24 @@ describe('Test lib.js:', function() {
                 expect(badProp(i)).toThrow('bad property string');
             }
         });
+
+        it('wraps values when cannot set an array property', function() {
+            var obj = {x: 4, y: 5, foo: {bar: 6, baz: 7}};
+
+            np(obj, 'x[0]').set(10);
+            np(obj, 'y[2]').set(11);
+            np(obj, 'foo.bar[0]').set(12);
+            np(obj, 'foo.baz[2]').set(13);
+
+            expect(obj).toEqual({
+                x: [10],
+                y: [5, undefined, 11],
+                foo: {
+                    bar: [12],
+                    baz: [7, undefined, 13]
+                }
+            });
+        });
     });
 
     describe('objectFromPath', function() {


### PR DESCRIPTION
See #1580 

This is just speculative. I don't necessarily think it's a good idea, but I'm submitting it to confirm whether it's actually a _bad_ idea. If the current value is not an array or an object and you try to set an array value, it wraps the current value in an array before setting. Unless I'm mistaken, this should only affect cases that currently throw an error.