### PR TITLE
Sankey tooltip calc relative to div.svg-container rather than gd

### DIFF
--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -135,7 +135,7 @@ module.exports = function plot(gd, calcData) {
 
     var linkHoverFollow = function(element, d) {
         var trace = d.link.trace;
-        var rootBBox = gd.getBoundingClientRect();
+        var rootBBox = gd._fullLayout._paperdiv.node().getBoundingClientRect();
         var boundingBox = element.getBoundingClientRect();
         var hoverCenterX = boundingBox.left + boundingBox.width / 2;
         var hoverCenterY = boundingBox.top + boundingBox.height / 2;
@@ -193,7 +193,7 @@ module.exports = function plot(gd, calcData) {
     var nodeHoverFollow = function(element, d) {
         var trace = d.node.trace;
         var nodeRect = d3.select(element).select('.nodeRect');
-        var rootBBox = gd.getBoundingClientRect();
+        var rootBBox = gd._fullLayout._paperdiv.node().getBoundingClientRect();
         var boundingBox = nodeRect.node().getBoundingClientRect();
         var hoverCenterX0 = boundingBox.left - 2 - rootBBox.left;
         var hoverCenterX1 = boundingBox.right + 2 - rootBBox.left;


### PR DESCRIPTION
Fixes remaining issue of https://github.com/plotly/plotly.js/issues/2014

The fix is that Sankey tooltip positioning be relative to `div.svg-container` rather than `gd`, a difference that's significant if there's a margin specified on (or is effective on) `div.svg-container`.