### PR TITLE
Don't try to draw spikeline if the axis isn't on the chart.

### DIFF
--- a/src/plots/cartesian/graph_interact.js
+++ b/src/plots/cartesian/graph_interact.js
@@ -864,8 +864,8 @@ function createSpikelines(hoverData, opts) {
     var c0 = hoverData[0];
     var xa = c0.xa;
     var ya = c0.ya;
-    var showX = xa.showspikes;
-    var showY = ya.showspikes;
+    var showX = xa.showspikes && xa.visible && (xa.showline || xa.showticklabels);
+    var showY = ya.showspikes && ya.visible && (ya.showline || ya.showticklabels);
 
     // Remove old spikeline items
     container.selectAll('.spikeline').remove();

--- a/test/jasmine/tests/hover_spikeline_test.js
+++ b/test/jasmine/tests/hover_spikeline_test.js
@@ -39,5 +39,19 @@ describe('spikeline', function() {
             expect(d3.selectAll('line.spikeline').size()).toEqual(2);
             expect(d3.selectAll('circle.spikeline').size()).toEqual(0);
         });
+
+        it('doesn\t draw a line when the axis isn\'t visible', function() {
+            Plotly.relayout('graph', 'yaxis.visible', false);
+            Fx.hover('graph', {xval: 2, yval: 3}, 'xy');
+            expect(d3.selectAll('line.spikeline').size()).toEqual(2);
+            expect(d3.selectAll('circle.spikeline').size()).toEqual(0);
+        });
+
+        it('doesn\t draw a line when the axis has no line or labels', function() {
+            Plotly.relayout('graph', ['yaxis.showticklabels', 'yaxis.showline'], [false, false]);
+            Fx.hover('graph', {xval: 2, yval: 3}, 'xy');
+            expect(d3.selectAll('line.spikeline').size()).toEqual(2);
+            expect(d3.selectAll('circle.spikeline').size()).toEqual(0);
+        });
     });
 });


### PR DESCRIPTION
Noticed the line wasn't being drawn and errors were being logged to console on the last chart at https://plot.ly/javascript/line-charts/. This should clean that up.