### PR TITLE
Fix stacking of centered hover info elements #865

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1135,7 +1135,7 @@ function alignHoverText(hoverLabels, rotateLabels) {
 
         g.select('path').attr('d', d.anchor === 'middle' ?
             // middle aligned: rect centered on data
-            ('M-' + (d.bx / 2 + d.tx2width / 2) + ',-' + (d.by / 2) +
+            ('M-' + (d.bx / 2 + d.tx2width / 2) + ',' + (offsetY - d.by / 2) +
               'h' + d.bx + 'v' + d.by + 'h-' + d.bx + 'Z') :
             // left or right aligned: side rect with arrow to data
             ('M0,0L' + (horzSign * HOVERARROWSIZE + offsetX) + ',' + (HOVERARROWSIZE + offsetY) +


### PR DESCRIPTION
This fixes #865: boxes of multiple centered hover info elements had all the same vertical position, hence hiding each other and not "following" associated text labels in terms of positioning.

Final solution:
![865_stacked_centered_hover_info_elements](https://user-images.githubusercontent.com/4652260/37028469-9a85bf36-2134-11e8-9b9e-f73cf9f968d9.png)

