### PR TITLE
Contour restyle zmin zmax

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1624,8 +1624,8 @@ function _restyle(gd, aobj, _traces) {
                     flags.docalc = true;
                 }
 
-                // some attributes declare a 'recalc' flag
-                if(valObject.recalc) {
+                // some attributes declare an 'editType' flaglist
+                if(valObject.editType === 'docalc') {
                     flags.docalc = true;
                 }
 

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1624,6 +1624,11 @@ function _restyle(gd, aobj, _traces) {
                     flags.docalc = true;
                 }
 
+                // some attributes declare a 'recalc' flag
+                if(valObject.recalc) {
+                    flags.docalc = true;
+                }
+
                 // all the other ones, just modify that one attribute
                 param.set(newVal);
             }

--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -128,7 +128,10 @@ module.exports = extendFlat({}, {
         })
     }
 },
-    colorscaleAttrs,
-    { autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false}) },
+    colorscaleAttrs, {
+        autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false}),
+        zmin: extendFlat({}, colorscaleAttrs.zmin, {recalc: true}),
+        zmax: extendFlat({}, colorscaleAttrs.zmax, {recalc: true})
+    },
     { colorbar: colorbarAttrs }
 );

--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -130,8 +130,8 @@ module.exports = extendFlat({}, {
 },
     colorscaleAttrs, {
         autocolorscale: extendFlat({}, colorscaleAttrs.autocolorscale, {dflt: false}),
-        zmin: extendFlat({}, colorscaleAttrs.zmin, {recalc: true}),
-        zmax: extendFlat({}, colorscaleAttrs.zmax, {recalc: true})
+        zmin: extendFlat({}, colorscaleAttrs.zmin, {editType: 'docalc'}),
+        zmax: extendFlat({}, colorscaleAttrs.zmax, {editType: 'docalc'})
     },
     { colorbar: colorbarAttrs }
 );

--- a/src/traces/histogram2dcontour/attributes.js
+++ b/src/traces/histogram2dcontour/attributes.js
@@ -35,6 +35,9 @@ module.exports = extendFlat({}, {
     contours: contourAttrs.contours,
     line: contourAttrs.line
 },
-    colorscaleAttrs,
+    colorscaleAttrs, {
+        zmin: extendFlat({}, colorscaleAttrs.zmin, {recalc: true}),
+        zmax: extendFlat({}, colorscaleAttrs.zmax, {recalc: true})
+    },
     { colorbar: colorbarAttrs }
 );

--- a/src/traces/histogram2dcontour/attributes.js
+++ b/src/traces/histogram2dcontour/attributes.js
@@ -36,8 +36,8 @@ module.exports = extendFlat({}, {
     line: contourAttrs.line
 },
     colorscaleAttrs, {
-        zmin: extendFlat({}, colorscaleAttrs.zmin, {recalc: true}),
-        zmax: extendFlat({}, colorscaleAttrs.zmax, {recalc: true})
+        zmin: extendFlat({}, colorscaleAttrs.zmin, {editType: 'docalc'}),
+        zmax: extendFlat({}, colorscaleAttrs.zmax, {editType: 'docalc'})
     },
     { colorbar: colorbarAttrs }
 );

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -363,6 +363,72 @@ describe('Test plot api', function() {
             expect(PlotlyInternal.plot.calls.count()).toEqual(2);
         });
 
+        it('should clear calcdata when restyling \'zmin\' and \'zmax\' on contour traces', function() {
+            var contour = {
+                data: [{
+                    type: 'contour',
+                    z: [[1, 2, 3], [1, 2, 1]]
+                }]
+            };
+
+            var histogram2dcontour = {
+                data: [{
+                    type: 'histogram2dcontour',
+                    x: [1, 1, 2, 2, 2, 3],
+                    y: [0, 0, 0, 0, 1, 3]
+                }]
+            };
+
+            var mocks = [contour, histogram2dcontour];
+
+            mocks.forEach(function(gd) {
+                mockDefaultsAndCalc(gd);
+                PlotlyInternal.plot.calls.reset();
+                Plotly.restyle(gd, 'zmin', 0);
+                expect(gd.calcdata).toBeUndefined();
+                expect(PlotlyInternal.plot).toHaveBeenCalled();
+
+                mockDefaultsAndCalc(gd);
+                PlotlyInternal.plot.calls.reset();
+                Plotly.restyle(gd, 'zmax', 10);
+                expect(gd.calcdata).toBeUndefined();
+                expect(PlotlyInternal.plot).toHaveBeenCalled();
+            });
+        });
+
+        it('should not clear calcdata when restyling \'zmin\' and \'zmax\' on heatmap traces', function() {
+            var heatmap = {
+                data: [{
+                    type: 'heatmap',
+                    z: [[1, 2, 3], [1, 2, 1]]
+                }]
+            };
+
+            var histogram2d = {
+                data: [{
+                    type: 'histogram2d',
+                    x: [1, 1, 2, 2, 2, 3],
+                    y: [0, 0, 0, 0, 1, 3]
+                }]
+            };
+
+            var mocks = [heatmap, histogram2d];
+
+            mocks.forEach(function(gd) {
+                mockDefaultsAndCalc(gd);
+                PlotlyInternal.plot.calls.reset();
+                Plotly.restyle(gd, 'zmin', 0);
+                expect(gd.calcdata).toBeDefined();
+                expect(PlotlyInternal.plot).toHaveBeenCalled();
+
+                mockDefaultsAndCalc(gd);
+                PlotlyInternal.plot.calls.reset();
+                Plotly.restyle(gd, 'zmax', 10);
+                expect(gd.calcdata).toBeDefined();
+                expect(PlotlyInternal.plot).toHaveBeenCalled();
+            });
+        });
+
         it('ignores undefined values', function() {
             var gd = {
                 data: [{x: [1, 2, 3], y: [1, 2, 3], type: 'scatter'}],

--- a/test/jasmine/tests/plotschema_test.js
+++ b/test/jasmine/tests/plotschema_test.js
@@ -76,7 +76,7 @@ describe('plot schema', function() {
                     var valObject = valObjects[attr.valType],
                         opts = valObject.requiredOpts
                             .concat(valObject.otherOpts)
-                            .concat(['valType', 'description', 'role']);
+                            .concat(['valType', 'description', 'role', 'recalc']);
 
                     Object.keys(attr).forEach(function(key) {
                         expect(opts.indexOf(key) !== -1).toBe(true, key, attr);

--- a/test/jasmine/tests/plotschema_test.js
+++ b/test/jasmine/tests/plotschema_test.js
@@ -76,7 +76,7 @@ describe('plot schema', function() {
                     var valObject = valObjects[attr.valType],
                         opts = valObject.requiredOpts
                             .concat(valObject.otherOpts)
-                            .concat(['valType', 'description', 'role', 'recalc']);
+                            .concat(['valType', 'description', 'role', 'editType']);
 
                     Object.keys(attr).forEach(function(key) {
                         expect(opts.indexOf(key) !== -1).toBe(true, key, attr);


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1649

So, turns out that restyling `zmin` and `zmax` for contour traces has been broken since `v1.0.0` and nobody noticed :expressionless:  

This PR fixes this by making `zmin` and `zmax` redo calcdata as the contour [calc](https://github.com/plotly/plotly.js/blob/2105fd48663b616503337518bab28621c1804497/src/traces/contour/calc.js#L26) does use it. Note that this isn't the case for `heatmap` traces where `zmin` and `zmax` are only used in the [plot](https://github.com/plotly/plotly.js/blob/2105fd48663b616503337518bab28621c1804497/src/traces/heatmap/plot.js#L174) step.

cc @alexcjohnson 