### PR TITLE
Fix box & violin inner parts removal

### DIFF
--- a/src/traces/box/plot.js
+++ b/src/traces/box/plot.js
@@ -102,6 +102,7 @@ function plotBoxAndWhiskers(sel, axes, trace, t) {
 
     var fn;
     if(trace.type === 'box' ||
+        trace.type === 'candlestick' ||
         (trace.type === 'violin' && (trace.box || {}).visible)
     ) {
         fn = Lib.identity;

--- a/src/traces/box/plot.js
+++ b/src/traces/box/plot.js
@@ -292,6 +292,9 @@ function plotBoxMean(sel, axes, trace, t) {
     var bPos = t.bPos;
     var bPosPxOffset = t.bPosPxOffset || 0;
 
+    // to support violin mean lines
+    var mode = trace.boxmean || (trace.meanline || {}).visible;
+
     // to support for one-sided box
     var bdPos0;
     var bdPos1;
@@ -325,14 +328,14 @@ function plotBoxMean(sel, axes, trace, t) {
         if(trace.orientation === 'h') {
             d3.select(this).attr('d',
                 'M' + m + ',' + pos0 + 'V' + pos1 +
-                (trace.boxmean === 'sd' ?
+                (mode === 'sd' ?
                     'm0,0L' + sl + ',' + posc + 'L' + m + ',' + pos0 + 'L' + sh + ',' + posc + 'Z' :
                     '')
             );
         } else {
             d3.select(this).attr('d',
                 'M' + pos0 + ',' + m + 'H' + pos1 +
-                (trace.boxmean === 'sd' ?
+                (mode === 'sd' ?
                     'm0,0L' + posc + ',' + sl + 'L' + pos0 + ',' + m + 'L' + posc + ',' + sh + 'Z' :
                     '')
             );

--- a/src/traces/box/plot.js
+++ b/src/traces/box/plot.js
@@ -100,15 +100,10 @@ function plotBoxAndWhiskers(sel, axes, trace, t) {
         bdPos1 = t.bdPos;
     }
 
-    var fn;
-    if(trace.type === 'box' ||
-        trace.type === 'candlestick' ||
-        (trace.type === 'violin' && (trace.box || {}).visible)
-    ) {
-        fn = Lib.identity;
-    }
-
-    var paths = sel.selectAll('path.box').data(fn || []);
+    var paths = sel.selectAll('path.box').data((
+        trace.type !== 'violin' ||
+        trace.box
+    ) ? Lib.identity : []);
 
     paths.enter().append('path')
         .style('vector-effect', 'non-scaling-stroke')
@@ -307,14 +302,10 @@ function plotBoxMean(sel, axes, trace, t) {
         bdPos1 = t.bdPos;
     }
 
-    var fn;
-    if(trace.type === 'box' && trace.boxmean ||
-        (trace.type === 'violin' && (trace.box || {}).visible && (trace.meanline || {}).visible)
-    ) {
-        fn = Lib.identity;
-    }
-
-    var paths = sel.selectAll('path.mean').data(fn || []);
+    var paths = sel.selectAll('path.mean').data((
+        (trace.type === 'box' && trace.boxmean) ||
+        (trace.type === 'violin' && trace.box && trace.meanline)
+    ) ? Lib.identity : []);
 
     paths.enter().append('path')
         .attr('class', 'mean')

--- a/src/traces/violin/style.js
+++ b/src/traces/violin/style.js
@@ -35,11 +35,17 @@ module.exports = function style(gd, cd) {
             .call(Color.stroke, boxLine.color)
             .call(Color.fill, box.fillcolor);
 
+        var meanLineStyle = {
+            'stroke-width': meanLineWidth + 'px',
+            'stroke-dasharray': (2 * meanLineWidth) + 'px,' + meanLineWidth + 'px'
+        };
+
         sel.selectAll('path.mean')
-            .style({
-                'stroke-width': meanLineWidth + 'px',
-                'stroke-dasharray': (2 * meanLineWidth) + 'px,' + meanLineWidth + 'px'
-            })
+            .style(meanLineStyle)
+            .call(Color.stroke, meanline.color);
+
+        sel.selectAll('path.meanline')
+            .style(meanLineStyle)
             .call(Color.stroke, meanline.color);
 
         stylePoints(sel, trace, gd);

--- a/test/jasmine/tests/box_test.js
+++ b/test/jasmine/tests/box_test.js
@@ -3,6 +3,7 @@ var Lib = require('@src/lib');
 
 var Box = require('@src/traces/box');
 
+var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var failTest = require('../assets/fail_test');
@@ -343,6 +344,57 @@ describe('Box edge cases', function() {
             });
             expect(outliers.length).toBe(1);
             expect(outliers[0].x).toBe(0);
+        })
+        .catch(failTest)
+        .then(done);
+    });
+});
+
+describe('Test box restyle:', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('should be able to add/remove innner parts', function(done) {
+        var fig = Lib.extendDeep({}, require('@mocks/box_plot_jitter.json'));
+        // start with just 1 box
+        delete fig.data[0].boxpoints;
+
+        function _assertOne(msg, exp, trace3, k, query) {
+            expect(trace3.selectAll(query).size())
+                .toBe(exp[k] || 0, k + ' - ' + msg);
+        }
+
+        function _assert(msg, exp) {
+            var trace3 = d3.select(gd).select('.boxlayer > .trace');
+            _assertOne(msg, exp, trace3, 'boxCnt', 'path.box');
+            _assertOne(msg, exp, trace3, 'meanlineCnt', 'path.mean');
+            _assertOne(msg, exp, trace3, 'ptsCnt', 'path.point');
+        }
+
+        Plotly.plot(gd, fig)
+        .then(function() {
+            _assert('base', {boxCnt: 1});
+        })
+        .then(function() { return Plotly.restyle(gd, 'boxmean', true); })
+        .then(function() {
+            _assert('with meanline', {boxCnt: 1, meanlineCnt: 1});
+        })
+        .then(function() { return Plotly.restyle(gd, 'boxmean', 'sd'); })
+        .then(function() {
+            _assert('with mean+sd line', {boxCnt: 1, meanlineCnt: 1});
+        })
+        .then(function() { return Plotly.restyle(gd, 'boxpoints', 'all'); })
+        .then(function() {
+            _assert('with mean+sd line + pts', {boxCnt: 1, meanlineCnt: 1, ptsCnt: 9});
+        })
+        .then(function() { return Plotly.restyle(gd, 'boxmean', false); })
+        .then(function() {
+            _assert('with pts', {boxCnt: 1, ptsCnt: 9});
         })
         .catch(failTest)
         .then(done);

--- a/test/jasmine/tests/violin_test.js
+++ b/test/jasmine/tests/violin_test.js
@@ -7,7 +7,7 @@ var Violin = require('@src/traces/violin');
 var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
-var fail = require('../assets/fail_test');
+var failTest = require('../assets/fail_test');
 var mouseEvent = require('../assets/mouse_event');
 var supplyAllDefaults = require('../assets/supply_defaults');
 
@@ -434,7 +434,7 @@ describe('Test violin hover:', function() {
     }]
     .forEach(function(specs) {
         it('should generate correct hover labels ' + specs.desc, function(done) {
-            run(specs).catch(fail).then(done);
+            run(specs).catch(failTest).then(done);
         });
     });
 
@@ -466,7 +466,7 @@ describe('Test violin hover:', function() {
                 mouseEvent('mousemove', 250, 250);
                 assertViolinHoverLine([299.35, 250, 200.65, 250]);
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
 
@@ -477,7 +477,7 @@ describe('Test violin hover:', function() {
                 mouseEvent('mousemove', 300, 250);
                 assertViolinHoverLine([299.35, 250, 250, 250]);
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
 
@@ -488,7 +488,7 @@ describe('Test violin hover:', function() {
                 mouseEvent('mousemove', 200, 250);
                 assertViolinHoverLine([200.65, 250, 250, 250]);
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
     });


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/2777 and a bunch of other restyle/react bugs introduced in https://github.com/plotly/plotly.js/pull/2579, where the box and violin meanlines and points d3-data-binds assume a clean parent `<g>` and didn't care about clearing parts that should no longer be visible.

cc @alexcjohnson @dmt0