### PR TITLE
No default needed for table line

### DIFF
--- a/src/traces/table/attributes.js
+++ b/src/traces/table/attributes.js
@@ -114,11 +114,13 @@ module.exports = overrideAll({
             width: {
                 valType: 'number',
                 arrayOk: true,
+                dflt: 1,
                 role: 'style'
             },
             color: {
                 valType: 'color',
                 arrayOk: true,
+                dflt: 'grey',
                 role: 'style'
             }
         },
@@ -192,11 +194,13 @@ module.exports = overrideAll({
             width: {
                 valType: 'number',
                 arrayOk: true,
+                dflt: 1,
                 role: 'style'
             },
             color: {
                 valType: 'color',
                 arrayOk: true,
+                dflt: 'grey',
                 role: 'style'
             }
         },

--- a/test/image/mocks/table_latex_multitrace.json
+++ b/test/image/mocks/table_latex_multitrace.json
@@ -33,7 +33,6 @@
                     ["$$\\cos\\theta=\\pm\\sqrt{\\displaystyle\\frac{1+\\cos\\theta}{2}}$$", "$$\\sin\\theta=\\pm\\sqrt{\\displaystyle\\frac{1-\\cos\\theta}{2}}$$"]
                 ],
                 "align": ["right", "center", "center"],
-                "line": {"color": "grey", "width": 1},
                 "font": {"family": "Arial", "size": 12, "color": ["black"]}
             }
         },


### PR DESCRIPTION
Currently, the JSON spec must have a `line` spec, which is not ideal as it can be supplied with good defaults.