### PR TITLE
Plots.resize - additional check for gd.layout

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -90,7 +90,7 @@ plots.resize = function(gd) {
 
         gd._redrawTimer = setTimeout(function() {
             // return if there is nothing to resize
-            if(gd.layout.width && gd.layout.height) {
+            if(gd.layout && gd.layout.width && gd.layout.height) {
                 resolve(gd);
                 return;
             }

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -89,8 +89,8 @@ plots.resize = function(gd) {
         if(gd._redrawTimer) clearTimeout(gd._redrawTimer);
 
         gd._redrawTimer = setTimeout(function() {
-            // return if there is nothing to resize
-            if(gd.layout && gd.layout.width && gd.layout.height) {
+            // return if there is nothing to resize or is hidden
+            if(!gd.layout || (gd.layout.width && gd.layout.height) || isHidden(gd)) {
                 resolve(gd);
                 return;
             }

--- a/test/jasmine/tests/plot_promise_test.js
+++ b/test/jasmine/tests/plot_promise_test.js
@@ -2,7 +2,7 @@ var Plotly = require('@lib/index');
 var Events = require('@src/lib/events');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
-
+var failTest = require('../assets/fail_test');
 
 describe('Plotly.___ methods', function() {
     'use strict';
@@ -468,7 +468,9 @@ describe('Plotly.___ methods', function() {
                 expect(gd).toBeDefined();
                 expect(typeof gd).toBe('object');
                 expect(gd.layout).toBeDefined();
-            }).then(done);
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('should return a rejected promise if gd is hidden', function(done) {
@@ -478,7 +480,9 @@ describe('Plotly.___ methods', function() {
             }, function(err) {
                 expect(err).toBeDefined();
                 expect(err.message).toBe('Resize must be passed a displayed plot div element.');
-            }).then(done);
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('should return a rejected promise if gd is detached from the DOM', function(done) {
@@ -488,7 +492,30 @@ describe('Plotly.___ methods', function() {
             }, function(err) {
                 expect(err).toBeDefined();
                 expect(err.message).toBe('Resize must be passed a displayed plot div element.');
-            }).then(done);
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
+        it('should return a resolved promise if plot has been purged and there is nothing to resize', function(done) {
+            var resizePromise = Plotly.Plots.resize(initialDiv);
+
+            Plotly.purge(initialDiv);
+            destroyGraphDiv();
+
+            resizePromise
+                .catch(failTest)
+                .then(done);
+        });
+
+        it('should return a resolved promise if plot has been hidden and gd is hidden', function(done) {
+            var resizePromise = Plotly.Plots.resize(initialDiv);
+
+            initialDiv.style.display = 'none';
+
+            resizePromise
+                .catch(failTest)
+                .then(done);
         });
 
         it('errors before even generating a promise if gd is not defined', function() {


### PR DESCRIPTION
While working with `plotly` & `react-plotly`, from time to time I could notice minor error in my console:

```
Uncaught TypeError: Cannot read property 'width' of undefined
```

First, I thought the error is somewhere on my side but later it was clear it was inside `plotly` library. I backtracked the error and ended up here:

```js
if(gd.layout.width && gd.layout.height)
```

=> https://github.com/plotly/plotly.js/blob/master/src/plots/plots.js#L75-L113

Reproducing it was possible by changing my routes faster than usual – not waiting for plotly to finish rendering charts – chaos monkey style. Apparently when you delete DOM node from your HTML, `gd` variables still holds the reference to the element which doesn't exist anymore. In that case if you try to call `gd.layout.width/height` it will throw an error because `layout` is `undefined`.

### How to reproduce it:
- `npm start`
- open JS console and type:
```js
gd.layout
=> {updatemenus: Array(18), xaxis: {…}, yaxis: {…}, height: 450, width: 1100, …}
```
- remove `gd` element:
```js
gd.parentElement.removeChild(gd)
```
- try to call it again:
```js
gd.layout
=> undefined
```

If you call `gd`, it still points to `#graph`: 
```js
gd
=> <div class="dashboard-plot" id="graph"></div>
```