### PR TITLE
Legend events

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -85,7 +85,7 @@ var Events = {
     },
 
     /*
-     * This function behaves like jQueries triggerHandler. It calls
+     * This function behaves like jQuery's triggerHandler. It calls
      * all handlers for a particular event and returns the return value
      * of the LAST handler. This function also triggers jQuery's
      * triggerHandler for backwards compatibility.
@@ -98,7 +98,7 @@ var Events = {
         var jQueryHandlerValue;
         var nodeEventHandlerValue;
         /*
-         * If Jquery exists run all its handlers for this event and
+         * If jQuery exists run all its handlers for this event and
          * collect the return value of the LAST handler function
          */
         if(typeof jQuery !== 'undefined') {
@@ -133,9 +133,9 @@ var Events = {
         nodeEventHandlerValue = lastHandler(data);
 
         /*
-         * Return either the jquery handler value if it exists or the
-         * nodeEventHandler value. Jquery event value superceeds nodejs
-         * events for backwards compatability reasons.
+         * Return either the jQuery handler value if it exists or the
+         * nodeEventHandler value. jQuery event value supersedes nodejs
+         * events for backwards compatibility reasons.
          */
         return jQueryHandlerValue !== undefined ? jQueryHandlerValue :
             nodeEventHandlerValue;

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -9,11 +9,10 @@ var helpers = require('@src/components/legend/helpers');
 var anchorUtils = require('@src/components/legend/anchor_utils');
 
 var d3 = require('d3');
-var fail = require('../assets/fail_test');
+var failTest = require('../assets/fail_test');
 var delay = require('../assets/delay');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
-
 
 describe('legend defaults', function() {
     'use strict';
@@ -538,7 +537,7 @@ describe('legend relayout update', function() {
         .then(function() {
             expect(d3.selectAll('g.legend').size()).toBe(1);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -575,7 +574,7 @@ describe('legend relayout update', function() {
         }).then(function() {
             assertLegendStyle('rgb(0, 0, 255)', 'rgb(255, 0, 0)', 10);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 });
@@ -907,7 +906,7 @@ describe('legend interaction', function() {
             .then(function() {
                 assertVisible(gd, [true, true, true, true]);
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
     });
@@ -976,7 +975,7 @@ describe('legend interaction', function() {
                     {target: 3},
                     {target: 4}
                 ]);
-            }).catch(fail).then(done);
+            }).catch(failTest).then(done);
         });
     });
 
@@ -1023,7 +1022,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, 'legendonly', true]))
                     .then(click(0))
                     .then(assertVisible([false, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('clicking once toggles true -> legendonly', function(done) {
@@ -1031,7 +1030,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, 'legendonly', true]))
                     .then(click(1))
                     .then(assertVisible([false, 'legendonly', 'legendonly']))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('double-clicking isolates a visible trace ', function(done) {
@@ -1040,14 +1039,14 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, true, true]))
                     .then(click(0, 2))
                     .then(assertVisible([false, true, 'legendonly']))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('double-clicking an isolated trace shows all non-hidden traces', function(done) {
                 Promise.resolve()
                     .then(click(0, 2))
                     .then(assertVisible([false, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
         });
 
@@ -1077,7 +1076,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, 'legendonly', true, 'legendonly']))
                     .then(click(1))
                     .then(assertVisible([false, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('isolates legendgroups as a whole', function(done) {
@@ -1086,7 +1085,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, true, 'legendonly', true]))
                     .then(click(1, 2))
                     .then(assertVisible([false, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
         });
 
@@ -1119,7 +1118,7 @@ describe('legend interaction', function() {
             it('computes the initial visibility correctly', function(done) {
                 Promise.resolve()
                     .then(assertVisible([false, true, true, true, true, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('toggles the visibility of a non-groupby trace in the presence of groupby traces', function(done) {
@@ -1128,7 +1127,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, true, 'legendonly', true, true, true, true, true]))
                     .then(click(1))
                     .then(assertVisible([false, true, true, true, true, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('toggles the visibility of the first group in a groupby trace', function(done) {
@@ -1137,7 +1136,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, 'legendonly', true, true, true, true, true, true]))
                     .then(click(0))
                     .then(assertVisible([false, true, true, true, true, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('toggles the visibility of the third group in a groupby trace', function(done) {
@@ -1146,7 +1145,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, true, true, true, 'legendonly', true, true, true]))
                     .then(click(3))
                     .then(assertVisible([false, true, true, true, true, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('double-clicking isolates a non-groupby trace', function(done) {
@@ -1155,7 +1154,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, true, 'legendonly', 'legendonly', 'legendonly', 'legendonly', 'legendonly', 'legendonly']))
                     .then(click(0, 2))
                     .then(assertVisible([false, true, true, true, true, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
 
             it('double-clicking isolates a groupby trace', function(done) {
@@ -1164,7 +1163,7 @@ describe('legend interaction', function() {
                     .then(assertVisible([false, 'legendonly', true, 'legendonly', 'legendonly', 'legendonly', 'legendonly', 'legendonly']))
                     .then(click(1, 2))
                     .then(assertVisible([false, true, true, true, true, true, true, true]))
-                    .catch(fail).then(done);
+                    .catch(failTest).then(done);
             });
         });
     });


### PR DESCRIPTION
This PR adds legend two events `plotly_legendclick` and `plotly_legenddoubleclick`. Note that, as per @alexcjohnson 's recommendation in https://github.com/plotly/plotly.js/issues/65#issuecomment-162097388, these new events are emitted using `Events.triggerHandlers` which allows users to cancel the default click/doubleclick behavior via the (last) handler's return value. This PR chose this strategy despite this note:

https://github.com/plotly/plotly.js/blob/4ed586a6402073cc5c50a40cad5f652d7472fcce/src/lib/events.js#L93-L96

Is it fair to say `Events.triggerHandlers` is a good idea afterall or is there a better solution?

-----

Tagging this PR `discussion needed` as there are as few debatable things here:

- should we really use `Events.triggerHandlers`? One drawback of using it: the custom handlers must be called **before** the default handlers, meaning the users won't have access to the to-be-updated `visible` trace attribute values - which could be confusing for users that want to augment the default behavior (but maybe listening to `plotly_restyle` is good enough for that use case?)
- should `plotly_legendclick` and `plotly_legenddoubleclick` be the same event? For example, maybe both click and doubleclick could trigger `plotly_legendclick` where the click/doubleclick distinction would be made using addition event data field (e.g `numClick: 1 || 2`). This would allows users to define their own click-vs-doubleclick timeouts.
- can anyone think of any other useful field to include in the event data?

----

Referencing numerous related legend feature requests:

- click/hover events for labels/legends https://github.com/plotly/plotly.js/issues/65 (this PR would close the _click_ part)
- Add ability to disable legend trace toggling https://github.com/plotly/plotly.js/issues/665 (this PR adds a _way_, but it might be nice to add attributes for this so that the behavior can be exported)
- https://github.com/plotly/plotly.js/issues/674, https://github.com/plotly/plotly.js/issues/1462 are more specific requests. They would all be possible in user-land through the events added in this PR.

cc @jackparmer @willdurand