### PR TITLE
Fixup choropleth select test

### DIFF
--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -717,10 +717,11 @@ describe('Test select box and lasso per trace:', function() {
         addInvisible(fig, false);
 
         // add a trace with no locations which will then make trace invisible, lacking DOM elements
-        fig.data.push(Lib.extendDeep({}, fig.data[0]));
-        fig.data[1].text = [];
-        fig.data[1].locations = [];
-        fig.data[1].z = [];
+        var emptyChoroplethTrace = Lib.extendDeep({}, fig.data[0]);
+        emptyChoroplethTrace.text = [];
+        emptyChoroplethTrace.locations = [];
+        emptyChoroplethTrace.z = [];
+        fig.data.push(emptyChoroplethTrace);
 
         Plotly.plot(gd, fig)
         .then(function() {


### PR DESCRIPTION
Tests are currently failing on [master](https://circleci.com/gh/plotly/plotly.js/5411#tests/containers/1) because PR https://github.com/plotly/plotly.js/pull/2099 got merged on a branch behind https://github.com/plotly/plotly.js/pull/2081 

In detail, the PR #2099 branch didn't have #2081's `addInvisible` utility which messed up the trace indices and lead to a failing test.

@monfera please review.