### PR TITLE
Move plotly.animate to Lib.syncOrAsync

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2700,7 +2700,7 @@ Plotly.animate = function(gd, frameOrGroupNameOrFrameList, animationOpts) {
                 }
             });
         }
-    ]);
+    ], gd);
 };
 
 /**

--- a/test/jasmine/tests/animate_test.js
+++ b/test/jasmine/tests/animate_test.js
@@ -768,4 +768,30 @@ describe('animating scatter traces', function() {
             expect(trace.style('opacity')).toEqual('0.1');
         }).catch(fail).then(done);
     });
+
+    it('places animate on the main plotly.js queue', function(done) {
+        Plotly.plot(gd, [{
+            x: [1, 2, 3],
+            y: [4, 5, 6],
+            opacity: 1
+        }]).then(function() {
+            gd._promises.push(delay(100)());
+            var checked = false;
+
+            Plotly.animate(gd, [{
+                data: [{'line.color': 'red'}]
+            }], {
+                frame: {duration: 0, redraw: false},
+                mode: 'immediate'
+            }).then(function() {
+                expect(gd._fullData[0].line.color).toBe('red');
+                expect(checked).toBe(true);
+            }).catch(fail).then(done);
+
+            setTimeout(function() {
+                expect(gd._fullData[0].line.color).not.toBe('red');
+                checked = true;
+            }, 50);
+        }).catch(fail);
+    });
 });


### PR DESCRIPTION
This PR moves the content of `Plotly.animate` into `Lib.syncOrAsync` so that it better fits into the plotly queue. The particular use-case is `Plotly.restyle` and `Plotly.animate` called in synchronous series (i.e. not promise-chained), though I'm currently unable to produce a situation that actually triggers any problems. I stumbled upon the possibility of a problem while working on the notifier, and solved things just by properly `then`-ing all the plotly API calls. That's good practice anyway, but this is also probably the right way for things to be.

I'm not quite sure how to produce a test case for this (short of inspecting the promise queue, except those are just anonymous callbacks, right?), but I'm glad to try if someone can come up with an idea that's not inherently fragile due to a race condition.

Additional note: there are only ~240 lines due to an indentation change. I've only changed this:

```javascript
return new Promise(...)
```

into this

```javascript
return Lib.syncOrAsync([
  function () {
    return new Promise(...)
  }
], gd);
```

/cc @alexcjohnson @etpinard 