### PR TITLE
Fix text position in centered tooltips #2154

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1124,10 +1124,6 @@ function alignHoverText(hoverLabels, rotateLabels) {
             tx2x = txx + alignShift * (d.txwidth + HOVERTEXTPAD),
             offsetX = 0,
             offsetY = d.offset;
-        if(d.anchor === 'middle') {
-            txx -= d.tx2width / 2;
-            tx2x -= d.tx2width / 2;
-        }
         if(rotateLabels) {
             offsetY *= -YSHIFTY;
             offsetX = d.offset * YSHIFTX;

--- a/test/image/mocks/centered-tooltips.json
+++ b/test/image/mocks/centered-tooltips.json
@@ -1,0 +1,58 @@
+{
+    "data": [
+        {
+            "y": [
+                1,
+                2,
+                6,
+                3,
+                5,
+                6
+            ],
+            "x": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "text": [
+                "short label",
+                "short label",
+                "Very long label named San Francisco",
+                "Very long label named San Francisco",
+                "Very long label named San Francisco"
+            ]
+        },
+        {
+            "y": [
+                6,
+                5,
+                1,
+                4,
+                1,
+                0
+            ],
+            "x": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "text": [
+                "short label",
+                "short label",
+                "Very long label named San Francisco",
+                "Very long label named San Francisco",
+                "Very long label named San Francisco"
+            ]
+        }
+    ],
+    "layout": {
+        "width": 400,
+        "height": 300
+    }
+}


### PR DESCRIPTION
Suggested fix for #2154. Added test mock seems to cover #865 as well.

Regarding the fix:
- Deleted the lines in `alignHoverText` because it fixes the scenario in question and because I wasn't able to figure out the intent of these four lines of code.
- To figure out the intent, I also tracked down the origin of this piece of code: it was introduced in 2e69310. I studied the change set of this commit and its message, but wasn't able to understand the exact intent either.
- I'm not entirely sure that the deleted lines are relevant for certain kinds of plots. I guess a more experienced contributer is able to make a better judge.

Regarding tests:
- I added a *mock* that reproduces the issue and have noticed that for each mock there's an image as the rendered result. This image is missing in this commit, because I'm not sure how to run the image pixel tests described in [image test README](https://github.com/plotly/plotly.js/blob/master/test/image/README.md) and trigger the required `hover` event.

Regarding related issue #865:
- Added test mock shows the problem when two tooltips overlap.