### PR TITLE
Passthrough the wheel event if the scrollbar is at the very top or bottom

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -269,7 +269,9 @@ module.exports = function draw(gd) {
             scrollBarY = constants.scrollBarMargin -
                 scrollBoxY / scrollBoxYMax * scrollBarYMax;
             scrollHandler(scrollBarY, scrollBoxY);
-            d3.event.preventDefault();
+            if(scrollBoxY !== 0 && scrollBoxY !== -scrollBoxYMax) {
+                d3.event.preventDefault();
+            }
         });
 
         // to be safe, remove previous listeners


### PR DESCRIPTION
On a page with several charts, if you happen to have the cursor such that it winds up over a legend with scrollbar as you scroll the page, the scrollbar scrolls, but then captures all further `wheel` events. This change makes it so that the event is passed through to the page if the scrollbar is at the very top or bottom of the box so that the rest of the page can scroll.