### PR TITLE
Break circular refs in old fullData and fullLayout

### DIFF
--- a/src/lib/relink_private.js
+++ b/src/lib/relink_private.js
@@ -28,6 +28,9 @@ module.exports = function relinkPrivateKeys(toContainer, fromContainer) {
             toVal = toContainer[k];
 
         if(k.charAt(0) === '_' || typeof fromVal === 'function') {
+            // to help break circular references and improve garbage collection,
+            // remove these objects from the fromContainer
+            fromContainer[k] = null;
 
             // if it already exists at this point, it's something
             // that we recreate each time around, so ignore it


### PR DESCRIPTION
cc @etpinard @dfcreative This doesn't seem to be the whole story, but it does look like it helps the garbage collector in repeated-restyle workloads like #1755 