### PR TITLE
Accept empty transforms

### DIFF
--- a/src/plot_api/plot_schema.js
+++ b/src/plot_api/plot_schema.js
@@ -166,10 +166,13 @@ exports.findArrayAttributes = function(trace) {
 
         for(var i = 0; i < transforms.length; i++) {
             var transform = transforms[i];
+            var module = transform._module;
 
-            stack = ['transforms[' + i + ']'];
+            if(module) {
+                stack = ['transforms[' + i + ']'];
 
-            exports.crawl(transform._module.attributes, callback, 1);
+                exports.crawl(module.attributes, callback, 1);
+            }
         }
     }
 

--- a/test/jasmine/tests/transform_multi_test.js
+++ b/test/jasmine/tests/transform_multi_test.js
@@ -17,7 +17,7 @@ describe('general transforms:', function() {
 
     var traceIn, traceOut;
 
-    it('filters empty transforms', function() {
+    it('passes through empty transforms', function() {
         traceIn = {
             y: [2, 1, 2],
             transforms: [{}]
@@ -456,7 +456,7 @@ describe('invalid transforms', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('filters them', function(done) {
+    it('ignores them', function(done) {
         Plotly.plot(gd, [{
             y: [1, 2, 3],
             transforms: [{}]

--- a/test/jasmine/tests/transform_multi_test.js
+++ b/test/jasmine/tests/transform_multi_test.js
@@ -17,6 +17,17 @@ describe('general transforms:', function() {
 
     var traceIn, traceOut;
 
+    it('filters empty transforms', function() {
+        traceIn = {
+            y: [2, 1, 2],
+            transforms: [{}]
+        };
+
+        traceOut = Plots.supplyTraceDefaults(traceIn, 0, fullLayout);
+
+        expect(traceOut.transforms).toEqual([{}]);
+    });
+
     it('supplyTraceDefaults should supply the transform defaults', function() {
         traceIn = {
             y: [2, 1, 2],
@@ -434,6 +445,26 @@ describe('multiple transforms:', function() {
         });
     });
 
+});
+
+describe('invalid transforms', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('filters them', function(done) {
+        Plotly.plot(gd, [{
+            y: [1, 2, 3],
+            transforms: [{}]
+        }]).then(function() {
+            expect(gd._fullData[0].transforms.length).toEqual(1);
+            done();
+        });
+    });
 });
 
 describe('multiple traces with transforms:', function() {


### PR DESCRIPTION
`transforms: [{}]` causes plotly to fail with:

<img width="483" alt="screen shot 2017-06-28 at 11 19 27" src="https://user-images.githubusercontent.com/572717/27645288-b80373ac-5bf3-11e7-80a8-c3775bea5340.png">

See: https://codepen.io/rsreusser/pen/GEyWav

I could have it compress empty transforms out of the picture (`[{}] --> []`, but because of indexing (it should work but I'm too worried it'll cause unexpected failures elsewhere), I've elected to just leave `[{}]` --> `[{}]`. This PR prevents it from throwing an error.