### PR TITLE
Add textpoint class to scatter text points

### DIFF
--- a/src/traces/scatter/plot.js
+++ b/src/traces/scatter/plot.js
@@ -460,6 +460,7 @@ function plotOne(gd, idx, plotinfo, cdscatter, cdscatterAll, element, transition
         });
 
         join.selectAll('text')
+            .classed('textpoint', true)
             .call(Drawing.textPointStyle, trace)
             .each(function(d) {
 

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -373,13 +373,13 @@ describe('end-to-end scatter tests', function() {
         }).catch(fail).then(done);
     });
 
-    it('adds "textpoint" class to scatter text points', function (done) {
+    it('adds "textpoint" class to scatter text points', function(done) {
         Plotly.plot(gd, [{
             mode: 'text',
             x: [1, 2, 3],
             y: [2, 3, 4],
             text: ['a', 'b', 'c']
-        }]).then(function () {
+        }]).then(function() {
             expect(Plotly.d3.selectAll('.textpoint').size()).toBe(3);
         }).catch(fail).then(done);
     });

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -372,6 +372,17 @@ describe('end-to-end scatter tests', function() {
 
         }).catch(fail).then(done);
     });
+
+    it('adds "textpoint" class to scatter text points', function (done) {
+        Plotly.plot(gd, [{
+            mode: 'text',
+            x: [1, 2, 3],
+            y: [2, 3, 4],
+            text: ['a', 'b', 'c']
+        }]).then(function () {
+            expect(Plotly.d3.selectAll('.textpoint').size()).toBe(3);
+        }).catch(fail).then(done);
+    });
 });
 
 describe('scatter hoverPoints', function() {


### PR DESCRIPTION
This PR adds a `'textpoint'` class to text points of scatter traces so that they can more easily and consistently be selected. I have no preference on the class name, but `'textpoint'` seemed reasonably descriptive (better than `'text'`, which is a little vague/overgeneral IMO)