### PR TITLE
Bump regl to 1.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9619,9 +9619,9 @@
       "dev": true
     },
     "regl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.1.tgz",
-      "integrity": "sha1-KZXmOnmExSDvLaD28QJ/cFEzgUA="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.6.tgz",
+      "integrity": "sha512-9VdMFKJodSpjLS+bH8i4e+6cmtXGyRS6S06kKM8no5+EzTzqgm9VXjvIXFan99LRSC/zx7w3hnaVCAjspgai7w=="
     },
     "regl-error2d": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ndarray-ops": "^1.2.2",
     "point-cluster": "^3.1.4",
     "polybooljs": "^1.2.0",
-    "regl": "^1.3.1",
+    "regl": "^1.3.6",
     "regl-error2d": "^2.0.5",
     "regl-line2d": "^3.0.9",
     "regl-scatter2d": "^3.0.4",


### PR DESCRIPTION
PR https://github.com/regl-project/regl/pull/479 merged in several browser-dependent fixes to regl (that we used for scattergl, splom and parcoords traces). 

This PR doesn't resolve any open plotly.js issue, but might fix a few unreported browser-dependent issues.

cc @dy 