### PR TITLE
don't write out strings from find_locale_strings during tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-image": "node tasks/test_image.js",
     "test-image-gl2d": "node tasks/test_image.js gl2d_* --queue",
     "test-export": "node tasks/test_export.js",
-    "test-syntax": "node tasks/test_syntax.js && npm run find-strings",
+    "test-syntax": "node tasks/test_syntax.js && npm run find-strings -- --no-output",
     "test-bundle": "node tasks/test_bundle.js",
     "test": "npm run test-jasmine && npm run test-bundle && npm run test-image && npm run test-image-gl2d && npm run test-syntax && npm run lint",
     "start-test_dashboard": "node devtools/test_dashboard/server.js",

--- a/tasks/find_locale_strings.js
+++ b/tasks/find_locale_strings.js
@@ -13,6 +13,8 @@ var EXIT_CODE = 0;
 
 var localizeRE = /(^|[\.])(_|localize)$/;
 
+var noOutput = process.argv.indexOf('--no-output') !== -1;
+
 // main
 findLocaleStrings();
 
@@ -70,11 +72,16 @@ function findLocaleStrings() {
         }
 
         if(!EXIT_CODE) {
-            var strings = Object.keys(dict).sort().map(function(k) {
-                return k + spaces(maxLen - k.length) + '  // ' + dict[k];
-            }).join('\n');
-            common.writeFile(constants.pathToTranslationKeys, strings);
-            console.log('ok find_locale_strings');
+            if(noOutput) {
+                console.log('ok find_locale_strings - no output requested.');
+            }
+            else {
+                var strings = Object.keys(dict).sort().map(function(k) {
+                    return k + spaces(maxLen - k.length) + '  // ' + dict[k];
+                }).join('\n');
+                common.writeFile(constants.pathToTranslationKeys, strings);
+                console.log('ok find_locale_strings - wrote new key file.');
+            }
         }
     });
 }


### PR DESCRIPTION
but we still want to run the rest of the script as it ensures we wrapped all strings

@etpinard as discussed in https://github.com/plotly/plotly.js/pull/2227#discussion_r159028225 so we're not modifying `dist/` when we don't intend to. `build` will still produce a new `translation_keys.txt` file.