### PR TITLE
fix: tooltip misplaced in RTL documents

### DIFF
--- a/src/css/_base.scss
+++ b/src/css/_base.scss
@@ -1,4 +1,5 @@
 &, div {
+    direction: ltr;
     font-family: 'Open Sans', verdana, arial, sans-serif;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
plotly breaks when inserted in a documented with RTL direction

as can be seen here :  

![RTL bug](https://image.ibb.co/hEtX7T/tooltip_misplaced.png)
