### PR TITLE
Allow selection.style getter in event handlers

### DIFF
--- a/test/image/strict-d3.js
+++ b/test/image/strict-d3.js
@@ -32,10 +32,10 @@ selProto.style = function() {
 
     if(sel.size()) {
         if(typeof obj === 'string') {
-            if(arguments.length === 1) {
+            if(arguments.length === 1 && !d3.event) {
                 throw new Error('d3 selection.style called as getter: ' +
-                    'disallowed as it can fail for unattached elements. ' +
-                    'Use node.style.attribute instead.');
+                    'disallowed outside event handlers as it can fail for ' +
+                    'unattached elements. Use node.style.attribute instead.');
             }
             checkStyleVal(sel, obj, arguments[1]);
         } else {


### PR DESCRIPTION
Fixes #2244 

@monfera you're right, `d3.svg.brush` doesn't work in a way that my idea of disabling the check inside it would work. But here's an alternative: if `d3.event` is truthy then we know we're in a user-initiated event, and so at least within the contexts of our own test systems we know the plot must be visible because the user is interacting with it!

Seem reasonable?