### PR TITLE
Optimize the text measuring of legend items when rendering large amount of traces

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -572,7 +572,16 @@ function computeTextDimensions(g, gd) {
             textLines = textSpans[0].length || 1;
 
         height = lineHeight * textLines;
-        width = text.node() && Drawing.bBox(text.node()).width;
+
+        // If there are more than 20 traces (> 20 legend items), estimate the text width
+        // so that the overhead of measureing text is not too big
+        if(gd.data.length <= 20) {
+            width = text.node() && Drawing.bBox(text.node()).width;
+        } else {
+            // "7" is empirical number based on some case studies in Sketch
+            width = legendItem.trace.name.length * 7 * opts.font.size / 11
+        }
+
 
         // approximation to height offset to center the font
         // to avoid getBoundingClientRect

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -579,7 +579,7 @@ function computeTextDimensions(g, gd) {
             width = text.node() && Drawing.bBox(text.node()).width;
         } else {
             // "7" is empirical number based on some case studies in Sketch
-            width = legendItem.trace.name.length * 7 * opts.font.size / 11
+            width = legendItem.trace.name.length * 7 * opts.font.size / 11;
         }
 
 


### PR DESCRIPTION
I open this as a separate PR from https://github.com/plotly/plotly.js/pull/1585, because I am not sure if you guys will be willing to take this one.

The logic behind my change here is that if you want to plot reasonable amount of traces, we will give one very precise measuring and layout on legend items. But if you go crazy, we will sacrifice the precision of legend item layout (which probably does not matter anymore in this case) for way much better performance.

On my machine, this change reduced the rendering time for
- 100 traces (200 points per trace) from 1.6 seconds to 1.1 seconds
- 300 traces (200 points per trace) from 5.7 seconds to 2.8 seconds
- 500 traces (200 points per trace) from 12.4 seconds to 5.8 seconds