### PR TITLE
Do not collapse duplicate end points when `line.simplify: false`

### DIFF
--- a/src/traces/scatter/line_points.js
+++ b/src/traces/scatter/line_points.js
@@ -19,7 +19,6 @@ var constants = require('./constants');
 module.exports = function linePoints(d, opts) {
     var xa = opts.xaxis;
     var ya = opts.yaxis;
-    var simplify = opts.simplify;
     var connectGaps = opts.connectGaps;
     var baseTolerance = opts.baseTolerance;
     var shape = opts.shape;
@@ -53,10 +52,6 @@ module.exports = function linePoints(d, opts) {
 
     // deviation variables are (signed) pixel distances normal to the cluster vector
     var clusterMinDeviation, clusterMaxDeviation, thisDeviation;
-
-    if(!simplify) {
-        baseTolerance = minTolerance = -1;
-    }
 
     // turn one calcdata point into pixel coordinates
     function getPt(index) {
@@ -357,7 +352,7 @@ module.exports = function linePoints(d, opts) {
             // can't decimate if nonlinear line shape
             // TODO: we *could* decimate [hv]{2,3} shapes if we restricted clusters to horz or vert again
             // but spline would be verrry awkward to decimate
-            if(!linear) {
+            if(!linear || !opts.simplify) {
                 addPt(clusterHighPt);
                 continue;
             }

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -345,6 +345,12 @@ describe('Test scatter', function() {
         });
 
         it('should not collapse straight lines if simplify is false', function() {
+            var ptsIn = [[0, 0], [5, 10], [13, 26], [15, 30], [15, 30], [15, 30], [15, 30]];
+            var ptsOut = callLinePoints(ptsIn, {simplify: false});
+            expect(ptsOut).toEqual([ptsIn]);
+        });
+
+        it('should not collapse duplicate end points if simplify is false', function() {
             var ptsIn = [[0, 0], [5, 10], [13, 26], [15, 30], [22, 16], [28, 4], [30, 0]];
             var ptsOut = callLinePoints(ptsIn, {simplify: false});
             expect(ptsOut).toEqual([ptsIn]);


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/2794 by allowing smooth transitions of lines with the same number of coordinates:

![peek 2018-07-13 10-06](https://user-images.githubusercontent.com/6675409/42698851-150d6e9e-868d-11e8-8147-58165c44b8f9.gif)

cc @alexcjohnson 