### PR TITLE
Do not clear _glcanvas ref during layout replot edits

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -3265,9 +3265,6 @@ function makePlotFramework(gd) {
     fullLayout._glcontainer.enter().append('div')
         .classed('gl-container', true);
 
-    // That is initialized in drawFramework if there are `gl` traces
-    fullLayout._glcanvas = null;
-
     fullLayout._paperdiv.selectAll('.main-svg').remove();
 
     fullLayout._paper = fullLayout._paperdiv.insert('svg', ':first-child')

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -1033,6 +1033,40 @@ describe('@gl Test gl2d plots', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('@gl should clear canvases on *replot* edits', function(done) {
+        Plotly.plot(gd, [{
+            type: 'scattergl',
+            y: [1, 2, 1]
+        }, {
+            type: 'scattergl',
+            y: [2, 1, 2]
+        }])
+        .then(function() {
+            expect(gd._fullLayout._glcanvas).toBeDefined();
+            expect(gd._fullLayout._glcanvas.size()).toBe(3);
+
+            expect(gd._fullLayout._glcanvas.data()[0].regl).toBeDefined();
+            expect(gd._fullLayout._glcanvas.data()[1].regl).toBeDefined();
+            // this is canvas is for parcoords only
+            expect(gd._fullLayout._glcanvas.data()[2].regl).toBeUndefined();
+
+            spyOn(gd._fullLayout._glcanvas.data()[0].regl, 'clear').and.callThrough();
+            spyOn(gd._fullLayout._glcanvas.data()[1].regl, 'clear').and.callThrough();
+
+            return Plotly.update(gd,
+                {visible: [false]},
+                {'xaxis.title': 'Tsdads', 'yaxis.ditck': 0.2},
+                [0]
+            );
+        })
+        .then(function() {
+            expect(gd._fullLayout._glcanvas.data()[0].regl.clear).toHaveBeenCalledTimes(1);
+            expect(gd._fullLayout._glcanvas.data()[1].regl.clear).toHaveBeenCalledTimes(1);
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('Test scattergl autorange:', function() {


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/2791

Some edits may call `makePlotFramework` in plot_api.js, we can't clear the ref to glcanvas there as we need to properly clear the canvases.

cc @alexcjohnson @dy