### PR TITLE
Selection on `choropleth` to work even if an invisible trace is present

### DIFF
--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -23,6 +23,11 @@ var MINSELECT = constants.MINSELECT;
 
 function getAxId(ax) { return ax._id; }
 
+function visible(searchInfo) {
+    var cd0 = searchInfo.cd[0];
+    return cd0 && cd0.trace && cd0.trace.visible === true;
+}
+
 module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
     var zoomLayer = dragOptions.gd._fullLayout._zoomlayer,
         dragBBox = dragOptions.element.getBoundingClientRect(),
@@ -190,6 +195,7 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
                 selection = [];
                 for(i = 0; i < searchTraces.length; i++) {
                     searchInfo = searchTraces[i];
+                    if(!visible(searchInfo)) continue;
                     var thisSelection = fillSelectionItem(
                         searchInfo.selectPoints(searchInfo, poly), searchInfo
                     );
@@ -218,6 +224,7 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
                 outlines.remove();
                 for(i = 0; i < searchTraces.length; i++) {
                     searchInfo = searchTraces[i];
+                    if(!visible(searchInfo)) continue;
                     searchInfo.selectPoints(searchInfo, false);
                 }
 

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -23,11 +23,6 @@ var MINSELECT = constants.MINSELECT;
 
 function getAxId(ax) { return ax._id; }
 
-function visible(searchInfo) {
-    var cd0 = searchInfo.cd[0];
-    return cd0 && cd0.trace && cd0.trace.visible === true;
-}
-
 module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
     var zoomLayer = dragOptions.gd._fullLayout._zoomlayer,
         dragBBox = dragOptions.element.getBoundingClientRect(),
@@ -79,7 +74,7 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
     for(i = 0; i < gd.calcdata.length; i++) {
         cd = gd.calcdata[i];
         trace = cd[0].trace;
-        if(!trace._module || !trace._module.selectPoints) continue;
+        if(trace.visible !== true || !trace._module || !trace._module.selectPoints) continue;
 
         if(dragOptions.subplot) {
             if(
@@ -195,7 +190,6 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
                 selection = [];
                 for(i = 0; i < searchTraces.length; i++) {
                     searchInfo = searchTraces[i];
-                    if(!visible(searchInfo)) continue;
                     var thisSelection = fillSelectionItem(
                         searchInfo.selectPoints(searchInfo, poly), searchInfo
                     );
@@ -224,7 +218,6 @@ module.exports = function prepSelect(e, startX, startY, dragOptions, mode) {
                 outlines.remove();
                 for(i = 0; i < searchTraces.length; i++) {
                     searchInfo = searchTraces[i];
-                    if(!visible(searchInfo)) continue;
                     searchInfo.selectPoints(searchInfo, false);
                 }
 

--- a/src/traces/bar/select.js
+++ b/src/traces/bar/select.js
@@ -13,11 +13,8 @@ var DESELECTDIM = require('../../constants/interactions').DESELECTDIM;
 module.exports = function selectPoints(searchInfo, polygon) {
     var cd = searchInfo.cd;
     var selection = [];
-    var trace = cd[0].trace;
     var node3 = cd[0].node3;
     var i;
-
-    if(trace.visible !== true) return [];
 
     if(polygon === false) {
         // clear selection

--- a/src/traces/choropleth/select.js
+++ b/src/traces/choropleth/select.js
@@ -47,7 +47,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     }
 
     if(node3) {
-        node3.selectAll('path').style('opacity', function (d) {
+        node3.selectAll('path').style('opacity', function(d) {
             return d.dim ? DESELECTDIM : 1;
         });
     }

--- a/src/traces/choropleth/select.js
+++ b/src/traces/choropleth/select.js
@@ -46,11 +46,9 @@ module.exports = function selectPoints(searchInfo, polygon) {
         }
     }
 
-    if(node3) {
-        node3.selectAll('path').style('opacity', function(d) {
-            return d.dim ? DESELECTDIM : 1;
-        });
-    }
+    node3.selectAll('path').style('opacity', function(d) {
+        return d.dim ? DESELECTDIM : 1;
+    });
 
     return selection;
 };

--- a/src/traces/choropleth/select.js
+++ b/src/traces/choropleth/select.js
@@ -46,9 +46,11 @@ module.exports = function selectPoints(searchInfo, polygon) {
         }
     }
 
-    node3.selectAll('path').style('opacity', function(d) {
-        return d.dim ? DESELECTDIM : 1;
-    });
+    if(node3) {
+        node3.selectAll('path').style('opacity', function (d) {
+            return d.dim ? DESELECTDIM : 1;
+        });
+    }
 
     return selection;
 };

--- a/src/traces/scatter/select.js
+++ b/src/traces/scatter/select.js
@@ -26,7 +26,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
 
     // TODO: include lines? that would require per-segment line properties
     var hasOnlyLines = (!subtypes.hasMarkers(trace) && !subtypes.hasText(trace));
-    if(trace.visible !== true || hasOnlyLines) return [];
+    if(hasOnlyLines) return [];
 
     var opacity = Array.isArray(marker.opacity) ? 1 : marker.opacity;
 

--- a/src/traces/scattergeo/select.js
+++ b/src/traces/scattergeo/select.js
@@ -22,7 +22,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     var di, lonlat, x, y, i;
 
     var hasOnlyLines = (!subtypes.hasMarkers(trace) && !subtypes.hasText(trace));
-    if(trace.visible !== true || hasOnlyLines) return [];
+    if(hasOnlyLines) return [];
 
     var marker = trace.marker;
     var opacity = Array.isArray(marker.opacity) ? 1 : marker.opacity;

--- a/src/traces/scattergl/select.js
+++ b/src/traces/scattergl/select.js
@@ -26,7 +26,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     var scene = glTrace.scene;
 
     var hasOnlyLines = (!subtypes.hasMarkers(trace) && !subtypes.hasText(trace));
-    if(trace.visible !== true || hasOnlyLines) return [];
+    if(hasOnlyLines) return [];
 
     // filter out points by visible scatter ones
     if(polygon === false) {

--- a/src/traces/scattermapbox/select.js
+++ b/src/traces/scattermapbox/select.js
@@ -24,7 +24,7 @@ module.exports = function selectPoints(searchInfo, polygon) {
     // to not insert data-driven 'circle-opacity' when we don't need to
     trace._hasDimmedPts = false;
 
-    if(trace.visible !== true || !subtypes.hasMarkers(trace)) return [];
+    if(!subtypes.hasMarkers(trace)) return [];
 
     if(polygon === false) {
         for(i = 0; i < cd.length; i++) {

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -687,6 +687,12 @@ describe('Test select box and lasso per trace:', function() {
         fig.layout.dragmode = 'select';
         fig.layout.geo.scope = 'europe';
 
+        // add a trace with no locations which will then make trace invisible, lacking DOM elements
+        fig.data.push(Lib.extendDeep({}, fig.data[0]));
+        fig.data[1].text = [];
+        fig.data[1].locations = [];
+        fig.data[1].z = [];
+
         Plotly.plot(gd, fig)
         .then(function() {
             return _run(


### PR DESCRIPTION
Box select and lasso to work in the presence of an invisible `choropleth` trace. Updated test case signals if the small fix is commented out.