### PR TITLE
added hoverlabel namelength option

### DIFF
--- a/src/components/fx/attributes.js
+++ b/src/components/fx/attributes.js
@@ -33,6 +33,13 @@ module.exports = {
             family: extendFlat({}, fontAttrs.family, { arrayOk: true }),
             size: extendFlat({}, fontAttrs.size, { arrayOk: true }),
             color: extendFlat({}, fontAttrs.color, { arrayOk: true })
+        },
+        namelength: {
+            valType: 'number',
+            min: 0,
+            dflt: 15,
+            role: 'style',
+            description: 'Sets the length (in number of characters) of the hover labels for this trace'
         }
     }
 };

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -689,7 +689,7 @@ function createHoverText(hoverData, opts, gd) {
             // strip out our pseudo-html elements from d.name (if it exists at all)
             name = svgTextUtils.plainText(d.name || '');
 
-            if(name.length > 15) name = name.substr(0, 12) + '...';
+            if(name.length > commonLabelOpts.namelength) name = name.substr(0, commonLabelOpts.namelength - 3) + '...';
         }
 
         // used by other modules (initially just ternary) that

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -689,7 +689,7 @@ function createHoverText(hoverData, opts, gd) {
             // strip out our pseudo-html elements from d.name (if it exists at all)
             name = svgTextUtils.plainText(d.name || '');
 
-            if(name.length > commonLabelOpts.namelength) name = name.substr(0, commonLabelOpts.namelength - 3) + '...';
+            if(name.length > commonLabelOpts.namelength && commonLabelOpts.namelength > 0) name = name.substr(0, commonLabelOpts.namelength - 3) + '...';
         }
 
         // used by other modules (initially just ternary) that

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -15,5 +15,6 @@ module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts
 
     coerce('hoverlabel.bgcolor', opts.bgcolor);
     coerce('hoverlabel.bordercolor', opts.bordercolor);
+    coerce('hoverlabel.namelength', opts.namelength);
     Lib.coerceFont(coerce, 'hoverlabel.font', opts.font);
 };

--- a/src/components/fx/layout_attributes.js
+++ b/src/components/fx/layout_attributes.js
@@ -55,6 +55,13 @@ module.exports = {
                 dflt: constants.HOVERFONTSIZE
             }),
             color: extendFlat({}, fontAttrs.color)
+        },
+        namelength: {
+            valType: 'number',
+            min: 0,
+            dflt: 15,
+            role: 'style',
+            description: 'Sets the length (in number of characters) of the hover labels for this trace'
         }
     }
 };


### PR DESCRIPTION
Implementation of [this](https://github.com/plotly/plotly.js/issues/1777)