### PR TITLE
Legend lines width

### DIFF
--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -34,6 +34,13 @@ module.exports = {
         editType: 'legend',
         description: 'Sets the width (in px) of the border enclosing the legend.'
     },
+    linewidth: {
+        valType: 'number',
+        min: 0,
+        role: 'style',
+        editType: 'legend',
+        description: 'Sets the width (in px) of the legend lines.'
+    },
     font: fontAttrs({
         editType: 'legend',
         description: 'Sets the font used to text the legend items.'

--- a/src/components/legend/defaults.js
+++ b/src/components/legend/defaults.js
@@ -61,6 +61,7 @@ module.exports = function legendDefaults(layoutIn, layoutOut, fullData) {
     coerce('bgcolor', layoutOut.paper_bgcolor);
     coerce('bordercolor');
     coerce('borderwidth');
+    coerce('linewidth');
     Lib.coerceFont(coerce, 'font', layoutOut.font);
 
     coerce('orientation');

--- a/src/components/legend/style.js
+++ b/src/components/legend/style.js
@@ -78,10 +78,11 @@ module.exports = function style(s, gd) {
 
         var line = d3.select(this).select('.legendlines').selectAll('path')
             .data(showLine ? [d] : []);
+        var lineWidth = gd._fullLayout.legend.linewidth;
         line.enter().append('path').classed('js-line', true)
             .attr('d', 'M5,0h30');
         line.exit().remove();
-        line.call(Drawing.lineGroupStyle);
+        line.call(Drawing.lineGroupStyle, lineWidth);
     }
 
     function stylePoints(d) {


### PR DESCRIPTION
Related to [#147](https://github.com/plotly/plotly.js/issues/147) and [#340](https://github.com/ropensci/plotly/issues/340)

This PR adds legend-linewidth config attribute. The purpose of new attribute is to let users to customize legend line thickness.

linewidth is number

- when not mentioned, then trace width will be taken. 
- when mentioned both, then linewidth is of higher priority, then trace width