### PR TITLE
Fix Plotly.react add/remove traces bug

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2372,7 +2372,7 @@ function diffData(gd, oldFullData, newFullData, immutable) {
     if(oldFullData.length !== newFullData.length) {
         return {
             fullReplot: true,
-            clearCalc: true
+            calc: true
         };
     }
 

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -2610,6 +2610,29 @@ describe('Test plot api', function() {
             images.draw.calls.reset();
         }
 
+        it('can add / remove traces', function(done) {
+            var data1 = [{y: [1, 2, 3], mode: 'markers'}];
+            var data2 = [data1[0], {y: [2, 3, 1], mode: 'markers'}];
+            var layout = {};
+            Plotly.newPlot(gd, data1, layout)
+            .then(countPlots)
+            .then(function() {
+                expect(d3.selectAll('.point').size()).toBe(3);
+
+                return Plotly.react(gd, data2, layout);
+            })
+            .then(function() {
+                expect(d3.selectAll('.point').size()).toBe(6);
+
+                return Plotly.react(gd, data1, layout);
+            })
+            .then(function() {
+                expect(d3.selectAll('.point').size()).toBe(3);
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
         it('should notice new data by ===, without layout.datarevision', function(done) {
             var data = [{y: [1, 2, 3], mode: 'markers'}];
             var layout = {};


### PR DESCRIPTION
Fixes #2602 - not sure how this worked before #2577 but it must have. And I'm kind of amazed that we didn't have an add/remove traces test for `Plotly.react` before... oh well, now we do!

cc @etpinard 