### PR TITLE
fix spikesnap: cursor in FF

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -279,11 +279,9 @@ function _hover(gd, evt, subplot, noHoverEvent) {
         if(hasUserCalledHover) {
             if('xpx' in evt) xpx = evt.xpx;
             else xpx = xaArray[0]._length / 2;
-            evt.pointerX = xpx + xaArray[0]._offset;
 
             if('ypx' in evt) ypx = evt.ypx;
             else ypx = yaArray[0]._length / 2;
-            evt.pointerY = ypx + yaArray[0]._offset;
         }
         else {
             // fire the beforehover event and quit if it returns false
@@ -300,12 +298,13 @@ function _hover(gd, evt, subplot, noHoverEvent) {
 
             // in case hover was called from mouseout into hovertext,
             // it's possible you're not actually over the plot anymore
-            if(xpx < 0 || xpx > dbb.width || ypx < 0 || ypx > dbb.height) {
+            if(xpx < 0 || xpx > xaArray[0]._length || ypx < 0 || ypx > yaArray[0]._length) {
                 return dragElement.unhoverRaw(gd, evt);
             }
-            evt.pointerX = evt.offsetX;
-            evt.pointerY = evt.offsetY;
         }
+
+        evt.pointerX = xpx + xaArray[0]._offset;
+        evt.pointerY = ypx + yaArray[0]._offset;
 
         if('xval' in evt) xvalArray = helpers.flat(subplots, evt.xval);
         else xvalArray = helpers.p2c(xaArray, xpx);

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -73,6 +73,9 @@ function assertSrcContents() {
     // Forbidden in IE in any context
     var IE_BLACK_LIST = ['classList'];
 
+    // not implemented in FF, or inconsistent with others
+    var FF_BLACK_LIST = ['offsetX', 'offsetY'];
+
     // require'd built-in modules
     var BUILTINS = ['events'];
 
@@ -102,6 +105,9 @@ function assertSrcContents() {
                     }
                     else if(IE_SVG_BLACK_LIST.indexOf(lastPart) !== -1) {
                         logs.push(file + ' : contains .' + lastPart + ' (IE failure in SVG)');
+                    }
+                    else if(FF_BLACK_LIST.indexOf(lastPart) !== -1) {
+                        logs.push(file + ' : contains .' + lastPart + ' (FF failure)');
                     }
                 }
                 else if(node.type === 'Identifier' && node.source() === 'getComputedStyle') {


### PR DESCRIPTION
Fixes #2588 
`evt.offset(X|Y)` isn't implemented consistently in Firefox vs other browsers. Stopped using it and blacklisted it as a property.

The little offset I saw in Chrome https://github.com/plotly/plotly.js/issues/2588#issuecomment-385072182 seems to be a weird interaction of Chrome and my second monitor (non-retina, vs. the laptop's retina monitor which does not show this offset) that shows up even in bare `mouseover` events, so doesn't seem like we can fix that.

cc @etpinard 