### PR TITLE
Eliminate circular dependencies

### DIFF
--- a/src/components/annotations/click.js
+++ b/src/components/annotations/click.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
-
 
 module.exports = {
     hasClickToShow: hasClickToShow,
@@ -59,7 +57,7 @@ function onClick(gd, hoverData) {
         update['annotations[' + offSet[i] + '].visible'] = false;
     }
 
-    return Plotly.update(gd, {}, update);
+    return gd._plotAPI.update({}, update);
 }
 
 /*

--- a/src/components/annotations/draw.js
+++ b/src/components/annotations/draw.js
@@ -11,7 +11,6 @@
 
 var d3 = require('d3');
 
-var Plotly = require('../../plotly');
 var Plots = require('../../plots/plots');
 var Lib = require('../../lib');
 var Axes = require('../../plots/cartesian/axes');
@@ -594,7 +593,7 @@ function drawRaw(gd, options, index, subplotId, xa, ya) {
                     },
                     doneFn: function(dragged) {
                         if(dragged) {
-                            Plotly.relayout(gd, update);
+                            gd._plotAPI.relayout(update);
                             var notesBox = document.querySelector('.js-notes-box-panel');
                             if(notesBox) notesBox.redraw(notesBox.selectedObj);
                         }
@@ -675,7 +674,7 @@ function drawRaw(gd, options, index, subplotId, xa, ya) {
                 doneFn: function(dragged) {
                     setCursor(annTextGroupInner);
                     if(dragged) {
-                        Plotly.relayout(gd, update);
+                        gd._plotAPI.relayout(update);
                         var notesBox = document.querySelector('.js-notes-box-panel');
                         if(notesBox) notesBox.redraw(notesBox.selectedObj);
                     }
@@ -701,7 +700,7 @@ function drawRaw(gd, options, index, subplotId, xa, ya) {
                     update[ya._name + '.autorange'] = true;
                 }
 
-                Plotly.relayout(gd, update);
+                gd._plotAPI.relayout(update);
             });
     }
     else annText.call(textLayout);

--- a/src/components/colorbar/draw.js
+++ b/src/components/colorbar/draw.js
@@ -12,7 +12,6 @@
 var d3 = require('d3');
 var tinycolor = require('tinycolor2');
 
-var Plotly = require('../../plotly');
 var Plots = require('../../plots/plots');
 var Registry = require('../../registry');
 var Axes = require('../../plots/cartesian/axes');
@@ -584,7 +583,7 @@ module.exports = function draw(gd, id) {
                     setCursor(container);
 
                     if(dragged && xf !== undefined && yf !== undefined) {
-                        Plotly.restyle(gd,
+                        gd._plotAPI.restyle(
                             {'colorbar.x': xf, 'colorbar.y': yf},
                             getTrace().index);
                     }

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -12,7 +12,6 @@
 var mouseOffset = require('mouse-event-offset');
 var hasHover = require('has-hover');
 
-var Plotly = require('../../plotly');
 var Lib = require('../../lib');
 
 var constants = require('../../plots/cartesian/constants');
@@ -216,7 +215,7 @@ dragElement.coverSlip = coverSlip;
 
 function finishDrag(gd) {
     gd._dragging = false;
-    if(gd._replotPending) Plotly.plot(gd);
+    if(gd._replotPending) gd._plotAPI.plot();
 }
 
 function pointerOffset(e) {

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -10,7 +10,6 @@
 
 var d3 = require('d3');
 
-var Plotly = require('../../plotly');
 var Lib = require('../../lib');
 var Plots = require('../../plots/plots');
 var Registry = require('../../registry');
@@ -336,7 +335,7 @@ module.exports = function draw(gd) {
             },
             doneFn: function(dragged, numClicks, e) {
                 if(dragged && xf !== undefined && yf !== undefined) {
-                    Plotly.relayout(gd, {'legend.x': xf, 'legend.y': yf});
+                    gd._plotAPI.relayout({'legend.x': xf, 'legend.y': yf});
                 } else {
                     var clickedTrace =
                         fullLayout._infolayer.selectAll('g.traces').filter(function() {
@@ -425,7 +424,7 @@ function drawTexts(g, gd) {
                     update.name = text;
                 }
 
-                return Plotly.restyle(gd, update, traceIndex);
+                return gd._plotAPI.restyle(update, traceIndex);
             });
     } else {
         text.call(textLayout);

--- a/src/components/legend/handle_click.js
+++ b/src/components/legend/handle_click.js
@@ -8,7 +8,6 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
 var Lib = require('../../lib');
 var Registry = require('../../registry');
 
@@ -112,7 +111,7 @@ module.exports = function handleClick(g, gd, numClicks) {
             }
         }
 
-        Plotly.relayout(gd, 'hiddenlabels', hiddenSlices);
+        gd._plotAPI.relayout('hiddenlabels', hiddenSlices);
     } else {
         var hasLegendgroup = legendgroup && legendgroup.length;
         var traceIndicesInGroup = [];
@@ -218,6 +217,6 @@ module.exports = function handleClick(g, gd, numClicks) {
             }
         }
 
-        Plotly.restyle(gd, attrUpdate, attrIndices);
+        gd._plotAPI.restyle(attrUpdate, attrIndices);
     }
 };

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
 var Plots = require('../../plots/plots');
 var Axes = require('../../plots/cartesian/axes');
 var Lib = require('../../lib');
@@ -251,7 +250,7 @@ function handleCartesian(gd, ev) {
         aobj[astr] = val;
     }
 
-    Plotly.relayout(gd, aobj);
+    gd._plotAPI.relayout(aobj);
 }
 
 modeBarButtons.zoom3d = {
@@ -304,7 +303,7 @@ function handleDrag3d(gd, ev) {
         layoutUpdate[sceneIds[i] + '.' + parts[1]] = val;
     }
 
-    Plotly.relayout(gd, layoutUpdate);
+    gd._plotAPI.relayout(layoutUpdate);
 }
 
 modeBarButtons.resetCameraDefault3d = {
@@ -343,7 +342,7 @@ function handleCamera3d(gd, ev) {
         }
     }
 
-    Plotly.relayout(gd, aobj);
+    gd._plotAPI.relayout(aobj);
 }
 
 modeBarButtons.hoverClosest3d = {
@@ -404,7 +403,7 @@ function handleHover3d(gd, ev) {
         button._previousVal = Lib.extendDeep({}, currentSpikes);
     }
 
-    Plotly.relayout(gd, layoutUpdate);
+    gd._plotAPI.relayout(layoutUpdate);
 }
 
 modeBarButtons.zoomInGeo = {
@@ -498,7 +497,7 @@ function toggleHover(gd) {
 
     var newHover = gd._fullLayout.hovermode ? false : onHoverVal;
 
-    Plotly.relayout(gd, 'hovermode', newHover);
+    gd._plotAPI.relayout('hovermode', newHover);
 }
 
 // buttons when more then one plot types are present
@@ -555,7 +554,7 @@ modeBarButtons.toggleSpikelines = {
         var aobj = setSpikelineVisibility(gd);
 
         aobj.hovermode = 'closest';
-        Plotly.relayout(gd, aobj);
+        gd._plotAPI.relayout(aobj);
     }
 };
 
@@ -597,6 +596,6 @@ modeBarButtons.resetViewMapbox = {
             }
         }
 
-        Plotly.relayout(gd, aObj);
+        gd._plotAPI.relayout(aObj);
     }
 };

--- a/src/components/rangeselector/draw.js
+++ b/src/components/rangeselector/draw.js
@@ -11,7 +11,6 @@
 
 var d3 = require('d3');
 
-var Plotly = require('../../plotly');
 var Plots = require('../../plots/plots');
 var Color = require('../color');
 var Drawing = require('../drawing');
@@ -66,7 +65,7 @@ module.exports = function draw(gd) {
             button.on('click', function() {
                 if(gd._dragged) return;
 
-                Plotly.relayout(gd, update);
+                gd._plotAPI.relayout(update);
             });
 
             button.on('mouseover', function() {

--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -10,7 +10,6 @@
 
 var d3 = require('d3');
 
-var Plotly = require('../../plotly');
 var Plots = require('../../plots/plots');
 
 var Lib = require('../../lib');
@@ -247,7 +246,7 @@ function setDataRange(rangeSlider, gd, axisOpts, opts) {
         dataMax = clamp(opts.p2d(opts._pixelMax));
 
     window.requestAnimationFrame(function() {
-        Plotly.relayout(gd, axisOpts._name + '.range', [dataMin, dataMax]);
+        gd._plotAPI.relayout(axisOpts._name + '.range', [dataMin, dataMax]);
     });
 }
 

--- a/src/components/shapes/draw.js
+++ b/src/components/shapes/draw.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-var Plotly = require('../../plotly');
 var Lib = require('../../lib');
 var Axes = require('../../plots/cartesian/axes');
 var Color = require('../color');
@@ -214,7 +213,7 @@ function setupDragElement(gd, shapePath, shapeOptions, index) {
     function endDrag(dragged) {
         setCursor(shapePath);
         if(dragged) {
-            Plotly.relayout(gd, update);
+            gd._plotAPI.relayout(update);
         }
     }
 

--- a/src/components/titles/index.js
+++ b/src/components/titles/index.js
@@ -12,8 +12,8 @@
 var d3 = require('d3');
 var isNumeric = require('fast-isnumeric');
 
-var Plotly = require('../../plotly');
-var Plots = require('../../plots/plots');
+var previousPromises = require('../../plots/previous_promises');
+var fontWeight = require('../../plots/font_weight');
 var Lib = require('../../lib');
 var Drawing = require('../drawing');
 var Color = require('../color');
@@ -124,12 +124,12 @@ Titles.draw = function(gd, titleClass, options) {
             'font-size': d3.round(fontSize, 2) + 'px',
             fill: Color.rgb(fontColor),
             opacity: opacity * Color.opacity(fontColor),
-            'font-weight': Plots.fontWeight
+            'font-weight': fontWeight
         })
         .attr(attributes)
         .call(svgTextUtils.convertToTspans, gd);
 
-        return Plots.previousPromises(gd);
+        return previousPromises(gd);
     }
 
     function scootTitle(titleElIn) {
@@ -222,8 +222,8 @@ Titles.draw = function(gd, titleClass, options) {
 
         el.call(svgTextUtils.makeEditable, {gd: gd})
             .on('edit', function(text) {
-                if(traceIndex !== undefined) Plotly.restyle(gd, prop, text, traceIndex);
-                else Plotly.relayout(gd, prop, text);
+                if(traceIndex !== undefined) gd._plotAPI.restyle(prop, text, traceIndex);
+                else gd._plotAPI.relayout(prop, text);
             })
             .on('cancel', function() {
                 this.text(this.attr('data-unformatted'))

--- a/src/plot_api/bind_plot_api.js
+++ b/src/plot_api/bind_plot_api.js
@@ -1,0 +1,44 @@
+/**
+* Copyright 2012-2017, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+
+module.exports = function bindPlotAPI(gd, Plotly) {
+    var i;
+
+    if(gd._plotAPI) return;
+
+    gd._plotAPI = {};
+    var methods = [
+        'plot', 'newPlot', 'restyle', 'relayout', 'redraw',
+        'update', 'extendTraces', 'prependTraces', 'addTraces',
+        'deleteTraces', 'moveTraces', 'purge', 'addFrames',
+        'deleteFrames', 'animate'
+    ];
+
+    function bindMethod(method) {
+        return function() {
+            var i;
+            var args = [gd];
+            for(i = 0; i < arguments.length; i++) {
+                args[i + 1] = arguments[i];
+            }
+            return method.apply(null, args);
+        };
+    }
+
+    for(i = 0; i < methods.length; i++) {
+        gd._plotAPI[methods[i]] = bindMethod(Plotly[methods[i]]);
+    }
+
+    // This is needed for snapshot/toimage, which needs to plot to a *different* gd.
+    // In other words, it's just regular Plotly plot:
+    gd._plotAPI.plotWithGd = Plotly.plot;
+};

--- a/src/plot_api/purge.js
+++ b/src/plot_api/purge.js
@@ -1,0 +1,53 @@
+/**
+* Copyright 2012-2017, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+var Plots = require('../plots/plots');
+var Events = require('../lib/events');
+var helpers = require('./helpers');
+
+/**
+ * Purge a graph container div back to its initial pre-Plotly.plot state
+ *
+ * This method is contained in its own file since it needs to be run internally
+ * on things that may or may not be a plot, so that it's difficult to require
+ * without creating a circular dependency. (see: plot_api/to_image.js)
+ *
+ * @param {string id or DOM element} gd
+ *      the id or DOM element of the graph container div
+ */
+module.exports = function purge(gd) {
+    gd = helpers.getGraphDiv(gd);
+
+    var fullLayout = gd._fullLayout || {},
+        fullData = gd._fullData || [];
+
+    // remove gl contexts
+    Plots.cleanPlot([], {}, fullData, fullLayout);
+
+    // purge properties
+    Plots.purge(gd);
+
+    // purge event emitter methods
+    Events.purge(gd);
+
+    // remove plot container
+    if(fullLayout._container) fullLayout._container.remove();
+
+    delete gd._context;
+    delete gd._replotPending;
+    delete gd._mouseDownTime;
+    delete gd._legendMouseDownTime;
+    delete gd._hmpixcount;
+    delete gd._hmlumcount;
+    delete gd._plotAPI;
+
+    return gd;
+};

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -10,10 +10,10 @@
 'use strict';
 
 var d3 = require('d3');
-var Plotly = require('../plotly');
 var Registry = require('../registry');
 var Plots = require('../plots/plots');
 var Lib = require('../lib');
+var Axes = require('../plots/cartesian/axes');
 
 var Color = require('../components/color');
 var Drawing = require('../components/drawing');
@@ -45,7 +45,7 @@ exports.lsInner = function(gd) {
     var fullLayout = gd._fullLayout;
     var gs = fullLayout._size;
     var pad = gs.p;
-    var axList = Plotly.Axes.list(gd);
+    var axList = Axes.list(gd);
 
     // _has('cartesian') means SVG specifically, not GL2D - but GL2D
     // can still get here because it makes some of the SVG structure
@@ -343,7 +343,7 @@ exports.lsInner = function(gd) {
         if(showFreeY) freeFinished[ya._id] = 1;
     });
 
-    Plotly.Axes.makeClipPaths(gd);
+    Axes.makeClipPaths(gd);
     exports.drawMainTitle(gd);
     ModeBar.manage(gd);
 
@@ -474,7 +474,7 @@ exports.doColorBars = function(gd) {
 exports.layoutReplot = function(gd) {
     var layout = gd.layout;
     gd.layout = undefined;
-    return Plotly.plot(gd, '', layout);
+    return gd._plotAPI.plot('', layout);
 };
 
 exports.doLegend = function(gd) {
@@ -483,7 +483,7 @@ exports.doLegend = function(gd) {
 };
 
 exports.doTicksRelayout = function(gd) {
-    Plotly.Axes.doTicks(gd, 'redraw');
+    Axes.doTicks(gd, 'redraw');
     exports.drawMainTitle(gd);
     return Plots.previousPromises(gd);
 };

--- a/src/plot_api/to_image.js
+++ b/src/plot_api/to_image.js
@@ -8,8 +8,8 @@
 
 'use strict';
 
-var Plotly = require('../plotly');
 var Lib = require('../lib');
+var purge = require('./purge');
 
 var helpers = require('../snapshot/helpers');
 var toSVG = require('../snapshot/tosvg');
@@ -157,7 +157,7 @@ function toImage(gd, opts) {
             var width = clonedGd._fullLayout.width;
             var height = clonedGd._fullLayout.height;
 
-            Plotly.purge(clonedGd);
+            purge(clonedGd);
             document.body.removeChild(clonedGd);
 
             if(format === 'svg') {
@@ -198,7 +198,7 @@ function toImage(gd, opts) {
     }
 
     return new Promise(function(resolve, reject) {
-        Plotly.plot(clonedGd, data, layoutImage, configImage)
+        gd._plotAPI.plotWithGd(clonedGd, data, layoutImage, configImage)
             .then(redrawFunc)
             .then(wait)
             .then(convert)

--- a/src/plotly.js
+++ b/src/plotly.js
@@ -19,14 +19,20 @@
  */
 
 // configuration
-exports.defaultConfig = require('./plot_api/plot_config');
+module.exports.defaultConfig = require('./plot_api/plot_config');
 
 // plots
-exports.Plots = require('./plots/plots');
-exports.Axes = require('./plots/cartesian/axes');
+module.exports.Plots = require('./plots/plots');
+module.exports.Axes = require('./plots/cartesian/axes');
 
 // components
-exports.ModeBar = require('./components/modebar');
+module.exports.ModeBar = require('./components/modebar');
 
 // plot api
-require('./plot_api/plot_api');
+var API = require('./plot_api/plot_api');
+
+for(var method in API) {
+    if(API.hasOwnProperty(method)) {
+        module.exports[method] = API[method];
+    }
+}

--- a/src/plots/cartesian/axis_ids.js
+++ b/src/plots/cartesian/axis_ids.js
@@ -9,10 +9,10 @@
 'use strict';
 
 var Registry = require('../../registry');
-var Plots = require('../plots');
 var Lib = require('../../lib');
 
 var constants = require('./constants');
+var getSubplotIds = require('../get_subplot_ids');
 
 
 // convert between axis names (xaxis, xaxis2, etc, elements of gd.layout)
@@ -65,7 +65,7 @@ function listNames(gd, axLetter, only2d) {
     var names = filterAxis(fullLayout, '');
     if(only2d) return names;
 
-    var sceneIds3D = Plots.getSubplotIds(fullLayout, 'gl3d') || [];
+    var sceneIds3D = getSubplotIds(fullLayout, 'gl3d') || [];
     for(var i = 0; i < sceneIds3D.length; i++) {
         var sceneId = sceneIds3D[i];
         names = names.concat(

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -12,7 +12,6 @@
 var d3 = require('d3');
 var tinycolor = require('tinycolor2');
 
-var Plotly = require('../../plotly');
 var Registry = require('../../registry');
 var Lib = require('../../lib');
 var svgTextUtils = require('../../lib/svg_text_utils');
@@ -332,7 +331,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                     .on('edit', function(text) {
                         var v = ax.d2r(text);
                         if(v !== undefined) {
-                            Plotly.relayout(gd, attrStr, v);
+                            gd._contet.api.relayout(attrStr, v);
                         }
                     });
             }
@@ -646,7 +645,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         }
 
         gd.emit('plotly_doubleclick', null);
-        Plotly.relayout(gd, attrs);
+        gd._plotAPI.relayout(attrs);
     }
 
     // dragTail - finish a drag event with a redraw
@@ -662,7 +661,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         // accumulated MathJax promises - wait for them before we relayout.
         Lib.syncOrAsync([
             Plots.previousPromises,
-            function() { Plotly.relayout(gd, updates); }
+            function() { gd._plotAPI.relayout(updates); }
         ], gd);
     }
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -331,7 +331,7 @@ module.exports = function dragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                     .on('edit', function(text) {
                         var v = ax.d2r(text);
                         if(v !== undefined) {
-                            gd._contet.api.relayout(attrStr, v);
+                            gd._plotAPI.relayout(attrStr, v);
                         }
                     });
             }

--- a/src/plots/cartesian/transition_axes.js
+++ b/src/plots/cartesian/transition_axes.js
@@ -11,7 +11,6 @@
 
 var d3 = require('d3');
 
-var Plotly = require('../../plotly');
 var Registry = require('../../registry');
 var Drawing = require('../../components/drawing');
 var Axes = require('./axes');
@@ -275,7 +274,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
         // Signal that this transition has completed:
         onComplete && onComplete();
 
-        return Plotly.relayout(gd, aobj).then(function() {
+        return gd._plotAPI.relayout(aobj).then(function() {
             for(var i = 0; i < affectedSubplots.length; i++) {
                 unsetSubplotTransform(affectedSubplots[i]);
             }
@@ -292,7 +291,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
             axi.range = axi._r.slice();
         }
 
-        return Plotly.relayout(gd, aobj).then(function() {
+        return gd._plotAPI.relayout(aobj).then(function() {
             for(var i = 0; i < affectedSubplots.length; i++) {
                 unsetSubplotTransform(affectedSubplots[i]);
             }

--- a/src/plots/command.js
+++ b/src/plots/command.js
@@ -9,7 +9,6 @@
 
 'use strict';
 
-var Plotly = require('../plotly');
 var Lib = require('../lib');
 
 /*
@@ -264,9 +263,9 @@ function bindingValueHasChanged(gd, binding, cache) {
 exports.executeAPICommand = function(gd, method, args) {
     if(method === 'skip') return Promise.resolve();
 
-    var apiMethod = Plotly[method];
+    var apiMethod = gd._plotAPI[method];
 
-    var allArgs = [gd];
+    var allArgs = [];
 
     if(!Array.isArray(args)) args = [];
 

--- a/src/plots/font_weight.js
+++ b/src/plots/font_weight.js
@@ -1,0 +1,13 @@
+/**
+* Copyright 2012-2017, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+// TODO make this a plot attribute?
+module.exports.fontWeight = 'normal';

--- a/src/plots/get_subplot_ids.js
+++ b/src/plots/get_subplot_ids.js
@@ -1,0 +1,54 @@
+/**
+* Copyright 2012-2017, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+
+var Registry = require('../registry');
+
+/**
+ * Get the ids of the current subplots.
+ *
+ * @param {object} layout plotly full layout object.
+ * @param {string} type subplot type to look for.
+ *
+ * @return {array} list of ordered subplot ids (strings).
+ *
+ */
+module.exports = function getSubplotIds(layout, type) {
+    var _module = Registry.subplotsRegistry[type];
+
+    if(!_module) return [];
+
+    // layout must be 'fullLayout' here
+    if(type === 'cartesian' && (!layout._has || !layout._has('cartesian'))) return [];
+    if(type === 'gl2d' && (!layout._has || !layout._has('gl2d'))) return [];
+    if(type === 'cartesian' || type === 'gl2d') {
+        return Object.keys(layout._plots || {});
+    }
+
+    var attrRegex = _module.attrRegex,
+        layoutKeys = Object.keys(layout),
+        subplotIds = [];
+
+    for(var i = 0; i < layoutKeys.length; i++) {
+        var layoutKey = layoutKeys[i];
+
+        if(attrRegex.test(layoutKey)) subplotIds.push(layoutKey);
+    }
+
+    // order the ids
+    var idLen = _module.idRoot.length;
+    subplotIds.sort(function(a, b) {
+        var aNum = +(a.substr(idLen) || 1),
+            bNum = +(b.substr(idLen) || 1);
+        return aNum - bNum;
+    });
+
+    return subplotIds;
+};

--- a/src/plots/previous_promises.js
+++ b/src/plots/previous_promises.js
@@ -1,0 +1,19 @@
+/**
+* Copyright 2012-2017, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+// for use in Lib.syncOrAsync, check if there are any
+// pending promises in this plot and wait for them
+module.exports = function(gd) {
+    if((gd._promises || []).length) {
+        return Promise.all(gd._promises)
+            .then(function() { gd._promises = []; });
+    }
+};

--- a/src/registry.js
+++ b/src/registry.js
@@ -25,6 +25,7 @@ exports.allTypes = [];
 exports.subplotsRegistry = {};
 exports.transformsRegistry = {};
 exports.componentsRegistry = {};
+exports.dataArrayContainers = ['transforms'];
 exports.layoutArrayContainers = [];
 exports.layoutArrayRegexes = [];
 exports.traceLayoutAttributes = {};

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -195,7 +195,7 @@ function assertCircularDeps() {
         var logs = [];
 
         // see https://github.com/plotly/plotly.js/milestone/9
-        var MAX_ALLOWED_CIRCULAR_DEPS = 17;
+        var MAX_ALLOWED_CIRCULAR_DEPS = 0;
 
         if(circularDeps.length > MAX_ALLOWED_CIRCULAR_DEPS) {
             console.log(circularDeps.join('\n'));

--- a/test/jasmine/tests/command_test.js
+++ b/test/jasmine/tests/command_test.js
@@ -1,5 +1,6 @@
 var Plotly = require('@lib/index');
 var PlotlyInternal = require('@src/plotly');
+var bindPlotAPI = require('@src/plot_api/bind_plot_api');
 var Plots = Plotly.Plots;
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
@@ -13,6 +14,7 @@ describe('Plots.executeAPICommand', function() {
 
     beforeEach(function() {
         gd = createGraphDiv();
+        bindPlotAPI(gd, PlotlyInternal);
     });
 
     afterEach(function() {

--- a/test/jasmine/tests/command_test.js
+++ b/test/jasmine/tests/command_test.js
@@ -14,7 +14,6 @@ describe('Plots.executeAPICommand', function() {
 
     beforeEach(function() {
         gd = createGraphDiv();
-        bindPlotAPI(gd, PlotlyInternal);
     });
 
     afterEach(function() {
@@ -26,6 +25,7 @@ describe('Plots.executeAPICommand', function() {
             spyOn(PlotlyInternal, 'restyle').and.callFake(function() {
                 return Promise.resolve('resolution');
             });
+            bindPlotAPI(gd, PlotlyInternal);
         });
 
         it('calls the API method and resolves', function(done) {
@@ -46,6 +46,7 @@ describe('Plots.executeAPICommand', function() {
             spyOn(PlotlyInternal, 'restyle').and.callFake(function() {
                 return Promise.reject('rejection');
             });
+            bindPlotAPI(gd, PlotlyInternal);
         });
 
         it('calls the API method and rejects', function(done) {

--- a/test/jasmine/tests/command_test.js
+++ b/test/jasmine/tests/command_test.js
@@ -7,6 +7,7 @@ var destroyGraphDiv = require('../assets/destroy_graph_div');
 var fail = require('../assets/fail_test');
 var Lib = require('@src/lib');
 
+
 describe('Plots.executeAPICommand', function() {
     'use strict';
 

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -2008,15 +2008,15 @@ describe('Queue', function() {
         })
         .then(function() {
             expect(gd.undoQueue.index).toEqual(1);
-            expect(gd.undoQueue.queue[0].undo.args[0][1]['marker.color']).toEqual([null]);
-            expect(gd.undoQueue.queue[0].redo.args[0][1]['marker.color']).toEqual('red');
+            expect(gd.undoQueue.queue[0].undo.args[0][0]['marker.color']).toEqual([null]);
+            expect(gd.undoQueue.queue[0].redo.args[0][0]['marker.color']).toEqual('red');
 
             return Plotly.relayout(gd, 'title', 'A title');
         })
         .then(function() {
             expect(gd.undoQueue.index).toEqual(2);
-            expect(gd.undoQueue.queue[1].undo.args[0][1].title).toEqual(null);
-            expect(gd.undoQueue.queue[1].redo.args[0][1].title).toEqual('A title');
+            expect(gd.undoQueue.queue[1].undo.args[0][0].title).toEqual(null);
+            expect(gd.undoQueue.queue[1].redo.args[0][0].title).toEqual('A title');
 
             return Plotly.restyle(gd, 'mode', 'markers');
         })
@@ -2024,43 +2024,43 @@ describe('Queue', function() {
             expect(gd.undoQueue.index).toEqual(2);
             expect(gd.undoQueue.queue[2]).toBeUndefined();
 
-            expect(gd.undoQueue.queue[1].undo.args[0][1].mode).toEqual([null]);
-            expect(gd.undoQueue.queue[1].redo.args[0][1].mode).toEqual('markers');
+            expect(gd.undoQueue.queue[1].undo.args[0][0].mode).toEqual([null]);
+            expect(gd.undoQueue.queue[1].redo.args[0][0].mode).toEqual('markers');
 
-            expect(gd.undoQueue.queue[0].undo.args[0][1].title).toEqual(null);
-            expect(gd.undoQueue.queue[0].redo.args[0][1].title).toEqual('A title');
+            expect(gd.undoQueue.queue[0].undo.args[0][0].title).toEqual(null);
+            expect(gd.undoQueue.queue[0].redo.args[0][0].title).toEqual('A title');
 
             return Plotly.restyle(gd, 'transforms[0]', { type: 'filter' });
         })
         .then(function() {
-            expect(gd.undoQueue.queue[1].undo.args[0][1])
+            expect(gd.undoQueue.queue[1].undo.args[0][0])
                 .toEqual({ 'transforms[0]': null });
-            expect(gd.undoQueue.queue[1].redo.args[0][1])
+            expect(gd.undoQueue.queue[1].redo.args[0][0])
                 .toEqual({ 'transforms[0]': { type: 'filter' } });
 
             return Plotly.relayout(gd, 'updatemenus[0]', { buttons: [] });
         })
         .then(function() {
-            expect(gd.undoQueue.queue[1].undo.args[0][1])
+            expect(gd.undoQueue.queue[1].undo.args[0][0])
                 .toEqual({ 'updatemenus[0]': null });
-            expect(gd.undoQueue.queue[1].redo.args[0][1])
+            expect(gd.undoQueue.queue[1].redo.args[0][0])
                 .toEqual({ 'updatemenus[0]': { buttons: [] } });
 
             return Plotly.relayout(gd, 'updatemenus[0]', null);
         })
         .then(function() {
             // buttons have been stripped out because it's an empty container array...
-            expect(gd.undoQueue.queue[1].undo.args[0][1])
+            expect(gd.undoQueue.queue[1].undo.args[0][0])
                 .toEqual({ 'updatemenus[0]': {} });
-            expect(gd.undoQueue.queue[1].redo.args[0][1])
+            expect(gd.undoQueue.queue[1].redo.args[0][0])
                 .toEqual({ 'updatemenus[0]': null });
 
             return Plotly.restyle(gd, 'transforms[0]', null);
         })
         .then(function() {
-            expect(gd.undoQueue.queue[1].undo.args[0][1])
+            expect(gd.undoQueue.queue[1].undo.args[0][0])
                 .toEqual({ 'transforms[0]': [ { type: 'filter' } ]});
-            expect(gd.undoQueue.queue[1].redo.args[0][1])
+            expect(gd.undoQueue.queue[1].redo.args[0][0])
                 .toEqual({ 'transforms[0]': null });
         })
         .catch(failTest)

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -10,6 +10,7 @@ var pkg = require('../../../package.json');
 var subroutines = require('@src/plot_api/subroutines');
 var helpers = require('@src/plot_api/helpers');
 var editTypes = require('@src/plot_api/edit_types');
+var bindPlotAPI = require('@src/plot_api/bind_plot_api');
 
 var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
@@ -17,6 +18,11 @@ var destroyGraphDiv = require('../assets/destroy_graph_div');
 var fail = require('../assets/fail_test');
 var checkTicks = require('../assets/custom_assertions').checkTicks;
 
+function withoutAPI(gd) {
+    gd = Lib.extendFlat({}, gd);
+    delete gd._plotAPI;
+    return gd;
+}
 
 describe('Test plot api', function() {
     'use strict';
@@ -580,6 +586,7 @@ describe('Test plot api', function() {
             gd.calcdata = gd._fullData.map(function(trace) {
                 return [{x: 1, y: 1, trace: trace}];
             });
+            bindPlotAPI(gd, PlotlyInternal);
         }
 
         it('calls Scatter.arraysToCalcdata and Plots.style on scatter styling', function() {
@@ -1226,6 +1233,7 @@ describe('Test plot api', function() {
                 ]
             };
             spyOn(PlotlyInternal, 'redraw');
+            bindPlotAPI(gd, PlotlyInternal);
         });
 
         it('should throw an error when indices are omitted', function() {
@@ -1324,6 +1332,7 @@ describe('Test plot api', function() {
             gd = { data: [{'name': 'a'}, {'name': 'b'}] };
             spyOn(PlotlyInternal, 'redraw');
             spyOn(PlotlyInternal, 'moveTraces');
+            bindPlotAPI(gd, PlotlyInternal);
         });
 
         it('should throw an error when traces is not an object or an array of objects', function() {
@@ -1341,7 +1350,7 @@ describe('Test plot api', function() {
             }).toThrowError(Error, 'all values in traces array must be non-array objects');
 
             // make sure we didn't muck with gd.data if things failed!
-            expect(gd).toEqual(expected);
+            expect(withoutAPI(gd)).toEqual(withoutAPI(expected));
         });
 
         it('should throw an error when traces and newIndices arrays are unequal', function() {
@@ -1360,7 +1369,7 @@ describe('Test plot api', function() {
             }).toThrow(new Error('newIndices must be valid indices for gd.data.'));
 
             // make sure we didn't muck with gd.data if things failed!
-            expect(gd).toEqual(expected);
+            expect(withoutAPI(gd)).toEqual(withoutAPI(expected));
         });
 
         it('should work when newIndices is undefined', function() {
@@ -1429,6 +1438,7 @@ describe('Test plot api', function() {
                 ]
             };
             spyOn(PlotlyInternal, 'redraw');
+            bindPlotAPI(gd, PlotlyInternal);
         });
 
         it('throw an error when index arrays are unequal', function() {
@@ -1565,6 +1575,7 @@ describe('Test plot api', function() {
 
             spyOn(PlotlyInternal, 'redraw');
             spyOn(Plotly.Queue, 'add');
+            bindPlotAPI(gd, PlotlyInternal);
         });
 
         it('should throw an error when gd.data isn\'t an array.', function() {
@@ -1734,7 +1745,7 @@ describe('Test plot api', function() {
 
             var undoArgs = Plotly.Queue.add.calls.first().args[2];
 
-            Plotly.prependTraces.apply(null, undoArgs);
+            gd._plotAPI.prependTraces.apply(null, undoArgs);
 
             expect(gd.data).toEqual(cachedData);
         });
@@ -1752,7 +1763,7 @@ describe('Test plot api', function() {
 
             var undoArgs = Plotly.Queue.add.calls.first().args[2];
 
-            Plotly.extendTraces.apply(null, undoArgs);
+            gd._plotAPI.extendTraces.apply(null, undoArgs);
 
             expect(gd.data).toEqual(cachedData);
         });
@@ -1771,7 +1782,7 @@ describe('Test plot api', function() {
 
             var undoArgs = Plotly.Queue.add.calls.first().args[2];
 
-            Plotly.prependTraces.apply(null, undoArgs);
+            gd._plotAPI.prependTraces.apply(null, undoArgs);
 
             expect(gd.data).toEqual(cachedData);
         });

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -415,7 +415,7 @@ describe('Test Plots', function() {
         it('should unset everything in the gd except _context', function() {
             var expectedKeys = [
                 '_ev', '_internalEv', 'on', 'once', 'removeListener', 'removeAllListeners',
-                '_internalOn', '_internalOnce', '_removeInternalListener',
+                '_internalOn', '_internalOnce', '_removeInternalListener', '_plotAPI',
                 '_removeAllInternalListeners', 'emit', '_context', '_replotPending',
                 '_hmpixcount', '_hmlumcount', '_mouseDownTime', '_legendMouseDownTime',
             ];


### PR DESCRIPTION
resolves #236.

This PR eliminates all circular dependencies (🎉), mainly by adding `gd._plotAPI.*` (as suggested in #236) which binds (curries?) the `gd` to the arguments automatically. That is, you can call `gd._plotAPI.redraw()` or `gd._plotAPI.restyle([....])`. This eliminates the need for `var Plotly = require('../../plotly')`, which accounted for the vast majority of circular dependencies.

I didn't really find a need for nontrivial changes (has the component registry been implemented since #236?) since all other circular dependencies could be resolved by moving one or two functions to their own files. Though it's a bit ugly to require `get_subplot_id.js` separately. I'm open to different thoughts on this.

I expect a couple failing tests to remain since `spyOn` got somewhat more tricky to enforce and required binding the API manually in order to make sure it was the correct, spied-upon API.

Edit: *almost*. One circular dependency remains. Remaining issue:

- [ ] `toImage` requires plot api --> circular