### PR TITLE
Replace @src shortcut paths with `../../../src` in test assets

### DIFF
--- a/test/jasmine/assets/custom_matchers.js
+++ b/test/jasmine/assets/custom_matchers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var isNumeric = require('fast-isnumeric');
-var Lib = require('@src/lib');
+var Lib = require('../../../src/lib');
 var deepEqual = require('deep-equal');
 
 module.exports = {

--- a/test/jasmine/assets/double_click.js
+++ b/test/jasmine/assets/double_click.js
@@ -1,6 +1,6 @@
 var click = require('./click');
 var getNodeCoords = require('./get_node_coords');
-var DBLCLICKDELAY = require('@src/constants/interactions').DBLCLICKDELAY;
+var DBLCLICKDELAY = require('../../../src/constants/interactions').DBLCLICKDELAY;
 
 /*
  * double click on a point.

--- a/test/jasmine/assets/modebar_button.js
+++ b/test/jasmine/assets/modebar_button.js
@@ -1,9 +1,7 @@
 'use strict';
 
 var d3 = require('d3');
-
-var modeBarButtons = require('@src/components/modebar/buttons');
-
+var modeBarButtons = require('../../../src/components/modebar/buttons');
 
 module.exports = function selectButton(modeBar, name) {
     var button = {};

--- a/test/jasmine/assets/mouse_event.js
+++ b/test/jasmine/assets/mouse_event.js
@@ -1,4 +1,4 @@
-var Lib = require('@src/lib');
+var Lib = require('../../../src/lib');
 
 module.exports = function(type, x, y, opts) {
     var fullOpts = {


### PR DESCRIPTION
So that they can be more easily reused in other projects e.g. in https://github.com/plotly/support-assets/pull/150

@rreusser @alexcjohnson @n-riesco 
