### PR TITLE
Fix mapbox layout layer updates

### DIFF
--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -39,8 +39,9 @@ proto.update = function update(opts) {
         this.updateLayer(opts);
     } else if(this.needsNewSource(opts)) {
         // IMPORTANT: must delete layer before source to not cause errors
-        this.updateLayer(opts);
+        this.removeLayer();
         this.updateSource(opts);
+        this.updateLayer(opts);
     } else if(this.needsNewLayer(opts)) {
         this.updateLayer(opts);
     } else {
@@ -87,8 +88,7 @@ proto.updateLayer = function(opts) {
     var map = this.map;
     var convertedOpts = convertOpts(opts);
 
-    if(map.getLayer(this.idLayer)) map.removeLayer(this.idLayer);
-
+    this.removeLayer();
     this.layerType = opts.type;
 
     if(isVisible(opts)) {
@@ -108,6 +108,13 @@ proto.updateStyle = function(opts) {
         var convertedOpts = convertOpts(opts);
         this.mapbox.setOptions(this.idLayer, 'setLayoutProperty', convertedOpts.layout);
         this.mapbox.setOptions(this.idLayer, 'setPaintProperty', convertedOpts.paint);
+    }
+};
+
+proto.removeLayer = function() {
+    var map = this.map;
+    if(map.getLayer(this.idLayer)) {
+        map.removeLayer(this.idLayer);
     }
 };
 

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -674,6 +674,56 @@ describe('@noCI, mapbox plots', function() {
         .then(done);
     }, LONG_TIMEOUT_INTERVAL);
 
+    it('should be able to react to layer changes', function(done) {
+        function makeFigure(color) {
+            return {
+                data: [{type: 'scattermapbox'}],
+                layout: {
+                    mapbox: {
+                        layers: [{
+                            color: color,
+                            sourcetype: 'geojson',
+                            type: 'fill',
+                            source: {
+                                type: 'Feature',
+                                properties: {},
+                                geometry: {
+                                    type: 'Polygon',
+                                    coordinates: [[
+                                        [174.74475860595703, -36.86533886128865],
+                                        [174.77737426757812, -36.86533886128865],
+                                        [174.77737426757812, -36.84913134182603],
+                                        [174.74475860595703, -36.84913134182603],
+                                        [174.74475860595703, -36.86533886128865]
+                                    ]]
+                                }
+                            }
+                        }]
+                    }
+                }
+            };
+        }
+
+        function _assert(color) {
+            var mapInfo = getMapInfo(gd);
+            var layer = mapInfo.layers[mapInfo.layoutLayers[0]];
+
+            expect(mapInfo.layoutLayers.length).toBe(1, 'one layer');
+            expect(mapInfo.layoutSources.length).toBe(1, 'one layer source');
+            expect(String(layer.paint._values['fill-color'].value.value)).toBe(color, 'layer color');
+        }
+
+        Plotly.react(gd, makeFigure('blue')).then(function() {
+            _assert('rgba(0,0,255,1)');
+            return Plotly.react(gd, makeFigure('red'));
+        })
+        .then(function() {
+            _assert('rgba(255,0,0,1)');
+        })
+        .catch(failTest)
+        .then(done);
+    }, LONG_TIMEOUT_INTERVAL);
+
     it('should be able to update the access token', function(done) {
         Plotly.relayout(gd, 'mapbox.accesstoken', 'wont-work').catch(function(err) {
             expect(gd._fullLayout.mapbox.accesstoken).toEqual('wont-work');


### PR DESCRIPTION
- when a new source is given, remove layer, update source and add new layer in that order to avoid mapbox-gl errors.

Some more info about how mapbox layout layers are updated:

These are the available update pathways:

https://github.com/plotly/plotly.js/blob/27c77c11f2eab9cf773543926938743d2eb2b0fc/src/plots/mapbox/layers.js#L35-L51

where `needsNewSource` is fairly dumb (but fast):

https://github.com/plotly/plotly.js/blob/27c77c11f2eab9cf773543926938743d2eb2b0fc/src/plots/mapbox/layers.js#L53-L62

which explains why 

```js
// new source object on each react
function makeFigure() {
  return {
    // ...
   layout: {
      mapbox: {
        layers: [{source: {/**/}}]
      }
   }
  }
}

Plotly.react(gd, makeFigure())
Plotly.react(gd, makeFigure())
```

can behave differently than

```js
// same source object
var source = {/* */}

function makeFigure() {
  return {
    // ...
   layout: {
      mapbox: {
        layers: [{source: source}]
      }
   }
  }
}

Plotly.react(gd, makeFigure())
Plotly.react(gd, makeFigure())
```

So perhaps we could add `uid` attribute in each mapbox layer so that users that create a new source object on each react call can see their map update faster. Thoughts?

cc @alexcjohnson

