### PR TITLE
Coerce hoverformat on visible-false axes

### DIFF
--- a/src/components/colorbar/defaults.js
+++ b/src/components/colorbar/defaults.js
@@ -53,11 +53,9 @@ module.exports = function colorbarDefaults(containerIn, containerOut, layout) {
 
     handleTickValueDefaults(colorbarIn, colorbarOut, coerce, 'linear');
 
-    handleTickLabelDefaults(colorbarIn, colorbarOut, coerce, 'linear',
-        {outerTicks: false, font: layout.font, noHover: true});
-
-    handleTickMarkDefaults(colorbarIn, colorbarOut, coerce, 'linear',
-        {outerTicks: false, font: layout.font, noHover: true});
+    var opts = {outerTicks: false, font: layout.font};
+    handleTickLabelDefaults(colorbarIn, colorbarOut, coerce, 'linear', opts);
+    handleTickMarkDefaults(colorbarIn, colorbarOut, coerce, 'linear', opts);
 
     coerce('title', layout._dfltTitle.colorbar);
     Lib.coerceFont(coerce, 'titlefont', layout.font);

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -59,6 +59,9 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
         orderedCategories(letter, containerOut.categoryorder, containerOut.categoryarray, options.data) :
         [];
 
+
+    if(axType !== 'category' && !options.noHover) coerce('hoverformat');
+
     if(!visible) return containerOut;
 
     var dfltColor = coerce('color');

--- a/src/plots/cartesian/tick_label_defaults.js
+++ b/src/plots/cartesian/tick_label_defaults.js
@@ -12,9 +12,6 @@
 var Lib = require('../../lib');
 var layoutAttributes = require('./layout_attributes');
 
-/**
- * options: inherits font, outerTicks, noHover from axes.handleAxisDefaults
- */
 module.exports = function handleTickLabelDefaults(containerIn, containerOut, coerce, axType, options) {
     var showAttrDflt = getShowAttrDflt(containerIn);
 
@@ -48,8 +45,6 @@ module.exports = function handleTickLabelDefaults(containerIn, containerOut, coe
             }
         }
     }
-
-    if(axType !== 'category' && !options.noHover) coerce('hoverformat');
 };
 
 /*

--- a/src/plots/polar/layout_defaults.js
+++ b/src/plots/polar/layout_defaults.js
@@ -143,7 +143,6 @@ function handleDefaults(contIn, contOut, coerce, opts) {
         if(visible) {
             handleTickValueDefaults(axIn, axOut, coerceAxis, axOut.type);
             handleTickLabelDefaults(axIn, axOut, coerceAxis, axOut.type, {
-                noHover: false,
                 tickSuffixDflt: axOut.thetaunit === 'degrees' ? '°' : undefined
             });
             handleTickMarkDefaults(axIn, axOut, coerceAxis, {outerTicks: true});
@@ -174,7 +173,7 @@ function handleDefaults(contIn, contOut, coerce, opts) {
             coerceAxis('layer');
         }
 
-        coerceAxis('hoverformat');
+        if(axType !== 'category') coerceAxis('hoverformat');
 
         axOut._input = axIn;
     }

--- a/src/plots/ternary/layout/axis_defaults.js
+++ b/src/plots/ternary/layout/axis_defaults.js
@@ -44,8 +44,7 @@ module.exports = function supplyLayoutDefaults(containerIn, containerOut, option
     coerce('min');
 
     handleTickValueDefaults(containerIn, containerOut, coerce, 'linear');
-    handleTickLabelDefaults(containerIn, containerOut, coerce, 'linear',
-        { noHover: false });
+    handleTickLabelDefaults(containerIn, containerOut, coerce, 'linear', {});
     handleTickMarkDefaults(containerIn, containerOut, coerce,
         { outerTicks: true });
 

--- a/src/traces/carpet/axis_defaults.js
+++ b/src/traces/carpet/axis_defaults.js
@@ -29,7 +29,6 @@ var autoType = require('../../plots/cartesian/axis_autotype');
  *  font: the default font to inherit
  *  outerTicks: boolean, should ticks default to outside?
  *  showGrid: boolean, should gridlines be shown by default?
- *  noHover: boolean, this axis doesn't support hover effects?
  *  data: the plot data to use in choosing auto type
  *  bgColor: the plot background color, to calculate default gridline colors
  */
@@ -37,8 +36,6 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, options)
     var letter = options.letter,
         font = options.font || {},
         attributes = carpetAttrs[letter + 'axis'];
-
-    options.noHover = true;
 
     function coerce(attr, dflt) {
         return Lib.coerce(containerIn, containerOut, attributes, attr, dflt);

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -535,6 +535,18 @@ describe('Test axes', function() {
                 expect(layoutOut[axName].scaleratio).toBeUndefined();
             });
         });
+
+        it('should coerce hoverformat even on visible: false axes', function() {
+            layoutIn = {
+                xaxis: {
+                    visible: false,
+                    hoverformat: 'g'
+                }
+            };
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+            expect(layoutOut.xaxis.hoverformat).toEqual('g');
+        });
     });
 
     describe('constraints relayout', function() {

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -168,6 +168,43 @@ describe('Test polar plots defaults:', function() {
         expect(Lib.log).toHaveBeenCalledWith('Polar plots do not support date angular axes yet.');
         expect(layoutOut.polar.angularaxis.type).toBe('linear');
     });
+
+    it('should not coerce hoverformat on category axes', function() {
+        _supply({}, [{
+            type: 'scatterpolar',
+            r: ['a', 'b'],
+            theta: ['c', 'd'],
+            visible: true,
+            subplot: 'polar'
+        }]);
+
+        expect(layoutOut.polar.radialaxis.hoverformat).toBeUndefined();
+        expect(layoutOut.polar.angularaxis.hoverformat).toBeUndefined();
+    });
+
+    it('should coerce hoverformat even for `visible: false` axes', function() {
+        _supply({
+            polar: {
+                radialaxis: {
+                    visible: false,
+                    hoverformat: 'g'
+                },
+                angularaxis: {
+                    visible: false,
+                    hoverformat: 'g'
+                }
+            }
+        }, [{
+            type: 'scatterpolar',
+            r: [1, 2],
+            theta: [90, 180],
+            visible: true,
+            subplot: 'polar'
+        }]);
+
+        expect(layoutOut.polar.radialaxis.hoverformat).toBe('g');
+        expect(layoutOut.polar.angularaxis.hoverformat).toBe('g');
+    });
 });
 
 describe('Test relayout on polar subplots:', function() {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/2317

`visible: false` axes should still support `hoverformat` as demonstrated in the https://github.com/plotly/plotly.js/issues/2317 fiddle. 

To do so, this PR move the `coerce('hoverformat')` out of `handleTickLabelDefaults` -- which does not get called for `visible: false` axes -- to the base axis default handler. 