### PR TITLE
Ignore bare closing tags in html-like input

### DIFF
--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -402,7 +402,10 @@ function buildSVGText(containerNode, str) {
     function exitNode(type) {
         // A bare closing tag can't close the root node. If we encounter this it
         // means there's an extra closing tag that can just be ignored:
-        if(nodeStack.length === 1) return;
+        if(nodeStack.length === 1) {
+            Lib.log('Ignoring unexpected end tag </' + type + '>.', str);
+            return;
+        }
 
         var innerNode = nodeStack.pop();
 

--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -400,7 +400,12 @@ function buildSVGText(containerNode, str) {
     }
 
     function exitNode(type) {
+        // A bare closing tag can't close the root node. If we encounter this it
+        // means there's an extra closing tag that can just be ignored:
+        if(nodeStack.length === 1) return;
+
         var innerNode = nodeStack.pop();
+
         if(type !== innerNode.type) {
             Lib.log('Start tag <' + innerNode.type + '> doesnt match end tag <' +
                 type + '>. Pretending it did match.', str);

--- a/test/jasmine/tests/svg_text_utils_test.js
+++ b/test/jasmine/tests/svg_text_utils_test.js
@@ -371,5 +371,19 @@ describe('svg+text utils', function() {
                     opener(2.6) + 'modified' + closer, textCase);
             });
         });
+
+        it('ignores bare closing tags', function() {
+            var node = mockTextSVGElement('</sub>');
+
+            // sub shows up as a zero-width space (u200B) on either side of the 5:
+            expect(node.text()).toEqual('');
+        });
+
+        it('ignores extra closing tags', function() {
+            var node = mockTextSVGElement('test<sub>5</sub></sub>more');
+
+            // sub shows up as a zero-width space (u200B) on either side of the 5:
+            expect(node.text()).toEqual('test\u200b5\u200bmore');
+        });
     });
 });


### PR DESCRIPTION
See #1923. This PR modifies svg text utils to ignore dangling closing tags when there's nothing on the stack.