### PR TITLE
Enable multiple selection for box/lasso tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "ndarray-fill": "^1.0.2",
     "ndarray-homography": "^1.0.0",
     "ndarray-ops": "^1.2.2",
+    "poly-bool": "^1.0.0",
     "regl": "^1.3.0",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",

--- a/src/lib/polygon.js
+++ b/src/lib/polygon.js
@@ -31,6 +31,8 @@ var polygon = module.exports = {};
  *          returns boolean: is pt inside the polygon (including on its edges)
  */
 polygon.tester = function tester(ptsIn) {
+    if(Array.isArray(ptsIn[0][0])) return polygon.multitester(ptsIn);
+
     var pts = ptsIn.slice(),
         xmin = pts[0][0],
         xmax = xmin,
@@ -157,6 +159,39 @@ polygon.tester = function tester(ptsIn) {
         pts: pts,
         contains: isRect ? rectContains : contains,
         isRect: isRect
+    };
+};
+
+/**
+ * Test multiple polygons
+ */
+polygon.multitester = function multitester(list) {
+    var testers = [], xmin, xmax, ymin, ymax;
+
+    for(var i = 0; i < list.length; i++) {
+        var tester = polygon.tester(list[i]);
+        testers.push(tester);
+        xmin = Math.min(xmin, tester.xmin);
+        xmax = Math.max(xmax, tester.xmax);
+        ymin = Math.min(ymin, tester.ymin);
+        ymax = Math.max(ymax, tester.ymax);
+    }
+
+    function contains(pt, arg) {
+        for(var i = 0; i < testers.length; i++) {
+            if(testers[i].contains(pt, arg)) return true;
+        }
+        return false;
+    }
+
+    return {
+        xmin: xmin,
+        xmax: xmax,
+        ymin: ymin,
+        ymax: ymax,
+        pts: [],
+        contains: contains,
+        isRect: false
     };
 };
 

--- a/src/lib/polygon.js
+++ b/src/lib/polygon.js
@@ -166,7 +166,11 @@ polygon.tester = function tester(ptsIn) {
  * Test multiple polygons
  */
 polygon.multitester = function multitester(list) {
-    var testers = [], xmin, xmax, ymin, ymax;
+    var testers = [],
+        xmin = list[0][0][0],
+        xmax = xmin,
+        ymin = list[0][0][1],
+        ymax = ymin;
 
     for(var i = 0; i < list.length; i++) {
         var tester = polygon.tester(list[i]);

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -171,10 +171,10 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             else if(isSelectOrLasso(dragModeNow)) {
                 dragOptions.xaxes = xa;
                 dragOptions.yaxes = ya;
-                if(!e.shiftKey) {
+                if(!e.shiftKey || !dragOptions.polygons) {
                     // list of all prev polygons and their merge
                     dragOptions.polygons = [];
-                    dragOptions.mergedPolygons = null;
+                    dragOptions.mergedPolygons = [];
                 }
                 prepSelect(e, startX, startY, dragOptions, dragModeNow);
             }

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -171,10 +171,17 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             else if(isSelectOrLasso(dragModeNow)) {
                 dragOptions.xaxes = xa;
                 dragOptions.yaxes = ya;
-                if(!e.shiftKey || !dragOptions.polygons) {
-                    // list of all prev polygons and their merge
+                // take over selection polygons from prev mode, if any
+                if(e.shiftKey && dragOptions.plotinfo.selectionPolygons && !dragOptions.polygons) {
+                    dragOptions.polygons = dragOptions.plotinfo.selectionPolygons;
+                    dragOptions.mergedPolygons = dragOptions.plotinfo.selectionMergedPolygons;
+                }
+                // create new polygons, if shift mode
+                else if(!e.shiftKey || (e.shiftKey && !dragOptions.plotinfo.selectionPolygons)) {
+                    dragOptions.plotinfo.selectionPolygons =
                     dragOptions.polygons = [];
-                    dragOptions.mergedPolygons = [];
+                    dragOptions.mergedPolygons =
+                    dragOptions.plotinfo.selectionMergedPolygons = [];
                 }
                 prepSelect(e, startX, startY, dragOptions, dragModeNow);
             }

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -190,6 +190,11 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
     dragElement.init(dragOptions);
 
+    // FIXME: this hack highlights selection once we enter select/lasso mode
+    if(isSelectOrLasso(gd._fullLayout.dragmode) && dragOptions.plotinfo.selectionPolygons) {
+        showSelect(zoomlayer, dragOptions);
+    }
+
     var x0,
         y0,
         box,
@@ -912,6 +917,25 @@ function clearSelect(zoomlayer) {
     // here. The selection itself will be removed when the plot redraws
     // at the end.
     zoomlayer.selectAll('.select-outline').remove();
+}
+
+function showSelect(zoomlayer, dragOptions) {
+    var outlines = zoomlayer.selectAll('path.select-outline').data([1, 2]),
+        xs = dragOptions.plotinfo.xaxis._offset,
+        ys = dragOptions.plotinfo.yaxis._offset,
+        paths = [],
+        polygons = dragOptions.plotinfo.selectionMergedPolygons;
+
+    for(var i = 0; i < polygons.length; i++) {
+        var ppts = polygons[i];
+        paths.push(ppts.join('L') + 'L' + ppts[0]);
+    }
+
+    outlines.enter()
+        .append('path')
+        .attr('class', function(d) { return 'select-outline select-outline-' + d; })
+        .attr('transform', 'translate(' + xs + ', ' + ys + ')')
+        .attr('d', 'M' + paths.join('M') + 'Z');
 }
 
 function updateZoombox(zb, corners, box, path0, dimmed, lum) {

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -140,7 +140,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 // to pan (or to zoom if it already is pan) on shift
                 if(e.shiftKey) {
                     if(dragModeNow === 'pan') dragModeNow = 'zoom';
-                    else dragModeNow = 'pan';
+                    else if(!isSelectOrLasso(dragModeNow)) dragModeNow = 'pan';
                 }
                 else if(e.ctrlKey) {
                     dragModeNow = 'pan';
@@ -171,6 +171,11 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             else if(isSelectOrLasso(dragModeNow)) {
                 dragOptions.xaxes = xa;
                 dragOptions.yaxes = ya;
+                if(!e.shiftKey) {
+                    // list of all prev polygons and their merge
+                    dragOptions.polygons = [];
+                    dragOptions.mergedPolygons = null;
+                }
                 prepSelect(e, startX, startY, dragOptions, dragModeNow);
             }
         }

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -134,16 +134,12 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         plotinfo: plotinfo,
         prepFn: function(e, startX, startY) {
             var dragModeNow = gd._fullLayout.dragmode;
-            var isShift = false;
 
             if(isMainDrag) {
                 // main dragger handles all drag modes, and changes
                 // to pan (or to zoom if it already is pan) on shift
                 if(e.shiftKey) {
                     if(dragModeNow === 'pan') dragModeNow = 'zoom';
-                    else if(isSelectOrLasso(dragModeNow)) {
-                        isShift = true;
-                    }
                     else dragModeNow = 'pan';
                 }
                 else if(e.ctrlKey) {
@@ -928,7 +924,7 @@ function removeZoombox(gd) {
 }
 
 function isSelectOrLasso(dragmode) {
-    return dragmode === 'lasso' || dragmode === 'select'
+    return dragmode === 'lasso' || dragmode === 'select';
 }
 
 function xCorners(box, y0) {

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -172,16 +172,15 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 dragOptions.xaxes = xa;
                 dragOptions.yaxes = ya;
                 // take over selection polygons from prev mode, if any
-                if(e.shiftKey && dragOptions.plotinfo.selectionPolygons && !dragOptions.polygons) {
-                    dragOptions.polygons = dragOptions.plotinfo.selectionPolygons;
-                    dragOptions.mergedPolygons = dragOptions.plotinfo.selectionMergedPolygons;
+                if(e.shiftKey && plotinfo.selection.polygons && !dragOptions.polygons) {
+                    dragOptions.polygons = plotinfo.selection.polygons;
+                    dragOptions.mergedPolygons = plotinfo.selection.mergedPolygons;
                 }
                 // create new polygons, if shift mode
-                else if(!e.shiftKey || (e.shiftKey && !dragOptions.plotinfo.selectionPolygons)) {
-                    dragOptions.plotinfo.selectionPolygons =
-                    dragOptions.polygons = [];
-                    dragOptions.mergedPolygons =
-                    dragOptions.plotinfo.selectionMergedPolygons = [];
+                else if(!e.shiftKey || (e.shiftKey && !plotinfo.selection.polygons)) {
+                    plotinfo.selection = {};
+                    plotinfo.selection.polygons = dragOptions.polygons = [];
+                    dragOptions.mergedPolygons = plotinfo.selection.mergedPolygons = [];
                 }
                 prepSelect(e, startX, startY, dragOptions, dragModeNow);
             }
@@ -191,7 +190,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     dragElement.init(dragOptions);
 
     // FIXME: this hack highlights selection once we enter select/lasso mode
-    if(isSelectOrLasso(gd._fullLayout.dragmode) && dragOptions.plotinfo.selectionPolygons) {
+    if(isSelectOrLasso(gd._fullLayout.dragmode) && plotinfo.selection) {
         showSelect(zoomlayer, dragOptions);
     }
 
@@ -921,10 +920,14 @@ function clearSelect(zoomlayer) {
 
 function showSelect(zoomlayer, dragOptions) {
     var outlines = zoomlayer.selectAll('path.select-outline').data([1, 2]),
-        xs = dragOptions.plotinfo.xaxis._offset,
-        ys = dragOptions.plotinfo.yaxis._offset,
-        paths = [],
-        polygons = dragOptions.plotinfo.selectionMergedPolygons;
+        plotinfo = dragOptions.plotinfo,
+        xaxis = plotinfo.xaxis,
+        yaxis = plotinfo.yaxis,
+        selection = plotinfo.selection,
+        polygons = selection.mergedPolygons,
+        xs = xaxis._offset,
+        ys = yaxis._offset,
+        paths = [];
 
     for(var i = 0; i < polygons.length; i++) {
         var ppts = polygons[i];

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -138,7 +138,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             if(isMainDrag) {
                 // main dragger handles all drag modes, and changes
                 // to pan (or to zoom if it already is pan) on shift
-                if(e.shiftKey) {
+                if(e.ctrlKey) {
                     if(dragModeNow === 'pan') dragModeNow = 'zoom';
                     else dragModeNow = 'pan';
                 }

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -134,13 +134,20 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         plotinfo: plotinfo,
         prepFn: function(e, startX, startY) {
             var dragModeNow = gd._fullLayout.dragmode;
+            var isShift = false;
 
             if(isMainDrag) {
                 // main dragger handles all drag modes, and changes
                 // to pan (or to zoom if it already is pan) on shift
-                if(e.ctrlKey) {
+                if(e.shiftKey) {
                     if(dragModeNow === 'pan') dragModeNow = 'zoom';
+                    else if(isSelectOrLasso(dragModeNow)) {
+                        isShift = true;
+                    }
                     else dragModeNow = 'pan';
+                }
+                else if(e.ctrlKey) {
+                    dragModeNow = 'pan';
                 }
             }
             // all other draggers just pan
@@ -921,9 +928,7 @@ function removeZoombox(gd) {
 }
 
 function isSelectOrLasso(dragmode) {
-    var modes = ['lasso', 'select'];
-
-    return modes.indexOf(dragmode) !== -1;
+    return dragmode === 'lasso' || dragmode === 'select'
 }
 
 function xCorners(box, y0) {

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -28,7 +28,7 @@ function getAxId(ax) { return ax._id; }
 module.exports = prepSelect;
 
 function prepSelect(e, startX, startY, dragOptions, mode) {
-    var plot = dragOptions.gd._fullLayout._zoomlayer,
+    var zoomlayer = dragOptions.gd._fullLayout._zoomlayer,
         dragBBox = dragOptions.element.getBoundingClientRect(),
         xs = dragOptions.plotinfo.xaxis._offset,
         ys = dragOptions.plotinfo.yaxis._offset,
@@ -48,7 +48,7 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
         filterPoly = filteredPolygon([[x0, y0]], constants.BENDPX);
     }
 
-    var outlines = plot.selectAll('path.select-outline').data([1, 2]);
+    var outlines = zoomlayer.selectAll('path.select-outline').data([1, 2]);
 
     outlines.enter()
         .append('path')
@@ -56,7 +56,7 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
         .attr('transform', 'translate(' + xs + ', ' + ys + ')')
         .attr('d', path0 + 'Z');
 
-    var corners = plot.append('path')
+    var corners = zoomlayer.append('path')
         .attr('class', 'zoombox-corners')
         .style({
             fill: color.background,
@@ -112,7 +112,7 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
     function ascending(a, b) { return a - b; }
 
     dragOptions.moveFn = function(dx0, dy0) {
-        var ax;
+        var ax, i;
         x1 = Math.max(0, Math.min(pw, dx0 + x0));
         y1 = Math.max(0, Math.min(ph, dy0 + y0));
 
@@ -161,7 +161,7 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
 
         // draw selection
         var paths = [];
-        for(var i = 0; i < mergedPolygons.length; i++) {
+        for(i = 0; i < mergedPolygons.length; i++) {
             var ppts = mergedPolygons[i];
             paths.push(ppts.join('L') + 'L' + ppts[0]);
         }
@@ -223,7 +223,7 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
         // we have to keep reference to arrays, therefore just replace items
         dragOptions.mergedPolygons.splice.apply(dragOptions.mergedPolygons, [0, dragOptions.mergedPolygons.length].concat(mergedPolygons));
     };
-};
+}
 
 function fillSelectionItem(selection, searchInfo) {
     if(Array.isArray(selection)) {

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -215,7 +215,9 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
 
         // save last polygons
         dragOptions.polygons.push(currentPolygon);
-        dragOptions.mergedPolygons = mergedPolygons;
+
+        // we have to keep reference to arrays, therefore just replace items
+        dragOptions.mergedPolygons.splice.apply(dragOptions.mergedPolygons, [0, dragOptions.mergedPolygons].concat(mergedPolygons));
     };
 };
 

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -25,8 +25,6 @@ var MINSELECT = constants.MINSELECT;
 function getAxId(ax) { return ax._id; }
 
 
-var selectedPolyPts = [], lastMergedPolyPts;
-
 module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
     var plot = dragOptions.gd._fullLayout._zoomlayer,
         dragBBox = dragOptions.element.getBoundingClientRect(),
@@ -150,15 +148,15 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
         else if(mode === 'lasso') {
             currentPoly.addPt([x1, y1]);
 
-            if(selectedPolyPts.length) {
-                mergedPolyPts = polybool(lastMergedPolyPts, [currentPoly.filtered], 'or');
+            if(dragOptions.polygons.length) {
+                mergedPolyPts = polybool(dragOptions.mergedPolygons, [currentPoly.filtered], 'or');
 
                 var mergedPaths = [];
                 for(i = 0; i < mergedPolyPts.length; i++) {
                     var ppts = mergedPolyPts[i];
                     mergedPaths.push(ppts.join('L') + 'L' + ppts[0]);
                 }
-                mergedTester = multipolygonTester(selectedPolyPts.concat([currentPoly.filtered]));
+                mergedTester = multipolygonTester(dragOptions.polygons.concat([currentPoly.filtered]));
                 outlines.attr('d', 'M' + mergedPaths.join('M') + 'Z');
             }
             else {
@@ -217,8 +215,8 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
             dragOptions.gd.emit('plotly_selected', eventData);
         }
 
-        lastMergedPolyPts = mergedPolyPts;
-        selectedPolyPts.push(currentPoly.filtered);
+        dragOptions.mergedPolygons = mergedPolyPts;
+        dragOptions.polygons.push(currentPoly.filtered);
     };
 };
 

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+var polybool = require('poly-bool')
 var polygon = require('../../lib/polygon');
 var color = require('../../components/color');
 var appendArrayPointValue = require('../../components/fx/helpers').appendArrayPointValue;
@@ -152,26 +153,32 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
             // FIXME: merge polygons here
             pts.addPt([x1, y1]);
 
-            var vertices = []
-            var roots = []
+            var ppts = []
             for (var i = 0; i < polygons.length; i++) {
-                var ppts = polygons[i].filtered
-                vertices = vertices.concat(ppts)
-                roots.push(ppts[0])
-                vertices.push(ppts[0])
+                ppts.push(polygons[i].filtered)
             }
-            while (roots.length) {
-                vertices.push(roots.pop())
-            }
-            poly = polygonTester(vertices);
+            var mergedpoly = polymerge(ppts)
+
+            // var vertices = []
+            // var roots = []
+            // for (var i = 0; i < polygons.length; i++) {
+            //     var ppts = polygons[i].filtered
+            //     vertices = vertices.concat(ppts)
+            //     roots.push(ppts[0])
+            //     vertices.push(ppts[0])
+            // }
+            // while (roots.length) {
+            //     vertices.push(roots.pop())
+            // }
+            poly = polygonTester(mergedpoly);
 
             // poly = polygonTester(pts.filtered);
 
-            var paths = []
-            for (var i = 0 ;i < polygons.length; i++) {
-                paths.push(polygons[i].filtered.join('L'))
-            }
-            outlines.attr('d', 'M' + paths.join('ZM') + 'Z');
+            // var paths = []
+            // for (var i = 0 ;i < polygons.length; i++) {
+            //     paths.push(polygons[i].filtered.join('L'))
+            // }
+            outlines.attr('d', 'M' + poly.pts.join('L') + 'Z');
         }
 
         selection = [];
@@ -240,4 +247,15 @@ function fillSelectionItem(selection, searchInfo) {
     }
 
     return selection;
+}
+
+
+function polymerge (list) {
+    let result = [list[0]]
+
+    for (var i = 1; i < list.length; i++) {
+        result = polybool([list[i]], result, 'or')
+    }
+
+    return result[0]
 }

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -25,7 +25,9 @@ var MINSELECT = constants.MINSELECT;
 function getAxId(ax) { return ax._id; }
 
 
-module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
+module.exports = prepSelect;
+
+function prepSelect(e, startX, startY, dragOptions, mode) {
     var plot = dragOptions.gd._fullLayout._zoomlayer,
         dragBBox = dragOptions.element.getBoundingClientRect(),
         xs = dragOptions.plotinfo.xaxis._offset,
@@ -151,19 +153,21 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
         if(dragOptions.polygons.length) {
             mergedPolygons = polybool(dragOptions.mergedPolygons, [currentPolygon], 'or');
             testPoly = multipolygonTester(dragOptions.polygons.concat([currentPolygon]));
-            var mergedPaths = [];
-            for(i = 0; i < mergedPolygons.length; i++) {
-                var ppts = mergedPolygons[i];
-                mergedPaths.push(ppts.join('L') + 'L' + ppts[0]);
-            }
-            outlines.attr('d', 'M' + mergedPaths.join('M') + 'Z');
         }
         else {
             mergedPolygons = [currentPolygon];
             testPoly = polygonTester(currentPolygon);
-            outlines.attr('d', 'M' + mergedPolygons[0].join('L') + 'Z');
         }
 
+        // draw selection
+        var paths = [];
+        for(var i = 0; i < mergedPolygons.length; i++) {
+            var ppts = mergedPolygons[i];
+            paths.push(ppts.join('L') + 'L' + ppts[0]);
+        }
+        outlines.attr('d', 'M' + paths.join('M') + 'Z');
+
+        // select points
         selection = [];
         for(i = 0; i < searchTraces.length; i++) {
             searchInfo = searchTraces[i];
@@ -217,7 +221,7 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
         dragOptions.polygons.push(currentPolygon);
 
         // we have to keep reference to arrays, therefore just replace items
-        dragOptions.mergedPolygons.splice.apply(dragOptions.mergedPolygons, [0, dragOptions.mergedPolygons].concat(mergedPolygons));
+        dragOptions.mergedPolygons.splice.apply(dragOptions.mergedPolygons, [0, dragOptions.mergedPolygons.length].concat(mergedPolygons));
     };
 };
 


### PR DESCRIPTION
Work in progress.

Related to https://github.com/plotly/plotly.js/issues/698.
Holding shift extends previous selection.
![impl](https://user-images.githubusercontent.com/300067/27842502-9682a06a-60d8-11e7-9086-7262b83c7bcb.gif)


Things to figure out:

* [ ] scattergl hover does not show info-tooltip
* [ ] panning breaks/resets the selection