### PR TITLE
Remove Promise polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ and more.
 * [Contributing](#contributing)
 * [Community](#community)
 * [Clients for R, Python, Node, and MATLAB](#clients-for-r-python-node-and-matlab)
+* [Browser Compatibility](#browser-compatibility)
 * [Creators](#creators)
 * [Copyright and license](#copyright-and-license)
 
@@ -153,6 +154,13 @@ Open-source clients to the plotly.js APIs are available at these links:
 |**Julia**| [plotly/Plotly.jl](https://github.com/plotly/Plotly.jl) | [plot.ly/julia/getting-started](https://plot.ly/julia/getting-started) |
 
 plotly.js charts can also be created and saved online for free at [plot.ly/plot](https://plot.ly/plot).
+
+## Browser Compatibility
+
+Besides [d3.js](http://d3js.org) and [stack.gl](http://stack.gl), plotly.js makes use of the [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) API, which is widely supported across browsers, see [promises](http://caniuse.com/promises/embed).
+
+But for legacy browsers, we advise using one of the many polyfills available ([core-js](https://github.com/zloirock/core-js) provides a wide variety of shims).
+
 
 ## Creators
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "d3": "^3.5.12",
     "d3-force": "^1.0.6",
     "delaunay-triangulate": "^1.1.6",
-    "es6-promise": "^3.0.2",
     "fast-isnumeric": "^1.1.1",
     "gl-contour2d": "^1.1.2",
     "gl-error2d": "^1.2.1",

--- a/src/core.js
+++ b/src/core.js
@@ -17,9 +17,6 @@ var Plotly = require('./plotly');
 // package version injected by `npm run preprocess`
 exports.version = '1.27.1';
 
-// inject promise polyfill
-require('es6-promise').polyfill();
-
 // inject plot css
 require('../build/plotcss');
 


### PR DESCRIPTION
This addresses https://github.com/plotly/plotly.js/issues/955. It basically just removes `es6-promise` polyfill as there is really no need for it unless you use a legacy browser.

I've also added some doc on this matter for users that do still use legacy browsers.