### PR TITLE
Enable touch interactions for select/lasso/others

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "gl-shader": "4.2.0",
     "gl-spikes2d": "^1.0.1",
     "gl-surface3d": "^1.3.0",
+    "has-hover": "^1.0.0",
     "mapbox-gl": "^0.22.0",
     "matrix-camera-controller": "^2.1.3",
     "mouse-change": "^1.4.0",

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -145,19 +145,19 @@ dragElement.init = function init(options) {
 
     function onDone(e) {
         if(hasHover) {
-            document.removeEventListener('mousemove', onMove);
-            document.removeEventListener('mouseup', onDone);
-            document.removeEventListener('mouseout', onDone);
+            dragCover.removeEventListener('mousemove', onMove);
+            dragCover.removeEventListener('mouseup', onDone);
+            dragCover.removeEventListener('mouseout', onDone);
 
             Lib.removeElement(dragCover);
         }
 
         else {
-            document.removeEventListener('touchmove', onMove);
-            document.removeEventListener('touchend', onDone);
+            dragCover.removeEventListener('touchmove', onMove);
+            dragCover.removeEventListener('touchend', onDone);
 
             if(cursor) {
-                document.documentElement.style.cursor = cursor;
+                dragCover.documentElement.style.cursor = cursor;
                 cursor = null;
             }
         }

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -84,7 +84,7 @@ dragElement.init = function init(options) {
         // so that others can look at and modify them
         gd._dragged = false;
         gd._dragging = true;
-        var offset = pointerOffset(e)
+        var offset = pointerOffset(e);
         startX = offset[0];
         startY = offset[1];
         initialTarget = e.target;
@@ -113,7 +113,7 @@ dragElement.init = function init(options) {
 
         // document acts as a dragcover for mobile, bc we can't create dragcover dynamically
         else {
-            dragCover = document
+            dragCover = document;
             document.addEventListener('touchmove', onMove);
             document.addEventListener('touchend', onDone);
 
@@ -126,8 +126,8 @@ dragElement.init = function init(options) {
     }
 
     function onMove(e) {
-        var offset = pointerOffset(e)
-        var dx = offset[0] - startX,
+        var offset = pointerOffset(e),
+            dx = offset[0] - startX,
             dy = offset[1] - startY,
             minDrag = options.minDrag || constants.MINDRAG;
 
@@ -184,7 +184,7 @@ dragElement.init = function init(options) {
                 e2 = new MouseEvent('click', e);
             }
             catch(err) {
-                var offset = pointerOffset(e)
+                var offset = pointerOffset(e);
                 e2 = document.createEvent('MouseEvents');
                 e2.initMouseEvent('click',
                     e.bubbles, e.cancelable,
@@ -235,5 +235,5 @@ function pointerOffset(e) {
     return mouseOffset(
         e.changedTouches && e.changedTouches[0] || e,
         document.body
-    )
+    );
 }

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -10,7 +10,6 @@
 'use strict';
 
 var mouseOffset = require('mouse-event-offset');
-var hasHover = require('has-hover');
 
 var Plotly = require('../../plotly');
 var Lib = require('../../lib');
@@ -30,13 +29,6 @@ dragElement.unhoverRaw = unhover.raw;
 /**
  * Abstracts click & drag interactions
  *
- * During the interaction, a "coverSlip" element - a transparent
- * div covering the whole page - is created, which has two key effects:
- * - Lets you drag beyond the boundaries of the plot itself without
- *   dropping (but if you drag all the way out of the browser window the
- *   interaction will end)
- * - Freezes the cursor: whatever mouse cursor the drag element had when the
- *   interaction started gets copied to the coverSlip for use until mouseup
  *
  * @param {object} options with keys:
  *      element (required) the DOM element to drag
@@ -65,19 +57,14 @@ dragElement.init = function init(options) {
         startY,
         newMouseDownTime,
         cursor,
-        dragCover,
         initialTarget;
 
     if(!gd._mouseDownTime) gd._mouseDownTime = 0;
 
     options.element.style.pointerEvents = 'all';
 
-    if(hasHover) {
-        options.element.onmousedown = onStart;
-    }
-    else {
-        options.element.ontouchstart = onStart;
-    }
+    options.element.onmousedown = onStart;
+    options.element.ontouchstart = onStart;
 
     function onStart(e) {
         // make dragging and dragged into properties of gd
@@ -102,24 +89,16 @@ dragElement.init = function init(options) {
 
         if(options.prepFn) options.prepFn(e, startX, startY);
 
-        if(hasHover) {
-            dragCover = coverSlip();
-            dragCover.addEventListener('mousemove', onMove);
-            dragCover.addEventListener('mouseup', onDone);
-            dragCover.addEventListener('mouseout', onDone);
-
-            dragCover.style.cursor = window.getComputedStyle(options.element).cursor;
-        }
 
         // document acts as a dragcover for mobile, bc we can't create dragcover dynamically
-        else {
-            dragCover = document;
-            document.addEventListener('touchmove', onMove);
-            document.addEventListener('touchend', onDone);
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onDone);
+        document.addEventListener('mouseout', onDone);
+        document.addEventListener('touchmove', onMove);
+        document.addEventListener('touchend', onDone);
 
-            cursor = window.getComputedStyle(document.documentElement).cursor;
-            document.documentElement.style.cursor = window.getComputedStyle(options.element).cursor;
-        }
+        cursor = window.getComputedStyle(document.documentElement).cursor;
+        document.documentElement.style.cursor = window.getComputedStyle(options.element).cursor;
 
 
         return Lib.pauseEvent(e);
@@ -144,24 +123,16 @@ dragElement.init = function init(options) {
     }
 
     function onDone(e) {
-        if(hasHover) {
-            dragCover.removeEventListener('mousemove', onMove);
-            dragCover.removeEventListener('mouseup', onDone);
-            dragCover.removeEventListener('mouseout', onDone);
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onDone);
+        document.removeEventListener('mouseout', onDone);
+        document.removeEventListener('touchmove', onMove);
+        document.removeEventListener('touchend', onDone);
 
-            Lib.removeElement(dragCover);
+        if(cursor) {
+            document.documentElement.style.cursor = cursor;
+            cursor = null;
         }
-
-        else {
-            dragCover.removeEventListener('touchmove', onMove);
-            dragCover.removeEventListener('touchend', onDone);
-
-            if(cursor) {
-                dragCover.documentElement.style.cursor = cursor;
-                cursor = null;
-            }
-        }
-
 
         if(!gd._dragging) {
             gd._dragged = false;

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -233,7 +233,7 @@ function finishDrag(gd) {
 
 function pointerOffset(e) {
     return mouseOffset(
-        e.changedTouches && e.changedTouches[0] || e,
+        e.changedTouches ? e.changedTouches[0] : e,
         document.body
     );
 }

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -12,6 +12,7 @@
 
 var d3 = require('d3');
 var isNumeric = require('fast-isnumeric');
+var hasHover = require('has-hover');
 
 var Plotly = require('../plotly');
 var Lib = require('../lib');
@@ -422,6 +423,11 @@ function setPlotContext(gd, config) {
         context.showTips = false;
         context.showLink = false;
         context.displayModeBar = false;
+    }
+
+    // make sure hover-only devices have mode bar visible
+    if(context.displayModeBar === 'hover' && !hasHover) {
+        context.displayModeBar = true;
     }
 }
 

--- a/src/plots/gl2d/camera.js
+++ b/src/plots/gl2d/camera.js
@@ -65,6 +65,7 @@ function createCamera(scene) {
         handleInteraction(1, xy[0], xy[1]);
     });
     element.addEventListener('touchmove', function(ev) {
+        ev.preventDefault()
         var xy = mouseOffset(ev.changedTouches[0], element);
         handleInteraction(1, xy[0], xy[1]);
     });

--- a/src/plots/gl2d/camera.js
+++ b/src/plots/gl2d/camera.js
@@ -65,7 +65,7 @@ function createCamera(scene) {
         handleInteraction(1, xy[0], xy[1]);
     });
     element.addEventListener('touchmove', function(ev) {
-        ev.preventDefault()
+        ev.preventDefault();
         var xy = mouseOffset(ev.changedTouches[0], element);
         handleInteraction(1, xy[0], xy[1]);
     });

--- a/src/plots/gl2d/camera.js
+++ b/src/plots/gl2d/camera.js
@@ -11,6 +11,7 @@
 
 var mouseChange = require('mouse-change');
 var mouseWheel = require('mouse-wheel');
+var mouseOffset = require('mouse-event-offset');
 var cartesianConstants = require('../cartesian/constants');
 
 module.exports = createCamera;
@@ -55,7 +56,23 @@ function createCamera(scene) {
         return false;
     }
 
-    result.mouseListener = mouseChange(element, function(buttons, x, y) {
+    result.mouseListener = mouseChange(element, handleInteraction);
+
+    // enable simple touch interactions
+    element.addEventListener('touchstart', function(ev) {
+        var xy = mouseOffset(ev.changedTouches[0], element);
+        handleInteraction(0, xy[0], xy[1]);
+        handleInteraction(1, xy[0], xy[1]);
+    });
+    element.addEventListener('touchmove', function(ev) {
+        var xy = mouseOffset(ev.changedTouches[0], element);
+        handleInteraction(1, xy[0], xy[1]);
+    });
+    element.addEventListener('touchend', function() {
+        handleInteraction(0, result.lastPos[0], result.lastPos[1]);
+    });
+
+    function handleInteraction(buttons, x, y) {
         var dataBox = scene.calcDataBox(),
             viewBox = plot.viewBox;
 
@@ -235,7 +252,7 @@ function createCamera(scene) {
 
         result.lastPos[0] = x;
         result.lastPos[1] = y;
-    });
+    }
 
     result.wheelListener = mouseWheel(element, function(dx, dy) {
         var dataBox = scene.calcDataBox(),

--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -525,10 +525,22 @@ proto.updateTraces = function(fullData, calcData) {
 };
 
 proto.updateFx = function(dragmode) {
+    // switch to svg interactions in lasso/select mode
     if(dragmode === 'lasso' || dragmode === 'select') {
         this.mouseContainer.style['pointer-events'] = 'none';
     } else {
         this.mouseContainer.style['pointer-events'] = 'auto';
+    }
+
+    // set proper cursor
+    if(dragmode === 'pan') {
+        this.mouseContainer.style.cursor = 'move';
+    }
+    else if(dragmode === 'zoom') {
+        this.mouseContainer.style.cursor = 'crosshair';
+    }
+    else {
+        this.mouseContainer.style.cursor = null;
     }
 };
 

--- a/src/traces/scattergl/convert.js
+++ b/src/traces/scattergl/convert.js
@@ -401,7 +401,7 @@ proto.updateFast = function(options) {
     this.idToIndex = idToIndex;
 
     // form selected set
-    if(selection) {
+    if(selection && selection.length) {
         selPositions = new Float64Array(2 * selection.length);
 
         for(i = 0, l = selection.length; i < l; i++) {

--- a/test/jasmine/assets/touch_event.js
+++ b/test/jasmine/assets/touch_event.js
@@ -1,0 +1,44 @@
+var Lib = require('../../../src/lib');
+
+module.exports = function(type, x, y, opts) {
+    var el = (opts && opts.element) || document.elementFromPoint(x, y),
+        ev;
+
+    var touchObj = new Touch({
+        identifier: Date.now(),
+        target: el,
+        clientX: x,
+        clientY: y,
+        radiusX: 2.5,
+        radiusY: 2.5,
+        rotationAngle: 10,
+        force: 0.5,
+    });
+
+    var fullOpts = {
+        touches: [touchObj],
+        targetTouches: [],
+        changedTouches: [touchObj],
+        bubbles: true
+    };
+
+    if(opts && opts.altKey) {
+        fullOpts.altKey = opts.altKey;
+    }
+    if(opts && opts.ctrlKey) {
+        fullOpts.ctrlKey = opts.ctrlKey;
+    }
+    if(opts && opts.metaKey) {
+        fullOpts.metaKey = opts.metaKey;
+    }
+    if(opts && opts.shiftKey) {
+        fullOpts.shiftKey = opts.shiftKey;
+    }
+
+
+    ev = new window.TouchEvent(type, Lib.extendFlat({}, fullOpts, opts));
+
+    el.dispatchEvent(ev);
+
+    return el;
+};

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -182,6 +182,7 @@ func.defaultConfig = {
         _Chrome: {
             base: 'Chrome',
             flags: [
+                '--touch-events',
                 '--window-size=' + argv.width + ',' + argv.height,
                 isCI ? '--ignore-gpu-blacklist' : ''
             ]

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -315,7 +315,7 @@ describe('select box and lasso', function() {
             });
         });
 
-        it('@noCI should trigger selecting/selected/deselect events for touches', function(done) {
+        it('should trigger selecting/selected/deselect events for touches', function(done) {
             var selectingCnt = 0,
                 selectingData;
             gd.on('plotly_selecting', function(data) {

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -315,7 +315,7 @@ describe('select box and lasso', function() {
             });
         });
 
-        it('should trigger selecting/selected/deselect events for touches', function(done) {
+        it('@noCI should trigger selecting/selected/deselect events for touches', function(done) {
             var selectingCnt = 0,
                 selectingData;
             gd.on('plotly_selecting', function(data) {

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -7,6 +7,7 @@ var doubleClick = require('../assets/double_click');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var mouseEvent = require('../assets/mouse_event');
+var touchEvent = require('../assets/touch_event');
 var customMatchers = require('../assets/custom_matchers');
 
 
@@ -22,8 +23,22 @@ describe('select box and lasso', function() {
 
     afterEach(destroyGraphDiv);
 
-    function drag(path) {
+    function drag(path, options) {
         var len = path.length;
+
+        if(!options) options = {type: 'mouse'};
+
+        if(options.type === 'touch') {
+            touchEvent('touchstart', path[0][0], path[0][1]);
+
+            path.slice(1, len).forEach(function(pt) {
+                touchEvent('touchmove', pt[0], pt[1]);
+            });
+
+            touchEvent('touchend', path[len - 1][0], path[len - 1][1]);
+
+            return;
+        }
 
         mouseEvent('mousemove', path[0][0], path[0][1]);
         mouseEvent('mousedown', path[0][0], path[0][1]);
@@ -277,6 +292,50 @@ describe('select box and lasso', function() {
             });
 
             drag(lassoPath);
+
+            expect(selectingCnt).toEqual(3, 'with the correct selecting count');
+            assertEventData(selectingData.points, [{
+                curveNumber: 0,
+                pointNumber: 10,
+                x: 0.099,
+                y: 2.75
+            }], 'with the correct selecting points (1)');
+
+            expect(selectedCnt).toEqual(1, 'with the correct selected count');
+            assertEventData(selectedData.points, [{
+                curveNumber: 0,
+                pointNumber: 10,
+                x: 0.099,
+                y: 2.75,
+            }], 'with the correct selected points (2)');
+
+            doubleClick(250, 200).then(function() {
+                expect(doubleClickData).toBe(null, 'with the correct deselect data');
+                done();
+            });
+        });
+
+        it('should trigger selecting/selected/deselect events for touches', function(done) {
+            var selectingCnt = 0,
+                selectingData;
+            gd.on('plotly_selecting', function(data) {
+                selectingCnt++;
+                selectingData = data;
+            });
+
+            var selectedCnt = 0,
+                selectedData;
+            gd.on('plotly_selected', function(data) {
+                selectedCnt++;
+                selectedData = data;
+            });
+
+            var doubleClickData;
+            gd.on('plotly_deselect', function(data) {
+                doubleClickData = data;
+            });
+
+            drag(lassoPath, {type: 'touch'});
 
             expect(selectingCnt).toEqual(3, 'with the correct selecting count');
             assertEventData(selectingData.points, [{


### PR DESCRIPTION
Resolves https://github.com/plotly/plotly.js/issues/1790

We have to avoid creating `dragCover` for touch-only devices, because `touchmove`, unlike `mousemove`, requires the same element where `touchstart` happened.

Is there any particular reason we don't use `document` for catching mouse events? What makes `dragCover` different from `document`?

@etpinard @alexcjohnson 

TODO:

* [x] `dragCover` does not hide cursor for panning and makes it a text cursor, we have to disable 
 selection in a way similar to [this](https://github.com/dfcreative/mucss/blob/master/selection.js)
* [x] panning/zooming do not work for scatter2d, that is related to [gl2d/camera](https://github.com/plotly/plotly.js/blob/master/src/plots/gl2d/camera.js)
* [x] no mode cursor for scatter2d #1489
* [x] panning is mixed up with page scrolling if body content is long
* [x] double click should reset the selection