### PR TITLE
Restore dispatching 'click' on right-click

### DIFF
--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -104,7 +104,7 @@ dragElement.init = function init(options) {
 
         if(options.prepFn) options.prepFn(e, startX, startY);
 
-        if(hasHover) {
+        if(hasHover && (!e.buttons || (e.buttons && e.buttons !== 2))) {
             dragCover = coverSlip();
             dragCover.style.cursor = window.getComputedStyle(element).cursor;
         }

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -78,10 +78,6 @@ dragElement.init = function init(options) {
     element.ontouchstart = onStart;
 
     function onStart(e) {
-        if(e.buttons && e.buttons === 2) {    // right click
-            return;
-        }
-
         // make dragging and dragged into properties of gd
         // so that others can look at and modify them
         gd._dragged = false;
@@ -90,6 +86,7 @@ dragElement.init = function init(options) {
         startX = offset[0];
         startY = offset[1];
         initialTarget = e.target;
+        var rightClick = e.buttons && e.buttons === 2;
 
         newMouseDownTime = (new Date()).getTime();
         if(newMouseDownTime - gd._mouseDownTime < DBLCLICKDELAY) {
@@ -104,11 +101,11 @@ dragElement.init = function init(options) {
 
         if(options.prepFn) options.prepFn(e, startX, startY);
 
-        if(hasHover && (!e.buttons || (e.buttons && e.buttons !== 2))) {
+        if(hasHover && !rightClick) {
             dragCover = coverSlip();
             dragCover.style.cursor = window.getComputedStyle(element).cursor;
         }
-        else {
+        else if(!hasHover) {
             // document acts as a dragcover for mobile, bc we can't create dragcover dynamically
             dragCover = document;
             cursor = window.getComputedStyle(document.documentElement).cursor;

--- a/test/jasmine/tests/dragelement_test.js
+++ b/test/jasmine/tests/dragelement_test.js
@@ -137,7 +137,7 @@ describe('dragElement', function() {
         expect(countCoverSlip()).toEqual(0);
 
         mouseEvent('mouseup', this.x, this.y);
-        expect(mockObj.handleClick).not.toHaveBeenCalled();
+        expect(mockObj.handleClick).toHaveBeenCalled();
     });
 
     it('should fire off click event when down/up without dragging', function() {


### PR DESCRIPTION
Issue [#6353](https://community.plot.ly/t/plotly-click-event-stopped-firing-after-update-on-right-click/6353) and [#6352](https://community.plot.ly/t/annotation-right-click/6352)

Restore dispatching 'click' on right-click