### PR TITLE
IE/Edge SVG export fixes

### DIFF
--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -53,7 +53,11 @@ var fileSaver = function(url, name) {
 
         // IE 10+ (native saveAs)
         if(typeof navigator !== 'undefined' && navigator.msSaveBlob) {
-            navigator.msSaveBlob(new Blob([url]), name);
+            // At this point we are only dealing with a SVG encoded as
+            // a data URL (since IE only supports SVG)
+            var encoded = url.split(/^data:image\/svg\+xml,/)[1];
+            var svg = decodeURIComponent(encoded);
+            navigator.msSaveBlob(new Blob([svg]), name);
             resolve(name);
         }
 

--- a/src/snapshot/tosvg.js
+++ b/src/snapshot/tosvg.js
@@ -165,7 +165,7 @@ module.exports = function toSVG(gd, format, scale) {
         // url in svg are single quoted
         //   since we changed double to single
         //   we'll need to change these to double-quoted
-        s = s.replace(/(\('#)([^']*)('\))/gi, '(\"$2\")');
+        s = s.replace(/(\('#)([^']*)('\))/gi, '(\"#$2\")');
         // font names with spaces will be escaped single-quoted
         //   we'll need to change these to double-quoted
         s = s.replace(/(\\')/gi, '\"');

--- a/test/jasmine/tests/download_test.js
+++ b/test/jasmine/tests/download_test.js
@@ -32,7 +32,6 @@ describe('Plotly.downloadImage', function() {
 
     afterAll(function() {
         document.createElement = createElement;
-        navigator.msSaveBlob = msSaveBlob;
     });
 
     beforeEach(function() {
@@ -43,6 +42,7 @@ describe('Plotly.downloadImage', function() {
         destroyGraphDiv();
         Lib.isIE = isIE;
         slzProto.serializeToString = serializeToString;
+        navigator.msSaveBlob = msSaveBlob;
     });
 
     it('should be attached to Plotly', function() {

--- a/test/jasmine/tests/download_test.js
+++ b/test/jasmine/tests/download_test.js
@@ -81,7 +81,7 @@ describe('Plotly.downloadImage', function() {
         var savedBlob;
         navigator.msSaveBlob = function(blob) { savedBlob = blob; };
 
-        var expectedStart = '<svg class=\'main-svg\' xmlns=\'http://www.w3.org/2000/svg\' xmlns:xlink=\'http://www.w3.org/1999/xlink\' width=\'300\' height=\'300\' style=\'\' viewBox=\'0 0 300 300\'>';
+        var expectedStart = '<svg class=\'main-svg\' xmlns=\'http://www.w3.org/2000/svg\' xmlns:xlink=\'http://www.w3.org/1999/xlink\'';
         var plotClip = /clip-path='url\("#clip[0-9a-f]{6}xyplot"\)/;
         var legendClip = /clip-path=\'url\("#legend[0-9a-f]{6}"\)/;
 


### PR DESCRIPTION
Based off https://github.com/arbscht/plotly.js/pull/1 by @arbscht

Fixes #2063 and possibly #699

@arbscht can you confirm that this produces good output for you - particularly can you verify that a zoomed-in plot is still clipped correctly in the exported SVG?

cc @etpinard @bpostlethwaite 