### PR TITLE
Override toImage modebar button opts via config

### DIFF
--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -47,19 +47,29 @@ var modeBarButtons = module.exports = {};
 
 modeBarButtons.toImage = {
     name: 'toImage',
-    title: function(gd) { return _(gd, 'Download plot as a png'); },
+    title: function(gd) { return _(gd, 'Download plot'); },
     icon: Icons.camera,
     click: function(gd) {
-        var format = 'png';
+        var toImageButtonDefaults = gd._context.toImageButtonDefaults;
+        var opts = {format: toImageButtonDefaults.format || 'png'};
 
         Lib.notifier(_(gd, 'Taking snapshot - this may take a few seconds'), 'long');
 
         if(Lib.isIE()) {
             Lib.notifier(_(gd, 'IE only supports svg.  Changing format to svg.'), 'long');
-            format = 'svg';
+            opts.format = 'svg';
         }
 
-        Registry.call('downloadImage', gd, {'format': format})
+        if(toImageButtonDefaults.width) {
+            opts.width = toImageButtonDefaults.width;
+        }
+        if(toImageButtonDefaults.height) {
+            opts.height = toImageButtonDefaults.height;
+        }
+        if(toImageButtonDefaults.filename) {
+            opts.filename = toImageButtonDefaults.filename;
+        }
+        Registry.call('downloadImage', gd, opts)
           .then(function(filename) {
               Lib.notifier(_(gd, 'Snapshot succeeded') + ' - ' + filename, 'long');
           })

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -47,22 +47,28 @@ var modeBarButtons = module.exports = {};
 
 modeBarButtons.toImage = {
     name: 'toImage',
-    title: function(gd) { return _(gd, 'Download plot'); },
+    title: function(gd) {
+        var opts = gd._context.toImageButtonOptions || {};
+        var format = opts.format || 'png';
+        return format === 'png' ?
+            _(gd, 'Download plot as a png') : // legacy text
+            _(gd, 'Download plot'); // generic non-PNG text
+    },
     icon: Icons.camera,
     click: function(gd) {
-        var toImageButtonDefaults = gd._context.toImageButtonDefaults;
-        var opts = {format: toImageButtonDefaults.format || 'png'};
+        var toImageButtonOptions = gd._context.toImageButtonOptions;
+        var opts = {format: toImageButtonOptions.format || 'png'};
 
         Lib.notifier(_(gd, 'Taking snapshot - this may take a few seconds'), 'long');
 
-        if(Lib.isIE()) {
+        if(opts.format !== 'svg' && Lib.isIE()) {
             Lib.notifier(_(gd, 'IE only supports svg.  Changing format to svg.'), 'long');
             opts.format = 'svg';
         }
 
         ['filename', 'width', 'height', 'scale'].forEach(function(key) {
-            if(toImageButtonDefaults[key]) {
-                opts[key] = toImageButtonDefaults[key];
+            if(toImageButtonOptions[key]) {
+                opts[key] = toImageButtonOptions[key];
             }
         });
 

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -60,15 +60,12 @@ modeBarButtons.toImage = {
             opts.format = 'svg';
         }
 
-        if(toImageButtonDefaults.width) {
-            opts.width = toImageButtonDefaults.width;
-        }
-        if(toImageButtonDefaults.height) {
-            opts.height = toImageButtonDefaults.height;
-        }
-        if(toImageButtonDefaults.filename) {
-            opts.filename = toImageButtonDefaults.filename;
-        }
+        ['filename', 'width', 'height', 'scale'].forEach(function(key) {
+            if(toImageButtonDefaults[key]) {
+                opts[key] = toImageButtonDefaults[key];
+            }
+        });
+
         Registry.call('downloadImage', gd, opts)
           .then(function(filename) {
               Lib.notifier(_(gd, 'Snapshot succeeded') + ' - ' + filename, 'long');

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -118,7 +118,7 @@ module.exports = {
     // statically override options for toImage modebar button
     // allowed keys are format, filename, width, height, scale
     // see ./components/modebar/buttons.js
-    toImageButtonDefaults: {},
+    toImageButtonOptions: {},
 
     // add the plotly logo on the end of the mode bar
     displaylogo: true,

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -115,6 +115,10 @@ module.exports = {
      */
     modeBarButtons: false,
 
+    // statically override options for toImage modebar button
+    // allowed keys are format, filename, width, height
+    toImageButtonDefaults: {},
+
     // add the plotly logo on the end of the mode bar
     displaylogo: true,
 

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -116,7 +116,8 @@ module.exports = {
     modeBarButtons: false,
 
     // statically override options for toImage modebar button
-    // allowed keys are format, filename, width, height
+    // allowed keys are format, filename, width, height, scale
+    // see ./components/modebar/buttons.js
     toImageButtonDefaults: {},
 
     // add the plotly logo on the end of the mode bar

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -5,6 +5,7 @@ var manageModeBar = require('@src/components/modebar/manage');
 
 var Plotly = require('@lib/index');
 var Plots = require('@src/plots/plots');
+var Registry = require('@src/registry');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var selectButton = require('../assets/modebar_button');
@@ -766,6 +767,42 @@ describe('ModeBar', function() {
                 );
             }
         }
+
+        describe('toImage handlers', function() {
+            beforeEach(function() {
+                spyOn(Registry, 'call').and.callFake(function() {
+                    return Promise.resolve();
+                });
+                gd = createGraphDiv();
+            });
+
+            it('should use defaults', function(done) {
+                Plotly.plot(gd, {data: [], layout: {}})
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'toImage').click();
+                    expect(Registry.call).toHaveBeenCalledWith('downloadImage', gd,
+                        {format: 'png'});
+                    done();
+                });
+            });
+
+            it('should accept overriding defaults', function(done) {
+                Plotly.plot(gd, {data: [], layout: {}, config: {
+                    toImageButtonDefaults: {
+                        format: 'svg',
+                        filename: 'x',
+                        unsupported: 'should not pass'
+                    }
+                } })
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'toImage').click();
+                    expect(Registry.call).toHaveBeenCalledWith('downloadImage', gd,
+                        {format: 'svg', filename: 'x'});
+                    done();
+                });
+            });
+
+        });
 
         describe('cartesian handlers', function() {
 

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -788,7 +788,7 @@ describe('ModeBar', function() {
 
             it('should accept overriding defaults', function(done) {
                 Plotly.plot(gd, {data: [], layout: {}, config: {
-                    toImageButtonDefaults: {
+                    toImageButtonOptions: {
                         format: 'svg',
                         filename: 'x',
                         unsupported: 'should not pass'


### PR DESCRIPTION
This PR allows for selective overriding of default behaviour of the `toImage` modebar button. Specifying nothing falls through to the current defaults. Note sure about the implications of renaming the button, wrt to locale files.