### PR TITLE
Sanitize margin after 'autosize' relayouts

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -345,6 +345,7 @@ plots.supplyDefaults = function(gd, opts) {
 
         if(!newLayout.width) newFullLayout.width = oldWidth;
         if(!newLayout.height) newFullLayout.height = oldHeight;
+        plots.sanitizeMargins(newFullLayout);
     }
     else {
 
@@ -357,7 +358,7 @@ plots.supplyDefaults = function(gd, opts) {
             initialAutoSize = missingWidthOrHeight && (autosize || autosizable);
 
         if(initialAutoSize) plots.plotAutoSize(gd, newLayout, newFullLayout);
-        else if(missingWidthOrHeight) plots.sanitizeMargins(gd);
+        else if(missingWidthOrHeight) plots.sanitizeMargins(newFullLayout);
 
         // for backwards-compatibility with Plotly v1.x.x
         if(!autosize && missingWidthOrHeight) {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/2663 (aka the react-plotly.js issue that resulted in negative svg mesures)

There's probably a _better_ fix out there, but our autosize logic is such a mess that I was happy with this here. I hope @alexcjohnson will agree.