### PR TITLE
Fix tspan selector

### DIFF
--- a/src/traces/scatter/plot.js
+++ b/src/traces/scatter/plot.js
@@ -470,7 +470,7 @@ function plotOne(gd, idx, plotinfo, cdscatter, cdscatterAll, element, transition
                 var x = d.xp || xa.c2p(d.x),
                     y = d.yp || ya.c2p(d.y);
 
-                d3.select(this).selectAll('tspan').each(function() {
+                d3.select(this).selectAll('tspan.line').each(function() {
                     transition(d3.select(this)).attr({x: x, y: y});
                 });
             });


### PR DESCRIPTION
fixes #1556 

I thought this was going to be very problematic since I struggled with it a lot the first time, but it turned out to be pretty simple. Just required selecting `tspan.line` instead of `tspan` when tweaking properties for animation. It was positioning regular inline spans the same as lines, which I think was the extent of the problem.

cc @n-riesco 

No tests added since it's transient behavior that I don't quite know a good way to test.

An animation of this working simultaneously with tspans representing both `<span>` and `<br>` tags:

![ezgif-3-da7582232b](https://cloud.githubusercontent.com/assets/572717/25093794/cf4ff190-2361-11e7-85aa-074013c17bf1.gif)
