### PR TITLE
Plotly.purge in parcoords_test

### DIFF
--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -6,6 +6,7 @@ var Parcoords = require('@src/traces/parcoords');
 var attributes = require('@src/traces/parcoords/attributes');
 
 var createGraphDiv = require('../assets/create_graph_div');
+var delay = require('../assets/delay');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var fail = require('../assets/fail_test');
 var mouseEvent = require('../assets/mouse_event');
@@ -239,7 +240,6 @@ describe('parcoords initialization tests', function() {
 });
 
 describe('@gl parcoords', function() {
-
     beforeAll(function() {
         mock.data[0].dimensions.forEach(function(d) {
             d.values = d.values.slice(lineStart, lineStart + lineCount);
@@ -247,7 +247,13 @@ describe('@gl parcoords', function() {
         mock.data[0].line.color = mock.data[0].line.color.slice(lineStart, lineStart + lineCount);
     });
 
-    afterEach(destroyGraphDiv);
+    afterEach(function(done) {
+        var gd = d3.select('.js-plotly-plot').node();
+        if(gd) Plotly.purge(gd);
+        destroyGraphDiv();
+
+        return delay(50)().then(done);
+    });
 
     describe('edge cases', function() {
 
@@ -496,7 +502,7 @@ describe('@gl parcoords', function() {
             .then(done);
         });
 
-        it('@flaky Skip dimensions which are not plain objects or whose `values` is not an array', function(done) {
+        it('Skip dimensions which are not plain objects or whose `values` is not an array', function(done) {
 
             var mockCopy = Lib.extendDeep({}, mock1);
             var newDimension, i, j;


### PR DESCRIPTION
@etpinard this seems to make `parcoords_test` pass reliably - and I can even take out the `@flaky` tag I added in #2399. (I did get a gl2d failure in one of these runs though... https://circleci.com/gh/plotly/plotly.js/7227)

I seem to recall trying to add `Plotly.purge` directly to `destroyGraphDiv` once before, and running into problems that looked like I was purging after the next test case had already started... anyway that's why I added the `delay(50)().then(done)`, and if that's really required it doesn't seem like a good idea to add it to *every* `destroyGraphDiv` - though perhaps we can make this into a variant just for use with gl tests? Or maybe we can detect gl contexts and only purge/delay if we find one?

A little more detail on my investigations:
- Even when the tests failed in normal CI, they would consistently work if I ssh into the same CI container and run them right after they fail. But I can see the tests that fail in the normal run take a very long time in ssh.
- The gl tests run much more slowly on CI than locally. The non-gl tests also run slower but only a little, whereas the gl tests run far slower on CI:
  - the full gl suite goes about 3x slower:
    -`npm run test-jasmine -- --tags=gl --skip-tags=noCI,flaky`
    - local: ~45 sec
    - CI ssh ~2 min 32 sec
  - just parcoords is an extreme case >6x slower!
    - `npm run test-jasmine -- --tags=gl --skip-tags=noCI,flaky parcoords`:
    - local ~9 sec
    - CI ssh ~57 sec
  - Adding `Plotly.purge` doesn't make things go faster - unsurprisingly it adds a couple of seconds - but it does seem to make the timing more consistent from one test case to the next, as though the need to purge was building up and then when the system finally decided to do it on its own, it took an enormous amount of time and caused a timeout. If that's the case, then we could also consider increasing the 30-sec [no activity timeout](https://github.com/plotly/plotly.js/blob/77c218a7676a1e10880448ca915d308155dd31aa/test/jasmine/karma.conf.js#L172).