### PR TITLE
More indexToPoints 

### DIFF
--- a/src/transforms/sort.js
+++ b/src/transforms/sort.js
@@ -10,6 +10,7 @@
 
 var Lib = require('../lib');
 var Axes = require('../plots/cartesian/axes');
+var pointsAccessorFunction = require('./helpers').pointsAccessorFunction;
 
 exports.moduleType = 'transform';
 
@@ -87,18 +88,27 @@ exports.calcTransform = function(gd, trace, opts) {
     var arrayAttrs = trace._arrayAttrs;
     var d2c = Axes.getDataToCoordFunc(gd, trace, target, targetArray);
     var indices = getIndices(opts, targetArray, d2c);
+    var originalPointsAccessor = pointsAccessorFunction(trace.transforms, opts);
+    var indexToPoints = {};
+    var i, j;
 
-    for(var i = 0; i < arrayAttrs.length; i++) {
+    for(i = 0; i < arrayAttrs.length; i++) {
         var np = Lib.nestedProperty(trace, arrayAttrs[i]);
         var arrayOld = np.get();
         var arrayNew = new Array(len);
 
-        for(var j = 0; j < len; j++) {
+        for(j = 0; j < len; j++) {
             arrayNew[j] = arrayOld[indices[j]];
         }
 
         np.set(arrayNew);
     }
+
+    for(j = 0; j < len; j++) {
+        indexToPoints[j] = originalPointsAccessor(indices[j]);
+    }
+
+    opts._indexToPoints = indexToPoints;
 };
 
 function getIndices(opts, targetArray, d2c) {

--- a/test/jasmine/tests/transform_groupby_test.js
+++ b/test/jasmine/tests/transform_groupby_test.js
@@ -57,8 +57,10 @@ describe('groupby', function() {
                 expect(gd._fullData.length).toEqual(2);
                 expect(gd._fullData[0].x).toEqual([1, -1, 0, 3]);
                 expect(gd._fullData[0].y).toEqual([1, 2, 1, 1]);
+                expect(gd._fullData[0].transforms[0]._indexToPoints).toEqual({0: [0], 1: [1], 2: [3], 3: [6]});
                 expect(gd._fullData[1].x).toEqual([-2, 1, 2]);
                 expect(gd._fullData[1].y).toEqual([3, 2, 3]);
+                expect(gd._fullData[1].transforms[0]._indexToPoints).toEqual({0: [2], 1: [4], 2: [5]});
 
                 assertDims([4, 3]);
 
@@ -459,6 +461,7 @@ describe('groupby', function() {
                     expect(gd._fullData[0].x).toEqual([1, -1, 0, 3]);
                     expect(gd._fullData[0].y).toEqual([0, 1, 3, 6]);
                     expect(gd._fullData[0].marker.line.width).toEqual([4, 2, 2, 3]);
+
 
                     expect(gd._fullData[1].ids).toEqual(['r', 'y', 'u']);
                     expect(gd._fullData[1].x).toEqual([-2, 1, 2]);

--- a/test/jasmine/tests/transform_sort_test.js
+++ b/test/jasmine/tests/transform_sort_test.js
@@ -90,6 +90,15 @@ describe('Test sort transform calc:', function() {
         expect(out[0].ids).toEqual(['n0', 'n2', 'n1', 'z', 'p1', 'p3', 'p2']);
         expect(out[0].marker.color).toEqual([0.1, 0.3, 0.2, 0.1, 0.2, 0.4, 0.3]);
         expect(out[0].marker.size).toEqual([10, 5, 20, 1, 6, 10, 0]);
+        expect(out[0].transforms[0]._indexToPoints).toEqual({
+            0: [0],
+            1: [2],
+            2: [1],
+            3: [3],
+            4: [4],
+            5: [6],
+            6: [5]
+        });
     });
 
     it('should sort all array attributes (descending case)', function() {
@@ -104,6 +113,15 @@ describe('Test sort transform calc:', function() {
         expect(out[0].ids).toEqual(['p2', 'p1', 'p3', 'z', 'n1', 'n0', 'n2']);
         expect(out[0].marker.color).toEqual([0.3, 0.2, 0.4, 0.1, 0.2, 0.1, 0.3]);
         expect(out[0].marker.size).toEqual([0, 6, 10, 1, 20, 10, 5]);
+        expect(out[0].transforms[0]._indexToPoints).toEqual({
+            0: [5],
+            1: [4],
+            2: [6],
+            3: [3],
+            4: [1],
+            5: [0],
+            6: [2]
+        });
     });
 
     it('should sort via nested targets', function() {
@@ -119,6 +137,15 @@ describe('Test sort transform calc:', function() {
         expect(out[0].ids).toEqual(['n1', 'n0', 'p3', 'p1', 'n2', 'z', 'p2']);
         expect(out[0].marker.color).toEqual([0.2, 0.1, 0.4, 0.2, 0.3, 0.1, 0.3]);
         expect(out[0].marker.size).toEqual([20, 10, 10, 6, 5, 1, 0]);
+        expect(out[0].transforms[0]._indexToPoints).toEqual({
+            0: [1],
+            1: [0],
+            2: [6],
+            3: [4],
+            4: [2],
+            5: [3],
+            6: [5]
+        });
     });
 
     it('should sort via dates targets', function() {


### PR DESCRIPTION
This PR computes @monfera 's brilliant `indexToPoints` map objects (first added in #2126)  for `sort` and `groupby` transforms, in preparation for _transform-compatible_ persistent selections in https://github.com/plotly/plotly.js/pull/2135 - which will use `indexToPoints` heavily :muscle: 

More info of the topic in https://github.com/plotly/plotly.js/issues/2128.

cc @monfera @alexcjohnson 