### PR TITLE
Sankey: render a thin but visible node even if `value` is very low

### DIFF
--- a/src/traces/sankey/render.js
+++ b/src/traces/sankey/render.js
@@ -182,7 +182,7 @@ function nodeModel(uniqueKeys, d, n) {
         zoneThicknessPad = c.nodePadAcross,
         zoneLengthPad = d.nodePad / 2,
         visibleThickness = n.dx + 0.5,
-        visibleLength = n.dy - 0.5;
+        visibleLength = Math.max(1, n.dy - 0.5);
 
     var basicKey = n.label;
     var foundKey = uniqueKeys[basicKey];

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -311,6 +311,29 @@ describe('sankey tests', function() {
                     done();
                 });
         });
+
+        it('\'node\' remains visible even if \'value\' is very low', function(done) {
+
+            var gd = createGraphDiv();
+            var minimock = [{
+                type: 'sankey',
+                node: {
+                    label: ['a', 'b1', 'b2']
+                },
+                link: {
+                    source: [0, 0],
+                    target: [1, 2],
+                    value: [1000000, 0.001]
+                }
+            }];
+            Plotly.plot(gd, minimock)
+                .then(function() {
+                    expect(d3.selectAll('.sankey .nodeRect')[0].reduce(function(prevMin, rect) {
+                        return Math.min(prevMin, d3.select(rect).attr('height'));
+                    }, Infinity)).toEqual(1);
+                    done();
+                });
+        });
     });
 
     describe('Test hover/click interactions:', function() {


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/2015 (see before/after example there)
Issue found when looking at https://github.com/plotly/plotly.js/issues/2014

Jasmine test produces this DOM tree:

![image](https://user-images.githubusercontent.com/1548516/30595956-03287a3a-9d53-11e7-8dae-a4c0b11a5f03.png)

