### PR TITLE
Parcoords: ellipsize long labels; show full text in tooltip

### DIFF
--- a/src/traces/parcoords/parcoords.js
+++ b/src/traces/parcoords/parcoords.js
@@ -598,7 +598,20 @@ module.exports = function(root, svg, styledData, layout, callbacks) {
     axisTitle
         .attr('transform', 'translate(0,' + -c.axisTitleOffset + ')')
         .text(function(d) {return d.label;})
-        .each(function(d) {Drawing.font(axisTitle, d.model.labelFont);});
+        .each(function(d) {Drawing.font(axisTitle, d.model.labelFont);})
+        .each(function(d) {
+            // Ellipsize long labels
+            var maxWidth = d.xScale(1) - 5;
+            while(this.textContent.length > 2 &&
+                  this.getComputedTextLength() > maxWidth) {
+                this.textContent = this.textContent.slice(0, -2) + '…';
+            }
+        });
+
+    // Tooltip
+    axisTitle.enter()
+        .append('title')
+        .text(function(d) {return d.label;});
 
     var axisExtent = axisOverlays.selectAll('.axisExtent')
         .data(repeat, keyFun);


### PR DESCRIPTION
Ellipsizes labels that are too long to prevent overlapping. But always show full label text in mouse hover tooltip.

Fixes https://github.com/plotly/plotly.js/issues/1703.

### Before
![screenshot - 05182017 - 07 49 37 pm](https://cloud.githubusercontent.com/assets/684364/26216098/2a5f3190-3c03-11e7-8e06-fc35371b9420.png)


### After
![screenshot - 05182017 - 07 47 22 pm](https://cloud.githubusercontent.com/assets/684364/26216017/de295a4e-3c02-11e7-86d1-e133bd65eb85.png)