### PR TITLE
Fixup sort transform event data text using

### DIFF
--- a/test/jasmine/tests/transform_sort_test.js
+++ b/test/jasmine/tests/transform_sort_test.js
@@ -273,7 +273,7 @@ describe('Test sort transform interactions:', function() {
         }
 
         function hover(gd, id) {
-            return new Promise(function(resolve) {
+            return new Promise(function(resolve, reject) {
                 gd.once('plotly_hover', function(eventData) {
                     delete gd._lastHoverTime;
                     resolve(eventData);
@@ -281,6 +281,10 @@ describe('Test sort transform interactions:', function() {
 
                 var pos = getPxPos(gd, id);
                 mouseEvent('mousemove', pos[0], pos[1]);
+
+                setTimeout(function() {
+                    reject('plotly_hover did not get called!');
+                }, 100);
             });
         }
 

--- a/test/jasmine/tests/transform_sort_test.js
+++ b/test/jasmine/tests/transform_sort_test.js
@@ -258,7 +258,7 @@ describe('Test sort transform interactions:', function() {
         .then(done);
     });
 
-    it('does not preserve hover/click `pointNumber` value', function(done) {
+    it('does not preserve event data `pointNumber` value', function(done) {
         var gd = createGraphDiv();
 
         function getPxPos(gd, id) {
@@ -275,30 +275,12 @@ describe('Test sort transform interactions:', function() {
         function hover(gd, id) {
             return new Promise(function(resolve) {
                 gd.once('plotly_hover', function(eventData) {
+                    delete gd._lastHoverTime;
                     resolve(eventData);
                 });
 
                 var pos = getPxPos(gd, id);
                 mouseEvent('mousemove', pos[0], pos[1]);
-            });
-        }
-
-        function click(gd, id) {
-            return new Promise(function(resolve) {
-                gd.once('plotly_click', function(eventData) {
-                    resolve(eventData);
-                });
-
-                var pos = getPxPos(gd, id);
-                mouseEvent('mousemove', pos[0], pos[1]);
-                mouseEvent('mousedown', pos[0], pos[1]);
-                mouseEvent('mouseup', pos[0], pos[1]);
-            });
-        }
-
-        function wait() {
-            return new Promise(function(resolve) {
-                setTimeout(resolve, 100);
             });
         }
 
@@ -334,12 +316,10 @@ describe('Test sort transform interactions:', function() {
         .then(function(eventData) {
             assertPt(eventData, 0, 1, 3, 'D');
         })
-        .then(wait)
-        .then(function() { return click(gd, 'G'); })
+        .then(function() { return hover(gd, 'G'); })
         .then(function(eventData) {
             assertPt(eventData, 1, 1, 6, 'G');
         })
-        .then(wait)
         .then(function() {
             return Plotly.restyle(gd, 'transforms[0].enabled', true);
         })
@@ -347,8 +327,7 @@ describe('Test sort transform interactions:', function() {
         .then(function(eventData) {
             assertPt(eventData, 0, 1, 1, 'D');
         })
-        .then(wait)
-        .then(function() { return click(gd, 'G'); })
+        .then(function() { return hover(gd, 'G'); })
         .then(function(eventData) {
             assertPt(eventData, 1, 1, 5, 'G');
         })
@@ -359,8 +338,7 @@ describe('Test sort transform interactions:', function() {
         .then(function(eventData) {
             assertPt(eventData, 0, 1, 1, 'D');
         })
-        .then(wait)
-        .then(function() { return click(gd, 'G'); })
+        .then(function() { return hover(gd, 'G'); })
         .then(function(eventData) {
             assertPt(eventData, 1, 1, 5, 'G');
         })


### PR DESCRIPTION
This test doesn't behave well on CI as noticed by @alexcjohnson and @rreusser 

So to remedy this problem, we'll test sort transform event data using hover events only:

- hover and click when invoked programmatically back-to-back don't behave well.
- this test case makes assertions on the event data (i.e. `gd._hoverdata`) which is the same for hover and click
- use `delete gd._lastHoverTime` to :hocho: that annoying wait promise

