### PR TITLE
hide off-plot annotations

### DIFF
--- a/src/components/annotations/draw.js
+++ b/src/components/annotations/draw.js
@@ -316,7 +316,7 @@ function drawRaw(gd, options, index, subplotId, xa, ya) {
                         annotationIsOffscreen = true;
                     }
 
-                    if(annotationIsOffscreen) return;
+                    if(annotationIsOffscreen) continue;
                 }
                 basePx = ax._offset + ax.r2p(options[axLetter]);
                 autoAlignFraction = 0.5;


### PR DESCRIPTION
fixes #1771 

@etpinard the bug was actually introduced in https://github.com/plotly/plotly.js/commit/aa58118e3665dd60d3fdda689ae58cf1814f99c2 - nice easy fix, plus a test 🔒 