### PR TITLE
Use @etpinard/gl-text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,69 @@
         "acorn": "5.4.1"
       }
     },
+    "@etpinard/gl-text": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@etpinard/gl-text/-/gl-text-1.1.6.tgz",
+      "integrity": "sha512-sN007FwlqdSKJt2/cnGZu3jsAN7G4R/wxk/D6ZivPuQtrwJ42B68iuAqysJPgFepUTAsDRtGAOd1U7tZxfDJwA==",
+      "requires": {
+        "color-normalize": "1.1.0",
+        "css-font": "1.2.0",
+        "detect-kerning": "2.1.2",
+        "es6-weak-map": "2.0.2",
+        "flatten-vertex-data": "1.0.2",
+        "font-atlas": "2.1.0",
+        "font-measure": "1.2.2",
+        "gl-util": "3.0.8",
+        "is-plain-obj": "1.1.0",
+        "object-assign": "4.1.1",
+        "parse-rect": "1.2.0",
+        "parse-unit": "1.0.1",
+        "pick-by-alias": "1.2.0",
+        "regl": "1.3.6",
+        "to-px": "1.0.1",
+        "typedarray-pool": "1.1.0"
+      },
+      "dependencies": {
+        "color-normalize": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.1.0.tgz",
+          "integrity": "sha512-OY+unS2qneabd/72V0VLfwxQHvJ1t3JxM8d7LBPBwaVeda4vbrKuKRgtR1ieuIUdnXN7mWTg8FrrQMmsG7xd3w==",
+          "requires": {
+            "clamp": "1.0.1",
+            "color-rgba": "2.1.0",
+            "dtype": "2.0.0"
+          }
+        },
+        "color-parse": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.7.tgz",
+          "integrity": "sha512-8G6rPfyTZhWYKU7D2hwywTjA4YlqX/Z7ClqTEzh5ENc5QkLOff0u8EuyNZR6xScEBhWpAyiDrrVGNUE/Btg2LA==",
+          "requires": {
+            "color-name": "1.1.3",
+            "defined": "1.0.0",
+            "is-plain-obj": "1.1.0"
+          }
+        },
+        "color-rgba": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.0.tgz",
+          "integrity": "sha512-yAmMouVOLRAtYJwP52qymiscIMpw2g7VO82pkW+a88BpW1AZ+O6JDxAAojLljGO0pQkkvZLLN9oQNTEgT+RFiw==",
+          "requires": {
+            "clamp": "1.0.1",
+            "color-parse": "1.3.7",
+            "color-space": "1.15.0"
+          }
+        },
+        "flatten-vertex-data": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
+          "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
+          "requires": {
+            "dtype": "2.0.0"
+          }
+        }
+      }
+    },
     "@mapbox/geojson-area": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
@@ -5125,70 +5188,6 @@
         "ndarray-scratch": "1.2.0",
         "surface-nets": "1.0.2",
         "typedarray-pool": "1.1.0"
-      }
-    },
-    "gl-text": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.5.tgz",
-      "integrity": "sha512-vb6WKUUT+90Zy0SeqI1dNcOYw7kMIBCwE5d+8qjDoKWrwHapR3ADbZQ/ohHKEMum1h8jZxoypgE1BCBPOX3x8g==",
-      "requires": {
-        "bit-twiddle": "1.0.2",
-        "color-normalize": "1.1.0",
-        "css-font": "1.2.0",
-        "detect-kerning": "2.1.2",
-        "es6-weak-map": "2.0.2",
-        "flatten-vertex-data": "1.0.2",
-        "font-atlas": "2.1.0",
-        "font-measure": "1.2.2",
-        "gl-util": "3.0.8",
-        "is-plain-obj": "1.1.0",
-        "object-assign": "4.1.1",
-        "parse-rect": "1.2.0",
-        "parse-unit": "1.0.1",
-        "pick-by-alias": "1.2.0",
-        "regl": "1.3.6",
-        "to-px": "1.0.1",
-        "typedarray-pool": "1.1.0"
-      },
-      "dependencies": {
-        "color-normalize": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.1.0.tgz",
-          "integrity": "sha512-OY+unS2qneabd/72V0VLfwxQHvJ1t3JxM8d7LBPBwaVeda4vbrKuKRgtR1ieuIUdnXN7mWTg8FrrQMmsG7xd3w==",
-          "requires": {
-            "clamp": "1.0.1",
-            "color-rgba": "2.1.0",
-            "dtype": "2.0.0"
-          }
-        },
-        "color-parse": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.7.tgz",
-          "integrity": "sha512-8G6rPfyTZhWYKU7D2hwywTjA4YlqX/Z7ClqTEzh5ENc5QkLOff0u8EuyNZR6xScEBhWpAyiDrrVGNUE/Btg2LA==",
-          "requires": {
-            "color-name": "1.1.3",
-            "defined": "1.0.0",
-            "is-plain-obj": "1.1.0"
-          }
-        },
-        "color-rgba": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.0.tgz",
-          "integrity": "sha512-yAmMouVOLRAtYJwP52qymiscIMpw2g7VO82pkW+a88BpW1AZ+O6JDxAAojLljGO0pQkkvZLLN9oQNTEgT+RFiw==",
-          "requires": {
-            "clamp": "1.0.1",
-            "color-parse": "1.3.7",
-            "color-space": "1.15.0"
-          }
-        },
-        "flatten-vertex-data": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
-          "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
-          "requires": {
-            "dtype": "2.0.0"
-          }
-        }
       }
     },
     "gl-texture2d": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "gl-spikes2d": "^1.0.1",
     "gl-surface3d": "^1.3.5",
     "gl-streamtube3d": "^1.0.0",
-    "gl-text": "^1.1.5",
+    "@etpinard/gl-text": "^1.1.6",
     "glslify": "^6.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -13,7 +13,7 @@ var createLine = require('regl-line2d');
 var createError = require('regl-error2d');
 var cluster = require('point-cluster');
 var arrayRange = require('array-range');
-var Text = require('gl-text');
+var Text = require('@etpinard/gl-text');
 
 var Registry = require('../../registry');
 var Lib = require('../../lib');


### PR DESCRIPTION
The `orca graph` command in `tasks/noci_test.sh` is broken at the moment on master. Commit https://github.com/a-vis/gl-text/commit/0205af86cec209b92ddda6fd2dc25d6648055f01 fixes the broken. By the way, orca produces very crisp scattergl text baselines :tada:  

I promised 1.39.0 will be out today and because of https://github.com/a-vis/gl-text/issues/1, I need to do this stupid thing. cc @dy 

