### PR TITLE
Remove smith attribute

### DIFF
--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -168,14 +168,6 @@ module.exports = {
             'forked graphs from the plotly service (at https://plot.ly or on-premise).'
         ].join(' ')
     },
-    smith: {
-        // will become a boolean if/when we implement this
-        valType: 'enumerated',
-        role: 'info',
-        values: [false],
-        dflt: false,
-        editType: 'none'
-    },
     showlegend: {
         // handled in legend.supplyLayoutDefaults
         // but included here because it's not in the legend object

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1137,7 +1137,6 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut) {
 
     coerce('separators');
     coerce('hidesources');
-    coerce('smith');
 
     Registry.getComponentMethod(
         'calendars',

--- a/test/image/mocks/contour_match_edges.json
+++ b/test/image/mocks/contour_match_edges.json
@@ -10487,7 +10487,6 @@
       "title":"Click to enter Plot title",
       "plot_bgcolor":"#fff",
       "dragmode":"zoom",
-      "smith":false,
       "width":964,
       "bargap":0.2,
       "xaxis":{

--- a/test/image/mocks/gl3d_opacity-surface.json
+++ b/test/image/mocks/gl3d_opacity-surface.json
@@ -7848,7 +7848,6 @@
     "paper_bgcolor": "#fff",
     "plot_bgcolor": "#fff",
     "dragmode": "zoom",
-    "smith": false,
     "scene": {
       "domain": {
         "y": [

--- a/test/image/mocks/titles-avoid-labels.json
+++ b/test/image/mocks/titles-avoid-labels.json
@@ -175,7 +175,6 @@
         "hovermode": "x",
         "separators": ".,",
         "hidesources": false,
-        "smith": false,
         "showlegend": false
     }
 }


### PR DESCRIPTION
We had a plan a long time ago to support smith charts, but never did.
If/when we decide to do this, it probably won't be implemented with a simple global attribute anyhow.

cc @cldougl 

