### PR TITLE
Fix RE used to correct quotes used in URLs for IE.

### DIFF
--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -35,7 +35,7 @@ function svgToImg(opts) {
             // url in svg are single quoted
             //   since we changed double to single
             //   we'll need to change these to double-quoted
-            svg = svg.replace(/(\('#)(.*)('\))/gi, '(\"$2\")');
+            svg = svg.replace(/(\('#)([^']*)('\))/gi, '(\"$2\")');
             // font names with spaces will be escaped single-quoted
             //   we'll need to change these to double-quoted
             svg = svg.replace(/(\\')/gi, '\"');


### PR DESCRIPTION
The `svgToImg()` function tries to normalize the SVG for compatibility
with IE.  However, currently it use a regular expression that is too
greedy when matching the attribute values that need quotes changed from
single to double.  The result is that invalid XML is generated and will
cause IE11 to fail with a `XML 5607` error and `svgToImg()` will never
return.  Edge will not complain but will receive invalid XML, which
causes problems when used.

This change restricts matching to only data surrounded by single quotes.

Seems like a jasmine test should be added for `svgToImg()` along the
lines of

  `it('Returns valid XML',...)`

Also addresses: https://community.plot.ly/t/plotly-toimage-xml5607-error-in-ie11/4223
