### PR TITLE
Fix karma tests in windows

### DIFF
--- a/tasks/util/strict_d3.js
+++ b/tasks/util/strict_d3.js
@@ -18,7 +18,7 @@ module.exports = transformTools.makeRequireTransform('requireTransform',
         var pathOut;
 
         if(pathIn === 'd3' && opts.file !== pathToStrictD3Module) {
-            pathOut = 'require(\'' + pathToStrictD3Module + '\')';
+            pathOut = 'require(' + JSON.stringify(pathToStrictD3Module) + ')';
         }
 
         if(pathOut) return cb(null, pathOut);


### PR DESCRIPTION
Otherwise `npm run test-jasmine` fails with karma-browserify as 
```sh
07 09 2017 10:43:12.748:ERROR [framework.browserify]: bundle error
07 09 2017 10:43:12.764:ERROR [framework.browserify]: Error: Cannot find module 'C:projectsplotly.js    estimagestrict-d
3.js' from 'C:\projects\plotly.js\test\jasmine\tests'
```