### PR TITLE
add empty protocol to link whitelist for IE relative links

### DIFF
--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -254,11 +254,11 @@ var TAG_CLOSE = {
 
 /*
  * Whitelist of protocols in user-supplied urls. Mostly we want to avoid javascript
- * and related attack vectors. The empty string is there for IE, that treats
- * relative paths as having no protocol, while other browsers have these explicitly
- * inherit the protocol of the page they're in.
+ * and related attack vectors. The empty items are there for IE, that in various
+ * versions treats relative paths as having different flavors of no protocol, while
+ * other browsers have these explicitly inherit the protocol of the page they're in.
  */
-var PROTOCOLS = ['http:', 'https:', 'mailto:', ''];
+var PROTOCOLS = ['http:', 'https:', 'mailto:', '', undefined, ':'];
 
 var STRIP_TAGS = new RegExp('</?(' + Object.keys(TAG_STYLES).join('|') + ')( [^>]*)?/?>', 'g');
 

--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -252,7 +252,13 @@ var TAG_CLOSE = {
     sub: '<tspan dy="-0.21em">&#x200b;</tspan>'
 };
 
-var PROTOCOLS = ['http:', 'https:', 'mailto:'];
+/*
+ * Whitelist of protocols in user-supplied urls. Mostly we want to avoid javascript
+ * and related attack vectors. The empty string is there for IE, that treats
+ * relative paths as having no protocol, while other browsers have these explicitly
+ * inherit the protocol of the page they're in.
+ */
+var PROTOCOLS = ['http:', 'https:', 'mailto:', ''];
 
 var STRIP_TAGS = new RegExp('</?(' + Object.keys(TAG_STYLES).join('|') + ')( [^>]*)?/?>', 'g');
 


### PR DESCRIPTION
Currently relative links (`<a href="/path/to/file">Link!</a>`) that users insert in their plots fail in IE, because it treats the protocol of such a link as `''` - other browsers have these inherit from the page you're in. This fixes that.

@etpinard I can't think of a way to test this (since I can't find any way on Chrome or FF to generate an empty protocol) can you?

@scjody I don't see any way to turn this into an XSS attack, do you?