### PR TITLE
numeric sort for component edits

### DIFF
--- a/src/plot_api/manage_arrays.js
+++ b/src/plot_api/manage_arrays.js
@@ -101,7 +101,7 @@ exports.applyContainerArrayChanges = function applyContainerArrayChanges(gd, np,
         return true;
     }
 
-    var componentNums = Object.keys(edits).map(Number).sort(),
+    var componentNums = Object.keys(edits).map(Number).sort(function(a, b) { return a - b; }),
         componentArrayIn = np.get(),
         componentArray = componentArrayIn || [],
         // componentArrayFull is used just to keep splices in line between

--- a/src/plot_api/manage_arrays.js
+++ b/src/plot_api/manage_arrays.js
@@ -13,6 +13,7 @@ var nestedProperty = require('../lib/nested_property');
 var isPlainObject = require('../lib/is_plain_object');
 var noop = require('../lib/noop');
 var Loggers = require('../lib/loggers');
+var sorterAsc = require('../lib/search').sorterAsc;
 var Registry = require('../registry');
 
 
@@ -101,7 +102,7 @@ exports.applyContainerArrayChanges = function applyContainerArrayChanges(gd, np,
         return true;
     }
 
-    var componentNums = Object.keys(edits).map(Number).sort(function(a, b) { return a - b; }),
+    var componentNums = Object.keys(edits).map(Number).sort(sorterAsc),
         componentArrayIn = np.get(),
         componentArray = componentArrayIn || [],
         // componentArrayFull is used just to keep splices in line between

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -223,6 +223,33 @@ describe('annotations relayout', function() {
         .then(done);
     });
 
+    it('should sort correctly when index>10', function(done) {
+        var addall = {};
+        var delall = {};
+
+        // leave the first one alone, but delete and re-add all the others
+        for(var i = 1; i < gd.layout.annotations.length; i++) {
+            addall['annotations[' + i + ']'] = {text: i, x: i / 10, y: 0};
+            delall['annotations[' + i + ']'] = null;
+        }
+
+        Plotly.relayout(gd, delall)
+        .then(function() {
+            expect(gd.layout.annotations).toEqual([mock.layout.annotations[0]]);
+
+            return Plotly.relayout(gd, addall);
+        })
+        .then(function() {
+            var annotations = gd.layout.annotations;
+            expect(annotations.length).toBe(mock.layout.annotations.length);
+            for(var i = 1; i < annotations.length; i++) {
+                expect(annotations[i].text).toBe(i);
+            }
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
     it('should be able update annotations', function(done) {
         var updateObj = { 'annotations[0].text': 'hello' };
 


### PR DESCRIPTION
Not the first time I've been bitten by the default sort being alphabetical even if the items are numbers... This made a bug where if you tried to add annotations 9 and 10 in a single `relayout`, it would try to add 10 first but it couldn't do that because 9 didn't exist yet (or if it did, 10 would get inserted in the array in the wrong places) and similar problems on deletion.

@etpinard OK?