### PR TITLE
Some CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,25 @@ jobs:
           command: |
             sudo cp /usr/share/zoneinfo/America/Anchorage /etc/localtime
       - run:
-          name: Run jasmine tests
+          name: Run jasmine tests (batch 1)
           command: ./.circleci/test.sh jasmine
+
+  test-jasmine2:
+    docker:
+      # need '-browsers' version to test in real (xvfb-wrapped) browsers
+      - image: circleci/node:8.9.4-browsers
+    working_directory: ~/plotly.js
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/plotly.js
+      - run:
+          name: Set timezone to Alaska time (arbitrary timezone to test date logic)
+          command: |
+            sudo cp /usr/share/zoneinfo/America/Anchorage /etc/localtime
+      - run:
+          name: Run jasmine tests (batch 2)
+          command: ./.circleci/test.sh jasmine2
 
   test-image:
     docker:
@@ -98,6 +115,9 @@ workflows:
     jobs:
       - build
       - test-jasmine:
+          requires:
+            - build
+      - test-jasmine2:
           requires:
             - build
       - test-image:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -9,8 +9,13 @@ EXIT_STATE=0
 case $1 in
 
     jasmine)
-        npm run test-jasmine    || EXIT_STATE=$?
-        npm run test-bundle     || EXIT_STATE=$?
+        npm run test-jasmine -- --skip-tags=gl,noCI || EXIT_STATE=$?
+        exit $EXIT_STATE
+        ;;
+
+    jasmine2)
+        npm run test-jasmine -- --tags=gl --skip-tags=noCI || EXIT_STATE=$?
+        npm run test-bundle                                || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;
 
@@ -22,8 +27,8 @@ case $1 in
         ;;
 
     syntax)
-        npm run lint            || EXIT_STATE=$?
-        npm run test-syntax     || EXIT_STATE=$?
+        npm run lint        || EXIT_STATE=$?
+        npm run test-syntax || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;
 

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -43,6 +43,10 @@ if(argv.info) {
         '    No need to add the `_test.js` suffix, we expand them correctly here.',
         '  - `--bundleTest` set the bundle test suite `test/jasmine/bundle_tests/ to be run.',
         '    Note that only one bundle test can be run at a time.',
+        '  - Use `--tags` to specify which `@` tags to test (if any) e.g `npm run test-jasmine -- --tags=gl`',
+        '    will run only gl tests.',
+        '  - Use `--skip-tags` to specify which `@` tags to skip (if any) e.g `npm run test-jasmine -- --skip-tags=gl`',
+        '    will skip all gl tests.',
         '',
         'Other options:',
         '  - `--info`: show this info message',
@@ -101,9 +105,7 @@ var pathToJQuery = path.join(__dirname, 'assets', 'jquery-1.8.3.min.js');
 var pathToIE9mock = path.join(__dirname, 'assets', 'ie9_mock.js');
 var pathToCustomMatchers = path.join(__dirname, 'assets', 'custom_matchers.js');
 
-
 function func(config) {
-
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     //
@@ -202,9 +204,17 @@ func.defaultConfig = {
         debug: true
     },
 
-    // unfortunately a few tests don't behave well on CI
-    // using `karma-jasmine-spec-tags`
+    // Options for `karma-jasmine-spec-tags`
+    // see https://www.npmjs.com/package/karma-jasmine-spec-tags
+    //
+    // A few tests don't behave well on CI
     // add @noCI to the spec description to skip a spec on CI
+    //
+    // Label tests that require a WebGL-context by @gl so that
+    // they can be skipped using:
+    // - $ npm run test-jasmine -- --skip-tags=gl
+    // or run is isolation easily using:
+    // - $ npm run test-jasmine -- --tags=gl
     client: {
         tagPrefix: '@',
         skipTags: isCI ? 'noCI' : null

--- a/test/jasmine/tests/geo_test.js
+++ b/test/jasmine/tests/geo_test.js
@@ -1072,7 +1072,7 @@ describe('Test geo interactions', function() {
         .then(done);
     });
 
-    it('@noCI should clear hover label when cursor slips off subplot', function(done) {
+    it('should clear hover label when cursor slips off subplot', function(done) {
         var gd = createGraphDiv();
         var fig = Lib.extendDeep({}, require('@mocks/geo_orthographic.json'));
 

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -64,7 +64,7 @@ var mock4 = {
     layout: {}
 };
 
-describe('Test hover and click interactions', function() {
+describe('@gl Test hover and click interactions', function() {
     var gd;
 
     function makeHoverFn(gd, x, y) {
@@ -532,7 +532,7 @@ describe('Test hover and click interactions', function() {
     });
 });
 
-describe('@noCI Test gl2d lasso/select:', function() {
+describe('@noCI @gl Test gl2d lasso/select:', function() {
     var mockFancy = require('@mocks/gl2d_14.json');
     var mockFast = Lib.extendDeep({}, mockFancy, {
         data: [{mode: 'markers'}],

--- a/test/jasmine/tests/gl2d_date_axis_render_test.js
+++ b/test/jasmine/tests/gl2d_date_axis_render_test.js
@@ -3,7 +3,7 @@ var Plotly = require('@lib');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 
-describe('date axis', function() {
+describe('@gl date axis', function() {
 
     var gd;
 

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -18,7 +18,7 @@ function countCanvases() {
     return d3.selectAll('canvas').size();
 }
 
-describe('Test removal of gl contexts', function() {
+describe('@gl Test removal of gl contexts', function() {
     var gd;
 
     beforeEach(function() {
@@ -85,7 +85,7 @@ describe('Test removal of gl contexts', function() {
     });
 });
 
-describe('Test gl plot side effects', function() {
+describe('@gl Test gl plot side effects', function() {
     var gd;
 
     beforeEach(function() {
@@ -205,7 +205,7 @@ describe('Test gl plot side effects', function() {
     });
 });
 
-describe('Test gl2d plots', function() {
+describe('@gl Test gl2d plots', function() {
     var gd;
 
     var mock = require('@mocks/gl2d_10.json');

--- a/test/jasmine/tests/gl2d_pointcloud_test.js
+++ b/test/jasmine/tests/gl2d_pointcloud_test.js
@@ -144,7 +144,7 @@ function makePlot(gd, mock, done) {
         .then(done);
 }
 
-describe('contourgl plots', function() {
+describe('@gl pointcloud traces', function() {
 
     var gd;
 

--- a/test/jasmine/tests/gl2d_scatterplot_contour_test.js
+++ b/test/jasmine/tests/gl2d_scatterplot_contour_test.js
@@ -167,7 +167,7 @@ function makePlot(gd, mock, done) {
         .then(done);
 }
 
-describe('contourgl plots', function() {
+describe('@gl contourgl plots', function() {
 
     var gd;
 

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -20,7 +20,7 @@ function countCanvases() {
     return d3.selectAll('canvas').size();
 }
 
-describe('Test gl3d plots', function() {
+describe('@gl Test gl3d plots', function() {
     var gd, ptData;
 
     var mock = require('@mocks/gl3d_marker-arrays.json');
@@ -422,7 +422,7 @@ describe('Test gl3d plots', function() {
 
 });
 
-describe('Test gl3d modebar handlers', function() {
+describe('@gl Test gl3d modebar handlers', function() {
     var gd, modeBar;
 
     function assertScenes(cont, attr, val) {
@@ -650,7 +650,7 @@ describe('Test gl3d modebar handlers', function() {
     });
 });
 
-describe('Test gl3d drag and wheel interactions', function() {
+describe('@gl Test gl3d drag and wheel interactions', function() {
     var gd, relayoutCallback;
 
     function scroll(target) {
@@ -768,7 +768,7 @@ describe('Test gl3d drag and wheel interactions', function() {
     });
 });
 
-describe('Test gl3d relayout calls', function() {
+describe('@gl Test gl3d relayout calls', function() {
     var gd;
 
     beforeEach(function() {
@@ -834,7 +834,7 @@ describe('Test gl3d relayout calls', function() {
     });
 });
 
-describe('Test gl3d annotations', function() {
+describe('@gl Test gl3d annotations', function() {
     var gd;
 
     beforeEach(function() {
@@ -1212,7 +1212,7 @@ describe('Test gl3d annotations', function() {
     });
 });
 
-describe('Test removal of gl contexts', function() {
+describe('@gl Test removal of gl contexts', function() {
     var gd;
 
     beforeEach(function() {

--- a/test/jasmine/tests/gl_plot_interact_basic_test.js
+++ b/test/jasmine/tests/gl_plot_interact_basic_test.js
@@ -55,7 +55,7 @@ function testEvents(plot) {
     });
 }
 
-describe('gl3d plots', function() {
+describe('@gl gl3d plots', function() {
 
     var gd;
 

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -242,7 +242,7 @@ describe('parcoords initialization tests', function() {
     });
 });
 
-describe('@noCI parcoords', function() {
+describe('@gl parcoords', function() {
 
     beforeAll(function() {
         mock.data[0].dimensions.forEach(function(d) {
@@ -404,7 +404,7 @@ describe('@noCI parcoords', function() {
             });
         });
 
-        it('Works with 60 dimensions', function(done) {
+        it('@noCI Works with 60 dimensions', function(done) {
 
             var mockCopy = Lib.extendDeep({}, mock1);
             var newDimension, i, j;
@@ -434,7 +434,7 @@ describe('@noCI parcoords', function() {
             });
         });
 
-        it('Truncates 60+ dimensions to 60', function(done) {
+        it('@noCI Truncates 60+ dimensions to 60', function(done) {
 
             var mockCopy = Lib.extendDeep({}, mock1);
             var newDimension, i, j;
@@ -462,7 +462,7 @@ describe('@noCI parcoords', function() {
             });
         });
 
-        it('Truncates dimension values to the shortest array, retaining only 3 lines', function(done) {
+        it('@noCI Truncates dimension values to the shortest array, retaining only 3 lines', function(done) {
 
             var mockCopy = Lib.extendDeep({}, mock1);
             var newDimension, i, j;

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -702,7 +702,7 @@ describe('Test polar interactions:', function() {
         .then(done);
     });
 
-    it('@noCI should response to drag interactions on plot area', function(done) {
+    it('should response to drag interactions on plot area', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/polar_scatter.json'));
 
         // to avoid dragging on hover labels
@@ -793,7 +793,7 @@ describe('Test polar interactions:', function() {
         .then(done);
     });
 
-    it('@noCI should response to drag interactions on radial drag area', function(done) {
+    it('should response to drag interactions on radial drag area', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/polar_scatter.json'));
 
         // to avoid dragging on hover labels
@@ -877,7 +877,7 @@ describe('Test polar interactions:', function() {
         .then(done);
     });
 
-    it('@noCI should response to drag interactions on angular drag area', function(done) {
+    it('should response to drag interactions on angular drag area', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/polar_scatter.json'));
 
         // to avoid dragging on hover labels


### PR DESCRIPTION
This PR splits our jasmine test suites (which is getting pretty heavy :hamburger: ) into 2 separate CircleCI jobs: one for our gl3d, gl2d and parcoords tests (tag `@gl`) and another for all the other tests that aren't skipped on CI (that `@noCI` tag).

This does two things:

- speeds up our tests, they now run consistently under 10 minutes
- (hopefully) will help us with our intermittent test failures (gl tests seem to behave better in isolated runs for some reason).

Moreover, the PR removes a few `@noCI` tags from our suites. Upgrading to Chrome 64 in https://github.com/plotly/plotly.js/pull/2323 made some tests work on CI. To note, @monfera almost all your `parcoords` tests are runned on CI now.

cc @alexcjohnson @dfcreative @nicolaskruchten 