### PR TITLE
Bundle with browser-pack-flat plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,6 +1079,30 @@
         "umd": "3.0.1"
       }
     },
+    "browser-pack-flat": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/browser-pack-flat/-/browser-pack-flat-3.0.8.tgz",
+      "integrity": "sha512-1pKozTPswxbugz552PJoSzgn3LB54maoyRz2aHVxHF/gtCJmhQbxE3SsGcfs+VMl1Aqst1kk8vJxvNa0pJ/2cg==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "1.3.2",
+        "combine-source-map": "0.8.0",
+        "convert-source-map": "1.5.1",
+        "count-lines": "0.1.2",
+        "dedent": "0.7.0",
+        "estree-is-member-expression": "1.0.0",
+        "identifierfy": "1.1.1",
+        "is-require": "0.0.1",
+        "magic-string": "0.22.4",
+        "path-parse": "1.0.5",
+        "scope-analyzer": "1.3.0",
+        "stream-combiner": "0.2.2",
+        "through2": "2.0.3",
+        "transform-ast": "2.4.0",
+        "umd": "3.0.1",
+        "wrap-comment": "1.0.1"
+      }
+    },
     "browser-process-hrtime": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
@@ -1968,6 +1992,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "count-lines": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/count-lines/-/count-lines-0.1.2.tgz",
+      "integrity": "sha1-4zST+2hgqC9xWdgjeEP7+u/uWWI=",
+      "dev": true
+    },
     "country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
@@ -2239,6 +2269,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -3004,6 +3040,18 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+    },
+    "estree-is-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-is-function/-/estree-is-function-1.0.0.tgz",
+      "integrity": "sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA==",
+      "dev": true
+    },
+    "estree-is-member-expression": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-is-member-expression/-/estree-is-member-expression-1.0.0.tgz",
+      "integrity": "sha512-Ec+X44CapIGExvSZN+pGkmr5p7HwUVQoPQSd458Lqwvaf4/61k/invHSh4BYK8OXnCkfEhWuIoG5hayKLQStIg==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
@@ -4547,6 +4595,12 @@
         "node-source-walk": "3.3.0"
       }
     },
+    "get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -5654,6 +5708,16 @@
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
+    "identifierfy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/identifierfy/-/identifierfy-1.1.1.tgz",
+      "integrity": "sha1-j5Y2UK+jautC8v8O0V8pX/BAr/A=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2"
+      }
+    },
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
@@ -6104,6 +6168,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-relative-path/-/is-relative-path-1.0.2.tgz",
       "integrity": "sha1-CRtGoNZ8HtD+hfH4z93gBrslHUY=",
+      "dev": true
+    },
+    "is-require": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/is-require/-/is-require-0.0.1.tgz",
+      "integrity": "sha1-DR5tk+OAs1OG9HRUP//Jpm1Bgl4=",
       "dev": true
     },
     "is-resolvable": {
@@ -7606,6 +7676,15 @@
         "read-pkg-up": "1.0.1",
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
+      }
+    },
+    "merge-source-map": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
       }
     },
     "micromatch": {
@@ -10391,6 +10470,16 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "scope-analyzer": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/scope-analyzer/-/scope-analyzer-1.3.0.tgz",
+      "integrity": "sha512-ZLIOWdnoFpIS45APGI6kVXKFNP9FRAQQdiSujV8zJ9M7+fQjfEY9eqenj8txc8n0O+2sIPvP+mj2NH6mGeCS2w==",
+      "dev": true,
+      "requires": {
+        "estree-is-function": "1.0.0",
+        "get-assigned-identifiers": "1.2.0"
+      }
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -11048,6 +11137,16 @@
         }
       }
     },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1",
+        "through": "2.3.8"
+      }
+    },
     "stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -11684,6 +11783,30 @@
         }
       }
     },
+    "transform-ast": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/transform-ast/-/transform-ast-2.4.0.tgz",
+      "integrity": "sha512-vo/ALXqfvGTcyc8JJepHKAt+sYwVgLCOX2t85aB3En/YS+DgOB6rfMSSDygBDNQW7qpOg/IQm6AizXTlLWQQpA==",
+      "dev": true,
+      "requires": {
+        "acorn-node": "1.3.0",
+        "convert-source-map": "1.5.1",
+        "is-buffer": "1.1.6",
+        "magic-string": "0.21.3",
+        "merge-source-map": "1.0.4"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.21.3.tgz",
+          "integrity": "sha1-h+IBAJ6/3m9G3FdXMFpwr3HjFiQ=",
+          "dev": true,
+          "requires": {
+            "vlq": "0.2.3"
+          }
+        }
+      }
+    },
     "traverse-chain": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
@@ -12266,6 +12389,12 @@
           }
         }
       }
+    },
+    "wrap-comment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-comment/-/wrap-comment-1.0.1.tgz",
+      "integrity": "sha512-APccrMwl/ont0RHFTXNAQfM647duYYEfs6cngrIyTByTI0xbWnDnPSptFZhS68L4WCjt2ZxuhCFwuY6Pe88KZQ==",
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10256,6 +10256,12 @@
       "integrity": "sha512-nB641a6enJOh0fdsFHR9SiVCiOlAyjMplImDdjV3kWCzJZw9rwzvGwmpGuPmfX//Yxblh0pkzPcFcxA81iwmxA==",
       "dev": true
     },
+    "run-series": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
+      "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
+      "dev": true
+    },
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "devDependencies": {
     "brfs": "^1.4.4",
+    "browser-pack-flat": "^3.0.8",
     "browserify": "^15.2.0",
     "browserify-transform-tools": "^1.7.0",
     "check-node-version": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "prettysize": "1.1.0",
     "read-last-lines": "^1.1.0",
     "requirejs": "^2.3.1",
+    "run-series": "^1.1.4",
     "through2": "^2.0.3",
     "true-case-path": "^1.0.2",
     "watchify": "^3.10.0",

--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -51,6 +51,7 @@ tasks.push(function(cb) {
         standalone: 'Plotly',
         debug: DEV,
         compressAttrs: true,
+        packFlat: true,
         pathToMinBundle: constants.pathToPlotlyDistMin
     }, cb);
 });
@@ -67,6 +68,7 @@ tasks.push(function(cb) {
     _bundle(constants.pathToPlotlyIndex, constants.pathToPlotlyDistWithMeta, {
         standalone: 'Plotly',
         debug: DEV,
+        packFlat: true
     }, function() {
         makeSchema(constants.pathToPlotlyDistWithMeta, constants.pathToSchema)();
         cb();
@@ -80,6 +82,7 @@ constants.partialBundlePaths.forEach(function(pathObj) {
             standalone: 'Plotly',
             debug: DEV,
             compressAttrs: true,
+            packFlat: true,
             pathToMinBundle: pathObj.distMin
         }, cb);
     });

--- a/tasks/util/browserify_wrapper.js
+++ b/tasks/util/browserify_wrapper.js
@@ -21,6 +21,8 @@ var strictD3 = require('./strict_d3');
  *
  *  Additional option:
  *  - pathToMinBundle {string} path to destination minified bundle
+ *  - compressAttrs {boolean} do we compress attribute meta?
+ * @param {function} cb callback
  *
  * Outputs one bundle (un-minified) file if opts.pathToMinBundle is omitted
  * or opts.debug is true. Otherwise outputs two file: one un-minified bundle and
@@ -28,34 +30,46 @@ var strictD3 = require('./strict_d3');
  *
  * Logs basename of bundle when completed.
  */
-module.exports = function _bundle(pathToIndex, pathToBundle, opts) {
+module.exports = function _bundle(pathToIndex, pathToBundle, opts, cb) {
     opts = opts || {};
 
-    // do we output a minified file?
     var pathToMinBundle = opts.pathToMinBundle;
-    var outputMinified = !!pathToMinBundle;
 
     var browserifyOpts = {};
     browserifyOpts.standalone = opts.standalone;
     browserifyOpts.debug = opts.debug;
-    browserifyOpts.transform = outputMinified ? [compressAttributes] : [];
 
+    browserifyOpts.transform = [];
+    if(opts.compressAttrs) {
+        browserifyOpts.transform.push(compressAttributes);
+    }
     if(opts.debug) {
         browserifyOpts.transform.push(strictD3);
     }
 
     var b = browserify(pathToIndex, browserifyOpts);
 
+
+    var pending = opts.pathToMinBundle ? 2 : 1;
+
+    function done() {
+        if(cb && --pending === 0) cb(null);
+    }
+
     var bundleStream = b.bundle(function(err) {
-        if(err) throw err;
+        if(err) {
+            if(cb) cb(err);
+            else throw err;
+        }
     });
 
-    if(outputMinified) {
+    if(opts.pathToMinBundle) {
         bundleStream
             .pipe(minify(constants.uglifyOptions))
             .pipe(fs.createWriteStream(pathToMinBundle))
             .on('finish', function() {
                 logger(pathToMinBundle);
+                done();
             });
     }
 
@@ -63,14 +77,11 @@ module.exports = function _bundle(pathToIndex, pathToBundle, opts) {
         .pipe(fs.createWriteStream(pathToBundle))
         .on('finish', function() {
             logger(pathToBundle);
-            if(opts.then) {
-                opts.then();
-            }
+            done();
         });
 };
 
 function logger(pathToOutput) {
     var log = 'ok ' + path.basename(pathToOutput);
-
     console.log(log);
 }

--- a/tasks/util/browserify_wrapper.js
+++ b/tasks/util/browserify_wrapper.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var path = require('path');
 
 var browserify = require('browserify');
+var packFlat = require('browser-pack-flat/plugin');
 var minify = require('minify-stream');
 
 var constants = require('./constants');
@@ -12,16 +13,14 @@ var strictD3 = require('./strict_d3');
  *
  * @param {string} pathToIndex path to index file to bundle
  * @param {string} pathToBunlde path to destination bundle
- *
  * @param {object} opts
- *
  *  Browserify options:
  *  - standalone {string}
  *  - debug {boolean} [optional]
- *
  *  Additional option:
  *  - pathToMinBundle {string} path to destination minified bundle
  *  - compressAttrs {boolean} do we compress attribute meta?
+ *  - packFlat {boolean} do we use browser-pack-flat plugin?
  * @param {function} cb callback
  *
  * Outputs one bundle (un-minified) file if opts.pathToMinBundle is omitted
@@ -49,6 +48,9 @@ module.exports = function _bundle(pathToIndex, pathToBundle, opts, cb) {
 
     var b = browserify(pathToIndex, browserifyOpts);
 
+    if(opts.packFlat) {
+        b.plugin(packFlat);
+    }
 
     var pending = opts.pathToMinBundle ? 2 : 1;
 


### PR DESCRIPTION
A nice benefit from removing all circular deps in https://github.com/plotly/plotly.js/pull/2429, [`browser-pack-flat`](https://github.com/goto-bus-stop/browser-pack-flat) now allows us to trim some bundle bits (especially in our minified bundle). 

Here's what `browser-pack-flat` can trim:

![image](https://user-images.githubusercontent.com/6675409/37048709-afa82946-213c-11e8-8912-b8be4828db72.png)

that's about 10 gzip+minified `kB` per bundle. Not bad I think.

**That said**, using `browser-pack-flat` comes at a price :moneybag: , `npm run build` is not a bit slower and consumes a lot more memory. So I had to use [`run-series`](https://github.com/feross/run-series) to reduce memory consumption and make `npm run build` succeed consistently. Note also, I thinking of only using `browser-pack-flat` during `npm run build` to not slow `npm run watch` and `npm start`.


------------------

Referencing https://github.com/plotly/plotly-webpack/issues/2 that first discussed bundling with `browser-pack-flat`.



