### PR TITLE
Add failing test for sort + animate

### DIFF
--- a/test/jasmine/tests/animate_test.js
+++ b/test/jasmine/tests/animate_test.js
@@ -768,4 +768,36 @@ describe('animating scatter traces', function() {
             expect(trace.style('opacity')).toEqual('0.1');
         }).catch(fail).then(done);
     });
+
+    it('computes calcdata correctly when transforms are present', function (done) {
+        var isChecked = false;
+
+        Plotly.plot(gd, {
+            data: [{
+                x: [1, 2, 3],
+                y: [1, 2, 3],
+                mode: 'markers',
+                transforms: [{
+                    type: 'sort',
+                    target: [1, 3, 2]
+                }]
+            }],
+            frames: [
+                {name: 'frame1', data: [{y: [1, 2, 3]}]},
+                {name: 'frame2', data: [{y: [3, 1, 2]}]}
+            ]
+        }).then(function () {;
+            return Plotly.animate(gd, ['frame2'], {frame: {duration: 200, redraw: false}});
+        }).then(function () {
+            expect(isChecked).toBe(true);
+        }).catch(fail).then(done);
+
+        gd.on('plotly_animating', function () {
+            setTimeout(function () {
+                isChecked = true;
+                console.log('gd.calcdata[0][0].y:', gd.calcdata[0][0].y);
+                expect(gd.calcdata[0][0].y).toEqual(3);
+            }, 100);
+        })
+    });
 });


### PR DESCRIPTION
This PR adds a failing test for sort + transform that is fixed by #1737. It basically checks the value of `calcdata` after the transform has started but before it has finished in order to check that the result is as expected.

/cc @alexcjohnson @etpinard 