### PR TITLE
Add warning if an invalid scale is passed

### DIFF
--- a/src/components/colorscale/is_valid_scale.js
+++ b/src/components/colorscale/is_valid_scale.js
@@ -9,11 +9,15 @@
 
 'use strict';
 
+var Lib = require('../../lib');
 var scales = require('./scales');
 var isValidScaleArray = require('./is_valid_scale_array');
 
 
 module.exports = function isValidScale(scl) {
-    if(scales[scl] !== undefined) return true;
-    else return isValidScaleArray(scl);
+    if(scales[scl] !== undefined || isValidScaleArray(scl)) {
+        return true;
+    }
+    if(scl !== undefined) Lib.warn('Invalid scale passed', scl);
+    return false;
 };


### PR DESCRIPTION
When an invalid scale is passed, it's silently ignored if it's invalid. This makes it painful to debug (did I use the right parameter ? does this chart support colorscales ?). So I propose to add a warning for invalid scales.

Of course, people still have to do `Plotly.setPlotConfig({logging: true});`