### PR TITLE
fix #2633 - make sure we have a grid before attaching it to layoutOut

### DIFF
--- a/src/components/grid/index.js
+++ b/src/components/grid/index.js
@@ -201,7 +201,7 @@ function sizeDefaults(layoutIn, layoutOut) {
         if(hasXaxes) dfltColumns = xAxes.length;
     }
 
-    var gridOut = layoutOut.grid = {};
+    var gridOut = {};
 
     function coerce(attr, dflt) {
         return Lib.coerce(gridIn, gridOut, gridAttrs, attr, dflt);
@@ -234,6 +234,8 @@ function sizeDefaults(layoutIn, layoutOut) {
         x: fillGridPositions('x', coerce, dfltGapX, dfltSideX, columns),
         y: fillGridPositions('y', coerce, dfltGapY, dfltSideY, rows, reversed)
     };
+
+    layoutOut.grid = gridOut;
 }
 
 // coerce x or y sizing attributes and return an array of domains for this direction

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -908,6 +908,25 @@ describe('grids', function() {
         });
     }
 
+    it('does not barf on invalid grid objects', function(done) {
+        Plotly.newPlot(gd, makeData(['xy']), {grid: true})
+        .then(function() {
+            expect(gd._fullLayout.grid).toBeUndefined();
+
+            return Plotly.newPlot(gd, makeData(['xy']), {grid: {}});
+        })
+        .then(function() {
+            expect(gd._fullLayout.grid).toBeUndefined();
+
+            return Plotly.newPlot(gd, makeData(['xy']), {grid: {rows: 1, columns: 1}});
+        })
+        .then(function() {
+            expect(gd._fullLayout.grid).toBeUndefined();
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
     it('defaults to a coupled layout', function(done) {
         Plotly.newPlot(gd,
             // leave some empty rows/columns

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -922,6 +922,16 @@ describe('grids', function() {
         })
         .then(function() {
             expect(gd._fullLayout.grid).toBeUndefined();
+
+            // check Plotly.validate on the same grids too
+            [true, {}, {rows: 1, columns: 1}].forEach(function(gridVal) {
+                var validation = Plotly.validate([], {grid: gridVal});
+                expect(validation.length).toBe(1);
+                expect(validation[0]).toEqual(jasmine.objectContaining({
+                    astr: 'grid',
+                    code: 'unused'
+                }));
+            });
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
cc @etpinard a quick one - the key is attaching `gridOut` to `layoutOut` after [this short-circuit return](https://github.com/plotly/plotly.js/blob/2d84a8fba7aa27f36ff3c61e0e07616ab12cfd66/src/components/grid/index.js#L213)