### PR TITLE
Return empty set for invisible bar trace

### DIFF
--- a/src/traces/bar/select.js
+++ b/src/traces/bar/select.js
@@ -17,7 +17,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     var node3 = cd[0].node3;
     var i;
 
-    if(trace.visible !== true) return;
+    if(trace.visible !== true) return [];
 
     if(polygon === false) {
         // clear selection

--- a/src/traces/scatter/select.js
+++ b/src/traces/scatter/select.js
@@ -26,7 +26,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
 
     // TODO: include lines? that would require per-segment line properties
     var hasOnlyLines = (!subtypes.hasMarkers(trace) && !subtypes.hasText(trace));
-    if(trace.visible !== true || hasOnlyLines) return;
+    if(trace.visible !== true || hasOnlyLines) return [];
 
     var opacity = Array.isArray(marker.opacity) ? 1 : marker.opacity;
 

--- a/src/traces/scattergeo/select.js
+++ b/src/traces/scattergeo/select.js
@@ -22,7 +22,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     var di, lonlat, x, y, i;
 
     var hasOnlyLines = (!subtypes.hasMarkers(trace) && !subtypes.hasText(trace));
-    if(trace.visible !== true || hasOnlyLines) return;
+    if(trace.visible !== true || hasOnlyLines) return [];
 
     var marker = trace.marker;
     var opacity = Array.isArray(marker.opacity) ? 1 : marker.opacity;

--- a/src/traces/scattergl/select.js
+++ b/src/traces/scattergl/select.js
@@ -26,7 +26,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     var scene = glTrace.scene;
 
     var hasOnlyLines = (!subtypes.hasMarkers(trace) && !subtypes.hasText(trace));
-    if(trace.visible !== true || hasOnlyLines) return;
+    if(trace.visible !== true || hasOnlyLines) return [];
 
     // filter out points by visible scatter ones
     if(polygon === false) {

--- a/src/traces/scattermapbox/select.js
+++ b/src/traces/scattermapbox/select.js
@@ -24,7 +24,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     // to not insert data-driven 'circle-opacity' when we don't need to
     trace._hasDimmedPts = false;
 
-    if(trace.visible !== true || !subtypes.hasMarkers(trace)) return;
+    if(trace.visible !== true || !subtypes.hasMarkers(trace)) return [];
 
     if(polygon === false) {
         for(i = 0; i < cd.length; i++) {


### PR DESCRIPTION
Downstream processing expects an array here, even when a trace is not `visible`:

```
                    var thisSelection = fillSelectionItem(
                        searchInfo.selectPoints(searchInfo, poly), searchInfo
                    );
                    if(selection.length) {
                        for(var j = 0; j < thisSelection.length; j++) { // <- won't have a length as selectPoints is undefined
                            selection.push(thisSelection[j]);
                        }
                    }
```

(side note: `fillSelectionItem` handles the case of a non-array `selection`, in which case it just passes it on ie. doesn't try to set `curveNumber` etc. properties on `undefined`; the result of which is the same `undefined` as the value of the first arg)

There's a similar `return;` in `scatter`, `scattergeo`, `scattermapbox`.

Is it a good direction @etpinard ?