### PR TITLE
Fix select <-> pan double-click behavior

### DIFF
--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -144,98 +144,100 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     var dragOptions = {
         element: dragger,
         gd: gd,
-        plotinfo: plotinfo,
-        prepFn: function(e, startX, startY) {
-            var dragModeNow = gd._fullLayout.dragmode;
+        plotinfo: plotinfo
+    };
 
-            recomputeAxisLists();
+    dragOptions.prepFn = function(e, startX, startY) {
+        var dragModeNow = gd._fullLayout.dragmode;
 
-            if(!allFixedRanges) {
-                if(isMainDrag) {
-                    // main dragger handles all drag modes, and changes
-                    // to pan (or to zoom if it already is pan) on shift
-                    if(e.shiftKey) {
-                        if(dragModeNow === 'pan') dragModeNow = 'zoom';
-                        else if(!isSelectOrLasso(dragModeNow)) dragModeNow = 'pan';
-                    }
-                    else if(e.ctrlKey) {
-                        dragModeNow = 'pan';
-                    }
-                }
-                // all other draggers just pan
-                else dragModeNow = 'pan';
-            }
+        recomputeAxisLists();
 
-            if(dragModeNow === 'lasso') dragOptions.minDrag = 1;
-            else dragOptions.minDrag = undefined;
-
-            if(isSelectOrLasso(dragModeNow)) {
-                dragOptions.xaxes = xaxes;
-                dragOptions.yaxes = yaxes;
-                prepSelect(e, startX, startY, dragOptions, dragModeNow);
-            }
-            else if(allFixedRanges) {
-                clearSelect(zoomlayer);
-            }
-            else if(dragModeNow === 'zoom') {
-                dragOptions.moveFn = zoomMove;
-                dragOptions.doneFn = zoomDone;
-
-                // zoomMove takes care of the threshold, but we need to
-                // minimize this so that constrained zoom boxes will flip
-                // orientation at the right place
-                dragOptions.minDrag = 1;
-
-                zoomPrep(e, startX, startY);
-            }
-            else if(dragModeNow === 'pan') {
-                dragOptions.moveFn = plotDrag;
-                dragOptions.doneFn = dragTail;
-                clearSelect(zoomlayer);
-            }
-        },
-        clickFn: function(numClicks, evt) {
-            removeZoombox(gd);
-
-            if(numClicks === 2 && !singleEnd) doubleClick();
-
+        if(!allFixedRanges) {
             if(isMainDrag) {
-                Fx.click(gd, evt, plotinfo.id);
+                // main dragger handles all drag modes, and changes
+                // to pan (or to zoom if it already is pan) on shift
+                if(e.shiftKey) {
+                    if(dragModeNow === 'pan') dragModeNow = 'zoom';
+                    else if(!isSelectOrLasso(dragModeNow)) dragModeNow = 'pan';
+                }
+                else if(e.ctrlKey) {
+                    dragModeNow = 'pan';
+                }
             }
-            else if(numClicks === 1 && singleEnd) {
-                var ax = ns ? ya0 : xa0,
-                    end = (ns === 's' || ew === 'w') ? 0 : 1,
-                    attrStr = ax._name + '.range[' + end + ']',
-                    initialText = getEndText(ax, end),
-                    hAlign = 'left',
-                    vAlign = 'middle';
+            // all other draggers just pan
+            else dragModeNow = 'pan';
+        }
 
-                if(ax.fixedrange) return;
+        if(dragModeNow === 'lasso') dragOptions.minDrag = 1;
+        else dragOptions.minDrag = undefined;
 
-                if(ns) {
-                    vAlign = (ns === 'n') ? 'top' : 'bottom';
-                    if(ax.side === 'right') hAlign = 'right';
-                }
-                else if(ew === 'e') hAlign = 'right';
+        if(isSelectOrLasso(dragModeNow)) {
+            dragOptions.xaxes = xaxes;
+            dragOptions.yaxes = yaxes;
+            prepSelect(e, startX, startY, dragOptions, dragModeNow);
+        }
+        else if(allFixedRanges) {
+            clearSelect(zoomlayer);
+        }
+        else if(dragModeNow === 'zoom') {
+            dragOptions.moveFn = zoomMove;
+            dragOptions.doneFn = zoomDone;
 
-                if(gd._context.showAxisRangeEntryBoxes) {
-                    d3.select(dragger)
-                        .call(svgTextUtils.makeEditable, {
-                            gd: gd,
-                            immediate: true,
-                            background: gd._fullLayout.paper_bgcolor,
-                            text: String(initialText),
-                            fill: ax.tickfont ? ax.tickfont.color : '#444',
-                            horizontalAlign: hAlign,
-                            verticalAlign: vAlign
-                        })
-                        .on('edit', function(text) {
-                            var v = ax.d2r(text);
-                            if(v !== undefined) {
-                                Registry.call('relayout', gd, attrStr, v);
-                            }
-                        });
-                }
+            // zoomMove takes care of the threshold, but we need to
+            // minimize this so that constrained zoom boxes will flip
+            // orientation at the right place
+            dragOptions.minDrag = 1;
+
+            zoomPrep(e, startX, startY);
+        }
+        else if(dragModeNow === 'pan') {
+            dragOptions.moveFn = plotDrag;
+            dragOptions.doneFn = dragTail;
+            clearSelect(zoomlayer);
+        }
+    };
+
+    dragOptions.clickFn = function(numClicks, evt) {
+        removeZoombox(gd);
+
+        if(numClicks === 2 && !singleEnd) doubleClick();
+
+        if(isMainDrag) {
+            Fx.click(gd, evt, plotinfo.id);
+        }
+        else if(numClicks === 1 && singleEnd) {
+            var ax = ns ? ya0 : xa0,
+                end = (ns === 's' || ew === 'w') ? 0 : 1,
+                attrStr = ax._name + '.range[' + end + ']',
+                initialText = getEndText(ax, end),
+                hAlign = 'left',
+                vAlign = 'middle';
+
+            if(ax.fixedrange) return;
+
+            if(ns) {
+                vAlign = (ns === 'n') ? 'top' : 'bottom';
+                if(ax.side === 'right') hAlign = 'right';
+            }
+            else if(ew === 'e') hAlign = 'right';
+
+            if(gd._context.showAxisRangeEntryBoxes) {
+                d3.select(dragger)
+                    .call(svgTextUtils.makeEditable, {
+                        gd: gd,
+                        immediate: true,
+                        background: gd._fullLayout.paper_bgcolor,
+                        text: String(initialText),
+                        fill: ax.tickfont ? ax.tickfont.color : '#444',
+                        horizontalAlign: hAlign,
+                        verticalAlign: vAlign
+                    })
+                    .on('edit', function(text) {
+                        var v = ax.d2r(text);
+                        if(v !== undefined) {
+                            Registry.call('relayout', gd, attrStr, v);
+                        }
+                    });
             }
         }
     };

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -174,30 +174,32 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         if(isSelectOrLasso(dragModeNow)) {
             dragOptions.xaxes = xaxes;
             dragOptions.yaxes = yaxes;
+            // this attaches moveFn, clickFn, doneFn on dragOptions
             prepSelect(e, startX, startY, dragOptions, dragModeNow);
-        }
-        else if(allFixedRanges) {
-            clearSelect(zoomlayer);
-        }
-        else if(dragModeNow === 'zoom') {
-            dragOptions.moveFn = zoomMove;
-            dragOptions.doneFn = zoomDone;
+        } else {
+            dragOptions.clickFn = clickFn;
 
-            // zoomMove takes care of the threshold, but we need to
-            // minimize this so that constrained zoom boxes will flip
-            // orientation at the right place
-            dragOptions.minDrag = 1;
+            if(allFixedRanges) {
+                clearSelect(zoomlayer);
+            } else if(dragModeNow === 'zoom') {
+                dragOptions.moveFn = zoomMove;
+                dragOptions.doneFn = zoomDone;
 
-            zoomPrep(e, startX, startY);
-        }
-        else if(dragModeNow === 'pan') {
-            dragOptions.moveFn = plotDrag;
-            dragOptions.doneFn = dragTail;
-            clearSelect(zoomlayer);
+                // zoomMove takes care of the threshold, but we need to
+                // minimize this so that constrained zoom boxes will flip
+                // orientation at the right place
+                dragOptions.minDrag = 1;
+
+                zoomPrep(e, startX, startY);
+            } else if(dragModeNow === 'pan') {
+                dragOptions.moveFn = plotDrag;
+                dragOptions.doneFn = dragTail;
+                clearSelect(zoomlayer);
+            }
         }
     };
 
-    dragOptions.clickFn = function(numClicks, evt) {
+    function clickFn(numClicks, evt) {
         removeZoombox(gd);
 
         if(numClicks === 2 && !singleEnd) doubleClick();
@@ -240,7 +242,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                     });
             }
         }
-    };
+    }
 
     dragElement.init(dragOptions);
 


### PR DESCRIPTION
Commit https://github.com/plotly/plotly.js/commit/20820cb70c4879c91e8ade621c829f1b5ac4c069 fixes https://github.com/plotly/plotly.js/issues/2667 which has been broken since https://github.com/plotly/plotly.js/pull/2527/commits/bb022818e7fe6c2c808ad440a633558398853325 (from one of the splom perf PRs) where drag handlers are no-longer reintialized when relayout'ing `dragmode`.

cc @alexcjohnson 