### PR TITLE
fix #1645 - ensure we don't draw ticks if there are none to draw

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -522,22 +522,27 @@ axes.calcTicks = function calcTicks(ax) {
     // find the first tick
     ax._tmin = axes.tickFirst(ax);
 
+    // add a tiny bit so we get ticks which may have rounded out
+    var startTick = rng[0] * 1.0001 - rng[1] * 0.0001;
+    var endTick = rng[1] * 1.0001 - rng[0] * 0.0001;
     // check for reversed axis
     var axrev = (rng[1] < rng[0]);
 
+    // No visible ticks? Quit.
+    // I've only seen this on category axes with all categories off the edge.
+    if((ax._tmin < startTick) !== axrev) return [];
+
     // return the full set of tick vals
-    var vals = [],
-        // add a tiny bit so we get ticks which may have rounded out
-        endtick = rng[1] * 1.0001 - rng[0] * 0.0001;
+    var vals = [];
     if(ax.type === 'category') {
-        endtick = (axrev) ? Math.max(-0.5, endtick) :
-            Math.min(ax._categories.length - 0.5, endtick);
+        endTick = (axrev) ? Math.max(-0.5, endTick) :
+            Math.min(ax._categories.length - 0.5, endTick);
     }
 
     var xPrevious = null;
     var maxTicks = Math.max(1000, ax._length || 0);
     for(var x = ax._tmin;
-            (axrev) ? (x >= endtick) : (x <= endtick);
+            (axrev) ? (x >= endTick) : (x <= endTick);
             x = axes.tickIncrement(x, ax.dtick, axrev, ax.calendar)) {
         // prevent infinite loops - no more than one tick per pixel,
         // and make sure each value is different from the previous

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2226,6 +2226,29 @@ describe('Test axes', function() {
             expect(ax._categories).toEqual(['a', 'b', 'c', 'd']);
         });
 
+        it('notices when all categories are off the edge', function() {
+            var ax = {
+                type: 'category',
+                _categories: ['a', 'b', 'c', 'd'],
+                _categoriesMap: {'a': 0, 'b': 1, 'c': 2, 'd': 3},
+                tickmode: 'linear',
+                tick0: 0,
+                dtick: 1,
+                range: [-0.5, 3.5]
+            };
+
+            // baseline
+            expect(mockCalc(ax)).toEqual(['a', 'b', 'c', 'd']);
+            // reversed baseline
+            ax.range = [3.5, -0.5];
+            expect(mockCalc(ax)).toEqual(['d', 'c', 'b', 'a']);
+
+            [[-5, -1], [-1, -5], [5, 10], [10, 5]].forEach(function(rng) {
+                ax.range = rng;
+                expect(mockCalc(ax).length).toBe(0, rng);
+            });
+        });
+
         it('should always start at year for date axis hover', function() {
             var ax = {
                 type: 'date',
@@ -2321,10 +2344,8 @@ describe('Test axes', function() {
                 range: [1e200, 2e200]
             });
 
-            // This actually gives text '-Infinity' because it can't
-            // calculate the first tick properly, but since it's not going to
-            // be able to do any better with the rest, we don't much care.
-            expect(textOut.length).toBe(1);
+            // with the fix for #1645 we're not even getting the '-Infinity' we used to :tada:
+            expect(textOut.length).toBe(0);
         });
 
         it('truncates at the greater of 1001 ticks or one per pixel', function() {


### PR DESCRIPTION
@etpinard a quick one I noticed while perusing old issues.