### PR TITLE
Fixup camera interaction relayout event data

### DIFF
--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -179,7 +179,7 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
         if(scene.fullSceneLayout.dragmode === false) return;
 
         var update = {};
-        update[scene.id] = getLayoutCamera(scene.camera);
+        update[scene.id + '.camera'] = getLayoutCamera(scene.camera);
         scene.saveCamera(scene.graphDiv.layout);
         scene.graphDiv.emit('plotly_relayout', update);
     };

--- a/test/jasmine/tests/gl_plot_interact_basic_test.js
+++ b/test/jasmine/tests/gl_plot_interact_basic_test.js
@@ -38,7 +38,7 @@ function verifyInteractionEffects(tuple) {
     expect(tuple.relayoutCallback).toHaveBeenCalledTimes(1);
 
     // Check structure of event callback value contents
-    expect(tuple.relayoutCallback).toHaveBeenCalledWith(jasmine.objectContaining({scene: cameraStructure}));
+    expect(tuple.relayoutCallback).toHaveBeenCalledWith(jasmine.objectContaining({'scene.camera': cameraStructure}));
 
     // Check camera contents on the DIV layout
     var divCamera = tuple.graphDiv.layout.scene.camera;


### PR DESCRIPTION
Another bug I found when working on gl3d annotations.

On scene drag/pan, we fire a `plotly_relayout` event mocking the equivalent `Plotly.relayout` call that would generate the current view.

Previously, the mocked event data looked:

```js
{ scene: { eye: {/**/}, up: {/**/}, center: {/**/} }
```
(or `scene2: // ...` for multiple-scene graphs) which isn't compatible with our plot schema

Now with this PR, the mocked event data is:

```js
{ 'scene.camera': { eye: {/**/}, up: {/**/}, center: {/**/} }
```

cc @monfera 