### PR TITLE
Install @plotly/mapbox-gl fork instead of 'regular' mapbox-gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "gl-shader": "4.2.0",
     "gl-spikes2d": "^1.0.1",
     "gl-surface3d": "^1.3.0",
-    "mapbox-gl": "^0.22.0",
+    "@plotly/mapbox-gl": "0.22.1",
     "matrix-camera-controller": "^2.1.3",
     "mouse-change": "^1.4.0",
     "mouse-wheel": "^1.0.2",


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1745

... so that plotly.js install properly on npm@5
