### PR TITLE
Fix heatmapgl point number event data

### DIFF
--- a/src/traces/contourgl/convert.js
+++ b/src/traces/contourgl/convert.js
@@ -77,7 +77,7 @@ proto.handlePick = function(pickResult) {
         ],
         textLabel: this.textLabels[index],
         name: this.name,
-        pointIndex: [xIndex, yIndex],
+        pointIndex: [yIndex, xIndex],
         hoverinfo: this.hoverinfo
     };
 };

--- a/src/traces/heatmapgl/convert.js
+++ b/src/traces/heatmapgl/convert.js
@@ -63,7 +63,7 @@ proto.handlePick = function(pickResult) {
         ],
         textLabel: this.textLabels[index],
         name: this.name,
-        pointIndex: [xIndex, yIndex],
+        pointIndex: [yIndex, xIndex],
         hoverinfo: this.hoverinfo
     };
 };

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -326,6 +326,39 @@ describe('Test hover and click interactions', function() {
         .then(done);
     });
 
+    it('should output correct event data for heatmapgl (asymmetric case) ', function(done) {
+        var _mock = {
+            data: [{
+                type: 'heatmapgl',
+                z: [[1, 2, 0], [2, 3, 1]],
+                text: [['a', 'b', 'c'], ['D', 'E', 'F']],
+                hoverlabel: {
+                    bgcolor: [['red', 'blue', 'green'], ['cyan', 'pink', 'black']]
+                }
+            }]
+        };
+
+        var run = makeRunner([540, 150], {
+            x: 2,
+            y: 1,
+            curveNumber: 0,
+            pointNumber: [1, 2],
+            bgColor: 'rgb(0, 0, 0)',
+            borderColor: 'rgb(255, 255, 255)',
+            fontSize: 13,
+            fontFamily: 'Arial',
+            fontColor: 'rgb(255, 255, 255)'
+        }, {
+            noUnHover: true,
+            msg: 'heatmapgl'
+        });
+
+        Plotly.plot(gd, _mock)
+        .then(run)
+        .catch(fail)
+        .then(done);
+    });
+
     it('should output correct event data for scattergl after visibility restyle', function(done) {
         var _mock = Lib.extendDeep({}, mock4);
 


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/1825

Luckily, the problem described in #1825 only concerns `heatmapgl` - as opposed to the solution proposed in https://github.com/plotly/plotly.js/pull/1833. 

The patch is simple. It brings `heatmapgl`'s `pointNumber` event data field on par with other 2D trace types. This PR also adds an _asymmetric_ `heatmapgl` hover test case. 

cc @alexcjohnson @dfcreative 