### PR TITLE
Fix scattercarpet calc

### DIFF
--- a/src/traces/scattercarpet/calc.js
+++ b/src/traces/scattercarpet/calc.js
@@ -12,10 +12,10 @@
 var isNumeric = require('fast-isnumeric');
 
 var Axes = require('../../plots/cartesian/axes');
-var Lib = require('../../lib');
 
 var subTypes = require('../scatter/subtypes');
 var calcColorscale = require('../scatter/colorscale_calc');
+var arraysToCalcdata = require('../scatter/arrays_to_calcdata');
 var lookupCarpet = require('../carpet/lookup_carpetid');
 
 module.exports = function calc(gd, trace) {
@@ -68,8 +68,7 @@ module.exports = function calc(gd, trace) {
 
     calcColorscale(trace);
 
-    // this has migrated up from arraysToCalcdata as we have a reference to 's' here
-    if(typeof s !== 'undefined') Lib.mergeArray(s, cd, 'ms');
+    arraysToCalcdata(cd, trace);
 
     return cd;
 };

--- a/test/jasmine/tests/carpet_test.js
+++ b/test/jasmine/tests/carpet_test.js
@@ -512,3 +512,61 @@ describe('Test carpet interactions:', function() {
         .then(done);
     });
 });
+
+describe('scattercarpet array attributes', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('works in both initial draws and restyles', function(done) {
+        var mock = Lib.extendDeep({}, require('@mocks/scattercarpet.json'));
+
+        var mc = ['#000', '#00f', '#0ff', '#ff0'];
+        var ms = [10, 20, 30, 40];
+        var ms2 = [5, 6, 7, 8];
+        var mlw = [1, 2, 3, 4];
+        var mlc = ['#00e', '#0ee', '#ee0', '#eee'];
+
+        // add some arrayOk array attributes
+        mock.data[5].marker = {
+            color: mc,
+            size: ms,
+            line: {
+                width: mlw,
+                color: mlc
+            }
+        };
+
+        Plotly.plot(gd, mock)
+        .then(function() {
+            for(var i = 0; i < 4; i++) {
+                var pt = gd.calcdata[5][i];
+                expect(pt.mc).toBe(mc[i]);
+                expect(pt.ms).toBe(ms[i]);
+                expect(pt.mlw).toBe(mlw[i]);
+                expect(pt.mlc).toBe(mlc[i]);
+            }
+
+            // turn one array into a constant, another into a new array,
+            return Plotly.restyle(gd, {'marker.color': '#f00', 'marker.size': [ms2]},
+                null, [5]);
+        })
+        .then(function() {
+            expect(gd._fullData[5].marker.color).toBe('#f00');
+
+            for(var i = 0; i < 4; i++) {
+                var pt = gd.calcdata[5][i];
+                expect(pt.mc).toBeUndefined();
+                expect(pt.ms).toBe(ms2[i]);
+                expect(pt.mlw).toBe(mlw[i]);
+                expect(pt.mlc).toBe(mlc[i]);
+            }
+        })
+        .catch(fail)
+        .then(done);
+    });
+});


### PR DESCRIPTION
This addresses @alexcjohnson's comment that scattercarpet was doing something weird and not handling array properties correctly. I mostly copied scattercarpet from scatterternary, but I wasn't quite able to reconstruct the removed line in this PR. I replaced it with `arraysToCalcdata` and it seems like things work fine though.