### PR TITLE
Add crossline functionality

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -385,6 +385,19 @@ function _hover(gd, evt, subplot, noHoverEvent) {
             yval = yvalArray[subploti];
         }
 
+        var showSpikes = fullLayout.xaxis && fullLayout.xaxis.showspikes && fullLayout.yaxis && fullLayout.yaxis.showspikes;
+        var showCrosslines = fullLayout.xaxis && fullLayout.xaxis.showcrossline || fullLayout.yaxis && fullLayout.yaxis.showcrossline;
+
+        // Find the points for the crosslines first to avoid overwriting the hoverLabels data.
+        if(fullLayout._has('cartesian') && showCrosslines && !(showSpikes && hovermode === 'closest')) {
+            if(fullLayout.yaxis.showcrossline) {
+                crosslinePoints.hLinePoint = findCrosslinePoint(pointData, xval, yval, 'y', crosslinePoints.hLinePoint);
+            }
+            if(fullLayout.xaxis.showcrossline) {
+                crosslinePoints.vLinePoint = findCrosslinePoint(pointData, xval, yval, 'x', crosslinePoints.vLinePoint);
+            }
+        }
+
         // Now find the points.
         if(trace._module && trace._module.hoverPoints) {
             var newPoints = trace._module.hoverPoints(pointData, xval, yval, mode, fullLayout._hoverlayer);
@@ -408,22 +421,11 @@ function _hover(gd, evt, subplot, noHoverEvent) {
             hoverData.splice(0, closedataPreviousLength);
             distance = hoverData[0].distance;
         }
-
-        var showSpikes = fullLayout.xaxis && fullLayout.xaxis.showspikes && fullLayout.yaxis && fullLayout.yaxis.showspikes;
-        var showCrosslines = fullLayout.xaxis && fullLayout.xaxis.showcrossline || fullLayout.yaxis && fullLayout.yaxis.showcrossline;
-
-        if(fullLayout._has('cartesian') && showCrosslines && !(showSpikes && hovermode === 'closest')) {
-            // Now find the points for the crosslines.
-            if(fullLayout.yaxis.showcrossline) {
-                crosslinePoints.hLinePoint = findCrosslinePoint(pointData, xval, yval, 'y', crosslinePoints.hLinePoint);
-            }
-            if(fullLayout.xaxis.showcrossline) {
-                crosslinePoints.vLinePoint = findCrosslinePoint(pointData, xval, yval, 'x', crosslinePoints.vLinePoint);
-            }
-        }
     }
 
     function findCrosslinePoint(pointData, xval, yval, mode, endPoint) {
+        var tmpDistance = pointData.distance;
+        var tmpIndex = pointData.index;
         var resultPoint = endPoint;
         pointData.distance = Infinity;
         pointData.index = false;
@@ -447,6 +449,8 @@ function _hover(gd, evt, subplot, noHoverEvent) {
                 }
             }
         }
+        pointData.index = tmpIndex;
+        pointData.distance = tmpDistance;
         return resultPoint;
     }
 
@@ -1164,7 +1168,7 @@ function cleanPoint(d, hovermode) {
     return d;
 }
 
-function createCrosslines(hoverData, fullLayout) {
+function createCrosslines(closestPoints, fullLayout) {
     var showXSpikeline = fullLayout.xaxis && fullLayout.xaxis.showspikes;
     var showYSpikeline = fullLayout.yaxis && fullLayout.yaxis.showspikes;
     var showH = fullLayout.yaxis && fullLayout.yaxis.showcrossline;
@@ -1187,7 +1191,7 @@ function createCrosslines(hoverData, fullLayout) {
 
     // do not draw a crossline if there is a spikeline
     if(showV && !(showXSpikeline && hovermode === 'closest')) {
-        vLinePoint = hoverData.vLinePoint;
+        vLinePoint = closestPoints.vLinePoint;
         xa = vLinePoint.xa;
         vLinePointX = xa._offset + (vLinePoint.x0 + vLinePoint.x1) / 2;
 
@@ -1211,7 +1215,7 @@ function createCrosslines(hoverData, fullLayout) {
     }
 
     if(showH && !(showYSpikeline && hovermode === 'closest')) {
-        hLinePoint = hoverData.hLinePoint;
+        hLinePoint = closestPoints.hLinePoint;
         ya = hLinePoint.ya;
         hLinePointY = ya._offset + (hLinePoint.y0 + hLinePoint.y1) / 2;
 

--- a/src/components/fx/index.js
+++ b/src/components/fx/index.js
@@ -59,6 +59,7 @@ function loneUnhover(containerOrSelection) {
 
     selection.selectAll('g.hovertext').remove();
     selection.selectAll('.spikeline').remove();
+    selection.selectAll('.crossline').remove();
 }
 
 // helpers for traces that use Fx.loneHover

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -166,6 +166,9 @@ Plotly.plot = function(gd, data, layout, config) {
     // save initial show spikes once per graph
     if(graphWasEmpty) Plotly.Axes.saveShowSpikeInitial(gd);
 
+    // save initial show crosslines once per graph
+    if(graphWasEmpty) Plotly.Axes.saveShowCrosslineInitial(gd);
+
     // prepare the data and find the autorange
 
     // generate calcdata, if we need to

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -426,6 +426,30 @@ axes.saveShowSpikeInitial = function(gd, overwrite) {
     return hasOneAxisChanged;
 };
 
+// save a copy of the initial crossline visibility
+axes.saveShowCrosslineInitial = function(gd, overwrite) {
+    var axList = axes.list(gd, '', true),
+        hasOneAxisChanged = false;
+
+    for(var i = 0; i < axList.length; i++) {
+        var ax = axList[i];
+
+        var isNew = (ax._showCrosslineInitial === undefined);
+        var hasChanged = (
+            isNew || !(
+                ax.showcrossline === ax._showcrossline
+            )
+        );
+
+        if((isNew) || (overwrite && hasChanged)) {
+            ax._showCrosslineInitial = ax.showcrossline;
+            hasOneAxisChanged = true;
+        }
+
+    }
+    return hasOneAxisChanged;
+};
+
 // axes.expand: if autoranging, include new data in the outer limits
 // for this axis
 // data is an array of numbers (ie already run through ax.d2c)
@@ -2121,7 +2145,7 @@ axes.doTicks = function(gd, axid, skipTitle) {
                         top: pos,
                         bottom: pos,
                         left: ax._offset,
-                        rigth: ax._offset + ax._length,
+                        right: ax._offset + ax._length,
                         width: ax._length,
                         height: 0
                     };

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -387,6 +387,28 @@ module.exports = {
             'plotted on'
         ].join(' ')
     },
+    showcrossline: {
+        valType: 'boolean',
+        dflt: false,
+        role: 'style',
+        editType: 'none',
+        description: 'Determines whether or not crossline are drawn for this axis.'
+    },
+    crosslinecolor: {
+        valType: 'color',
+        dflt: null,
+        role: 'style',
+        editType: 'none',
+        description: 'Sets the crossline color. If undefined, will use the contrast to background color'
+    },
+    crosslinethickness: {
+        valType: 'number',
+        dflt: 2,
+        role: 'style',
+        editType: 'none',
+        description: 'Sets the width (in px) of the zero line.'
+    },
+    crosslinedash: extendFlat({}, dash, {dflt: 'solid', editType: 'none'}),
     tickfont: fontAttrs({
         editType: 'ticks',
         description: 'Sets the tick font.'

--- a/src/plots/cartesian/layout_defaults.js
+++ b/src/plots/cartesian/layout_defaults.js
@@ -191,6 +191,13 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
 
         handleAxisDefaults(axLayoutIn, axLayoutOut, coerce, defaultOptions, layoutOut);
 
+        var showCrossline = coerce('showcrossline');
+        if(showCrossline) {
+            coerce('crosslinecolor');
+            coerce('crosslinethickness');
+            coerce('crosslinedash');
+        }
+
         var showSpikes = coerce('showspikes');
         if(showSpikes) {
             coerce('spikecolor');

--- a/test/jasmine/tests/hover_crossline_test.js
+++ b/test/jasmine/tests/hover_crossline_test.js
@@ -52,13 +52,13 @@ describe('crossline', function() {
             Plotly.plot(gd, _mock).then(function() {
                 _hover({xval: 2, yval: 3}, 'xy');
                 _assert(
-                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                    [[80, 250, 1036, 250], [557, 100, 557, 401]]
                 );
             })
             .then(function() {
                 _hover({xval: 30, yval: 40}, 'x2y2');
                 _assert(
-                    [[651, 167, 985, 167], [820, 115, 820, 220]]
+                    [[651, 167, 988, 167], [820, 115, 820, 220]]
                 );
             })
             .catch(fail)
@@ -74,13 +74,13 @@ describe('crossline', function() {
             Plotly.plot(gd, _mock).then(function() {
                 _hover({xval: 2, yval: 3}, 'xy');
                 _assert(
-                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                    [[80, 250, 1036, 250], [557, 100, 557, 401]]
                 );
             })
             .then(function() {
                 _hover({xval: 30, yval: 40}, 'x2y2');
                 _assert(
-                    [[651, 167, 985, 167], [820, 115, 820, 220]]
+                    [[651, 167, 988, 167], [820, 115, 820, 220]]
                 );
             })
             .catch(fail)
@@ -96,13 +96,13 @@ describe('crossline', function() {
             Plotly.plot(gd, _mock).then(function() {
                 _hover({xval: 2, yval: 3}, 'xy');
                 _assert(
-                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                    [[80, 250, 1036, 250], [557, 100, 557, 401]]
                 );
             })
             .then(function() {
                 _hover({xval: 30, yval: 40}, 'x2y2');
                 _assert(
-                    [[652, 167, 985, 167], [820, 115, 820, 220]]
+                    [[652, 167, 988, 167], [820, 115, 820, 220]]
                 );
             })
             .catch(fail)
@@ -118,13 +118,13 @@ describe('crossline', function() {
             Plotly.plot(gd, _mock).then(function() {
                 _hover({xval: 2, yval: 3}, 'xy');
                 _assert(
-                    [[80, 250, 1033, 250]]
+                    [[80, 250, 1036, 250]]
                 );
             })
             .then(function() {
                 _hover({xval: 30, yval: 40}, 'x2y2');
                 _assert(
-                    [[652, 167, 985, 167]]
+                    [[652, 167, 988, 167]]
                 );
             })
             .catch(fail)
@@ -146,7 +146,7 @@ describe('crossline', function() {
             .then(function() {
                 _hover({xval: 30, yval: 40}, 'x2y2');
                 _assert(
-                    [[818, 115, 818, 220]]
+                    [[820, 115, 820, 220]]
                 );
             })
             .catch(fail)

--- a/test/jasmine/tests/hover_crossline_test.js
+++ b/test/jasmine/tests/hover_crossline_test.js
@@ -1,0 +1,179 @@
+var d3 = require('d3');
+
+var Plotly = require('@lib/index');
+var Fx = require('@src/components/fx');
+var Lib = require('@src/lib');
+
+var fail = require('../assets/fail_test');
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+
+describe('crossline', function() {
+    'use strict';
+
+    afterEach(destroyGraphDiv);
+
+    describe('hover', function() {
+        var gd;
+
+        function makeMock() {
+            var _mock = Lib.extendDeep({}, require('@mocks/19.json'));
+            _mock.layout.xaxis.showcrossline = true;
+            _mock.layout.yaxis.showcrossline = true;
+            _mock.layout.xaxis2.showcrossline = true;
+            _mock.layout.hovermode = 'closest';
+            return _mock;
+        }
+
+        function _hover(evt, subplot) {
+            Fx.hover(gd, evt, subplot);
+            Lib.clearThrottle();
+        }
+
+        function _assert(lineExpect) {
+            var TOL = 5;
+            var lines = d3.selectAll('line.crossline');
+
+            expect(lines.size()).toBe(lineExpect.length, '# of line nodes');
+
+            lines.each(function(_, i) {
+                var sel = d3.select(this);
+                ['x1', 'y1', 'x2', 'y2'].forEach(function(d, j) {
+                    expect(sel.attr(d))
+                        .toBeWithin(lineExpect[i][j], TOL, 'line ' + i + ' attr ' + d);
+                });
+            });
+        }
+
+        it('draws lines and markers on enabled axes in the closest hovermode', function(done) {
+            gd = createGraphDiv();
+            var _mock = makeMock();
+
+            Plotly.plot(gd, _mock).then(function() {
+                _hover({xval: 2, yval: 3}, 'xy');
+                _assert(
+                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                );
+            })
+            .then(function() {
+                _hover({xval: 30, yval: 40}, 'x2y2');
+                _assert(
+                    [[651, 167, 985, 167], [820, 115, 820, 220]]
+                );
+            })
+            .catch(fail)
+            .then(done);
+        });
+
+        it('draws lines and markers on enabled axes in the x hovermode', function(done) {
+            gd = createGraphDiv();
+            var _mock = makeMock();
+
+            _mock.layout.hovermode = 'x';
+
+            Plotly.plot(gd, _mock).then(function() {
+                _hover({xval: 2, yval: 3}, 'xy');
+                _assert(
+                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                );
+            })
+            .then(function() {
+                _hover({xval: 30, yval: 40}, 'x2y2');
+                _assert(
+                    [[651, 167, 985, 167], [820, 115, 820, 220]]
+                );
+            })
+            .catch(fail)
+            .then(done);
+        });
+
+        it('draws lines and markers on enabled axes in the y hovermode', function(done) {
+            gd = createGraphDiv();
+            var _mock = makeMock();
+
+            _mock.layout.hovermode = 'y';
+
+            Plotly.plot(gd, _mock).then(function() {
+                _hover({xval: 2, yval: 3}, 'xy');
+                _assert(
+                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                );
+            })
+            .then(function() {
+                _hover({xval: 30, yval: 40}, 'x2y2');
+                _assert(
+                    [[652, 167, 985, 167], [820, 115, 820, 220]]
+                );
+            })
+            .catch(fail)
+            .then(done);
+        });
+
+        it('does not draw lines and markers on enabled axes if spikes are enabled on the same axes', function(done) {
+            gd = createGraphDiv();
+            var _mock = makeMock();
+
+            _mock.layout.xaxis.showspikes = true;
+
+            Plotly.plot(gd, _mock).then(function() {
+                _hover({xval: 2, yval: 3}, 'xy');
+                _assert(
+                    [[80, 250, 1033, 250]]
+                );
+            })
+            .then(function() {
+                _hover({xval: 30, yval: 40}, 'x2y2');
+                _assert(
+                    [[652, 167, 985, 167]]
+                );
+            })
+            .catch(fail)
+            .then(done);
+        });
+
+        it('does not draw lines and markers on enabled axes if spikes are enabled on the same axes', function(done) {
+            gd = createGraphDiv();
+            var _mock = makeMock();
+
+            _mock.layout.yaxis.showspikes = true;
+
+            Plotly.plot(gd, _mock).then(function() {
+                _hover({xval: 2, yval: 3}, 'xy');
+                _assert(
+                    [[557, 100, 557, 401]]
+                );
+            })
+            .then(function() {
+                _hover({xval: 30, yval: 40}, 'x2y2');
+                _assert(
+                    [[818, 115, 818, 220]]
+                );
+            })
+            .catch(fail)
+            .then(done);
+        });
+
+        it('draws lines and markers on enabled axes w/o tick labels', function(done) {
+            gd = createGraphDiv();
+            var _mock = makeMock();
+
+            _mock.layout.xaxis.showticklabels = false;
+            _mock.layout.yaxis.showticklabels = false;
+
+            Plotly.plot(gd, _mock).then(function() {
+                _hover({xval: 2, yval: 3}, 'xy');
+                _assert(
+                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                );
+            })
+            .then(function() {
+                _hover({xval: 30, yval: 40}, 'x2y2');
+                _assert(
+                    [[652, 167, 985, 167], [820, 115, 820, 220]]
+                );
+            })
+            .catch(fail)
+            .then(done);
+        });
+    });
+});

--- a/test/jasmine/tests/hover_crossline_test.js
+++ b/test/jasmine/tests/hover_crossline_test.js
@@ -163,13 +163,13 @@ describe('crossline', function() {
             Plotly.plot(gd, _mock).then(function() {
                 _hover({xval: 2, yval: 3}, 'xy');
                 _assert(
-                    [[80, 250, 1033, 250], [557, 100, 557, 401]]
+                    [[80, 250, 1036, 250], [557, 100, 557, 401]]
                 );
             })
             .then(function() {
                 _hover({xval: 30, yval: 40}, 'x2y2');
                 _assert(
-                    [[652, 167, 985, 167], [820, 115, 820, 220]]
+                    [[652, 167, 988, 167], [820, 115, 820, 220]]
                 );
             })
             .catch(fail)


### PR DESCRIPTION
This PR adds showcrossline, crosslinecolor, crosslinethickness and crosslinedash axis config attributes.

Related to [Issue #54](https://github.com/plotly/plotly.js/issues/54)

The purpose of the new attributes is to create a custom styled crossline for the corresponding axis.
The behavior of the crossline is similar to the behavior of the spikes feature, but there are several differences:
* crosslines do not depend on the selected hovermode
* crosslines are always drawn over the nearest x|y point, regardless of whether this point is within the max hover distance or not
* crosslines are always drawn across the entire plot area

The crosslines are automatically switched off when the spikes are turned on on the same axis.

Only the cartesian type of axis supports crosslines.

Screenshots:
![image](https://user-images.githubusercontent.com/618807/32556267-071cab3c-c4b0-11e7-9dc3-1e0c86efe03f.png)

![image](https://user-images.githubusercontent.com/618807/32556281-0d051cb4-c4b0-11e7-99e6-c3f4d74e040d.png)

