### PR TITLE
fixes #2512 - skip over BADNUM lonlat in scattermapbox select

### DIFF
--- a/src/traces/scattermapbox/select.js
+++ b/src/traces/scattermapbox/select.js
@@ -10,6 +10,7 @@
 
 var Lib = require('../../lib');
 var subtypes = require('../scatter/subtypes');
+var BADNUM = require('../../constants/numerical').BADNUM;
 
 module.exports = function selectPoints(searchInfo, polygon) {
     var cd = searchInfo.cd;
@@ -29,18 +30,21 @@ module.exports = function selectPoints(searchInfo, polygon) {
         for(i = 0; i < cd.length; i++) {
             var di = cd[i];
             var lonlat = di.lonlat;
-            var lonlat2 = [Lib.wrap180(lonlat[0]), lonlat[1]];
-            var xy = [xa.c2p(lonlat2), ya.c2p(lonlat2)];
 
-            if(polygon.contains(xy)) {
-                selection.push({
-                    pointNumber: i,
-                    lon: lonlat[0],
-                    lat: lonlat[1]
-                });
-                di.selected = 1;
-            } else {
-                di.selected = 0;
+            if(lonlat[0] !== BADNUM) {
+                var lonlat2 = [Lib.wrap180(lonlat[0]), lonlat[1]];
+                var xy = [xa.c2p(lonlat2), ya.c2p(lonlat2)];
+
+                if(polygon.contains(xy)) {
+                    selection.push({
+                        pointNumber: i,
+                        lon: lonlat[0],
+                        lat: lonlat[1]
+                    });
+                    di.selected = 1;
+                } else {
+                    di.selected = 0;
+                }
             }
         }
     }

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -777,6 +777,10 @@ describe('@flaky Test select box and lasso per trace:', function() {
         var assertSelectedPoints = makeAssertSelectedPoints();
 
         var fig = Lib.extendDeep({}, require('@mocks/mapbox_bubbles-text'));
+
+        fig.data[0].lon.push(null);
+        fig.data[0].lat.push(null);
+
         fig.layout.dragmode = 'select';
         fig.config = {
             mapboxAccessToken: require('@build/credentials.json').MAPBOX_ACCESS_TOKEN


### PR DESCRIPTION
cc @alexcjohnson @cpsievert 