### PR TITLE
Create two (not three) WebGL contexts for scattergl/splom graphs

### DIFF
--- a/src/lib/prepare_regl.js
+++ b/src/lib/prepare_regl.js
@@ -23,8 +23,12 @@ var createRegl = require('regl');
  * @param {array} extensions : list of extension to pass to createRegl
  */
 module.exports = function prepareRegl(gd, extensions) {
-    gd._fullLayout._glcanvas.each(function(d) {
+    var fullLayout = gd._fullLayout;
+
+    fullLayout._glcanvas.each(function(d) {
         if(d.regl) return;
+        // only parcoords needs pick layer
+        if(d.pick && !fullLayout._has('parcoords')) return;
 
         d.regl = createRegl({
             canvas: this,

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -8,7 +8,7 @@ var ScatterGl = require('@src/traces/scattergl');
 
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
-var fail = require('../assets/fail_test');
+var failTest = require('../assets/fail_test');
 var mouseEvent = require('../assets/mouse_event');
 var touchEvent = require('../assets/touch_event');
 var drag = require('../assets/drag');
@@ -202,7 +202,7 @@ describe('@gl Test gl plot side effects', function() {
         .then(function() {
             expect(gd.querySelector('.gl-canvas-context').width).toBe(300);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 });
@@ -350,7 +350,7 @@ describe('@gl Test gl2d plots', function() {
                 'yaxis.range[1]': jasmine.any(Number)
             }));
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -381,7 +381,7 @@ describe('@gl Test gl2d plots', function() {
         .then(function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 108, 100)[0]).not.toBe(0);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -423,7 +423,7 @@ describe('@gl Test gl2d plots', function() {
             expect(scene.error2d.draw).toHaveBeenCalledTimes(2, 'twice for x AND y');
             expect(scene.scatter2d.draw).toHaveBeenCalledTimes(3, 'both traces have markers');
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -451,7 +451,7 @@ describe('@gl Test gl2d plots', function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 158, 100)[3]).not.toBe(0);
             expect(readPixel(gd.querySelector('.gl-canvas-focus'), 168, 100)[3]).not.toBe(0);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -490,7 +490,7 @@ describe('@gl Test gl2d plots', function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 158, 100)[3]).not.toBe(0);
             expect(readPixel(gd.querySelector('.gl-canvas-focus'), 168, 100)[3]).not.toBe(0);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -514,7 +514,7 @@ describe('@gl Test gl2d plots', function() {
             expect(countCanvases()).toBe(0);
             expect(d3.selectAll('.scatterlayer > .trace').size()).toBe(1);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -567,7 +567,7 @@ describe('@gl Test gl2d plots', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray([6, 8], 3);
             expect(gd.layout.yaxis.range).toBeCloseToArray([5, 7], 3);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -634,7 +634,7 @@ describe('@gl Test gl2d plots', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray([-8.2, 24.2], 1);
             expect(gd.layout.yaxis.range).toBeCloseToArray([-0.12, 16.1], 1);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -690,7 +690,7 @@ describe('@gl Test gl2d plots', function() {
         .then(function() {
             assertAnnotation([327, 331]);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -744,7 +744,7 @@ describe('@gl Test gl2d plots', function() {
             expect(relayoutCallback).toHaveBeenCalledTimes(1);
 
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -768,7 +768,7 @@ describe('@gl Test gl2d plots', function() {
         .then(function() {
             expect(ScatterGl.calc).toHaveBeenCalledTimes(2);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -852,7 +852,7 @@ describe('@gl Test gl2d plots', function() {
             expect(scene.selectBatch).toBe(null, msg);
             expect(scene.unselectBatch).toBe(null, msg);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -869,7 +869,7 @@ describe('@gl Test gl2d plots', function() {
         .then(function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 100, 80)[0]).toBe(0);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -914,7 +914,7 @@ describe('@gl Test gl2d plots', function() {
             // and 105545275 after.
             expect(total).toBeGreaterThan(4e6);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 
@@ -945,7 +945,7 @@ describe('@gl Test gl2d plots', function() {
             expect(opts.positions)
                 .toBeCloseToArray([1, 1, 2, 2, 3, 1]);
         })
-        .catch(fail)
+        .catch(failTest)
         .then(done);
     });
 });
@@ -987,7 +987,7 @@ describe('Test scattergl autorange:', function() {
                     expect(gd._fullLayout.xaxis.range).toBeCloseToArray(glRangeX, 'x range');
                     expect(gd._fullLayout.yaxis.range).toBeCloseToArray(glRangeY, 'y range');
                 })
-                .catch(fail)
+                .catch(failTest)
                 .then(done);
             });
         });
@@ -1026,7 +1026,7 @@ describe('Test scattergl autorange:', function() {
                 expect(gd._fullLayout.xaxis.range).toBeCloseToArray([-0.079, 1.079], 2, 'x range');
                 expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-0.105, 1.105], 2, 'y range');
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
 
@@ -1044,7 +1044,7 @@ describe('Test scattergl autorange:', function() {
                 expect(gd._fullLayout.xaxis.range).toBeCloseToArray([-0.119, 1.119], 2, 'x range');
                 expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-0.199, 1.199], 2, 'y range');
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
     });

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -949,7 +949,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should create two WebGL context per graph', function(done) {
+    it('should create two WebGL contexts per graph', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl2d_stacked_subplots.json'));
 
         Plotly.plot(gd, fig).then(function() {

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -948,6 +948,20 @@ describe('@gl Test gl2d plots', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('should create two WebGL context per graph', function(done) {
+        var fig = Lib.extendDeep({}, require('@mocks/gl2d_stacked_subplots.json'));
+
+        Plotly.plot(gd, fig).then(function() {
+            var cnt = 0;
+            d3.select(gd).selectAll('canvas').each(function(d) {
+                if(d.regl) cnt++;
+            });
+            expect(cnt).toBe(2);
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('Test scattergl autorange:', function() {

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -770,8 +770,8 @@ describe('@gl parcoords Lifecycle methods', function() {
 });
 
 describe('@gl parcoords basic use', function() {
-    var mockCopy,
-        gd;
+    var mockCopy;
+    var gd;
 
     beforeEach(function(done) {
         mockCopy = Lib.extendDeep({}, mock);
@@ -788,6 +788,14 @@ describe('@gl parcoords basic use', function() {
     });
 
     afterAll(purgeGraphDiv);
+
+    it('should create three WebGL context per graph', function() {
+        var cnt = 0;
+        d3.select(gd).selectAll('canvas').each(function(d) {
+            if(d.regl) cnt++;
+        });
+        expect(cnt).toBe(3);
+    });
 
     it('`Plotly.plot` should have proper fields on `gd.data` on initial rendering', function() {
 

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -789,7 +789,7 @@ describe('@gl parcoords basic use', function() {
 
     afterAll(purgeGraphDiv);
 
-    it('should create three WebGL context per graph', function() {
+    it('should create three WebGL contexts per graph', function() {
         var cnt = 0;
         d3.select(gd).selectAll('canvas').each(function(d) {
             if(d.regl) cnt++;


### PR DESCRIPTION
As described in https://github.com/plotly/plotly.js/issues/2614, starting in version 1.36.0 all regl based graphs created 3 WebGL contexts (one for each [canvas layer](https://github.com/plotly/plotly.js/blob/dfb56d3a7b99ecf979365ed9b9c2c40747cdd915/src/plot_api/plot_api.js#L212-L224)). But one of these layer (the _pick_ layer) is only used in parcoords traces, so we can create two contexts instead of three on scattergl and splom graphs. 

Why did this happen? I got sloppy in commit https://github.com/plotly/plotly.js/pull/2505/commits/469e4cdb2a045d57ca5e062cd01444a3756f5fd0 where I failed to bring [this `d.pick` check](https://github.com/plotly/plotly.js/commit/469e4cdb2a045d57ca5e062cd01444a3756f5fd0#diff-e03c5a2a46f9392088513c32645ea9d5L341) into `prepareRegl`.

Reducing the number of WebGL context created does two things:

- allows more scattergl/splom graphs to be displayed on a given page before hitting the browsers' WebGL context limit (= 16 on recent Chrome versions)
- speed up first render benchmarks by ~40ms, which is significant (> 15%) on graphs with 1e5 points or less.

cc @alexcjohnson @dy 