### PR TITLE
Note test fix

### DIFF
--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -5,7 +5,8 @@ var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
 var Loggers = require('@src/lib/loggers');
 var Axes = require('@src/plots/cartesian/axes');
-var constants = require('@src/plots/cartesian/constants');
+var HOVERMINTIME = require('@src/plots/cartesian/constants').HOVERMINTIME;
+var DBLCLICKDELAY = require('@src/constants/interactions').DBLCLICKDELAY;
 
 var d3 = require('d3');
 var customMatchers = require('../assets/custom_matchers');
@@ -1095,8 +1096,8 @@ describe('annotation effects', function() {
                     mouseEvent('mouseout', pos[0], pos[1]);
                     mouseEvent('mousemove', 0, 0);
 
-                    setTimeout(resolve, constants.HOVERMINTIME * 1.5);
-                }, constants.HOVERMINTIME * 1.5);
+                    setTimeout(resolve, HOVERMINTIME * 1.1);
+                }, HOVERMINTIME * 1.1);
             });
         }
 
@@ -1106,7 +1107,9 @@ describe('annotation effects', function() {
             // so we only have to explicitly include pos0-2
             spec.push([pos0Head, '']);
             spec.push([pos2Head, '']);
-            var p = Promise.resolve();
+            var p = new Promise(function(resolve) {
+                setTimeout(resolve, HOVERMINTIME);
+            });
             spec.forEach(function(speci) {
                 p = p.then(function() {
                     return assertHoverLabel(speci[0], speci[1],
@@ -1122,7 +1125,7 @@ describe('annotation effects', function() {
 
                 setTimeout(function() {
                     resolve();
-                }, constants.HOVERMINTIME);
+                }, DBLCLICKDELAY * 1.1);
             });
         }
 

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -1095,8 +1095,8 @@ describe('annotation effects', function() {
                     mouseEvent('mouseout', pos[0], pos[1]);
                     mouseEvent('mousemove', 0, 0);
 
-                    setTimeout(resolve, constants.HOVERMINTIME);
-                }, constants.HOVERMINTIME);
+                    setTimeout(resolve, constants.HOVERMINTIME * 1.5);
+                }, constants.HOVERMINTIME * 1.5);
             });
         }
 
@@ -1107,10 +1107,10 @@ describe('annotation effects', function() {
             spec.push([pos0Head, '']);
             spec.push([pos2Head, '']);
             var p = Promise.resolve();
-            spec.forEach(function(speci, i) {
+            spec.forEach(function(speci) {
                 p = p.then(function() {
                     return assertHoverLabel(speci[0], speci[1],
-                        msg ? msg + ' (' + i + ')' : i);
+                        msg ? msg + ' (' + speci + ')' : speci);
                 });
             });
             return p;
@@ -1132,7 +1132,7 @@ describe('annotation effects', function() {
         }
 
         makePlot([
-            {x: 50, y: 50, text: 'hi', width: 50, ax: 0, ay: -40, xshift: -50, yshift: 50},
+            {x: 50, y: 50, text: 'hi', width: 50, height: 40, ax: 0, ay: -40, xshift: -50, yshift: 50},
             {x: 20, y: 20, text: 'bye', height: 40, showarrow: false},
             {x: 80, y: 80, text: 'why?', ax: 0, ay: -40}
         ], {}) // turn off the default editable: true


### PR DESCRIPTION
Pretty sure this fixes the intermittent test failure https://github.com/plotly/plotly.js/pull/1573#issuecomment-293684424

There may be other ways to do it (this adds ~1.5 sec to the test), but the main thing I think is avoiding an accidental doubleclick (and the associated autorange, which moves the annotations) by putting a delay after each click.

Tested 20x locally, which was enough to generally cause failure before...

cc @etpinard @rpaskowitz 