### PR TITLE
Better mapbox minification fix

### DIFF
--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -84,19 +84,6 @@ module.exports = {
     testContainerUrl: 'http://localhost:9010/',
     testContainerHome: '/var/www/streambed/image_server/plotly.js',
 
-    uglifyOptions: {
-        mangle: true,
-        // the compress flag break mapbox-gl,
-        // TODO find a way to only skip compression on mapbox-gl files
-        compress: false,
-        output: {
-            beautify: false,
-            ascii_only: true
-        },
-
-        sourceMap: false
-    },
-
     licenseDist: [
         '/**',
         '* plotly.js v' + pkg.version,

--- a/tasks/util/wrap_locale.js
+++ b/tasks/util/wrap_locale.js
@@ -4,8 +4,6 @@ var path = require('path');
 var minify = require('minify-stream');
 var intoStream = require('into-stream');
 
-var constants = require('./constants');
-
 var prefix = 'Plotly.register(';
 var suffix = ');';
 
@@ -25,8 +23,19 @@ module.exports = function wrap_locale(pathToInput, pathToOutput) {
 
         var rawOut = prefix + data.substr(moduleStart, moduleEnd - moduleStart) + suffix;
 
+        var uglifyOptions = {
+            ecma: 5,
+            mangle: true,
+            compress: true,
+            output: {
+                beautify: false,
+                ascii_only: true
+            },
+            sourceMap: false
+        };
+
         intoStream(rawOut)
-            .pipe(minify(constants.uglifyOptions))
+            .pipe(minify(uglifyOptions))
             .pipe(fs.createWriteStream(pathToOutput))
             .on('finish', function() {
                 logger(pathToOutput);

--- a/test/jasmine/bundle_tests/minified_bundle_test.js
+++ b/test/jasmine/bundle_tests/minified_bundle_test.js
@@ -1,0 +1,32 @@
+/* global Plotly:false */
+
+describe('Test plotly.min.js', function() {
+    'use strict';
+
+    // Note: this test doesn't have access to custom_matchers.js
+    // so you can only use standard jasmine matchers here.
+
+    it('should expose Plotly global', function() {
+        expect(window.Plotly).toBeDefined();
+    });
+
+    it('should be able to plot a mapbox plot', function(done) {
+        var gd = document.createElement('div');
+        document.body.appendChild(gd);
+
+        Plotly.plot(gd, [{
+            type: 'scattermapbox',
+            lon: [10, 20, 30],
+            lat: [10, 30, 20]
+        }], {}, {
+            mapboxAccessToken: 'pk.eyJ1IjoiZXRwaW5hcmQiLCJhIjoiY2luMHIzdHE0MGFxNXVubTRxczZ2YmUxaCJ9.hwWZful0U2CQxit4ItNsiQ'
+        })
+        .catch(function() {
+            fail('mapbox plot failed');
+        })
+        .then(function() {
+            document.body.removeChild(gd);
+            done();
+        });
+    });
+});

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -255,6 +255,12 @@ if(isFullSuite) {
             ];
             delete func.defaultConfig.preprocessors[pathToCustomMatchers];
             break;
+        case 'minified_bundle':
+            // browserified custom_matchers doesn't work with this route
+            // so clear them out of the files and preprocessors
+            func.defaultConfig.files = [constants.pathToPlotlyDistMin];
+            delete func.defaultConfig.preprocessors[pathToCustomMatchers];
+            break;
         case 'ie9':
             // load ie9_mock.js before plotly.js+test bundle
             // to catch reference errors that could occur


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/2787, though I wouldn't call it a great fix, but it's probably the best we can do in this repo.

By playing around with [terser's compression options](https://github.com/fabiosantoscode/terser#compress-options) (which is the default minifier in our dev-dep [minify-stream](https://github.com/goto-bus-stop/minify-stream)), I found that setting `typeofs: false` on bundles that include mapbox-gl fixes https://github.com/plotly/plotly.js/pull/2789. Moreover, I added a test to make sure this doesn't happen again.

With this PR our bundle sizes are back to where they were before https://github.com/plotly/plotly.js/pull/2789.