### PR TITLE
Bar axis autorange fix

### DIFF
--- a/src/traces/bar/calc.js
+++ b/src/traces/bar/calc.js
@@ -63,7 +63,11 @@ module.exports = function calc(gd, trace) {
     if(Array.isArray(base)) {
         for(i = 0; i < Math.min(base.length, cd.length); i++) {
             b = sa.d2c(base[i], 0, scalendar);
-            cd[i].b = (isNumeric(b)) ? b : 0;
+            if(isNumeric(b)) {
+                cd[i].b = +b;
+                cd[i].hasB = 1;
+            }
+            else cd[i].b = 0;
         }
         for(; i < cd.length; i++) {
             cd[i].b = 0;
@@ -71,9 +75,11 @@ module.exports = function calc(gd, trace) {
     }
     else {
         b = sa.d2c(base, 0, scalendar);
-        b = (isNumeric(b)) ? b : 0;
+        var hasBase = isNumeric(b);
+        b = hasBase ? b : 0;
         for(i = 0; i < cd.length; i++) {
             cd[i].b = b;
+            if(hasBase) cd[i].hasB = 1;
         }
     }
 

--- a/src/traces/bar/set_positions.js
+++ b/src/traces/bar/set_positions.js
@@ -467,8 +467,7 @@ function setBaseAndTop(gd, sa, sieve) {
     // along with the bases and tops of each bar.
     var traces = sieve.traces,
         sLetter = getAxisLetter(sa),
-        s0 = sa.l2c(sa.c2l(0)),
-        sRange = [s0, s0];
+        sRange = [null, null];
 
     for(var i = 0; i < traces.length; i++) {
         var trace = traces[i];
@@ -481,7 +480,7 @@ function setBaseAndTop(gd, sa, sieve) {
             bar[sLetter] = barTop;
 
             if(isNumeric(sa.c2l(barTop))) expandRange(sRange, barTop);
-            if(isNumeric(sa.c2l(barBase))) expandRange(sRange, barBase);
+            if(bar.hasB && isNumeric(sa.c2l(barBase))) expandRange(sRange, barBase);
         }
     }
 
@@ -497,8 +496,7 @@ function stackBars(gd, sa, sieve) {
         i, trace,
         j, bar;
 
-    var s0 = sa.l2c(sa.c2l(0)),
-        sRange = [s0, s0];
+    var sRange = [null, null];
 
     for(i = 0; i < traces.length; i++) {
         trace = traces[i];
@@ -518,7 +516,7 @@ function stackBars(gd, sa, sieve) {
 
             if(!barnorm) {
                 if(isNumeric(sa.c2l(barTop))) expandRange(sRange, barTop);
-                if(isNumeric(sa.c2l(barBase))) expandRange(sRange, barBase);
+                if(bar.hasB && isNumeric(sa.c2l(barBase))) expandRange(sRange, barBase);
             }
         }
     }
@@ -584,7 +582,7 @@ function normalizeBars(gd, sa, sieve) {
             bar[sLetter] = barTop;
 
             maybeExpand(barTop);
-            maybeExpand(barBase);
+            if(bar.hasB) maybeExpand(barBase);
         }
     }
 

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -707,6 +707,34 @@ describe('Bar.setPositions', function() {
         expect(Axes.getAutoRange(ya)).toBeCloseToArray([-1.11, 1.11], undefined, '(ya.range)');
     });
 
+    it('should include explicit base in size axis range', function() {
+        var barmodes = ['stack', 'group', 'overlay'];
+        barmodes.forEach(function(barmode) {
+            var gd = mockBarPlot([
+                {y: [3, 4, -5], base: [-1, -2, 7]}
+            ], {
+                barmode: barmode
+            });
+
+            var ya = gd._fullLayout.yaxis;
+            expect(Axes.getAutoRange(ya)).toBeCloseToArray([-2.5, 7.5]);
+        });
+    });
+
+    it('should not include date zero (1970) in date axis range', function() {
+        var barmodes = ['stack', 'group', 'overlay'];
+        barmodes.forEach(function(barmode) {
+            var gd = mockBarPlot([
+                {y: ['2017-01-01', '2017-01-03', '2017-01-19']}
+            ], {
+                barmode: barmode
+            });
+
+            var ya = gd._fullLayout.yaxis;
+            expect(Axes.getAutoRange(ya)).toEqual(['2016-12-31', '2017-01-20']);
+        });
+    });
+
     it('works with log axes (grouped bars)', function() {
         var gd = mockBarPlot([
             {y: [1, 10, 1e10, -1]},


### PR DESCRIPTION
fixes #2049 - cleaner handling of base and zero for bar axis autorange.

We don't need to include 0 explicitly in the autorange for bars (unless we're normalizing), nor should we be including the bar base unless that was explicitly specified.

Most of the time these extras were just redundant, but for bars on date axes (which is not really a kosher use of bars but we don't forbid it) the zero (1970) is arbitrary and it's confusing and useless if this gets included in the autorange.

cc @etpinard 