### PR TITLE
Fix hover label exponents

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1207,8 +1207,8 @@ axes.tickText = function(ax, x, hover) {
         return showAttr !== 'all' && x !== first_or_last;
     }
 
-    if (hover) {
-        hideexp = 'never'
+    if(hover) {
+        hideexp = 'never';
     } else {
         hideexp = ax.exponentformat !== 'none' && isHidden(ax.showexponent) ? 'hide' : '';
     }
@@ -1350,14 +1350,14 @@ function formatCategory(ax, out) {
 }
 
 function formatLinear(ax, out, hover, extraPrecision, hideexp) {
-    if (hideexp === 'never') {
+    if(hideexp === 'never') {
         // If this is a hover label, then we must *never* hide the exponent
         // for the sake of display, which could give the wrong value by
         // potentially many orders of magnitude. If hideexp was 'never', then
         // it's now succeeded by preventing the other condition from automating
         // this choice. Thus we can unset it so that the axis formatting takes
         // precedence.
-        hideexp = ''
+        hideexp = '';
     } else if(ax.showexponent === 'all' && Math.abs(out.x / ax.dtick) < 1e-6) {
         // don't add an exponent to zero if we're showing all exponents
         // so the only reason you'd show an exponent on zero is if it's the

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1207,7 +1207,11 @@ axes.tickText = function(ax, x, hover) {
         return showAttr !== 'all' && x !== first_or_last;
     }
 
-    hideexp = ax.exponentformat !== 'none' && isHidden(ax.showexponent) ? 'hide' : '';
+    if (hover) {
+        hideexp = 'never'
+    } else {
+        hideexp = ax.exponentformat !== 'none' && isHidden(ax.showexponent) ? 'hide' : '';
+    }
 
     if(ax.type === 'date') formatDate(ax, out, hover, extraPrecision);
     else if(ax.type === 'log') formatLog(ax, out, hover, extraPrecision, hideexp);
@@ -1346,10 +1350,18 @@ function formatCategory(ax, out) {
 }
 
 function formatLinear(ax, out, hover, extraPrecision, hideexp) {
-    // don't add an exponent to zero if we're showing all exponents
-    // so the only reason you'd show an exponent on zero is if it's the
-    // ONLY tick to get an exponent (first or last)
-    if(ax.showexponent === 'all' && Math.abs(out.x / ax.dtick) < 1e-6) {
+    if (hideexp === 'never') {
+        // If this is a hover label, then we must *never* hide the exponent
+        // for the sake of display, which could give the wrong value by
+        // potentially many orders of magnitude. If hideexp was 'never', then
+        // it's now succeeded by preventing the other condition from automating
+        // this choice. Thus we can unset it so that the axis formatting takes
+        // precedence.
+        hideexp = ''
+    } else if(ax.showexponent === 'all' && Math.abs(out.x / ax.dtick) < 1e-6) {
+        // don't add an exponent to zero if we're showing all exponents
+        // so the only reason you'd show an exponent on zero is if it's the
+        // ONLY tick to get an exponent (first or last)
         hideexp = 'hide';
     }
     out.text = numFormat(out.x, ax, hideexp, extraPrecision);

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2363,6 +2363,23 @@ describe('Test axes', function() {
 
             expect(mockCalc(ax).length).toBe(10001);
         });
+
+        it('never hides the exponent when in hover mode', function() {
+            var ax = {
+                type: 'linear',
+                tickmode: 'linear',
+                tick0: 0,
+                dtick: 2e20,
+                range: [0, 1.0732484076433121e21],
+                _length: 270
+            };
+
+            mockCalc(ax);
+
+            expect(mockHoverText(ax, 1e-21)).toBe('1e\u221221');
+            expect(mockHoverText(ax, 1)).toBe('1');
+            expect(mockHoverText(ax, 1e21)).toBe('1e+21');
+        });
     });
 
     describe('autoBin', function() {

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2376,9 +2376,9 @@ describe('Test axes', function() {
 
             mockCalc(ax);
 
-            expect(mockHoverText(ax, 1e-21)).toBe('1e\u221221');
+            expect(mockHoverText(ax, 1e-21)).toBe('1×10<sup>−21</sup>');
             expect(mockHoverText(ax, 1)).toBe('1');
-            expect(mockHoverText(ax, 1e21)).toBe('1e+21');
+            expect(mockHoverText(ax, 1e21)).toBe('1×10<sup>21</sup>');
         });
     });
 


### PR DESCRIPTION
This PR fixes #755 and #1711. After a bit of digging:

**The problem**: Hover labels are sometimes wrong by arbitrarily gigantic orders of magnitude, which is bad. Hover labels piggyback on `Axes.tickText`, which sometimes hides exponents and just shows 1/2/5 values. That's *always* invalid for hover labels since their exponent is not shown elsewhere as it is for axes.

**The solution**: whenever `'hover'` is passed to `tickText`, this PR prevents it from making any automated decision about whether to hide the exponent, instead just obeying the axis formatting.