### PR TITLE
Fix layout of centered hover info #2154

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1126,7 +1126,7 @@ function alignHoverText(hoverLabels, rotateLabels) {
             offsetY = d.offset;
         if(d.anchor === 'middle') {
             txx -= d.tx2width / 2;
-            tx2x -= d.tx2width / 2;
+            tx2x += d.txwidth / 2 + HOVERTEXTPAD;
         }
         if(rotateLabels) {
             offsetY *= -YSHIFTY;
@@ -1135,7 +1135,8 @@ function alignHoverText(hoverLabels, rotateLabels) {
 
         g.select('path').attr('d', d.anchor === 'middle' ?
             // middle aligned: rect centered on data
-            ('M-' + (d.bx / 2) + ',-' + (d.by / 2) + 'h' + d.bx + 'v' + d.by + 'h-' + d.bx + 'Z') :
+            ('M-' + (d.bx / 2 + d.tx2width / 2) + ',-' + (d.by / 2) +
+              'h' + d.bx + 'v' + d.by + 'h-' + d.bx + 'Z') :
             // left or right aligned: side rect with arrow to data
             ('M0,0L' + (horzSign * HOVERARROWSIZE + offsetX) + ',' + (HOVERARROWSIZE + offsetY) +
                 'v' + (d.by / 2 - HOVERARROWSIZE) +

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -1179,24 +1179,20 @@ describe('hover info', function() {
             expect(elem1BB.top - elem2BB.top).toBeWithin(0, tolerance, msg);
         }
 
-        it('renders labels inside boxes', function(done) {
+        it('renders labels inside boxes', function() {
             _hover(gd, 300, 150);
 
             var nodes = ensureCentered(centeredHoverInfoNodes());
             assertElemInside(nodes.primaryText, nodes.primaryBox, 'Primary text inside box');
             assertElemInside(nodes.secondaryText, nodes.secondaryBox, 'Secondary text inside box');
-
-            done();
         });
 
-        it('renders secondary info box right to primary info box', function(done) {
+        it('renders secondary info box right to primary info box', function() {
             _hover(gd, 300, 150);
 
             var nodes = ensureCentered(centeredHoverInfoNodes());
             assertElemRightTo(nodes.secondaryBox, nodes.primaryBox, 'Secondary box right to primary box');
             assertTopsAligned(nodes.secondaryBox, nodes.primaryBox, 'Top edges of primary and secondary boxes aligned');
-
-            done();
         });
     });
 });


### PR DESCRIPTION
This fixes #2154: when hover info (aka tooltip) is rendered in the center due to a lack of space left or right, the text overflowed the box and the secondary hove info (trace name) was hidden underneath the primary one.

Final solution:
![2154_layout_centered-hover-info-final](https://user-images.githubusercontent.com/4652260/36980410-7b55c67e-208a-11e8-8740-196d8f4aac7c.png)


Hint: part of the discussion took place in https://github.com/rmoestl/plotly.js/pull/1.