### PR TITLE
Fix for table scroll glitch

### DIFF
--- a/src/traces/table/plot.js
+++ b/src/traces/table/plot.js
@@ -705,7 +705,7 @@ function conditionalPanelRerender(gd, tableControlView, cellsColumnBlock, pages,
             // setTimeout might lag rendering but yields a smoother scroll, because fast scrolling makes
             // some repaints invisible ie. wasteful (DOM work blocks the main thread)
             var toRerender = cellsColumnBlock.filter(function(d, i) {return i === revolverIndex && pages[i] !== prevPages[i];});
-            renderColumnCellTree(gd, tableControlView, toRerender, toRerender);
+            renderColumnCellTree(gd, tableControlView, toRerender, cellsColumnBlock);
             prevPages[revolverIndex] = pages[revolverIndex];
         });
     }


### PR DESCRIPTION
The glitch sometimes occurs when manually stopping a fast mouse wheel scroll in a table with text wrapping that increases cell height - thanks @rreusser for the report!
