### PR TITLE
Link style

### DIFF
--- a/src/components/annotations/draw.js
+++ b/src/components/annotations/draw.js
@@ -188,6 +188,18 @@ function drawOne(gd, index) {
     }
 
     function drawGraphicalElements() {
+        // if the text has *only* a link, make the whole box into a link
+        var anchor = annText.selectAll('a');
+        if(anchor.size() === 1 && anchor.text() === annText.text()) {
+            var wholeLink = annTextGroupInner.insert('a', ':first-child').attr({
+                'xlink:xlink:href': anchor.attr('xlink:href'),
+                'xlink:xlink:show': anchor.attr('xlink:show')
+            })
+            .style({cursor: 'pointer'});
+
+            wholeLink.node().appendChild(annTextBG.node());
+        }
+
 
         // make sure lines are aligned the way they will be
         // at the end, even if their position changes

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -1251,4 +1251,38 @@ describe('annotation effects', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('makes the whole text box a link if the link is the whole text', function(done) {
+        makePlot([
+            {x: 20, y: 20, text: '<a href="https://plot.ly">Plot</a>', showarrow: false},
+            {x: 50, y: 50, text: '<a href="https://plot.ly">or</a> not', showarrow: false},
+            {x: 80, y: 80, text: '<a href="https://plot.ly">arrow</a>'},
+            {x: 20, y: 80, text: 'nor <a href="https://plot.ly">this</a>'}
+        ])
+        .then(function() {
+            function checkBoxLink(index, isLink) {
+                var boxLink = d3.selectAll('.annotation[data-index="' + index + '"] g>a');
+                expect(boxLink.size()).toBe(isLink ? 1 : 0);
+
+                var textLink = d3.selectAll('.annotation[data-index="' + index + '"] text a');
+                expect(textLink.size()).toBe(1);
+                checkLink(textLink);
+
+                if(isLink) checkLink(boxLink);
+            }
+
+            function checkLink(link) {
+                expect(link.style('cursor')).toBe('pointer');
+                expect(link.attr('xlink:href')).toBe('https://plot.ly');
+                expect(link.attr('xlink:show')).toBe('new');
+            }
+
+            checkBoxLink(0, true);
+            checkBoxLink(1, false);
+            checkBoxLink(2, true);
+            checkBoxLink(3, false);
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });

--- a/test/jasmine/tests/svg_text_utils_test.js
+++ b/test/jasmine/tests/svg_text_utils_test.js
@@ -6,7 +6,7 @@ var util = require('@src/lib/svg_text_utils');
 describe('svg+text utils', function() {
     'use strict';
 
-    describe('convertToTspans should', function() {
+    describe('convertToTspans', function() {
 
         function mockTextSVGElement(txt) {
             return d3.select('body')
@@ -60,7 +60,7 @@ describe('svg+text utils', function() {
             d3.select('#text').remove();
         });
 
-        it('check for XSS attack in href', function() {
+        it('checks for XSS attack in href', function() {
             var node = mockTextSVGElement(
                 '<a href="javascript:alert(\'attack\')">XSS</a>'
             );
@@ -70,7 +70,7 @@ describe('svg+text utils', function() {
             assertAnchorLink(node, null);
         });
 
-        it('check for XSS attack in href (with plenty of white spaces)', function() {
+        it('checks for XSS attack in href (with plenty of white spaces)', function() {
             var node = mockTextSVGElement(
                 '<a href =    "     javascript:alert(\'attack\')">XSS</a>'
             );
@@ -80,7 +80,7 @@ describe('svg+text utils', function() {
             assertAnchorLink(node, null);
         });
 
-        it('whitelist relative hrefs (interpreted as http)', function() {
+        it('whitelists relative hrefs (interpreted as http)', function() {
             var node = mockTextSVGElement(
                 '<a href="/mylink">mylink</a>'
             );
@@ -90,7 +90,7 @@ describe('svg+text utils', function() {
             assertAnchorLink(node, '/mylink');
         });
 
-        it('whitelist http hrefs', function() {
+        it('whitelists http hrefs', function() {
             var node = mockTextSVGElement(
                 '<a href="http://bl.ocks.org/">bl.ocks.org</a>'
             );
@@ -100,7 +100,7 @@ describe('svg+text utils', function() {
             assertAnchorLink(node, 'http://bl.ocks.org/');
         });
 
-        it('whitelist https hrefs', function() {
+        it('whitelists https hrefs', function() {
             var node = mockTextSVGElement(
                 '<a href="https://plot.ly">plot.ly</a>'
             );
@@ -110,7 +110,7 @@ describe('svg+text utils', function() {
             assertAnchorLink(node, 'https://plot.ly');
         });
 
-        it('whitelist mailto hrefs', function() {
+        it('whitelists mailto hrefs', function() {
             var node = mockTextSVGElement(
                 '<a href="mailto:support@plot.ly">support</a>'
             );
@@ -120,7 +120,7 @@ describe('svg+text utils', function() {
             assertAnchorLink(node, 'mailto:support@plot.ly');
         });
 
-        it('wrap XSS attacks in href', function() {
+        it('wraps XSS attacks in href', function() {
             var textCases = [
                 '<a href="XSS\" onmouseover="alert(1)\" style="font-size:300px">Subtitle</a>',
                 '<a href="XSS" onmouseover="alert(1)" style="font-size:300px">Subtitle</a>'
@@ -135,7 +135,7 @@ describe('svg+text utils', function() {
             });
         });
 
-        it('should keep query parameters in href', function() {
+        it('keeps query parameters in href', function() {
             var textCases = [
                 '<a href="https://abc.com/myFeature.jsp?name=abc&pwd=def">abc.com?shared-key</a>',
                 '<a href="https://abc.com/myFeature.jsp?name=abc&amp;pwd=def">abc.com?shared-key</a>'
@@ -150,7 +150,7 @@ describe('svg+text utils', function() {
             });
         });
 
-        it('allow basic spans', function() {
+        it('allows basic spans', function() {
             var node = mockTextSVGElement(
                 '<span>text</span>'
             );
@@ -159,7 +159,7 @@ describe('svg+text utils', function() {
             assertTspanStyle(node, null);
         });
 
-        it('ignore unquoted styles in spans', function() {
+        it('ignores unquoted styles in spans', function() {
             var node = mockTextSVGElement(
                 '<span style=unquoted>text</span>'
             );
@@ -168,7 +168,7 @@ describe('svg+text utils', function() {
             assertTspanStyle(node, null);
         });
 
-        it('allow quoted styles in spans', function() {
+        it('allows quoted styles in spans', function() {
             var node = mockTextSVGElement(
                 '<span style="quoted: yeah;">text</span>'
             );
@@ -177,7 +177,7 @@ describe('svg+text utils', function() {
             assertTspanStyle(node, 'quoted: yeah;');
         });
 
-        it('ignore extra stuff after span styles', function() {
+        it('ignores extra stuff after span styles', function() {
             var node = mockTextSVGElement(
                 '<span style="quoted: yeah;"disallowed: indeed;">text</span>'
             );
@@ -195,7 +195,7 @@ describe('svg+text utils', function() {
             assertTspanStyle(node, 'quoted: yeah&\';;');
         });
 
-        it('decode some HTML entities in text', function() {
+        it('decodes some HTML entities in text', function() {
             var node = mockTextSVGElement(
                 '100&mu; &amp; &lt; 10 &gt; 0 &nbsp;' +
                 '100 &times; 20 &plusmn; 0.5 &deg;'

--- a/test/jasmine/tests/svg_text_utils_test.js
+++ b/test/jasmine/tests/svg_text_utils_test.js
@@ -45,7 +45,11 @@ describe('svg+text utils', function() {
 
             expect(hasWrongAttr).toBe(false);
 
-            expect(a.attr('style')).toBe('cursor:pointer;' + (style || ''));
+            var fullStyle = style || '';
+            if(style) fullStyle += ';';
+            fullStyle += 'cursor:pointer';
+
+            expect(a.attr('style')).toBe(fullStyle);
         }
 
         function listAttributes(node) {
@@ -225,6 +229,51 @@ describe('svg+text utils', function() {
             );
 
             expect(node.text()).toEqual('100μ & < 10 > 0  100 × 20 ± 0.5 °');
+        });
+
+        it('supports superscript by itself', function() {
+            var node = mockTextSVGElement('<sup>123</sup>');
+            expect(node.html()).toBe(
+                '​<tspan style="font-size:70%" dy="-0.6em">123</tspan>' +
+                '<tspan dy="0.42em">​</tspan>');
+        });
+
+        it('supports subscript by itself', function() {
+            var node = mockTextSVGElement('<sub>123</sub>');
+            expect(node.html()).toBe(
+                '​<tspan style="font-size:70%" dy="0.3em">123</tspan>' +
+                '<tspan dy="-0.21em">​</tspan>');
+        });
+
+        it('supports superscript and subscript together with normal text', function() {
+            var node = mockTextSVGElement('SO<sub>4</sub><sup>2-</sup>');
+            expect(node.html()).toBe(
+                'SO​<tspan style="font-size:70%" dy="0.3em">4</tspan>' +
+                '<tspan dy="-0.21em">​</tspan>​' +
+                '<tspan style="font-size:70%" dy="-0.6em">2-</tspan>' +
+                '<tspan dy="0.42em">​</tspan>');
+        });
+
+        it('allows one <b> to span <br>s', function() {
+            var node = mockTextSVGElement('be <b>Bold<br>and<br><i>Strong</i></b>');
+            expect(node.html()).toBe(
+                '<tspan class="line" dy="0em">be ' +
+                    '<tspan style="font-weight:bold">Bold</tspan></tspan>' +
+                '<tspan class="line" dy="1.3em">' +
+                    '<tspan style="font-weight:bold">and</tspan></tspan>' +
+                '<tspan class="line" dy="2.6em">' +
+                    '<tspan style="font-weight:bold">' +
+                        '<tspan style="font-style:italic">Strong</tspan></tspan></tspan>');
+        });
+
+        it('allows one <sub> to span <br>s', function() {
+            var node = mockTextSVGElement('SO<sub>4<br>44</sub>');
+            expect(node.html()).toBe(
+                '<tspan class="line" dy="0em">SO​' +
+                    '<tspan style="font-size:70%" dy="0.3em">4</tspan></tspan>' +
+                '<tspan class="line" dy="1.3em">​' +
+                    '<tspan style="font-size:70%" dy="0.3em">44</tspan>' +
+                    '<tspan dy="-0.21em">​</tspan></tspan>');
         });
     });
 });

--- a/test/jasmine/tests/transform_sort_test.js
+++ b/test/jasmine/tests/transform_sort_test.js
@@ -283,7 +283,7 @@ describe('Test sort transform interactions:', function() {
 
         function wait() {
             return new Promise(function(resolve) {
-                setTimeout(resolve, 60);
+                setTimeout(resolve, 100);
             });
         }
 


### PR DESCRIPTION
Fixes #1674
- Make sure links in svg text get `cursor: pointer` like regular html links
- Allow style for `<a>` elements in text, and make our parsing of these fields more robust
- If all you have is a link, in annotation text, turn the whole text box into a clickable link

@etpinard OK?