### PR TITLE
Prohibit CSS transform usage on SVG elements due to IE

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
     "Uint8Array": true,
     "Int16Array": true,
     "Int32Array": true,
-    "ArrayBuffer": true
+    "ArrayBuffer": true,
+    "SVGElement": false
   },
   "rules": {
     "no-trailing-spaces": [2],

--- a/test/image/strict-d3.js
+++ b/test/image/strict-d3.js
@@ -17,17 +17,17 @@
 
         if(sel.size()) {
             if(typeof obj === 'string') {
-                checkVal(obj, arguments[1]);
+                checkVal(sel, obj, arguments[1]);
             }
             else {
-                Object.keys(obj).forEach(function(key) { checkVal(key, obj[key]); });
+                Object.keys(obj).forEach(function(key) { checkVal(sel, key, obj[key]); });
             }
         }
 
         return originalSelStyle.apply(sel, arguments);
     };
 
-    function checkVal(key, val) {
+    function checkVal(sel, key, val) {
         if(typeof val === 'string') {
             // in case of multipart styles (stroke-dasharray, margins, etc)
             // test each part separately
@@ -37,6 +37,11 @@
                     throw new Error('d3 selection.style called with value: ' + val);
                 }
             });
+
+            // Microsoft browsers incl. "Edge" don't support CSS transform on SVG elements
+            if(key === 'transform' && sel.node() instanceof SVGElement) {
+                throw new Error('d3 selection.style called on an SVG element with key: ' + key);
+            }
         }
 
     }


### PR DESCRIPTION
As [suggested](https://github.com/plotly/plotly.js/pull/1723#discussion_r118360733) by @etpinard 