### PR TITLE
Fix hover error in appendArrayPointValue

### DIFF
--- a/src/components/fx/helpers.js
+++ b/src/components/fx/helpers.js
@@ -94,6 +94,10 @@ function quadrature(dx, dy) {
 exports.appendArrayPointValue = function(pointData, trace, pointNumber) {
     var arrayAttrs = trace._arrayAttrs;
 
+    if(!arrayAttrs) {
+        return;
+    }
+
     for(var i = 0; i < arrayAttrs.length; i++) {
         var astr = arrayAttrs[i];
         var key;

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -1303,12 +1303,11 @@ describe('Test hover label custom styling:', function() {
 describe('ohlc hover interactions', function() {
     var data = [{
         type: 'candlestick',
+        x: ['2011-01-01', '2012-01-01'],
         open: [2, 2],
         high: [3, 3],
         low: [0, 0],
         close: [3, 3],
-        x: [1, 2, 3],
-        y: [0.12345, 0.23456, 0.34567]
     }];
 
     beforeEach(function() {

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -1299,3 +1299,27 @@ describe('Test hover label custom styling:', function() {
         .then(done);
     });
 });
+
+describe('ohlc hover interactions', function() {
+    var data = [{
+        type: 'candlestick',
+        open: [2, 2],
+        high: [3, 3],
+        low: [0, 0],
+        close: [3, 3],
+        x: [1, 2, 3],
+        y: [0.12345, 0.23456, 0.34567]
+    }];
+
+    beforeEach(function() {
+        this.gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    // See: https://github.com/plotly/plotly.js/issues/1807
+    it('should not fail in appendArrayPointValue', function() {
+        Plotly.plot(this.gd, data);
+        mouseEvent('mousemove', 203, 213);
+    });
+});

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -1320,5 +1320,7 @@ describe('ohlc hover interactions', function() {
     it('should not fail in appendArrayPointValue', function() {
         Plotly.plot(this.gd, data);
         mouseEvent('mousemove', 203, 213);
+
+        expect(d3.select('.hovertext').size()).toBe(1);
     });
 });


### PR DESCRIPTION
This PR address the issue in #1807 by exiting early if `arrayAttrs` is undefined. This may or may not be an appropriate fix. I could test this by passing it a plain object with no _arrayAttrs, but it seems to be of questionable value since `appendArrayPointValue` isn't tested otherwise. Can add, but I'll wait for a second opinion on the source of the problem.