### PR TITLE
Update mapbox-gl requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "gl-spikes2d": "^1.0.1",
     "gl-surface3d": "^1.3.1",
     "has-hover": "^1.0.1",
-    "mapbox-gl": "^0.22.0",
+    "mapbox-gl": "^0.40.1",
     "matrix-camera-controller": "^2.1.3",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",


### PR DESCRIPTION
mapbox-gl 0.22.1 is very old and transitively
pulls in a vulnerable version of concat-stream.
See https://snyk.io/vuln/npm:concat-stream:20160901