### PR TITLE
fix bug with unhover in gl2d

### DIFF
--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -67,6 +67,11 @@ function Scene2D(options, fullLayout) {
     // last pick result
     this.pickResult = null;
 
+    // is the mouse over the plot?
+    // it's OK if this says true when it's not, so long as
+    // when we get a mouseout we set it to false before handling
+    this.isMouseOver = true;
+
     this.bounds = [Infinity, Infinity, -Infinity, -Infinity];
 
     // flag to stop render loop
@@ -153,6 +158,15 @@ proto.makeFramework = function() {
     container.appendChild(canvas);
     container.appendChild(svgContainer);
     container.appendChild(mouseContainer);
+
+    var self = this;
+    mouseContainer.addEventListener('mouseout', function() {
+        self.isMouseOver = false;
+        self.unhover();
+    });
+    mouseContainer.addEventListener('mouseover', function() {
+        self.isMouseOver = true;
+    });
 };
 
 proto.toImage = function(format) {
@@ -574,7 +588,7 @@ proto.draw = function() {
 
         glplot.setDirty();
     }
-    else if(!camera.panning) {
+    else if(!camera.panning && this.isMouseOver) {
         this.selectBox.enabled = false;
 
         var size = fullLayout._size,
@@ -658,14 +672,20 @@ proto.draw = function() {
 
     // Remove hover effects if we're not over a point OR
     // if we're zooming or panning (in which case result is not set)
-    if(!result && this.lastPickResult) {
+    if(!result) {
+        this.unhover();
+    }
+
+    glplot.draw();
+};
+
+proto.unhover = function() {
+    if(this.lastPickResult) {
         this.spikes.update({});
         this.lastPickResult = null;
         this.graphDiv.emit('plotly_unhover');
         Fx.loneUnhover(this.svgContainer);
     }
-
-    glplot.draw();
 };
 
 proto.hoverFormatter = function(axisName, val) {

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -13,6 +13,7 @@ var fail = require('../assets/fail_test.js');
 var click = require('../assets/timed_click');
 var hover = require('../assets/hover');
 var delay = require('../assets/delay');
+var mouseEvent = require('../assets/mouse_event');
 
 // contourgl is not part of the dist plotly.js bundle initially
 Plotly.register([
@@ -84,11 +85,17 @@ describe('Test hover and click interactions', function() {
     function makeUnhoverFn(gd, x0, y0) {
         return function() {
             return new Promise(function(resolve) {
+                var initialElement = document.elementFromPoint(x0, y0);
                 // fairly realistic simulation of moving with the cursor
                 var canceler = setInterval(function() {
                     x0 -= 2;
                     y0 -= 2;
                     hover(x0, y0);
+
+                    var nowElement = document.elementFromPoint(x0, y0);
+                    if(nowElement !== initialElement) {
+                        mouseEvent('mouseout', x0, y0, {element: initialElement});
+                    }
                 }, 10);
 
                 gd.on('plotly_unhover', function() {


### PR DESCRIPTION
While working on axis constraints by restricting domain, I found that a bunch of tests were failing locally for me, consistently, on master as well as my branch. Most just needed increased tolerances so I'll just include them in the constraints PR. But this one, "scattergl after visibility restyle", pointed to a real bug in gl2d: if you mouseout of the gl2d plot while hovering on a point, it will not unhover.

@etpinard I guess in principle this should be an independent PR into master (in which case it would also need another commit from my branch that cleaned up the test suite so I could see where the failure was) but I need it in my `constrain-domain` branch to get tests to pass and somehow noone else encountered this error?

It would also be nice eventually if the `mouse-change` package would handle this itself somehow, rather than just calling its [`clearState`](https://github.com/mikolalysenko/mouse-change/blob/master/mouse-listen.js#L117) that's indistinguishable from a real hover event. But for now it seemed like we should handle this within the gl2d scene.