### PR TITLE
Annotationclick event

### DIFF
--- a/src/components/annotations/draw.js
+++ b/src/components/annotations/draw.js
@@ -112,7 +112,8 @@ function drawOne(gd, index) {
             gd.emit('plotly_clickannotation', {
                 index: index,
                 annotation: optionsIn,
-                fullAnnotation: options
+                fullAnnotation: options,
+                event: d3.event
             });
         });
 

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -1168,7 +1168,11 @@ describe('annotation effects', function() {
         ], {}) // turn off the default editable: true
         .then(function() {
             clickData = [];
-            gd.on('plotly_clickannotation', function(evt) { clickData.push(evt); });
+            gd.on('plotly_clickannotation', function(evt) {
+                expect(evt.event).toEqual(jasmine.objectContaining({type: 'click'}));
+                delete evt.event;
+                clickData.push(evt);
+            });
 
             gdBB = gd.getBoundingClientRect();
             pos0Head = [gdBB.left + 200, gdBB.top + 200];


### PR DESCRIPTION
@etpinard quick one to add the native mouse event to `plotly_clickannotation`