### PR TITLE
Bundle with pack-flat on ci

### DIFF
--- a/tasks/cibundle.js
+++ b/tasks/cibundle.js
@@ -15,8 +15,10 @@ var _bundle = require('./util/browserify_wrapper');
 // Browserify plotly.js and plotly.min.js
 _bundle(constants.pathToPlotlyIndex, constants.pathToPlotlyBuild, {
     standalone: 'Plotly',
-    pathToMinBundle: constants.pathToPlotlyDistMin,
-    debug: true
+    debug: true,
+    compressAttrs: true,
+    packFlat: true,
+    pathToMinBundle: constants.pathToPlotlyDistMin
 });
 
 // Browserify the geo assets


### PR DESCRIPTION
Probably not the greatest way to test those unfortunate `browser-pack-flat` hiccups, but oh well running our image tests with a pack-flat bundle would have been enough to catch https://github.com/plotly/plotly.js/issues/2456. This adds about 1 minute to our total test time on CI unfortunately (`browser-pack-flat` is kinda slow :turtle: ). I think this is an ok compromise for now. Thoughts?

--------

Some info from my investigations:

- I didn't find any issues (other than https://github.com/plotly/plotly.js/issues/2456.) by flipping through the docs page
- With the current master and a `browser-pack-flat` bundle, all image tests are passing
- Running the jasmine tests with `browser-pack-flat` with the current configuration isn't viable. It takes [more than 10 minutes to bundle plotly and the test code on CI](https://circleci.com/gh/plotly/plotly.js/7816).
- because of :arrow_heading_up: , I couldn't get a full clean run of jasmine test working. I tested a few test suites individually with `browser-pack-flat`. All test suites I tried were successful.
- Going forward, perhaps using something like [`exposify`](https://github.com/thlorenz/exposify) so that our jasmine test suites that require `lib/index.js` grab a pack-flat `build/plotly.js` bundle would be best.
- ... but really perhaps `browser-pack-flat` isn't worth the trouble?