### PR TITLE
Faster trace visibility toggling

### DIFF
--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -24,7 +24,7 @@ module.exports = {
         values: [true, false, 'legendonly'],
         role: 'info',
         dflt: true,
-        editType: 'calc',
+        editType: 'plot',
         description: [
             'Determines whether or not this trace is visible.',
             'If *legendonly*, the trace is not drawn,',

--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -216,7 +216,7 @@ function plotOne(gd, plotinfo, cdSubplot, transitionOpts, makeOnCompleteCallback
             var className = (_module.layerName || name + 'layer');
             var plotMethod = _module.plot;
 
-            // plot all traces of this type on this subplot at once
+            // plot all visible traces of this type on this subplot at once
             cdModuleAndOthers = getModuleCalcData(cdSubplot, plotMethod);
             cdModule = cdModuleAndOthers[0];
             // don't need to search the found traces again - in fact we need to NOT

--- a/src/plots/cartesian/type_defaults.js
+++ b/src/plots/cartesian/type_defaults.js
@@ -108,7 +108,7 @@ function getFirstNonEmptyTrace(data, id, axLetter) {
 
         if(trace.type === 'splom' &&
                 trace._length > 0 &&
-                trace['_' + axLetter + 'axes'][id]
+                (trace['_' + axLetter + 'axes'] || {})[id]
         ) {
             return trace;
         }

--- a/src/plots/get_data.js
+++ b/src/plots/get_data.js
@@ -69,6 +69,7 @@ exports.getModuleCalcData = function(calcdata, arg1) {
     for(var i = 0; i < calcdata.length; i++) {
         var cd = calcdata[i];
         var trace = cd[0].trace;
+        // N.B. 'legendonly' traces do not make it pass here
         if(trace.visible !== true) continue;
 
         // group calcdata trace not by 'module' (as the name of this function

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -277,6 +277,9 @@ var extraFormatKeys = [
  * gd._fullLayout._modules
  *   is a list of all the trace modules required to draw the plot.
  *
+ * gd._fullLayout._visibleModules
+ *   subset of _modules, a list of modules corresponding to visible:true traces.
+ *
  * gd._fullLayout._basePlotModules
  *   is a list of all the plot modules required to draw the plot.
  *
@@ -378,6 +381,7 @@ plots.supplyDefaults = function(gd, opts) {
 
     // clear the lists of trace and baseplot modules, and subplots
     newFullLayout._modules = [];
+    newFullLayout._visibleModules = [];
     newFullLayout._basePlotModules = [];
     var subplots = newFullLayout._subplots = emptySubplotLists();
 
@@ -420,7 +424,7 @@ plots.supplyDefaults = function(gd, opts) {
     newFullLayout._has = plots._hasPlotType.bind(newFullLayout);
 
     // special cases that introduce interactions between traces
-    var _modules = newFullLayout._modules;
+    var _modules = newFullLayout._visibleModules;
     for(i = 0; i < _modules.length; i++) {
         var _module = _modules[i];
         if(_module.cleanData) _module.cleanData(newFullData);
@@ -898,6 +902,7 @@ plots.clearExpandedTraceDefaultColors = function(trace) {
 
 plots.supplyDataDefaults = function(dataIn, dataOut, layout, fullLayout) {
     var modules = fullLayout._modules;
+    var visibleModules = fullLayout._visibleModules;
     var basePlotModules = fullLayout._basePlotModules;
     var cnt = 0;
     var colorCnt = 0;
@@ -913,8 +918,8 @@ plots.supplyDataDefaults = function(dataIn, dataOut, layout, fullLayout) {
         if(!_module) return;
 
         Lib.pushUnique(modules, _module);
+        if(fullTrace.visible === true) Lib.pushUnique(visibleModules, _module);
         Lib.pushUnique(basePlotModules, fullTrace._module.basePlotModule);
-
         cnt++;
 
         // TODO: do we really want color not to increment for explicitly invisible traces?
@@ -1475,7 +1480,7 @@ plots.supplyLayoutModuleDefaults = function(layoutIn, layoutOut, fullData, trans
     }
 
     // trace module layout defaults
-    var modules = layoutOut._modules;
+    var modules = layoutOut._visibleModules;
     for(i = 0; i < modules.length; i++) {
         _module = modules[i];
 
@@ -1579,7 +1584,7 @@ plots.purge = function(gd) {
 };
 
 plots.style = function(gd) {
-    var _modules = gd._fullLayout._modules;
+    var _modules = gd._fullLayout._visibleModules;
     var styleModules = [];
     var i;
 
@@ -2567,7 +2572,7 @@ function clearAxesCalc(axList) {
 plots.doSetPositions = function(gd) {
     var fullLayout = gd._fullLayout;
     var subplots = fullLayout._subplots.cartesian;
-    var modules = fullLayout._modules;
+    var modules = fullLayout._visibleModules;
     var methods = [];
     var i, j;
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -696,7 +696,7 @@ plots._hasPlotType = function(category) {
         if(basePlotModules[i].name === category) return true;
     }
 
-    // check trace modules
+    // check trace modules (including non-visible:true)
     var modules = this._modules || [];
     for(i = 0; i < modules.length; i++) {
         var name = modules[i].name;
@@ -912,7 +912,7 @@ plots.supplyDataDefaults = function(dataIn, dataOut, layout, fullLayout) {
         var _module = fullTrace._module;
         if(!_module) return;
 
-        if(fullTrace.visible === true) Lib.pushUnique(modules, _module);
+        Lib.pushUnique(modules, _module);
         Lib.pushUnique(basePlotModules, fullTrace._module.basePlotModule);
 
         cnt++;

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -572,6 +572,10 @@ function plot(gd, subplot, cdata) {
             }
 
             // precalculate px coords since we are not going to pan during select
+            // TODO, could do better here e.g.
+            // - spin that in a webworker
+            // - compute selection from polygons in data coordinates
+            //   (maybe just for linear axes)
             var xpx = stash.xpx = new Array(stash.count);
             var ypx = stash.ypx = new Array(stash.count);
             for(j = 0; j < stash.count; j++) {
@@ -614,6 +618,7 @@ function plot(gd, subplot, cdata) {
     // provide viewport and range
     var vpRange0 = {
         viewport: getViewport(fullLayout, xaxis, yaxis),
+        // TODO do we need those fallbacks?
         range: [
             (xaxis._rl || xaxis.range)[0],
             (yaxis._rl || yaxis.range)[0],

--- a/src/traces/scatterpolargl/index.js
+++ b/src/traces/scatterpolargl/index.js
@@ -54,6 +54,7 @@ function plot(container, subplot, cdata) {
 
     var scene = ScatterGl.sceneUpdate(container, subplot);
     scene.clear();
+    scene.visibleBatch = [];
 
     cdata.forEach(function(cdscatter, traceIndex) {
         if(!cdscatter || !cdscatter[0] || !cdscatter[0].trace) return;
@@ -63,6 +64,8 @@ function plot(container, subplot, cdata) {
         var rArray = stash.r;
         var thetaArray = stash.theta;
         var i, r, rr, theta, rad;
+
+        scene.uid2batchIndex[trace.uid] = traceIndex;
 
         var subRArray = rArray.slice();
         var subThetaArray = thetaArray.slice();

--- a/test/jasmine/tests/cartesian_test.js
+++ b/test/jasmine/tests/cartesian_test.js
@@ -194,14 +194,17 @@ describe('restyle', function() {
             })
             .then(function() {
                 expect(!!gd._fullLayout._plots.x2y2._scene).toBe(true);
+                expect(gd._fullLayout._plots.x2y2._scene.visibleBatch).toEqual([0]);
                 return Plotly.restyle(gd, {visible: 'legendonly'}, 1);
             })
             .then(function() {
-                expect(!!gd._fullLayout._plots.x2y2._scene).toBe(false);
+                expect(!!gd._fullLayout._plots.x2y2._scene).toBe(true);
+                expect(gd._fullLayout._plots.x2y2._scene.visibleBatch).toEqual([]);
                 return Plotly.restyle(gd, {visible: true}, 1);
             })
             .then(function() {
                 expect(!!gd._fullLayout._plots.x2y2._scene).toBe(true);
+                expect(gd._fullLayout._plots.x2y2._scene.visibleBatch).toEqual([0]);
             })
             .catch(failTest)
             .then(done);

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -358,27 +358,38 @@ describe('@gl Test gl2d plots', function() {
         var _mock = Lib.extendDeep({}, mock);
         _mock.data[0].line.width = 5;
 
+        function assertDrawCall(msg, exp) {
+            var draw = gd._fullLayout._plots.xy._scene.scatter2d.draw;
+            expect(draw).toHaveBeenCalledTimes(exp, msg);
+            draw.calls.reset();
+        }
+
         Plotly.plot(gd, _mock)
         .then(delay(30))
         .then(function() {
+            spyOn(gd._fullLayout._plots.xy._scene.scatter2d, 'draw');
             return Plotly.restyle(gd, 'visible', 'legendonly');
         })
         .then(function() {
-            expect(gd.querySelector('.gl-canvas-context')).toBe(null);
+            expect(readPixel(gd.querySelector('.gl-canvas-context'), 108, 100)[0]).toBe(0);
+            assertDrawCall('legendonly', 0);
 
             return Plotly.restyle(gd, 'visible', true);
         })
         .then(function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 108, 100)[0]).not.toBe(0);
+            assertDrawCall('back to visible', 1);
 
             return Plotly.restyle(gd, 'visible', false);
         })
         .then(function() {
-            expect(gd.querySelector('.gl-canvas-context')).toBe(null);
+            expect(readPixel(gd.querySelector('.gl-canvas-context'), 108, 100)[0]).toBe(0);
+            assertDrawCall('visible false', 0);
 
             return Plotly.restyle(gd, 'visible', true);
         })
         .then(function() {
+            assertDrawCall('back up', 1);
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 108, 100)[0]).not.toBe(0);
         })
         .catch(failTest)

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -579,6 +579,41 @@ describe('@gl Test splom interactions:', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('should toggle trace correctly', function(done) {
+        var fig = Lib.extendDeep({}, require('@mocks/splom_iris.json'));
+
+        function _assert(msg, exp) {
+            for(var i = 0; i < 3; i++) {
+                var draw = gd.calcdata[i][0].t._scene.draw;
+                expect(draw).toHaveBeenCalledTimes(exp[i], msg + ' - trace ' + i);
+                draw.calls.reset();
+            }
+        }
+
+        Plotly.plot(gd, fig).then(function() {
+            spyOn(gd.calcdata[0][0].t._scene, 'draw');
+            spyOn(gd.calcdata[1][0].t._scene, 'draw');
+            spyOn(gd.calcdata[2][0].t._scene, 'draw');
+
+            return Plotly.restyle(gd, 'visible', 'legendonly', [0, 2]);
+        })
+        .then(function() {
+            _assert('0-2 legendonly', [0, 1, 0]);
+
+            return Plotly.restyle(gd, 'visible', false);
+        })
+        .then(function() {
+            _assert('all gone', [0, 0, 0]);
+
+            return Plotly.restyle(gd, 'visible', true);
+        })
+        .then(function() {
+            _assert('all back', [1, 1, 1]);
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('@gl Test splom hover:', function() {

--- a/test/jasmine/tests/transform_groupby_test.js
+++ b/test/jasmine/tests/transform_groupby_test.js
@@ -15,6 +15,7 @@ function supplyDataDefaults(dataIn, dataOut) {
     return Plots.supplyDataDefaults(dataIn, dataOut, {}, {
         _subplots: {cartesian: ['xy'], xaxis: ['x'], yaxis: ['y']},
         _modules: [],
+        _visibleModules: [],
         _basePlotModules: [],
         _traceUids: dataIn.map(function() { return Lib.randstr(); })
     });

--- a/test/jasmine/tests/transform_multi_test.js
+++ b/test/jasmine/tests/transform_multi_test.js
@@ -16,6 +16,7 @@ var assertStyle = customAssertions.assertStyle;
 var mockFullLayout = {
     _subplots: {cartesian: ['xy'], xaxis: ['x'], yaxis: ['y']},
     _modules: [],
+    _visibleModules: [],
     _basePlotModules: [],
     _has: function() {},
     _dfltTitle: {x: 'xxx', y: 'yyy'},


### PR DESCRIPTION
... by changing `visible` from a 'calc' to a 'plot' edit type and using a "visible batch" in the scattergl code, similar to how selections are currently handled.

Graphs will slow calc steps will benefit the most. For example, on a 1e6 scattergl graph,

```js
Plotly.restyle(gd, 'visible', false)
setTimeout(() => {
  console.time('1')
  Plotly.restyle(gd, 'visible', true)
  console.timeEnd('1')
}, 500)
```

clocks in at about 30ms which is about 50x faster than on master :racehorse: 

Eventually, we could augment this PR by adding a new edit type that would bypass `drawFramework` and `initInteractions` (which are very :turtle:  for sploms), but I'll leave that for later if ok.

Note that commits https://github.com/plotly/plotly.js/commit/3790734abdf0c6c37f1864cba726ed2493820376 and https://github.com/plotly/plotly.js/commit/b816a8e68b8ddb86faef8b10f14f03ff584123ef might be a bit controversial and may have some side-effects during subplot/trace removal the spli through our tests, so I wouldn't mind a second opinion there.

I would appreciate if @dy could take a look at https://github.com/plotly/plotly.js/commit/e85725aec106b8ce629ec03691f4a9508f8e81ff and https://github.com/plotly/plotly.js/commit/cf65abd64816506309fb4d66689cbf6d1fb2d3aa

--------


To be merged in https://github.com/plotly/plotly.js/pull/2823 

cc @alexcjohnson and @dy 