### PR TITLE
fall back for contour labels when there's only one contour

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -742,11 +742,8 @@ function autoShiftMonthBins(binStart, data, dtick, dataMin, calendar) {
 // Ticks and grids
 // ----------------------------------------------------
 
-// calculate the ticks: text, values, positioning
-// if ticks are set to automatic, determine the right values (tick0,dtick)
-// in any case, set tickround to # of digits to round tick labels to,
-// or codes to this effect for log and date scales
-axes.calcTicks = function calcTicks(ax) {
+// ensure we have tick0, dtick, and tick rounding calculated
+axes.prepTicks = function(ax) {
     var rng = Lib.simpleMap(ax.range, ax.r2l);
 
     // calculate max number of (auto) ticks to display based on plot size
@@ -787,6 +784,15 @@ axes.calcTicks = function calcTicks(ax) {
 
     // now figure out rounding of tick values
     autoTickRound(ax);
+};
+
+// calculate the ticks: text, values, positioning
+// if ticks are set to automatic, determine the right values (tick0,dtick)
+// in any case, set tickround to # of digits to round tick labels to,
+// or codes to this effect for log and date scales
+axes.calcTicks = function calcTicks(ax) {
+    axes.prepTicks(ax);
+    var rng = Lib.simpleMap(ax.range, ax.r2l);
 
     // now that we've figured out the auto values for formatting
     // in case we're missing some ticktext, we can break out for array ticks

--- a/src/traces/carpet/calc_gridlines.js
+++ b/src/traces/carpet/calc_gridlines.js
@@ -37,7 +37,7 @@ module.exports = function calcGridlines(trace, cd, axisLetter, crossAxisLetter) 
     var na = trace.a.length;
     var nb = trace.b.length;
 
-    Axes.calcTicks(axis);
+    Axes.prepTicks(axis);
 
     // don't leave tickvals in axis looking like an attribute
     if(axis.tickmode === 'array') delete axis.tickvals;

--- a/src/traces/contour/plot.js
+++ b/src/traces/contour/plot.js
@@ -428,19 +428,19 @@ exports.labelFormatter = function(contours, colorbar, fullLayout) {
                     formatAxis.range = [value[0], value[value.length - 1]];
                 }
                 else formatAxis.range = [value, value];
-
-                if(formatAxis.range[0] === formatAxis.range[1]) {
-                    formatAxis.range[1] += formatAxis.range[0] || 1;
-                }
-                formatAxis.nticks = 1000;
             }
             else {
                 formatAxis.range = [contours.start, contours.end];
                 formatAxis.nticks = (contours.end - contours.start) / contours.size;
             }
 
+            if(formatAxis.range[0] === formatAxis.range[1]) {
+                formatAxis.range[1] += formatAxis.range[0] || 1;
+            }
+            if(!formatAxis.nticks) formatAxis.nticks = 1000;
+
             setConvert(formatAxis, fullLayout);
-            Axes.calcTicks(formatAxis);
+            Axes.prepTicks(formatAxis);
             formatAxis._tmin = null;
             formatAxis._tmax = null;
         }

--- a/test/jasmine/tests/contour_test.js
+++ b/test/jasmine/tests/contour_test.js
@@ -347,7 +347,7 @@ describe('contour calc', function() {
     });
 });
 
-describe('contour edits', function() {
+describe('contour plotting and editing', function() {
     var gd;
 
     beforeEach(function() {
@@ -384,6 +384,25 @@ describe('contour edits', function() {
             expect(gd._fullLayout.xaxis.type).toBe('category');
             checkTicks('y', ['Jan 102016', 'Jan 24', 'Feb 7', 'Feb 21'], 'date y #2');
             expect(gd._fullLayout.yaxis.type).toBe('date');
+        })
+        .catch(fail)
+        .then(done);
+    });
+
+    it('works and draws labels when explicitly specifying ncontours=1', function(done) {
+        Plotly.newPlot(gd, [{
+            z: [[0.20, 0.57], [0.3, 0.4]],
+            type: 'contour',
+            zmin: 0.4,
+            zmax: 0.41,
+            ncontours: 1,
+            showscale: false,
+            contours: {showlabels: true}
+        }], {
+            width: 500, height: 500
+        })
+        .then(function() {
+            expect(gd.querySelector('.contourlabels text').textContent).toBe('0.41');
         })
         .catch(fail)
         .then(done);


### PR DESCRIPTION
Fixes #2398 - the test case I added is the simplest distillation of the plot in the initial report.

Also: I broke up `Axes.calcTicks` -> new `prepTicks` only finishes setting up the axis object (`tick0`, `dtick`, `_tickround`, and `_tickexponent` - all the things `Axes.tickText` will need), but does not actually calculate all the ticks. This is potentially a noticeable improvement for constraint-type contours, where I set an arbitrarily large `nticks` merely to ensure we get a reasonable number of digits of precision. Carpet can take advantage of this as well in one place.

cc @etpinard 