### PR TITLE
Fix x-only zoom moves when `xaxis.fixedrange: true`

### DIFF
--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -331,10 +331,9 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         // look for small drags in one direction or the other,
         // and only drag the other axis
         else if(!yActive || dy < Math.min(Math.max(dx * 0.6, MINDRAG), MINZOOM)) {
-            if(dx < MINDRAG) {
+            if(dx < MINDRAG || !xActive) {
                 noZoom();
-            }
-            else {
+            } else {
                 box.t = 0;
                 box.b = ph;
                 zoomMode = 'x';


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/2748

Now zooming on `12.json` with `Plotly.relayout(gd,'xaxis.fixedrange',true)` gives

![peek 2018-07-04 18-00](https://user-images.githubusercontent.com/6675409/42295025-4475a078-7fb4-11e8-834a-b81edfdf8a6c.gif)

cc @alexcjohnson 
