### PR TITLE
bump gl-error3d to ^1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "fast-isnumeric": "^1.1.1",
     "gl-contour2d": "^1.1.2",
     "gl-error2d": "^1.2.1",
-    "gl-error3d": "^1.0.0",
+    "gl-error3d": "^1.0.5",
     "gl-heatmap2d": "^1.0.3",
     "gl-line2d": "^1.4.1",
     "gl-line3d": "^1.1.0",


### PR DESCRIPTION
to grab https://github.com/gl-vis/gl-error3d/pull/2 and :lock: down the https://github.com/plotly/plotly.js/issues/1562 fix.

