### PR TITLE
Set minify option 'compress' to false to fix mapbox-gl minification

### DIFF
--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -51,7 +51,6 @@ tasks.push(function(cb) {
         standalone: 'Plotly',
         debug: DEV,
         compressAttrs: true,
-        packFlat: true,
         pathToMinBundle: constants.pathToPlotlyDistMin
     }, cb);
 });
@@ -68,7 +67,6 @@ tasks.push(function(cb) {
     _bundle(constants.pathToPlotlyIndex, constants.pathToPlotlyDistWithMeta, {
         standalone: 'Plotly',
         debug: DEV,
-        packFlat: true
     }, function() {
         makeSchema(constants.pathToPlotlyDistWithMeta, constants.pathToSchema)();
         cb();
@@ -82,7 +80,6 @@ constants.partialBundlePaths.forEach(function(pathObj) {
             standalone: 'Plotly',
             debug: DEV,
             compressAttrs: true,
-            packFlat: true,
             pathToMinBundle: pathObj.distMin
         }, cb);
     });

--- a/tasks/cibundle.js
+++ b/tasks/cibundle.js
@@ -17,7 +17,6 @@ _bundle(constants.pathToPlotlyIndex, constants.pathToPlotlyBuild, {
     standalone: 'Plotly',
     debug: true,
     compressAttrs: true,
-    packFlat: true,
     pathToMinBundle: constants.pathToPlotlyDistMin
 });
 

--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -86,13 +86,14 @@ module.exports = {
 
     uglifyOptions: {
         mangle: true,
-        compress: {
-            warnings: false
-        },
+        // the compress flag break mapbox-gl,
+        // TODO find a way to only skip compression on mapbox-gl files
+        compress: false,
         output: {
             beautify: false,
             ascii_only: true
         },
+
         sourceMap: false
     },
 


### PR DESCRIPTION
a very unfortunate fix to https://github.com/plotly/plotly.js/issues/2787, we have a bunch of additional bytes, but at-least mapbox-gl is working.

![image](https://user-images.githubusercontent.com/6675409/42403832-0cc5906c-8152-11e8-8022-0c6e255b4859.png)

cc @alexcjohnson 

Does anyone know a way to skip uglify-js (-es, terser or other uglify-js folks) the `compress` step on only selected files? cc @dy 