### PR TITLE
Auto-retry jasmine test on CI

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -28,13 +28,14 @@ retry () {
 case $1 in
 
     jasmine)
-        retry npm run test-jasmine -- --skip-tags=gl,noCI
+        npm run test-jasmine -- --skip-tags=gl,noCI,flaky || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;
 
     jasmine2)
-        retry npm run test-jasmine -- --tags=gl --skip-tags=noCI
-        retry npm run test-bundle
+        npm run test-jasmine -- --tags=gl --skip-tags=noCI,flaky || EXIT_STATE=$?
+        retry npm run test-jasmine -- --tags=flaky --skip-tags=noCI
+        npm run test-bundle || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;
 

--- a/test/jasmine/tests/animate_test.js
+++ b/test/jasmine/tests/animate_test.js
@@ -720,7 +720,7 @@ describe('Animating multiple axes', function() {
         destroyGraphDiv();
     });
 
-    it('updates ranges of secondary axes', function(done) {
+    it('@flaky updates ranges of secondary axes', function(done) {
         Plotly.plot(gd, [
             {y: [1, 2, 3]},
             {y: [1, 2, 3], yaxis: 'y2'}

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -250,7 +250,7 @@ describe('@gl Test gl2d plots', function() {
         });
     }
 
-    it('should respond to drag interactions', function(done) {
+    it('@flaky should respond to drag interactions', function(done) {
         var _mock = Lib.extendDeep({}, mock);
 
         var relayoutCallback = jasmine.createSpy('relayoutCallback');

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -774,7 +774,7 @@ describe('@gl parcoords', function() {
 
         });
 
-        it('Calling `Plotly.animate` with patches targeting `dimensions` attributes should do the right thing', function(done) {
+        it('@flaky Calling `Plotly.animate` with patches targeting `dimensions` attributes should do the right thing', function(done) {
             Plotly.newPlot(gd, [{
                 type: 'parcoords',
                 line: {color: 'blue'},

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -107,7 +107,7 @@ var BOXEVENTS = [1, 2, 1];
 // assumes 5 points in the lasso path
 var LASSOEVENTS = [4, 2, 1];
 
-describe('Test select box and lasso in general:', function() {
+describe('@flaky Test select box and lasso in general:', function() {
     var mock = require('@mocks/14.json');
     var selectPath = [[93, 193], [143, 193]];
     var lassoPath = [[316, 171], [318, 239], [335, 243], [328, 169]];


### PR DESCRIPTION
Splitting the jasmine tests into two CI jobs did help alleviate some of our intermittent test failures, but these still happen in about 1 run out of 2.

As Circle CI 2.0 doesn't have an _auto-retry_ setting [yet](https://discuss.circleci.com/t/auto-retry-failed-builds/18611), we currently have to painfully navigate the CircleCI UI to restart our failed jobs. This is of course a waste time. So, I propose this in-house solution.

@alexcjohnson @dfcreative what do you think?

