### PR TITLE
Fix order of heatmap z-data

### DIFF
--- a/src/components/fx/helpers.js
+++ b/src/components/fx/helpers.js
@@ -105,11 +105,11 @@ exports.appendArrayPointValue = function(pointData, trace, pointNumber) {
         if(astr === 'ids') key = 'id';
         else if(astr === 'locations') key = 'location';
         else key = astr;
-
         if(pointData[key] === undefined) {
             var val = Lib.nestedProperty(trace, astr).get();
+
             pointData[key] = Array.isArray(pointNumber) ?
-                val[pointNumber[0]][pointNumber[1]] :
+                val[pointNumber[1]][pointNumber[0]] :
                 val[pointNumber];
         }
     }


### PR DESCRIPTION
Should fix https://github.com/plotly/plotly.js/issues/1825

If I get it right, we have rows layout `z: [[x,x,x,x], [x,x,x,x], ...]`, meaning that to retrieve a value we call `z[y][x]`, not `z[x][y]`.