### PR TITLE
Remove clip path from contourcarpet

### DIFF
--- a/src/traces/contourcarpet/plot.js
+++ b/src/traces/contourcarpet/plot.js
@@ -122,13 +122,6 @@ function plotOne(gd, plotinfo, cd) {
 
     // Draw contour lines:
     makeLines(plotGroup, pathinfo, contours);
-
-    // Clip the boundary of the plot:
-    clipBoundary(plotGroup, carpet);
-}
-
-function clipBoundary(plotGroup, carpet) {
-    plotGroup.attr('clip-path', 'url(#' + carpet.clipPathId + ')');
 }
 
 function makeContourGroup(plotinfo, cd, id) {


### PR DESCRIPTION
This PR removes the clip path from contourcarpet traces. If everything else is _perfect_, then it's already clipped and this serves no purpose. Expecting pixel-level differences (_half_ of lines along the edge are currently clipped by the clip path), but hopefully no substantial changes so that it can simply be removed.

Otherwise, I think maybe _reversing_ the clip path and changing the `clip-rule` might fix some of the self-intersecting carpet axis issues seen. But this is probably preferable.