### PR TITLE
throw an error if the test window is hidden

### DIFF
--- a/test/jasmine/assets/mouse_event.js
+++ b/test/jasmine/assets/mouse_event.js
@@ -1,6 +1,11 @@
 var Lib = require('../../../src/lib');
 
 module.exports = function(type, x, y, opts) {
+    var visibility = document.visibilityState;
+    if(visibility && visibility !== 'visible') {
+        throw new Error('document.visibilityState = "' + visibility + '" - Please make the window visible.');
+    }
+
     var fullOpts = {
         bubbles: true,
         clientX: x,


### PR DESCRIPTION
...when we try to emit a mouse event, which the browser may ignore if it's hidden

@etpinard this would have alerted me a bit quicker yesterday why my tests were failing sporadically 😅 

```
Error: document.visibilityState = "hidden" - Please make the window visible.
```