### PR TITLE
Sort + set 'categoryarray'

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -2003,7 +2003,7 @@ plots.doCalcdata = function(gd, traces) {
         }
     }
 
-    var hasCategoryAxis = plots.initCategories(axList);
+    var hasCategoryAxis = initCategories(axList);
 
     var hasCalcTransform = false;
 
@@ -2039,7 +2039,7 @@ plots.doCalcdata = function(gd, traces) {
             axList[i]._categories = [];
             axList[i]._categoriesMap = {};
         }
-        plots.initCategories(axList);
+        initCategories(axList);
     }
 
     // 'regular' loop
@@ -2085,7 +2085,7 @@ plots.doCalcdata = function(gd, traces) {
     }
 };
 
-plots.initCategories = function(axList) {
+function initCategories(axList) {
     var hasCategoryAxis = false;
 
     // initialize the category list, if there is one, so we start over
@@ -2103,7 +2103,7 @@ plots.initCategories = function(axList) {
     }
 
     return hasCategoryAxis;
-};
+}
 
 plots.rehover = function(gd) {
     if(gd._fullLayout._rehover) {

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1973,8 +1973,6 @@ plots.doCalcdata = function(gd, traces) {
 
     var trace, _module, i, j;
 
-    var hasCategoryAxis = false;
-
     // XXX: Is this correct? Needs a closer look so that *some* traces can be recomputed without
     // *all* needing doCalcdata:
     var calcdata = new Array(fullData.length);
@@ -1996,20 +1994,6 @@ plots.doCalcdata = function(gd, traces) {
     fullLayout._piecolormap = {};
     fullLayout._piedefaultcolorcount = 0;
 
-    // initialize the category list, if there is one, so we start over
-    // to be filled in later by ax.d2c
-    for(i = 0; i < axList.length; i++) {
-        axList[i]._categories = axList[i]._initialCategories.slice();
-
-        // Build the lookup map for initialized categories
-        axList[i]._categoriesMap = {};
-        for(j = 0; j < axList[i]._categories.length; j++) {
-            axList[i]._categoriesMap[axList[i]._categories[j]] = j;
-        }
-
-        if(axList[i].type === 'category') hasCategoryAxis = true;
-    }
-
     // If traces were specified and this trace was not included,
     // then transfer it over from the old calcdata:
     for(i = 0; i < fullData.length; i++) {
@@ -2018,6 +2002,8 @@ plots.doCalcdata = function(gd, traces) {
             continue;
         }
     }
+
+    var hasCategoryAxis = plots.initCategories(axList);
 
     var hasCalcTransform = false;
 
@@ -2051,9 +2037,9 @@ plots.doCalcdata = function(gd, traces) {
             axList[i]._min = [];
             axList[i]._max = [];
             axList[i]._categories = [];
-            // Reset the look up map
             axList[i]._categoriesMap = {};
         }
+        plots.initCategories(axList);
     }
 
     // 'regular' loop
@@ -2097,6 +2083,26 @@ plots.doCalcdata = function(gd, traces) {
                 gd.layout, fullLayout, fullData);
         }
     }
+};
+
+plots.initCategories = function(axList) {
+    var hasCategoryAxis = false;
+
+    // initialize the category list, if there is one, so we start over
+    // to be filled in later by ax.d2c
+    for(var i = 0; i < axList.length; i++) {
+        axList[i]._categories = axList[i]._initialCategories.slice();
+
+        // Build the lookup map for initialized categories
+        axList[i]._categoriesMap = {};
+        for(var j = 0; j < axList[i]._categories.length; j++) {
+            axList[i]._categoriesMap[axList[i]._categories[j]] = j;
+        }
+
+        if(axList[i].type === 'category') hasCategoryAxis = true;
+    }
+
+    return hasCategoryAxis;
 };
 
 plots.rehover = function(gd) {

--- a/test/jasmine/tests/transform_sort_test.js
+++ b/test/jasmine/tests/transform_sort_test.js
@@ -134,6 +134,21 @@ describe('Test sort transform calc:', function() {
         expect(out[0].y).toEqual([0, 2, 4, 3, 1]);
     });
 
+    it('should sort via categorical targets', function() {
+        var trace = extend({
+            transforms: [{ target: 'marker.size' }]
+        });
+        trace.x = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
+
+        var out = _transform([trace]);
+
+        expect(out[0].x).toEqual(['F', 'D', 'C', 'E', 'A', 'G', 'B']);
+        expect(out[0].y).toEqual([3, 1, 3, 2, 1, 1, 2]);
+        expect(out[0].ids).toEqual(['p2', 'z', 'n2', 'p1', 'n0', 'p3', 'n1']);
+        expect(out[0].marker.size).toEqual([0, 1, 5, 6, 10, 10, 20]);
+        expect(out[0].marker.color).toEqual([0.3, 0.1, 0.3, 0.2, 0.1, 0.4, 0.2]);
+    });
+
     it('should sort via custom targets', function() {
         var out = _transform([extend({
             transforms: [{

--- a/test/jasmine/tests/transform_sort_test.js
+++ b/test/jasmine/tests/transform_sort_test.js
@@ -355,4 +355,41 @@ describe('Test sort transform interactions:', function() {
         .catch(fail)
         .then(done);
     });
+
+    it('should honor *categoryarray* when set', function(done) {
+        var gd = createGraphDiv();
+
+        Plotly.plot(gd, [{
+            x: ['C', 'B', 'A'],
+            y: [3, 1, 2],
+            marker: {
+                size: [10, 20, 5]
+            },
+            transforms: [{
+                enabled: false,
+                type: 'sort',
+                target: [0, 2, 1],
+            }]
+        }], {
+            xaxis: {
+                categoryorder: 'trace',
+                categoryarray: ['A', 'B', 'C']
+            }
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis._categories).toEqual(['C', 'B', 'A']);
+
+            return Plotly.restyle(gd, 'transforms[0].enabled', true);
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis._categories).toEqual(['C', 'A', 'B']);
+
+            return Plotly.relayout(gd, 'xaxis.categoryorder', 'array');
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis._categories).toEqual(['A', 'B', 'C']);
+        })
+        .catch(fail)
+        .then(done);
+    });
 });


### PR DESCRIPTION
```js
Plotly.newPlot('graph', [{
  mode: 'markers',
  x: ['A', 'B', 'C'],
  y: ['a', 'b', 'c'],
  marker: { size: [20, 30, 50] },
  transforms: [{
    type: 'sort',
    target: [2, 1, 0]
  }]
}])
```

currently gives:

![image](https://cloud.githubusercontent.com/assets/6675409/26075686/2c2ee2b2-3984-11e7-8779-4f46b13c66c9.png)

where the categories are re-arranged after the `sort` transform - which is consistent with how we handle categories in `filter` transforms. See PR https://github.com/plotly/plotly.js/pull/1260 for more details.

But setting `layout.xaxis.categoryarray: ['A', 'B', 'C]` -- which implies that the category positions are fixed -- curently gives the same results as above.

With commit 7a2a2e1

```js
Plotly.newPlot('graph', [{
  mode: 'markers',
  x: ['A', 'B', 'C'],
  y: ['a', 'b', 'c'],
  marker: { size: [20, 30, 50] },
  transforms: [{
    type: 'sort',
    target: [2, 1, 0]
  }]
}], {
  xaxis: {
    categoryarray: ['A', 'B', 'C']
  }
})
```

now gives:

![image](https://cloud.githubusercontent.com/assets/6675409/26075882/f6545608-3984-11e7-8a18-4ee3880a46df.png)

where `categoryarray` is honored.

cc @n-riesco @alexcjohnson