### PR TITLE
Roll out General Update Pattern utils to `parcoords` and `sankey`

### DIFF
--- a/src/traces/parcoords/calc.js
+++ b/src/traces/parcoords/calc.js
@@ -11,7 +11,7 @@
 var hasColorscale = require('../../components/colorscale/has_colorscale');
 var calcColorscale = require('../../components/colorscale/calc');
 var Lib = require('../../lib');
-
+var wrap = require('../../lib/gup').wrap;
 
 module.exports = function calc(gd, trace) {
     var cs = !!trace.line.colorscale && Lib.isArray(trace.line.color);
@@ -22,8 +22,8 @@ module.exports = function calc(gd, trace) {
         calcColorscale(trace, trace.line.color, 'line', 'c');
     }
 
-    return [{
+    return wrap({
         lineColor: color,
         cscale: cscale
-    }];
+    });
 };

--- a/src/traces/parcoords/parcoords.js
+++ b/src/traces/parcoords/parcoords.js
@@ -13,10 +13,9 @@ var c = require('./constants');
 var Lib = require('../../lib');
 var d3 = require('d3');
 var Drawing = require('../../components/drawing');
-
-function keyFun(d) {return d.key;}
-
-function repeat(d) {return [d];}
+var keyFun = require('../../lib/gup').keyFun;
+var repeat = require('../../lib/gup').repeat;
+var unwrap = require('../../lib/gup').unwrap;
 
 function visible(dimension) {return !('visible' in dimension) || dimension.visible;}
 
@@ -124,10 +123,6 @@ function unitToColorScale(cscale) {
             return s(d);
         });
     };
-}
-
-function unwrap(d) {
-    return d[0]; // plotly data structure convention
 }
 
 function model(layout, d, i) {

--- a/src/traces/sankey/calc.js
+++ b/src/traces/sankey/calc.js
@@ -10,6 +10,7 @@
 
 var tarjan = require('strongly-connected-components');
 var Lib = require('../../lib');
+var wrap = require('../../lib/gup').wrap;
 
 function circularityPresent(nodeList, sources, targets) {
 
@@ -44,8 +45,8 @@ module.exports = function calc(gd, trace) {
         trace.node.color = [];
     }
 
-    return [{
+    return wrap({
         link: trace.link,
         node: trace.node
-    }];
+    });
 };

--- a/src/traces/sankey/render.js
+++ b/src/traces/sankey/render.js
@@ -16,12 +16,11 @@ var Drawing = require('../../components/drawing');
 var d3sankey = require('@plotly/d3-sankey').sankey;
 var d3Force = require('d3-force');
 var Lib = require('../../lib');
+var keyFun = require('../../lib/gup').keyFun;
+var repeat = require('../../lib/gup').repeat;
+var unwrap = require('../../lib/gup').unwrap;
 
 // basic data utilities
-
-function keyFun(d) {return d.key;}
-function repeat(d) {return [d];} // d3 data binding convention
-function unwrap(d) {return d[0];} // plotly data structure convention
 
 function persistOriginalPlace(nodes) {
     var i, distinctLayerPositions = [];


### PR DESCRIPTION
More traces to use these simple utils that yield a simple and robust pattern for constructing the scene graph (and wrapping/unwrapping data). I didn't prefix the functions as character count loss wouldn't have improved, so it was a drop-in replacement of preexisting, separate function defs.