### PR TITLE
Fix yet another histogram edge case

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -568,7 +568,7 @@ axes.autoBin = function(data, ax, nbins, is2d, calendar) {
             start: dataMin - 0.5,
             end: dataMax + 0.5,
             size: 1,
-            _count: dataMax - dataMin + 1
+            _dataSpan: dataMax - dataMin,
         };
     }
 
@@ -648,7 +648,7 @@ axes.autoBin = function(data, ax, nbins, is2d, calendar) {
         start: ax.c2r(binStart, 0, calendar),
         end: ax.c2r(binEnd, 0, calendar),
         size: dummyAx.dtick,
-        _count: bincount
+        _dataSpan: dataMax - dataMin
     };
 };
 

--- a/src/traces/histogram/calc.js
+++ b/src/traces/histogram/calc.js
@@ -253,7 +253,7 @@ function calcAllAutoBins(gd, trace, pa, mainData, _overlayEdgeCase) {
 
                 // Edge case: single-valued histogram overlaying others
                 // Use them all together to calculate the bin size for the single-valued one
-                if(isOverlay && binSpec._count === 1 && pa.type !== 'category') {
+                if(isOverlay && binSpec._dataSpan === 0 && pa.type !== 'category') {
                     // Several single-valued histograms! Stop infinite recursion,
                     // just return an extra flag that tells handleSingleValueOverlays
                     // to sort out this trace too

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2369,7 +2369,7 @@ describe('Test axes', function() {
                 start: -0.5,
                 end: 2.5,
                 size: 1,
-                _count: 3
+                _dataSpan: 2
             });
         });
 
@@ -2383,7 +2383,7 @@ describe('Test axes', function() {
                 start: undefined,
                 end: undefined,
                 size: 2,
-                _count: NaN
+                _dataSpan: NaN
             });
         });
 
@@ -2397,7 +2397,7 @@ describe('Test axes', function() {
                 start: undefined,
                 end: undefined,
                 size: 2,
-                _count: NaN
+                _dataSpan: NaN
             });
         });
 
@@ -2411,7 +2411,7 @@ describe('Test axes', function() {
                 start: undefined,
                 end: undefined,
                 size: 2,
-                _count: NaN
+                _dataSpan: NaN
             });
         });
 
@@ -2425,7 +2425,7 @@ describe('Test axes', function() {
                 start: 0.5,
                 end: 4.5,
                 size: 1,
-                _count: 4
+                _dataSpan: 3
             });
         });
 
@@ -2443,7 +2443,7 @@ describe('Test axes', function() {
                 start: -0.5,
                 end: 5.5,
                 size: 2,
-                _count: 3
+                _dataSpan: 3
             });
         });
     });

--- a/test/jasmine/tests/histogram2d_test.js
+++ b/test/jasmine/tests/histogram2d_test.js
@@ -191,42 +191,42 @@ describe('Test histogram2d', function() {
                 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
                 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4];
             Plotly.newPlot(gd, [{type: 'histogram2d', x: x1, y: y1}]);
-            expect(gd._fullData[0].xbins).toEqual({start: 0.5, end: 4.5, size: 1, _count: 4});
-            expect(gd._fullData[0].ybins).toEqual({start: 0.5, end: 4.5, size: 1, _count: 4});
+            expect(gd._fullData[0].xbins).toEqual({start: 0.5, end: 4.5, size: 1, _dataSpan: 3});
+            expect(gd._fullData[0].ybins).toEqual({start: 0.5, end: 4.5, size: 1, _dataSpan: 3});
             expect(gd._fullData[0].autobinx).toBe(true);
             expect(gd._fullData[0].autobiny).toBe(true);
 
             // same range but fewer samples increases sizes
             Plotly.restyle(gd, {x: [[1, 3, 4]], y: [[1, 2, 4]]});
-            expect(gd._fullData[0].xbins).toEqual({start: -0.5, end: 5.5, size: 2, _count: 3});
-            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 5.5, size: 2, _count: 3});
+            expect(gd._fullData[0].xbins).toEqual({start: -0.5, end: 5.5, size: 2, _dataSpan: 3});
+            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 5.5, size: 2, _dataSpan: 3});
             expect(gd._fullData[0].autobinx).toBe(true);
             expect(gd._fullData[0].autobiny).toBe(true);
 
             // larger range
             Plotly.restyle(gd, {x: [[10, 30, 40]], y: [[10, 20, 40]]});
-            expect(gd._fullData[0].xbins).toEqual({start: -0.5, end: 59.5, size: 20, _count: 3});
-            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 59.5, size: 20, _count: 3});
+            expect(gd._fullData[0].xbins).toEqual({start: -0.5, end: 59.5, size: 20, _dataSpan: 30});
+            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 59.5, size: 20, _dataSpan: 30});
             expect(gd._fullData[0].autobinx).toBe(true);
             expect(gd._fullData[0].autobiny).toBe(true);
 
             // explicit changes to bin settings
             Plotly.restyle(gd, 'xbins.start', 12);
-            expect(gd._fullData[0].xbins).toEqual({start: 12, end: 59.5, size: 20, _count: 3});
-            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 59.5, size: 20, _count: 3});
+            expect(gd._fullData[0].xbins).toEqual({start: 12, end: 59.5, size: 20, _dataSpan: 30});
+            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 59.5, size: 20, _dataSpan: 30});
             expect(gd._fullData[0].autobinx).toBe(false);
             expect(gd._fullData[0].autobiny).toBe(true);
 
             Plotly.restyle(gd, {'ybins.end': 12, 'ybins.size': 3});
-            expect(gd._fullData[0].xbins).toEqual({start: 12, end: 59.5, size: 20, _count: 3});
-            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 12, size: 3, _count: 3});
+            expect(gd._fullData[0].xbins).toEqual({start: 12, end: 59.5, size: 20, _dataSpan: 30});
+            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 12, size: 3, _dataSpan: 30});
             expect(gd._fullData[0].autobinx).toBe(false);
             expect(gd._fullData[0].autobiny).toBe(false);
 
             // restart autobin
             Plotly.restyle(gd, {autobinx: true, autobiny: true});
-            expect(gd._fullData[0].xbins).toEqual({start: -0.5, end: 59.5, size: 20, _count: 3});
-            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 59.5, size: 20, _count: 3});
+            expect(gd._fullData[0].xbins).toEqual({start: -0.5, end: 59.5, size: 20, _dataSpan: 30});
+            expect(gd._fullData[0].ybins).toEqual({start: -0.5, end: 59.5, size: 20, _dataSpan: 30});
             expect(gd._fullData[0].autobinx).toBe(true);
             expect(gd._fullData[0].autobiny).toBe(true);
         });
@@ -239,15 +239,15 @@ describe('Test histogram2d', function() {
                 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
                 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4];
             Plotly.newPlot(gd, [{type: 'histogram2d', x: x1, y: y1, autobinx: false, autobiny: false}]);
-            expect(gd._fullData[0].xbins).toEqual({start: 0.5, end: 4.5, size: 1, _count: 4});
-            expect(gd._fullData[0].ybins).toEqual({start: 0.5, end: 4.5, size: 1, _count: 4});
+            expect(gd._fullData[0].xbins).toEqual({start: 0.5, end: 4.5, size: 1, _dataSpan: 3});
+            expect(gd._fullData[0].ybins).toEqual({start: 0.5, end: 4.5, size: 1, _dataSpan: 3});
             expect(gd._fullData[0].autobinx).toBe(false);
             expect(gd._fullData[0].autobiny).toBe(false);
 
             // with autobin false this will no longer update the bins.
             Plotly.restyle(gd, {x: [[1, 3, 4]], y: [[1, 2, 4]]});
-            expect(gd._fullData[0].xbins).toEqual({start: 0.5, end: 4.5, size: 1, _count: 4});
-            expect(gd._fullData[0].ybins).toEqual({start: 0.5, end: 4.5, size: 1, _count: 4});
+            expect(gd._fullData[0].xbins).toEqual({start: 0.5, end: 4.5, size: 1, _dataSpan: 3});
+            expect(gd._fullData[0].ybins).toEqual({start: 0.5, end: 4.5, size: 1, _dataSpan: 3});
             expect(gd._fullData[0].autobinx).toBe(false);
             expect(gd._fullData[0].autobiny).toBe(false);
         });


### PR DESCRIPTION
Fixes #2393 - this bug was actually introduced with #2028 fixing some other histogram edge cases. But in that fix I accidentally conflated single-value (which should use the special logic added there to readjust bins) and single-bin (which can result from `Axes.autoBin` even with multiple distinct values in the data array). This special logic is only triggered with `barmode: 'overlay'` which is why that's all I tested here; it already worked correctly in any other `barmode`.

cc @etpinard 