### PR TITLE
Use isArrayOrTypedArray in gl_format_color.js

### DIFF
--- a/src/lib/gl_format_color.js
+++ b/src/lib/gl_format_color.js
@@ -14,6 +14,7 @@ var rgba = require('color-normalize');
 
 var Colorscale = require('../components/colorscale');
 var colorDflt = require('../components/color/attributes').defaultLine;
+var isArrayOrTypedArray = require('./is_array').isArrayOrTypedArray;
 
 var colorDfltRgba = rgba(colorDflt);
 var opacityDflt = 1;
@@ -37,10 +38,10 @@ function validateOpacity(opacityIn) {
 }
 
 function formatColor(containerIn, opacityIn, len) {
-    var colorIn = containerIn.color,
-        isArrayColorIn = Array.isArray(colorIn),
-        isArrayOpacityIn = Array.isArray(opacityIn),
-        colorOut = [];
+    var colorIn = containerIn.color;
+    var isArrayColorIn = isArrayOrTypedArray(colorIn);
+    var isArrayOpacityIn = isArrayOrTypedArray(opacityIn);
+    var colorOut = [];
 
     var sclFunc, getColor, getOpacity, colori, opacityi;
 

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -917,6 +917,37 @@ describe('@gl Test gl2d plots', function() {
         .catch(fail)
         .then(done);
     });
+
+    it('should work with typed array', function(done) {
+        Plotly.plot(gd, [{
+            type: 'scattergl',
+            mode: 'markers',
+            x: new Float32Array([1, 2, 3]),
+            y: new Float32Array([1, 2, 1]),
+            marker: {
+                size: 20,
+                colorscale: [[0, 'gray'], [1, 'red']],
+                cmin: 0,
+                cmax: 1,
+                showscale: true,
+                color: new Float32Array([0, 0.5, 1.0])
+            }
+        }])
+        .then(function() {
+            var opts = gd.calcdata[0][0].t._scene.markerOptions[0];
+
+            expect(opts.colors).toBeCloseTo2DArray([
+                [0.5, 0.5, 0.5, 1],
+                [0.75, 0.25, 0.25, 1],
+                [1, 0, 0, 1]
+            ]);
+
+            expect(opts.positions)
+                .toBeCloseToArray([1, 1, 2, 2, 3, 1]);
+        })
+        .catch(fail)
+        .then(done);
+    });
 });
 
 describe('Test scattergl autorange:', function() {


### PR DESCRIPTION
fixes #2591 - one `Array.isArray` -> `Lib.isArrayOrTypedArray` that slipped through in https://github.com/plotly/plotly.js/pull/2388

cc  @alexcjohnson @dy 