### PR TITLE
Added missing 'Saturday' string to locale-en

### DIFF
--- a/src/locale-en.js
+++ b/src/locale-en.js
@@ -15,7 +15,7 @@ module.exports = {
         'Click to enter Colorscale title': 'Click to enter Colourscale title'
     },
     format: {
-        days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+        days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
         shortDays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
         months: [
             'January', 'February', 'March', 'April', 'May', 'June',


### PR DESCRIPTION
For some reason `days` is missing everyone's favourite one 😉 