### PR TITLE
word breaking in notifier

### DIFF
--- a/build/plotcss.js
+++ b/build/plotcss.js
@@ -50,7 +50,7 @@ var rules = {
     "X .select-outline-2": "stroke:black;stroke-dasharray:2px 2px;",
     Y: "font-family:'Open Sans';position:fixed;top:50px;right:20px;z-index:10000;font-size:10pt;max-width:180px;",
     "Y p": "margin:0;",
-    "Y .notifier-note": "min-width:180px;max-width:250px;border:1px solid #fff;z-index:3000;margin:0;background-color:#8c97af;background-color:rgba(140,151,175,0.9);color:#fff;padding:10px;",
+    "Y .notifier-note": "min-width:180px;max-width:250px;border:1px solid #fff;z-index:3000;margin:0;background-color:#8c97af;background-color:rgba(140,151,175,0.9);color:#fff;padding:10px;overflow-wrap:break-word;word-wrap:break-word;-ms-hyphens:auto;-webkit-hyphens:auto;hyphens:auto;",
     "Y .notifier-close": "color:#fff;opacity:0.8;float:right;padding:0 5px;background:none;border:none;font-size:20px;font-weight:bold;line-height:20px;",
     "Y .notifier-close:hover": "color:#444;text-decoration:none;cursor:pointer;"
 };

--- a/src/css/_notifier.scss
+++ b/src/css/_notifier.scss
@@ -22,6 +22,13 @@
         background-color: rgba(140, 151, 175, 0.9);
         color: $color-bg-light;
         padding: 10px;
+
+        overflow-wrap: break-word;
+        word-wrap: break-word;
+
+        -ms-hyphens: auto;
+        -webkit-hyphens: auto;
+        hyphens: auto;
     }
 
     .notifier-close {


### PR DESCRIPTION
Fixes #2201
Break and hyphenate (in some browsers) long words. Not needed for English, but potentially important for eg German (long compound words?) and maybe asian languages with no spaces between word characters.

Chrome - regular words:
![chrome words](https://user-images.githubusercontent.com/2678795/34067152-bd05a2de-e1eb-11e7-94a9-ec08b1840a79.png)
long words:
![chrome long](https://user-images.githubusercontent.com/2678795/34067155-c89b4252-e1eb-11e7-89b6-2b01b57570ba.png)

FF - regular words:
![ff words](https://user-images.githubusercontent.com/2678795/34067157-cf84e9c4-e1eb-11e7-98a8-2b06e963f446.png)
long words:
![ff long](https://user-images.githubusercontent.com/2678795/34067160-d67361ca-e1eb-11e7-9990-da660061224c.png)

taken from https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
but modified: using `word-break`, no matter what I did there would be cases that short words got broken unnecessarily, so I removed it. Also `-moz-hyphens` didn't do anything - which was expected as `hyphens` is supposed to be supported in FF, but I don't ever seem to see hyphens there regardless.