### PR TITLE
Add parcoords 'dimension' to list of array containers found in traces

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1999,7 +1999,7 @@ plots.extendObjectWithContainers = function(dest, src, containerPaths) {
     return dest;
 };
 
-plots.dataArrayContainers = ['transforms'];
+plots.dataArrayContainers = ['transforms', 'dimensions'];
 plots.layoutArrayContainers = Registry.layoutArrayContainers;
 
 /*

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -7,6 +7,7 @@ var attributes = require('@src/traces/parcoords/attributes');
 
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
+var fail = require('../assets/fail_test');
 var mouseEvent = require('../assets/mouse_event');
 var supplyAllDefaults = require('../assets/supply_defaults');
 
@@ -582,7 +583,7 @@ describe('@noCI parcoords', function() {
                 expect(gd.data[1].dimensions[10].constraintrange).toEqual([100000, 150000]);
                 expect(gd.data[1].dimensions[1].constraintrange).not.toBeDefined();
 
-                expect(document.querySelectorAll('.axis').length).toEqual(20);  // one dimension is `visible: false`
+                expect(document.querySelectorAll('.axis').length).toEqual(20); // one dimension is `visible: false`
 
                 done();
             });
@@ -773,6 +774,44 @@ describe('@noCI parcoords', function() {
 
         });
 
+        it('Calling `Plotly.animate` with patches targeting `dimensions` attributes should do the right thing', function(done) {
+            Plotly.newPlot(gd, [{
+                type: 'parcoords',
+                line: {color: 'blue'},
+                dimensions: [{
+                    range: [1, 5],
+                    constraintrange: [1, 2],
+                    label: 'A',
+                    values: [1, 4]
+                }, {
+                    range: [1, 5],
+                    label: 'B',
+                    values: [3, 1.5],
+                    tickvals: [1.5, 3, 4.5]
+                }]
+            }])
+            .then(function() {
+                return Plotly.animate(gd, {
+                    data: [{
+                        'line.color': 'red',
+                        'dimensions[0].constraintrange': [1, 4]
+                    }],
+                    traces: [0],
+                    layout: {}
+                });
+            })
+            .then(function() {
+                expect(gd.data[0].line.color).toBe('red');
+                expect(gd.data[0].dimensions[0]).toEqual({
+                    range: [1, 5],
+                    constraintrange: [1, 4],
+                    label: 'A',
+                    values: [1, 4]
+                });
+            })
+            .catch(fail)
+            .then(done);
+        });
     });
 
     describe('Lifecycle methods', function() {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/2228

We already had logic built-in that merge data array container in frame. Previously only one special key was listed ('transforms`), now parcoords `dimensions` is there too.

@monfera would you mind reviewing this thing?