### PR TITLE
Add Building.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,78 @@
+# Building plotly.js
+
+## Webpack
+
+For plotly.js to build with Webpack you will need to install [ify-loader@v1.1.0+](https://github.com/hughsk/ify-loader) and add it to your `webpack.config.json`. This adds Browserify transform compatibility to Webpack which is necessary for some plotly.js dependencies.
+
+A repo that demonstrates how to build plotly.js with Webpack can be found [here](https://github.com/plotly/plotly-webpack). In short add `ify-loader` to the `module` section in your `webpack.config.js`:
+
+```js
+...
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                loader: 'ify-loader'
+            }
+        ]
+    },
+...
+```
+
+## Browserify
+
+Given source file:
+
+```js
+// file: index.js
+
+var Plotly = require('plotly.js');
+
+// ....
+```
+
+then simply run,
+
+
+```
+browserify index.js > bundle.js
+```
+
+to trim meta information (and thus save a few bytes), run:
+
+
+```
+browserify -t path/to/plotly.js/tasks/util/compress_attributes.js index.js > bundle.js
+```
+
+## Angular CLI
+
+Currently Angular CLI use Webpack under the hood to bundle and build your Angular application.
+Sadly it doesn't allow to override its Webpack config, and therefore to use the plugin mentioned in the [Webpack](#webpack) section.
+Without this plugin your build will fail when it tries to build glslify for WebGL plots.
+
+Currently 2 solutions exists to circumvent this issue :
+
+1) If you need to use WebGL plots, you can create a Webpack config from your Angular CLI projet with [ng eject](https://github.com/angular/angular-cli/wiki/eject). This will allow you to follow the instructions regarding Webpack.
+2) If you don't need to use WebGL plots, you can make a custom build containing only the required modules for your plots. The clean way to do it with Angular CLI is not the method described in the [Modules]((https://github.com/plotly/plotly.js/blob/master/README.md#modules) section of the README but the following :
+
+```typescript
+// in the Component you want to create a graph
+import * as Plotly from 'plotly.js';
+```
+
+```json
+// in src/tsconfig.app.json
+// List here the modules you want to import
+// this exemple is for scatter plots
+{
+    "compilerOptions": {
+        "paths": {
+            "plotly.js": [
+                "../node_modules/plotly.js/lib/core.js",
+                "../node_modules/plotly.js/lib/scatter.js"
+            ]
+        }
+    }
+}
+```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -47,14 +47,14 @@ browserify -t path/to/plotly.js/tasks/util/compress_attributes.js index.js > bun
 
 ## Angular CLI
 
-Currently Angular CLI use Webpack under the hood to bundle and build your Angular application.
-Sadly it doesn't allow to override its Webpack config, and therefore to use the plugin mentioned in the [Webpack](#webpack) section.
+Currently Angular CLI uses Webpack under the hood to bundle and build your Angular application.
+Sadly it doesn't allow you to override its Webpack config in order to add the plugin mentioned in the [Webpack](#webpack) section.
 Without this plugin your build will fail when it tries to build glslify for WebGL plots.
 
-Currently 2 solutions exists to circumvent this issue :
+Currently 2 solutions exists to circumvent this issue:
 
-1) If you need to use WebGL plots, you can create a Webpack config from your Angular CLI projet with [ng eject](https://github.com/angular/angular-cli/wiki/eject). This will allow you to follow the instructions regarding Webpack.
-2) If you don't need to use WebGL plots, you can make a custom build containing only the required modules for your plots. The clean way to do it with Angular CLI is not the method described in the [Modules](https://github.com/plotly/plotly.js/blob/master/README.md#modules) section of the README but the following :
+1) If you need to use WebGL plots, you can create a Webpack config from your Angular CLI project with [ng eject](https://github.com/angular/angular-cli/wiki/eject). This will allow you to follow the instructions regarding Webpack.
+2) If you don't need to use WebGL plots, you can make a custom build containing only the required modules for your plots. The clean way to do it with Angular CLI is not the method described in the [Modules](https://github.com/plotly/plotly.js/blob/master/README.md#modules) section of the README but the following:
 
 ```typescript
 // in the Component you want to create a graph
@@ -64,7 +64,7 @@ import * as Plotly from 'plotly.js';
 ```json
 // in src/tsconfig.app.json
 // List here the modules you want to import
-// this exemple is for scatter plots
+// this example is for scatter plots
 {
     "compilerOptions": {
         "paths": {

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -54,7 +54,7 @@ Without this plugin your build will fail when it tries to build glslify for WebG
 Currently 2 solutions exists to circumvent this issue :
 
 1) If you need to use WebGL plots, you can create a Webpack config from your Angular CLI projet with [ng eject](https://github.com/angular/angular-cli/wiki/eject). This will allow you to follow the instructions regarding Webpack.
-2) If you don't need to use WebGL plots, you can make a custom build containing only the required modules for your plots. The clean way to do it with Angular CLI is not the method described in the [Modules]((https://github.com/plotly/plotly.js/blob/master/README.md#modules) section of the README but the following :
+2) If you don't need to use WebGL plots, you can make a custom build containing only the required modules for your plots. The clean way to do it with Angular CLI is not the method described in the [Modules](https://github.com/plotly/plotly.js/blob/master/README.md#modules) section of the README but the following :
 
 ```typescript
 // in the Component you want to create a graph

--- a/README.md
+++ b/README.md
@@ -122,6 +122,41 @@ A repo that demonstrates how to build plotly.js with Webpack can be found [here]
 ...
 ```
 
+#### Building plotly.js with Angular CLI
+
+Currently Angular CLI use Webpack under the hood to bundle and build your Angular application.
+Sadly it doesn't allow to override its Webpack config, and therefore to use the plugin mentioned in [Building plotly.js with Webpack](#building-plotly.js-with-webpack).
+Without this plugin your build will fail when it tries to build glslify for GLSL plots.
+
+Currently 2 solutions exists to circumvent this issue :
+1) If you need to use GLSL plots, you can create a Webpack config from your Angular CLI projet with [ng eject](https://github.com/angular/angular-cli/wiki/eject).
+This will allow you to follow the instructions regarding Webpack.
+2) If you don't need to use GLSL plots, you can make a custom build containing only the required modules for your plots.
+The clean way to do it with Angular CLI is not the method described in [Modules](#modules) but the following :
+```typescript
+// in the Component you want to create a graph
+import * as Plotly from 'plotly.js';
+```
+
+```json
+// in src/tsconfig.app.json
+...
+    "compilerOptions": {
+        ...
+        "paths": {
+            "plotly.js": [
+                // List here the modules you want to import
+                // this exemple is enough for scatter plots
+                "../node_modules/plotly.js/lib/core.js",
+                "../node_modules/plotly.js/lib/scatter.js"
+            ]
+        }
+        ...
+    }
+...
+
+```
+
 ## Bugs and feature requests
 
 Have a bug or a feature request? Please first read the [issues guidelines](https://github.com/plotly/plotly.js/blob/master/CONTRIBUTING.md#opening-issues).

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ A repo that demonstrates how to build plotly.js with Webpack can be found [here]
 #### Building plotly.js with Angular CLI
 
 Currently Angular CLI use Webpack under the hood to bundle and build your Angular application.
-Sadly it doesn't allow to override its Webpack config, and therefore to use the plugin mentioned in [Building plotly.js with Webpack](#building-plotly.js-with-webpack).
+Sadly it doesn't allow to override its Webpack config, and therefore to use the plugin mentioned in [Building plotly.js with Webpack](#building-plotlyjs-with-webpack).
 Without this plugin your build will fail when it tries to build glslify for GLSL plots.
 
 Currently 2 solutions exists to circumvent this issue :
@@ -140,21 +140,18 @@ import * as Plotly from 'plotly.js';
 
 ```json
 // in src/tsconfig.app.json
-...
+// List here the modules you want to import
+// this exemple is for scatter plots
+{
     "compilerOptions": {
-        ...
         "paths": {
             "plotly.js": [
-                // List here the modules you want to import
-                // this exemple is enough for scatter plots
                 "../node_modules/plotly.js/lib/core.js",
                 "../node_modules/plotly.js/lib/scatter.js"
             ]
         }
-        ...
     }
-...
-
+}
 ```
 
 ## Bugs and feature requests

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and more.
 
 * [Quick start options](#quick-start-options)
 * [Modules](#modules)
-* [Building plotly.js](##building-plotlyjs)
+* [Building plotly.js](#building-plotlyjs)
 * [Bugs and feature requests](#bugs-and-feature-requests)
 * [Documentation](#documentation)
 * [Contributing](#contributing)
@@ -106,7 +106,7 @@ Important: the plotly.js code base contains some non-ascii characters. Therefore
 
 ## Building plotly.js
 
-Building instructions using `webpack`, `browserify` and other build frameworks in [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/master/BUILDING.md)
+Building instructions using `webpack`, `browserify` and other build frameworks are in [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/master/BUILDING.md)
 
 ## Bugs and feature requests
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ and more.
 
 * [Quick start options](#quick-start-options)
 * [Modules](#modules)
+* [Building plotly.js](#building-plotly.js)
 * [Bugs and feature requests](#bugs-and-feature-requests)
 * [Documentation](#documentation)
 * [Contributing](#contributing)
@@ -103,56 +104,9 @@ Important: the plotly.js code base contains some non-ascii characters. Therefore
 <script src="my-plotly-bundle.js" charset="utf-8"></script>
 ```
 
+## Building plotly.js
 
-#### Building plotly.js with Webpack
-
-For plotly.js to build with Webpack you will need to install [ify-loader@v1.1.0+](https://github.com/hughsk/ify-loader) and add it to your `webpack.config.json`. This adds Browserify transform compatibility to Webpack which is necessary for some plotly.js dependencies.
-
-A repo that demonstrates how to build plotly.js with Webpack can be found [here](https://github.com/rreusser/plotly-webpack). In short add `ify-loader` to the `module` section in your `webpack.config.js`:
-```js
-...
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                loader: 'ify-loader'
-            }
-        ]
-    },
-...
-```
-
-#### Building plotly.js with Angular CLI
-
-Currently Angular CLI use Webpack under the hood to bundle and build your Angular application.
-Sadly it doesn't allow to override its Webpack config, and therefore to use the plugin mentioned in [Building plotly.js with Webpack](#building-plotlyjs-with-webpack).
-Without this plugin your build will fail when it tries to build glslify for GLSL plots.
-
-Currently 2 solutions exists to circumvent this issue :
-1) If you need to use GLSL plots, you can create a Webpack config from your Angular CLI projet with [ng eject](https://github.com/angular/angular-cli/wiki/eject).
-This will allow you to follow the instructions regarding Webpack.
-2) If you don't need to use GLSL plots, you can make a custom build containing only the required modules for your plots.
-The clean way to do it with Angular CLI is not the method described in [Modules](#modules) but the following :
-```typescript
-// in the Component you want to create a graph
-import * as Plotly from 'plotly.js';
-```
-
-```json
-// in src/tsconfig.app.json
-// List here the modules you want to import
-// this exemple is for scatter plots
-{
-    "compilerOptions": {
-        "paths": {
-            "plotly.js": [
-                "../node_modules/plotly.js/lib/core.js",
-                "../node_modules/plotly.js/lib/scatter.js"
-            ]
-        }
-    }
-}
-```
+Building instructions using `webpack`, browserify` and other build frameworks in [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/master/BUILDING.md)
 
 ## Bugs and feature requests
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and more.
 
 * [Quick start options](#quick-start-options)
 * [Modules](#modules)
-* [Building plotly.js](#building-plotly.js)
+* [Building plotly.js](##building-plotlyjs)
 * [Bugs and feature requests](#bugs-and-feature-requests)
 * [Documentation](#documentation)
 * [Contributing](#contributing)
@@ -106,7 +106,7 @@ Important: the plotly.js code base contains some non-ascii characters. Therefore
 
 ## Building plotly.js
 
-Building instructions using `webpack`, browserify` and other build frameworks in [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/master/BUILDING.md)
+Building instructions using `webpack`, `browserify` and other build frameworks in [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/master/BUILDING.md)
 
 ## Bugs and feature requests
 

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -205,6 +205,7 @@ function assertFileNames() {
                 base === 'CONTRIBUTING.md' ||
                 base === 'CHANGELOG.md' ||
                 base === 'SECURITY.md' ||
+                base === 'BUILDING.md' ||
                 file.indexOf('mathjax') !== -1
             ) return;
 


### PR DESCRIPTION
For centralized and complete building instructions to eventually cover :sparkles:  all :sparkles: build frameworks.

This PR uses commits from @TomDemulierChevret's https://github.com/plotly/plotly.js/pull/2260/

cc @alexcjohnson