### PR TITLE
harden locationToFeature against non-string country names

### DIFF
--- a/src/lib/geo_location_utils.js
+++ b/src/lib/geo_location_utils.js
@@ -23,6 +23,8 @@ var locationmodeToIdFinder = {
 };
 
 exports.locationToFeature = function(locationmode, location, features) {
+    if(!location || typeof location !== 'string') return false;
+
     var locationId = getLocationId(locationmode, location);
 
     if(locationId) {

--- a/test/jasmine/tests/choropleth_test.js
+++ b/test/jasmine/tests/choropleth_test.js
@@ -160,3 +160,29 @@ describe('Test choropleth hover:', function() {
         .then(done);
     });
 });
+
+describe('choropleth bad data', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('should not throw an error with bad locations', function(done) {
+        spyOn(Lib, 'warn');
+        Plotly.newPlot(gd, [{
+            locations: ['canada', 0, null, '', 'utopia'],
+            z: [1, 2, 3, 4, 5],
+            locationmode: 'country names',
+            type: 'choropleth'
+        }])
+        .then(function() {
+            // only utopia warns - others are silently ignored
+            expect(Lib.warn).toHaveBeenCalledTimes(1);
+        })
+        .catch(fail)
+        .then(done);
+    });
+});

--- a/test/jasmine/tests/scattergeo_test.js
+++ b/test/jasmine/tests/scattergeo_test.js
@@ -13,6 +13,7 @@ var mouseEvent = require('../assets/mouse_event');
 var customAssertions = require('../assets/custom_assertions');
 var assertHoverLabelStyle = customAssertions.assertHoverLabelStyle;
 var assertHoverLabelContent = customAssertions.assertHoverLabelContent;
+var fail = require('../assets/fail_test');
 
 describe('Test scattergeo defaults', function() {
     var traceIn,
@@ -246,6 +247,7 @@ describe('Test scattergeo hover', function() {
             lat: [10, 20, 30],
             text: ['A', 'B', 'C']
         }])
+        .catch(fail)
         .then(done);
     });
 
@@ -280,6 +282,7 @@ describe('Test scattergeo hover', function() {
         Plotly.restyle(gd, 'hoverinfo', 'lon+lat+text+name').then(function() {
             check([381, 221], ['(10°, 10°)\nA', 'trace 0']);
         })
+        .catch(fail)
         .then(done);
     });
 
@@ -287,6 +290,7 @@ describe('Test scattergeo hover', function() {
         Plotly.restyle(gd, 'text', 'text').then(function() {
             check([381, 221], ['(10°, 10°)\ntext', null]);
         })
+        .catch(fail)
         .then(done);
     });
 
@@ -294,6 +298,7 @@ describe('Test scattergeo hover', function() {
         Plotly.restyle(gd, 'hovertext', 'hovertext').then(function() {
             check([381, 221], ['(10°, 10°)\nhovertext', null]);
         })
+        .catch(fail)
         .then(done);
     });
 
@@ -301,6 +306,7 @@ describe('Test scattergeo hover', function() {
         Plotly.restyle(gd, 'hovertext', ['Apple', 'Banana', 'Orange']).then(function() {
             check([381, 221], ['(10°, 10°)\nApple', null]);
         })
+        .catch(fail)
         .then(done);
     });
 
@@ -318,6 +324,7 @@ describe('Test scattergeo hover', function() {
                 fontFamily: 'Arial'
             });
         })
+        .catch(fail)
         .then(done);
     });
 
@@ -325,6 +332,32 @@ describe('Test scattergeo hover', function() {
         Plotly.restyle(gd, 'hoverinfo', [['lon', null, 'lat+name']]).then(function() {
             check([381, 221], ['lon: 10°', null]);
         })
+        .catch(fail)
+        .then(done);
+    });
+});
+
+describe('scattergeo bad data', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('should not throw an error with bad locations', function(done) {
+        spyOn(Lib, 'warn');
+        Plotly.newPlot(gd, [{
+            locations: ['canada', 0, null, '', 'utopia'],
+            locationmode: 'country names',
+            type: 'scattergeo'
+        }])
+        .then(function() {
+            // only utopia warns - others are silently ignored
+            expect(Lib.warn).toHaveBeenCalledTimes(1);
+        })
+        .catch(fail)
         .then(done);
     });
 });


### PR DESCRIPTION
Before, with `locationmode: 'country names'`, non-string locations would throw an error:

```
Uncaught TypeError: Cannot read property 'trim' of null
    at countryNameToISO3 (geo_location_utils.js:54)
```

Now they're just ignored silently - as opposed to strings that are unrecognized that generate a console warning. If it's just empty it seems clear you don't even want a warning. I suppose if it's not empty but also not a string it could be nice to still generate a warning, though that's not how most of plotly.js handles invalid data...

cc @etpinard 