### PR TITLE
Hover fix for colorbars with custom tickval / ticktext

### DIFF
--- a/src/components/fx/helpers.js
+++ b/src/components/fx/helpers.js
@@ -110,7 +110,7 @@ exports.appendArrayPointValue = function(pointData, trace, pointNumber) {
             var val = Lib.nestedProperty(trace, astr).get();
 
             if(Array.isArray(pointNumber)) {
-                if(Array.isArray(val) && Array.isArray(val[0])) {
+                if(Array.isArray(val) && Array.isArray(val[pointNumber[0]])) {
                     pointData[key] = val[pointNumber[0]][pointNumber[1]];
                 }
             } else {

--- a/src/components/fx/helpers.js
+++ b/src/components/fx/helpers.js
@@ -108,9 +108,14 @@ exports.appendArrayPointValue = function(pointData, trace, pointNumber) {
 
         if(pointData[key] === undefined) {
             var val = Lib.nestedProperty(trace, astr).get();
-            pointData[key] = Array.isArray(pointNumber) ?
-                val[pointNumber[0]][pointNumber[1]] :
-                val[pointNumber];
+
+            if(Array.isArray(pointNumber)) {
+                if(Array.isArray(val) && Array.isArray(val[0])) {
+                    pointData[key] = val[pointNumber[0]][pointNumber[1]];
+                }
+            } else {
+                pointData[key] = val[pointNumber];
+            }
         }
     }
 };

--- a/src/plot_api/plot_schema.js
+++ b/src/plot_api/plot_schema.js
@@ -142,13 +142,25 @@ exports.isValObject = function(obj) {
  *  list of array attributes for the given trace
  */
 exports.findArrayAttributes = function(trace) {
-    var arrayAttributes = [],
-        stack = [];
+    var arrayAttributes = [];
+    var stack = [];
 
     function callback(attr, attrName, attrs, level) {
         stack = stack.slice(0, level).concat([attrName]);
 
-        var splittableAttr = attr && (attr.valType === 'data_array' || attr.arrayOk === true);
+        var splittableAttr = (
+            attr &&
+            (attr.valType === 'data_array' || attr.arrayOk === true) &&
+            !(stack[level - 1] === 'colorbar' && (attrName === 'ticktext' || attrName === 'tickvals'))
+        );
+
+        // Manually exclude 'colorbar.tickvals' and 'colorbar.ticktext' for now
+        // which are declared as `valType: 'data_array'` but scale independently of
+        // the coordinate arrays.
+        //
+        // Down the road, we might want to add a schema field (e.g `uncorrelatedArray: true`)
+        // to distinguish attributes of the likes.
+
         if(!splittableAttr) return;
 
         var astr = toAttrString(stack);

--- a/test/jasmine/tests/gl_plot_interact_test.js
+++ b/test/jasmine/tests/gl_plot_interact_test.js
@@ -245,6 +245,20 @@ describe('Test gl3d plots', function() {
 
             expect(label.size()).toEqual(1);
             expect(label.select('text').text()).toEqual('2');
+
+            return Plotly.restyle(gd, {
+                'colorbar.tickvals': [[25]],
+                'colorbar.ticktext': [['single tick!']]
+            });
+        })
+        .then(_hover)
+        .then(function() {
+            assertEventData(1, 2, 43, 0, [1, 2], {
+                'hoverinfo': 'y',
+                'hoverlabel.font.color': 'cyan',
+                'colorbar.tickvals': undefined,
+                'colorbar.ticktext': undefined
+            });
         })
         .then(done);
     });


### PR DESCRIPTION
fixes https://community.plot.ly/t/tooltips-dont-show-up-in-a-heatmap/4972 first reported by @empet

Another bug introduced by https://github.com/plotly/plotly.js/pull/1770. This time `appendArrayPointValue` tried to dig into a trace's `colorbar.tickvals` and `colorbar.tickvals` with a 2D `pointNumber` leading a slew of exceptions during hover. Note that `colorbar.ticktext` and `colorbar.tickvals` are both declared as `valType: 'data_array'` at the moment.

The proposed fix in 0aa87c9da6914bad762e36c2571886db4c93ad93 isn't great, but feels the safest to my eyes.

Perhaps a better, more evolved fix would make a distinction between `data_array` attributes that are expected to have the same dimension as of the _main_ data coordinates (in 2D traces, that _main_ data coordinate is `z`). and _other_ `data_array` attributes. To note, we might **have to** do this to get `filter` and `sort` working for 2D traces in general.

cc @alexcjohnson 