### PR TITLE
Move the promise resolution to address IE11 bug

### DIFF
--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -99,11 +99,15 @@ module.exports = function draw(gd) {
                 var dataURL = canvas.toDataURL('image/png');
 
                 thisImage.attr('xlink:href', dataURL);
+                
+                // resolve promise in onload handler instead of on 'load' to support IE11
+                // see https://github.com/plotly/plotly.js/issues/1685 
+                // for more details
+                resolve();
             };
 
 
             thisImage.on('error', errorHandler);
-            thisImage.on('load', resolve);
 
             img.src = d.source;
 

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -99,9 +99,9 @@ module.exports = function draw(gd) {
                 var dataURL = canvas.toDataURL('image/png');
 
                 thisImage.attr('xlink:href', dataURL);
-                
+
                 // resolve promise in onload handler instead of on 'load' to support IE11
-                // see https://github.com/plotly/plotly.js/issues/1685 
+                // see https://github.com/plotly/plotly.js/issues/1685
                 // for more details
                 resolve();
             };


### PR DESCRIPTION
Addresses issue https://github.com/plotly/plotly.js/issues/1685

Fixes a bug with IE11 - when images are specified in the layout, the promise is never resolved from the `draw()` function.

```
plotly.newPlot(elem).then(function(){
    //never hit
});
```