### PR TITLE
Changes to make redrawObjs work by convention

### DIFF
--- a/src/components/annotations/index.js
+++ b/src/components/annotations/index.js
@@ -15,7 +15,8 @@ var clickModule = require('./click');
 module.exports = {
     moduleType: 'component',
     name: 'annotations',
-
+    isDrawable: true,
+    
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),
     includeBasePlot: require('../../plots/cartesian/include_components')('annotations'),

--- a/src/components/annotations/index.js
+++ b/src/components/annotations/index.js
@@ -16,7 +16,7 @@ module.exports = {
     moduleType: 'component',
     name: 'annotations',
     isDrawable: true,
-    
+
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),
     includeBasePlot: require('../../plots/cartesian/include_components')('annotations'),

--- a/src/components/annotations/index.js
+++ b/src/components/annotations/index.js
@@ -15,7 +15,6 @@ var clickModule = require('./click');
 module.exports = {
     moduleType: 'component',
     name: 'annotations',
-    isDrawable: true,
 
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),
@@ -25,6 +24,7 @@ module.exports = {
     draw: drawModule.draw,
     drawOne: drawModule.drawOne,
     drawRaw: drawModule.drawRaw,
+    updateOnPan: drawModule.drawOne,
 
     hasClickToShow: clickModule.hasClickToShow,
     onClick: clickModule.onClick,

--- a/src/components/images/index.js
+++ b/src/components/images/index.js
@@ -18,8 +18,8 @@ module.exports = {
     supplyLayoutDefaults: require('./defaults'),
     includeBasePlot: require('../../plots/cartesian/include_components')('images'),
 
-    draw: drawModule.draw,
-    updateOnPan: drawModule.draw,
+    draw: drawModule,
+    updateOnPan: drawModule,
 
     convertCoords: require('./convert_coords')
 };

--- a/src/components/images/index.js
+++ b/src/components/images/index.js
@@ -20,7 +20,6 @@ module.exports = {
 
     draw: drawModule.draw,
     updateOnPan: drawModule.draw,
-    updateOnPanShortCircuit: true,
 
     convertCoords: require('./convert_coords')
 };

--- a/src/components/images/index.js
+++ b/src/components/images/index.js
@@ -11,12 +11,14 @@
 module.exports = {
     moduleType: 'component',
     name: 'images',
-
+    isDrawable: true,
+    
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),
     includeBasePlot: require('../../plots/cartesian/include_components')('images'),
 
     draw: require('./draw'),
+    drawOne: require('./draw'),
 
     convertCoords: require('./convert_coords')
 };

--- a/src/components/images/index.js
+++ b/src/components/images/index.js
@@ -8,17 +8,19 @@
 
 'use strict';
 
+var drawModule = require('./draw');
+
 module.exports = {
     moduleType: 'component',
     name: 'images',
-    isDrawable: true,
 
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),
     includeBasePlot: require('../../plots/cartesian/include_components')('images'),
 
-    draw: require('./draw'),
-    drawOne: require('./draw'),
+    draw: drawModule.draw,
+    updateOnPan: drawModule.draw,
+    updateOnPanShortCircuit: true,
 
     convertCoords: require('./convert_coords')
 };

--- a/src/components/images/index.js
+++ b/src/components/images/index.js
@@ -12,7 +12,7 @@ module.exports = {
     moduleType: 'component',
     name: 'images',
     isDrawable: true,
-    
+
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),
     includeBasePlot: require('../../plots/cartesian/include_components')('images'),

--- a/src/components/images/index.js
+++ b/src/components/images/index.js
@@ -20,6 +20,7 @@ module.exports = {
 
     draw: drawModule,
     updateOnPan: drawModule,
+    updateOnPanShortCircuit: true,
 
     convertCoords: require('./convert_coords')
 };

--- a/src/components/shapes/index.js
+++ b/src/components/shapes/index.js
@@ -14,6 +14,7 @@ var drawModule = require('./draw');
 module.exports = {
     moduleType: 'component',
     name: 'shapes',
+    isDrawable: true,
 
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),

--- a/src/components/shapes/index.js
+++ b/src/components/shapes/index.js
@@ -14,7 +14,6 @@ var drawModule = require('./draw');
 module.exports = {
     moduleType: 'component',
     name: 'shapes',
-    isDrawable: true,
 
     layoutAttributes: require('./attributes'),
     supplyLayoutDefaults: require('./defaults'),
@@ -22,5 +21,6 @@ module.exports = {
 
     calcAutorange: require('./calc_autorange'),
     draw: drawModule.draw,
-    drawOne: drawModule.drawOne
+    drawOne: drawModule.drawOne,
+    updateOnPan: drawModule.drawOne
 };

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -617,7 +617,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
         var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'));
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'), item.updateOnPanShortCircuit);
         });
     }
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -617,7 +617,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
         var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'), item.updateOnPanShortCircuit);
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'));
         });
     }
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -613,12 +613,11 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         }
 
         // annotations and shapes 'draw' method is slow,
-        // use the finer-grained 'drawOne' method instead
+        // use the finer-grained 'drawOne' method instead (proxied through updateOnPan)
 
-        var componentsNeedingRedraw = Registry.getModules('component', true);
+        var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            // only issue here is that we cam't short circuit images
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'), item.updateOnPanShortCircuit);
         });
     }
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -616,7 +616,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         // use the finer-grained 'drawOne' method instead
 
         var componentsNeedingRedraw = Registry.getModules('component', true);
-        componentsNeedingRedraw.forEach(function(item){
+        componentsNeedingRedraw.forEach(function(item) {
             // only issue here is that we cam't short circuit images
             redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
         });

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -615,9 +615,11 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         // annotations and shapes 'draw' method is slow,
         // use the finer-grained 'drawOne' method instead
 
-        redrawObjs(gd._fullLayout.annotations || [], Registry.getComponentMethod('annotations', 'drawOne'));
-        redrawObjs(gd._fullLayout.shapes || [], Registry.getComponentMethod('shapes', 'drawOne'));
-        redrawObjs(gd._fullLayout.images || [], Registry.getComponentMethod('images', 'draw'), true);
+        var componentsNeedingRedraw = Registry.getModules('component', true);
+        componentsNeedingRedraw.forEach(function(item){
+            // only issue here is that we cam't short circuit images
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
+        });
     }
 
     function doubleClick() {

--- a/src/plots/cartesian/transition_axes.js
+++ b/src/plots/cartesian/transition_axes.js
@@ -108,10 +108,9 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
             }
         }
 
-        var componentsNeedingRedraw = Registry.getModules('component', true);
+        var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            // only issue here is that we cam't short circuit images
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'), item.updateOnPanShortCircuit);
         });
     }
 
@@ -144,10 +143,9 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
             }
         }
 
-        var componentsNeedingRedraw = Registry.getModules('component', true);
+        var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            // only issue here is that we cam't short circuit images
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'), item.updateOnPanShortCircuit);
         });
     }
 

--- a/src/plots/cartesian/transition_axes.js
+++ b/src/plots/cartesian/transition_axes.js
@@ -108,9 +108,11 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
             }
         }
 
-        redrawObjs(fullLayout.annotations || [], Registry.getComponentMethod('annotations', 'drawOne'));
-        redrawObjs(fullLayout.shapes || [], Registry.getComponentMethod('shapes', 'drawOne'));
-        redrawObjs(fullLayout.images || [], Registry.getComponentMethod('images', 'draw'), true);
+        var componentsNeedingRedraw = Registry.getModules('component', true);
+        componentsNeedingRedraw.forEach(function(item){
+            // only issue here is that we cam't short circuit images
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
+        });
     }
 
     if(!affectedSubplots.length) {
@@ -142,9 +144,11 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
             }
         }
 
-        redrawObjs(fullLayout.annotations || [], Registry.getComponentMethod('annotations', 'drawOne'));
-        redrawObjs(fullLayout.shapes || [], Registry.getComponentMethod('shapes', 'drawOne'));
-        redrawObjs(fullLayout.images || [], Registry.getComponentMethod('images', 'draw'), true);
+        var componentsNeedingRedraw = Registry.getModules('component', true);
+        componentsNeedingRedraw.forEach(function(item){
+            // only issue here is that we cam't short circuit images
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
+        });
     }
 
     function unsetSubplotTransform(subplot) {

--- a/src/plots/cartesian/transition_axes.js
+++ b/src/plots/cartesian/transition_axes.js
@@ -109,7 +109,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
         }
 
         var componentsNeedingRedraw = Registry.getModules('component', true);
-        componentsNeedingRedraw.forEach(function(item){
+        componentsNeedingRedraw.forEach(function(item) {
             // only issue here is that we cam't short circuit images
             redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
         });
@@ -145,7 +145,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
         }
 
         var componentsNeedingRedraw = Registry.getModules('component', true);
-        componentsNeedingRedraw.forEach(function(item){
+        componentsNeedingRedraw.forEach(function(item) {
             // only issue here is that we cam't short circuit images
             redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
         });

--- a/src/plots/cartesian/transition_axes.js
+++ b/src/plots/cartesian/transition_axes.js
@@ -110,7 +110,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
 
         var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'), item.updateOnPanShortCircuit);
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
         });
     }
 
@@ -145,7 +145,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
 
         var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'), item.updateOnPanShortCircuit);
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'));
         });
     }
 

--- a/src/plots/cartesian/transition_axes.js
+++ b/src/plots/cartesian/transition_axes.js
@@ -110,7 +110,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
 
         var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'drawOne'));
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'), item.updateOnPanShortCircuit);
         });
     }
 
@@ -145,7 +145,7 @@ module.exports = function transitionAxes(gd, newLayout, transitionOpts, makeOnCo
 
         var componentsNeedingRedraw = Registry.getUpdateOnPanComponents();
         componentsNeedingRedraw.forEach(function(item) {
-            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'));
+            redrawObjs(gd._fullLayout[item.name] || [], Registry.getComponentMethod(item.name, 'updateOnPan'), item.updateOnPanShortCircuit);
         });
     }
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -72,20 +72,20 @@ exports.apiMethodRegistry = {};
  *
  */
 exports.register = function register(_modules) {
-    if(!_modules) {
+    if (!_modules) {
         throw new Error('No argument passed to Plotly.register.');
-    } else if(_modules && !Array.isArray(_modules)) {
+    } else if (_modules && !Array.isArray(_modules)) {
         _modules = [_modules];
     }
 
-    for(var i = 0; i < _modules.length; i++) {
+    for (var i = 0; i < _modules.length; i++) {
         var newModule = _modules[i];
 
-        if(!newModule) {
+        if (!newModule) {
             throw new Error('Invalid module was attempted to be registered!');
         }
 
-        switch(newModule.moduleType) {
+        switch (newModule.moduleType) {
             case 'trace':
                 registerTraceModule(newModule);
                 break;
@@ -108,6 +108,19 @@ exports.register = function register(_modules) {
     }
 };
 
+exports.getModules = function (type, isDrawable) {
+    var selected = [];
+
+    for (var componentName in exports.componentsRegistry) {
+        var component = exports.componentsRegistry[componentName];
+        if( component.moduleType === type && component.isDrawable && component.isDrawable == isDrawable){
+            selected.push(component);
+        }
+    }
+
+    return selected;
+}
+
 /**
  * Get registered module using trace object or trace type
  *
@@ -116,9 +129,9 @@ exports.register = function register(_modules) {
  * @return {object}
  *  module object corresponding to trace type
  */
-exports.getModule = function(trace) {
+exports.getModule = function (trace) {
     var _module = exports.modules[getTraceType(trace)];
-    if(!_module) return false;
+    if (!_module) return false;
     return _module._module;
 };
 
@@ -131,16 +144,16 @@ exports.getModule = function(trace) {
  *  category in question
  * @return {boolean}
  */
-exports.traceIs = function(traceType, category) {
+exports.traceIs = function (traceType, category) {
     traceType = getTraceType(traceType);
 
     // old plot.ly workspace hack, nothing to see here
-    if(traceType === 'various') return false;
+    if (traceType === 'various') return false;
 
     var _module = exports.modules[traceType];
 
-    if(!_module) {
-        if(traceType && traceType !== 'area') {
+    if (!_module) {
+        if (traceType && traceType !== 'area') {
             Loggers.log('Unrecognized trace type ' + traceType + '.');
         }
 
@@ -161,11 +174,11 @@ exports.traceIs = function(traceType, category) {
  * @return {array}
  *  array of matching indices. If none found, returns []
  */
-exports.getTransformIndices = function(data, type) {
+exports.getTransformIndices = function (data, type) {
     var indices = [];
     var transforms = data.transforms || [];
-    for(var i = 0; i < transforms.length; i++) {
-        if(transforms[i].type === type) {
+    for (var i = 0; i < transforms.length; i++) {
+        if (transforms[i].type === type) {
             indices.push(i);
         }
     }
@@ -181,10 +194,10 @@ exports.getTransformIndices = function(data, type) {
  *  type of trace to test
  * @return {boolean}
  */
-exports.hasTransform = function(data, type) {
+exports.hasTransform = function (data, type) {
     var transforms = data.transforms || [];
-    for(var i = 0; i < transforms.length; i++) {
-        if(transforms[i].type === type) {
+    for (var i = 0; i < transforms.length; i++) {
+        if (transforms[i].type === type) {
             return true;
         }
     }
@@ -201,10 +214,10 @@ exports.hasTransform = function(data, type) {
  *  name of component module method
  * @return {function}
  */
-exports.getComponentMethod = function(name, method) {
+exports.getComponentMethod = function (name, method) {
     var _module = exports.componentsRegistry[name];
 
-    if(!_module) return noop;
+    if (!_module) return noop;
     return _module[method] || noop;
 };
 
@@ -215,7 +228,7 @@ exports.getComponentMethod = function(name, method) {
  * @param {...array} args : arguments passed to api method
  * @return {any} : returns api method output
  */
-exports.call = function() {
+exports.call = function () {
     var name = arguments[0];
     var args = [].slice.call(arguments, 1);
     return exports.apiMethodRegistry[name].apply(null, args);
@@ -226,17 +239,17 @@ function registerTraceModule(_module) {
     var categoriesIn = _module.categories;
     var meta = _module.meta;
 
-    if(exports.modules[thisType]) {
+    if (exports.modules[thisType]) {
         Loggers.log('Type ' + thisType + ' already registered');
         return;
     }
 
-    if(!exports.subplotsRegistry[_module.basePlotModule.name]) {
+    if (!exports.subplotsRegistry[_module.basePlotModule.name]) {
         registerSubplot(_module.basePlotModule);
     }
 
     var categoryObj = {};
-    for(var i = 0; i < categoriesIn.length; i++) {
+    for (var i = 0; i < categoriesIn.length; i++) {
         categoryObj[categoriesIn[i]] = true;
         exports.allCategories[categoriesIn[i]] = true;
     }
@@ -246,13 +259,13 @@ function registerTraceModule(_module) {
         categories: categoryObj
     };
 
-    if(meta && Object.keys(meta).length) {
+    if (meta && Object.keys(meta).length) {
         exports.modules[thisType].meta = meta;
     }
 
     exports.allTypes.push(thisType);
 
-    for(var componentName in exports.componentsRegistry) {
+    for (var componentName in exports.componentsRegistry) {
         mergeComponentAttrsToTrace(componentName, thisType);
     }
 
@@ -261,7 +274,7 @@ function registerTraceModule(_module) {
      * but don't merge them into the base schema as it would confuse the docs
      * (at least after https://github.com/plotly/documentation/issues/202 gets done!)
      */
-    if(_module.layoutAttributes) {
+    if (_module.layoutAttributes) {
         extendFlat(exports.traceLayoutAttributes, _module.layoutAttributes);
     }
 }
@@ -269,7 +282,7 @@ function registerTraceModule(_module) {
 function registerSubplot(_module) {
     var plotType = _module.name;
 
-    if(exports.subplotsRegistry[plotType]) {
+    if (exports.subplotsRegistry[plotType]) {
         Loggers.log('Plot type ' + plotType + ' already registered.');
         return;
     }
@@ -282,45 +295,45 @@ function registerSubplot(_module) {
     // not sure what's best for the 'cartesian' type at this point
     exports.subplotsRegistry[plotType] = _module;
 
-    for(var componentName in exports.componentsRegistry) {
+    for (var componentName in exports.componentsRegistry) {
         mergeComponentAttrsToSubplot(componentName, _module.name);
     }
 }
 
 function registerComponentModule(_module) {
-    if(typeof _module.name !== 'string') {
+    if (typeof _module.name !== 'string') {
         throw new Error('Component module *name* must be a string.');
     }
 
     var name = _module.name;
     exports.componentsRegistry[name] = _module;
 
-    if(_module.layoutAttributes) {
-        if(_module.layoutAttributes._isLinkedToArray) {
+    if (_module.layoutAttributes) {
+        if (_module.layoutAttributes._isLinkedToArray) {
             pushUnique(exports.layoutArrayContainers, name);
         }
         findArrayRegexps(_module);
     }
 
-    for(var traceType in exports.modules) {
+    for (var traceType in exports.modules) {
         mergeComponentAttrsToTrace(name, traceType);
     }
 
-    for(var subplotName in exports.subplotsRegistry) {
+    for (var subplotName in exports.subplotsRegistry) {
         mergeComponentAttrsToSubplot(name, subplotName);
     }
 
-    for(var transformType in exports.transformsRegistry) {
+    for (var transformType in exports.transformsRegistry) {
         mergeComponentAttrsToTransform(name, transformType);
     }
 
-    if(_module.schema && _module.schema.layout) {
+    if (_module.schema && _module.schema.layout) {
         extendDeepAll(baseLayoutAttributes, _module.schema.layout);
     }
 }
 
 function registerTransformModule(_module) {
-    if(typeof _module.name !== 'string') {
+    if (typeof _module.name !== 'string') {
         throw new Error('Transform module *name* must be a string.');
     }
 
@@ -328,26 +341,26 @@ function registerTransformModule(_module) {
     var hasTransform = typeof _module.transform === 'function';
     var hasCalcTransform = typeof _module.calcTransform === 'function';
 
-    if(!hasTransform && !hasCalcTransform) {
+    if (!hasTransform && !hasCalcTransform) {
         throw new Error(prefix + ' is missing a *transform* or *calcTransform* method.');
     }
-    if(hasTransform && hasCalcTransform) {
+    if (hasTransform && hasCalcTransform) {
         Loggers.log([
             prefix + ' has both a *transform* and *calcTransform* methods.',
             'Please note that all *transform* methods are executed',
             'before all *calcTransform* methods.'
         ].join(' '));
     }
-    if(!isPlainObject(_module.attributes)) {
+    if (!isPlainObject(_module.attributes)) {
         Loggers.log(prefix + ' registered without an *attributes* object.');
     }
-    if(typeof _module.supplyDefaults !== 'function') {
+    if (typeof _module.supplyDefaults !== 'function') {
         Loggers.log(prefix + ' registered without a *supplyDefaults* method.');
     }
 
     exports.transformsRegistry[_module.name] = _module;
 
-    for(var componentName in exports.componentsRegistry) {
+    for (var componentName in exports.componentsRegistry) {
         mergeComponentAttrsToTransform(componentName, _module.name);
     }
 }
@@ -364,7 +377,7 @@ function registerLocale(_module) {
     var locales = exports.localeRegistry;
 
     var localeObj = locales[locale];
-    if(!localeObj) locales[locale] = localeObj = {};
+    if (!localeObj) locales[locale] = localeObj = {};
 
     // Should we use this dict for the base locale?
     // In case we're overwriting a previous dict for this locale, check
@@ -372,27 +385,27 @@ function registerLocale(_module) {
     // overwriting, locales[locale] is undefined so this just checks if
     // baseLocale already had a dict or not.
     // Same logic for dateFormats
-    if(baseLocale !== locale) {
+    if (baseLocale !== locale) {
         var baseLocaleObj = locales[baseLocale];
-        if(!baseLocaleObj) locales[baseLocale] = baseLocaleObj = {};
+        if (!baseLocaleObj) locales[baseLocale] = baseLocaleObj = {};
 
-        if(hasDict && baseLocaleObj.dictionary === localeObj.dictionary) {
+        if (hasDict && baseLocaleObj.dictionary === localeObj.dictionary) {
             baseLocaleObj.dictionary = newDict;
         }
-        if(hasFormat && baseLocaleObj.format === localeObj.format) {
+        if (hasFormat && baseLocaleObj.format === localeObj.format) {
             baseLocaleObj.format = newFormat;
         }
     }
 
-    if(hasDict) localeObj.dictionary = newDict;
-    if(hasFormat) localeObj.format = newFormat;
+    if (hasDict) localeObj.dictionary = newDict;
+    if (hasFormat) localeObj.format = newFormat;
 }
 
 function findArrayRegexps(_module) {
-    if(_module.layoutAttributes) {
+    if (_module.layoutAttributes) {
         var arrayAttrRegexps = _module.layoutAttributes._arrayAttrRegexps;
-        if(arrayAttrRegexps) {
-            for(var i = 0; i < arrayAttrRegexps.length; i++) {
+        if (arrayAttrRegexps) {
+            for (var i = 0; i < arrayAttrRegexps.length; i++) {
                 pushUnique(exports.layoutArrayRegexes, arrayAttrRegexps[i]);
             }
         }
@@ -401,40 +414,40 @@ function findArrayRegexps(_module) {
 
 function mergeComponentAttrsToTrace(componentName, traceType) {
     var componentSchema = exports.componentsRegistry[componentName].schema;
-    if(!componentSchema || !componentSchema.traces) return;
+    if (!componentSchema || !componentSchema.traces) return;
 
     var traceAttrs = componentSchema.traces[traceType];
-    if(traceAttrs) {
+    if (traceAttrs) {
         extendDeepAll(exports.modules[traceType]._module.attributes, traceAttrs);
     }
 }
 
 function mergeComponentAttrsToTransform(componentName, transformType) {
     var componentSchema = exports.componentsRegistry[componentName].schema;
-    if(!componentSchema || !componentSchema.transforms) return;
+    if (!componentSchema || !componentSchema.transforms) return;
 
     var transformAttrs = componentSchema.transforms[transformType];
-    if(transformAttrs) {
+    if (transformAttrs) {
         extendDeepAll(exports.transformsRegistry[transformType].attributes, transformAttrs);
     }
 }
 
 function mergeComponentAttrsToSubplot(componentName, subplotName) {
     var componentSchema = exports.componentsRegistry[componentName].schema;
-    if(!componentSchema || !componentSchema.subplots) return;
+    if (!componentSchema || !componentSchema.subplots) return;
 
     var subplotModule = exports.subplotsRegistry[subplotName];
     var subplotAttrs = subplotModule.layoutAttributes;
     var subplotAttr = subplotModule.attr === 'subplot' ? subplotModule.name : subplotModule.attr;
-    if(Array.isArray(subplotAttr)) subplotAttr = subplotAttr[0];
+    if (Array.isArray(subplotAttr)) subplotAttr = subplotAttr[0];
 
     var componentLayoutAttrs = componentSchema.subplots[subplotAttr];
-    if(subplotAttrs && componentLayoutAttrs) {
+    if (subplotAttrs && componentLayoutAttrs) {
         extendDeepAll(subplotAttrs, componentLayoutAttrs);
     }
 }
 
 function getTraceType(traceType) {
-    if(typeof traceType === 'object') traceType = traceType.type;
+    if (typeof traceType === 'object') traceType = traceType.type;
     return traceType;
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -108,12 +108,11 @@ exports.register = function register(_modules) {
     }
 };
 
-exports.getModules = function(type, isDrawable) {
+exports.getUpdateOnPanComponents = function() {
     var selected = [];
-
     for(var componentName in exports.componentsRegistry) {
         var component = exports.componentsRegistry[componentName];
-        if(component.moduleType === type && component.isDrawable && component.isDrawable === isDrawable) {
+        if(component.updateOnPan) {
             selected.push(component);
         }
     }

--- a/src/registry.js
+++ b/src/registry.js
@@ -113,7 +113,7 @@ exports.getModules = function (type, isDrawable) {
 
     for (var componentName in exports.componentsRegistry) {
         var component = exports.componentsRegistry[componentName];
-        if( component.moduleType === type && component.isDrawable && component.isDrawable == isDrawable){
+        if (component.moduleType === type && component.isDrawable && component.isDrawable == isDrawable) {
             selected.push(component);
         }
     }

--- a/src/registry.js
+++ b/src/registry.js
@@ -72,20 +72,20 @@ exports.apiMethodRegistry = {};
  *
  */
 exports.register = function register(_modules) {
-    if (!_modules) {
+    if(!_modules) {
         throw new Error('No argument passed to Plotly.register.');
-    } else if (_modules && !Array.isArray(_modules)) {
+    } else if(_modules && !Array.isArray(_modules)) {
         _modules = [_modules];
     }
 
-    for (var i = 0; i < _modules.length; i++) {
+    for(var i = 0; i < _modules.length; i++) {
         var newModule = _modules[i];
 
-        if (!newModule) {
+        if(!newModule) {
             throw new Error('Invalid module was attempted to be registered!');
         }
 
-        switch (newModule.moduleType) {
+        switch(newModule.moduleType) {
             case 'trace':
                 registerTraceModule(newModule);
                 break;
@@ -108,18 +108,18 @@ exports.register = function register(_modules) {
     }
 };
 
-exports.getModules = function (type, isDrawable) {
+exports.getModules = function(type, isDrawable) {
     var selected = [];
 
-    for (var componentName in exports.componentsRegistry) {
+    for(var componentName in exports.componentsRegistry) {
         var component = exports.componentsRegistry[componentName];
-        if (component.moduleType === type && component.isDrawable && component.isDrawable == isDrawable) {
+        if(component.moduleType === type && component.isDrawable && component.isDrawable === isDrawable) {
             selected.push(component);
         }
     }
 
     return selected;
-}
+};
 
 /**
  * Get registered module using trace object or trace type
@@ -129,9 +129,9 @@ exports.getModules = function (type, isDrawable) {
  * @return {object}
  *  module object corresponding to trace type
  */
-exports.getModule = function (trace) {
+exports.getModule = function(trace) {
     var _module = exports.modules[getTraceType(trace)];
-    if (!_module) return false;
+    if(!_module) return false;
     return _module._module;
 };
 
@@ -144,16 +144,16 @@ exports.getModule = function (trace) {
  *  category in question
  * @return {boolean}
  */
-exports.traceIs = function (traceType, category) {
+exports.traceIs = function(traceType, category) {
     traceType = getTraceType(traceType);
 
     // old plot.ly workspace hack, nothing to see here
-    if (traceType === 'various') return false;
+    if(traceType === 'various') return false;
 
     var _module = exports.modules[traceType];
 
-    if (!_module) {
-        if (traceType && traceType !== 'area') {
+    if(!_module) {
+        if(traceType && traceType !== 'area') {
             Loggers.log('Unrecognized trace type ' + traceType + '.');
         }
 
@@ -174,11 +174,11 @@ exports.traceIs = function (traceType, category) {
  * @return {array}
  *  array of matching indices. If none found, returns []
  */
-exports.getTransformIndices = function (data, type) {
+exports.getTransformIndices = function(data, type) {
     var indices = [];
     var transforms = data.transforms || [];
-    for (var i = 0; i < transforms.length; i++) {
-        if (transforms[i].type === type) {
+    for(var i = 0; i < transforms.length; i++) {
+        if(transforms[i].type === type) {
             indices.push(i);
         }
     }
@@ -194,10 +194,10 @@ exports.getTransformIndices = function (data, type) {
  *  type of trace to test
  * @return {boolean}
  */
-exports.hasTransform = function (data, type) {
+exports.hasTransform = function(data, type) {
     var transforms = data.transforms || [];
-    for (var i = 0; i < transforms.length; i++) {
-        if (transforms[i].type === type) {
+    for(var i = 0; i < transforms.length; i++) {
+        if(transforms[i].type === type) {
             return true;
         }
     }
@@ -214,10 +214,10 @@ exports.hasTransform = function (data, type) {
  *  name of component module method
  * @return {function}
  */
-exports.getComponentMethod = function (name, method) {
+exports.getComponentMethod = function(name, method) {
     var _module = exports.componentsRegistry[name];
 
-    if (!_module) return noop;
+    if(!_module) return noop;
     return _module[method] || noop;
 };
 
@@ -228,7 +228,7 @@ exports.getComponentMethod = function (name, method) {
  * @param {...array} args : arguments passed to api method
  * @return {any} : returns api method output
  */
-exports.call = function () {
+exports.call = function() {
     var name = arguments[0];
     var args = [].slice.call(arguments, 1);
     return exports.apiMethodRegistry[name].apply(null, args);
@@ -239,17 +239,17 @@ function registerTraceModule(_module) {
     var categoriesIn = _module.categories;
     var meta = _module.meta;
 
-    if (exports.modules[thisType]) {
+    if(exports.modules[thisType]) {
         Loggers.log('Type ' + thisType + ' already registered');
         return;
     }
 
-    if (!exports.subplotsRegistry[_module.basePlotModule.name]) {
+    if(!exports.subplotsRegistry[_module.basePlotModule.name]) {
         registerSubplot(_module.basePlotModule);
     }
 
     var categoryObj = {};
-    for (var i = 0; i < categoriesIn.length; i++) {
+    for(var i = 0; i < categoriesIn.length; i++) {
         categoryObj[categoriesIn[i]] = true;
         exports.allCategories[categoriesIn[i]] = true;
     }
@@ -259,13 +259,13 @@ function registerTraceModule(_module) {
         categories: categoryObj
     };
 
-    if (meta && Object.keys(meta).length) {
+    if(meta && Object.keys(meta).length) {
         exports.modules[thisType].meta = meta;
     }
 
     exports.allTypes.push(thisType);
 
-    for (var componentName in exports.componentsRegistry) {
+    for(var componentName in exports.componentsRegistry) {
         mergeComponentAttrsToTrace(componentName, thisType);
     }
 
@@ -274,7 +274,7 @@ function registerTraceModule(_module) {
      * but don't merge them into the base schema as it would confuse the docs
      * (at least after https://github.com/plotly/documentation/issues/202 gets done!)
      */
-    if (_module.layoutAttributes) {
+    if(_module.layoutAttributes) {
         extendFlat(exports.traceLayoutAttributes, _module.layoutAttributes);
     }
 }
@@ -282,7 +282,7 @@ function registerTraceModule(_module) {
 function registerSubplot(_module) {
     var plotType = _module.name;
 
-    if (exports.subplotsRegistry[plotType]) {
+    if(exports.subplotsRegistry[plotType]) {
         Loggers.log('Plot type ' + plotType + ' already registered.');
         return;
     }
@@ -295,45 +295,45 @@ function registerSubplot(_module) {
     // not sure what's best for the 'cartesian' type at this point
     exports.subplotsRegistry[plotType] = _module;
 
-    for (var componentName in exports.componentsRegistry) {
+    for(var componentName in exports.componentsRegistry) {
         mergeComponentAttrsToSubplot(componentName, _module.name);
     }
 }
 
 function registerComponentModule(_module) {
-    if (typeof _module.name !== 'string') {
+    if(typeof _module.name !== 'string') {
         throw new Error('Component module *name* must be a string.');
     }
 
     var name = _module.name;
     exports.componentsRegistry[name] = _module;
 
-    if (_module.layoutAttributes) {
-        if (_module.layoutAttributes._isLinkedToArray) {
+    if(_module.layoutAttributes) {
+        if(_module.layoutAttributes._isLinkedToArray) {
             pushUnique(exports.layoutArrayContainers, name);
         }
         findArrayRegexps(_module);
     }
 
-    for (var traceType in exports.modules) {
+    for(var traceType in exports.modules) {
         mergeComponentAttrsToTrace(name, traceType);
     }
 
-    for (var subplotName in exports.subplotsRegistry) {
+    for(var subplotName in exports.subplotsRegistry) {
         mergeComponentAttrsToSubplot(name, subplotName);
     }
 
-    for (var transformType in exports.transformsRegistry) {
+    for(var transformType in exports.transformsRegistry) {
         mergeComponentAttrsToTransform(name, transformType);
     }
 
-    if (_module.schema && _module.schema.layout) {
+    if(_module.schema && _module.schema.layout) {
         extendDeepAll(baseLayoutAttributes, _module.schema.layout);
     }
 }
 
 function registerTransformModule(_module) {
-    if (typeof _module.name !== 'string') {
+    if(typeof _module.name !== 'string') {
         throw new Error('Transform module *name* must be a string.');
     }
 
@@ -341,26 +341,26 @@ function registerTransformModule(_module) {
     var hasTransform = typeof _module.transform === 'function';
     var hasCalcTransform = typeof _module.calcTransform === 'function';
 
-    if (!hasTransform && !hasCalcTransform) {
+    if(!hasTransform && !hasCalcTransform) {
         throw new Error(prefix + ' is missing a *transform* or *calcTransform* method.');
     }
-    if (hasTransform && hasCalcTransform) {
+    if(hasTransform && hasCalcTransform) {
         Loggers.log([
             prefix + ' has both a *transform* and *calcTransform* methods.',
             'Please note that all *transform* methods are executed',
             'before all *calcTransform* methods.'
         ].join(' '));
     }
-    if (!isPlainObject(_module.attributes)) {
+    if(!isPlainObject(_module.attributes)) {
         Loggers.log(prefix + ' registered without an *attributes* object.');
     }
-    if (typeof _module.supplyDefaults !== 'function') {
+    if(typeof _module.supplyDefaults !== 'function') {
         Loggers.log(prefix + ' registered without a *supplyDefaults* method.');
     }
 
     exports.transformsRegistry[_module.name] = _module;
 
-    for (var componentName in exports.componentsRegistry) {
+    for(var componentName in exports.componentsRegistry) {
         mergeComponentAttrsToTransform(componentName, _module.name);
     }
 }
@@ -377,7 +377,7 @@ function registerLocale(_module) {
     var locales = exports.localeRegistry;
 
     var localeObj = locales[locale];
-    if (!localeObj) locales[locale] = localeObj = {};
+    if(!localeObj) locales[locale] = localeObj = {};
 
     // Should we use this dict for the base locale?
     // In case we're overwriting a previous dict for this locale, check
@@ -385,27 +385,27 @@ function registerLocale(_module) {
     // overwriting, locales[locale] is undefined so this just checks if
     // baseLocale already had a dict or not.
     // Same logic for dateFormats
-    if (baseLocale !== locale) {
+    if(baseLocale !== locale) {
         var baseLocaleObj = locales[baseLocale];
-        if (!baseLocaleObj) locales[baseLocale] = baseLocaleObj = {};
+        if(!baseLocaleObj) locales[baseLocale] = baseLocaleObj = {};
 
-        if (hasDict && baseLocaleObj.dictionary === localeObj.dictionary) {
+        if(hasDict && baseLocaleObj.dictionary === localeObj.dictionary) {
             baseLocaleObj.dictionary = newDict;
         }
-        if (hasFormat && baseLocaleObj.format === localeObj.format) {
+        if(hasFormat && baseLocaleObj.format === localeObj.format) {
             baseLocaleObj.format = newFormat;
         }
     }
 
-    if (hasDict) localeObj.dictionary = newDict;
-    if (hasFormat) localeObj.format = newFormat;
+    if(hasDict) localeObj.dictionary = newDict;
+    if(hasFormat) localeObj.format = newFormat;
 }
 
 function findArrayRegexps(_module) {
-    if (_module.layoutAttributes) {
+    if(_module.layoutAttributes) {
         var arrayAttrRegexps = _module.layoutAttributes._arrayAttrRegexps;
-        if (arrayAttrRegexps) {
-            for (var i = 0; i < arrayAttrRegexps.length; i++) {
+        if(arrayAttrRegexps) {
+            for(var i = 0; i < arrayAttrRegexps.length; i++) {
                 pushUnique(exports.layoutArrayRegexes, arrayAttrRegexps[i]);
             }
         }
@@ -414,40 +414,40 @@ function findArrayRegexps(_module) {
 
 function mergeComponentAttrsToTrace(componentName, traceType) {
     var componentSchema = exports.componentsRegistry[componentName].schema;
-    if (!componentSchema || !componentSchema.traces) return;
+    if(!componentSchema || !componentSchema.traces) return;
 
     var traceAttrs = componentSchema.traces[traceType];
-    if (traceAttrs) {
+    if(traceAttrs) {
         extendDeepAll(exports.modules[traceType]._module.attributes, traceAttrs);
     }
 }
 
 function mergeComponentAttrsToTransform(componentName, transformType) {
     var componentSchema = exports.componentsRegistry[componentName].schema;
-    if (!componentSchema || !componentSchema.transforms) return;
+    if(!componentSchema || !componentSchema.transforms) return;
 
     var transformAttrs = componentSchema.transforms[transformType];
-    if (transformAttrs) {
+    if(transformAttrs) {
         extendDeepAll(exports.transformsRegistry[transformType].attributes, transformAttrs);
     }
 }
 
 function mergeComponentAttrsToSubplot(componentName, subplotName) {
     var componentSchema = exports.componentsRegistry[componentName].schema;
-    if (!componentSchema || !componentSchema.subplots) return;
+    if(!componentSchema || !componentSchema.subplots) return;
 
     var subplotModule = exports.subplotsRegistry[subplotName];
     var subplotAttrs = subplotModule.layoutAttributes;
     var subplotAttr = subplotModule.attr === 'subplot' ? subplotModule.name : subplotModule.attr;
-    if (Array.isArray(subplotAttr)) subplotAttr = subplotAttr[0];
+    if(Array.isArray(subplotAttr)) subplotAttr = subplotAttr[0];
 
     var componentLayoutAttrs = componentSchema.subplots[subplotAttr];
-    if (subplotAttrs && componentLayoutAttrs) {
+    if(subplotAttrs && componentLayoutAttrs) {
         extendDeepAll(subplotAttrs, componentLayoutAttrs);
     }
 }
 
 function getTraceType(traceType) {
-    if (typeof traceType === 'object') traceType = traceType.type;
+    if(typeof traceType === 'object') traceType = traceType.type;
     return traceType;
 }


### PR DESCRIPTION
We're looking to extend plotly so that we can embed some HTML components in graphs.

What we have so far works quite well but we are having to use a custom build of plotly to achieve what we want. 

I think that with few small modifications we could actually have plotly much more extensible which would be awesome! 

I may be wrong here and there may well already be a way to achieve what I'm aiming for but this is how I think it could work:

 - Allow images module to expose a `drawOne` method (even if it just proxies to `draw`) - this would make it uniform with the other modules that require `draw`ing
 - possibly allow modules to advertise that they are `draw`-able and will require re`draw`ing on pan / animation / whatever
 - extend `registry` to export a method allowing us to retrieve all registered modules (perhaps using a filter like `isDrawable:true` or whatever - we could check for the existence of drawOne before calling but I'm not sure how wastefull it would be to be passing about all modules and doing the checks when it's not needed
 - In places like `dragbox` instead of calling stuff explicitly like this: `redrawObjs(gd._fullLayout.annotations || [], Registry.getComponentMethod('annotations', 'drawOne'));` - we can now retrieve all modules using the filter and itterate over them calling `drawOne`