### PR TITLE
Scatter3d attributes fixups

### DIFF
--- a/src/components/colorscale/defaults.js
+++ b/src/components/colorscale/defaults.js
@@ -52,11 +52,13 @@ module.exports = function colorScaleDefaults(traceIn, traceOut, layout, coerce, 
     // ... until Scatter.colorbar can handle marker line colorbars
     if(prefix === 'marker.line.') return;
 
-    // handle both the trace case where the dflt is listed in attributes and
-    // the marker case where the dflt is determined by hasColorbar
-    var showScaleDftl;
-    if(prefix) showScaleDftl = hasColorbar(containerIn);
-    var showScale = coerce(prefix + 'showscale', showScaleDftl);
+    if(!opts.noScale) {
+        // handle both the trace case where the dflt is listed in attributes and
+        // the marker case where the dflt is determined by hasColorbar
+        var showScaleDftl;
+        if(prefix) showScaleDftl = hasColorbar(containerIn);
 
-    if(showScale) colorbarDefaults(containerIn, containerOut, layout);
+        var showScale = coerce(prefix + 'showscale', showScaleDftl);
+        if(showScale) colorbarDefaults(containerIn, containerOut, layout);
+    }
 };

--- a/src/components/colorscale/defaults.js
+++ b/src/components/colorscale/defaults.js
@@ -40,9 +40,9 @@ module.exports = function colorScaleDefaults(traceIn, traceOut, layout, coerce, 
 
     // handles both the trace case (autocolorscale is false by default) and
     // the marker and marker.line case (autocolorscale is true by default)
-    var autoColorscaleDftl;
-    if(sclIn !== undefined) autoColorscaleDftl = !isValidScale(sclIn);
-    coerce(prefix + 'autocolorscale', autoColorscaleDftl);
+    var autoColorscaleDflt;
+    if(sclIn !== undefined) autoColorscaleDflt = !isValidScale(sclIn);
+    coerce(prefix + 'autocolorscale', autoColorscaleDflt);
     var sclOut = coerce(prefix + 'colorscale');
 
     // reversescale is handled at the containerOut level
@@ -53,12 +53,12 @@ module.exports = function colorScaleDefaults(traceIn, traceOut, layout, coerce, 
     if(prefix === 'marker.line.') return;
 
     if(!opts.noScale) {
-        // handle both the trace case where the dflt is listed in attributes and
+        // handles both the trace case where the dflt is listed in attributes and
         // the marker case where the dflt is determined by hasColorbar
-        var showScaleDftl;
-        if(prefix) showScaleDftl = hasColorbar(containerIn);
+        var showScaleDflt;
+        if(prefix) showScaleDflt = hasColorbar(containerIn);
 
-        var showScale = coerce(prefix + 'showscale', showScaleDftl);
+        var showScale = coerce(prefix + 'showscale', showScaleDflt);
         if(showScale) colorbarDefaults(containerIn, containerOut, layout);
     }
 };

--- a/src/traces/scatter/line_defaults.js
+++ b/src/traces/scatter/line_defaults.js
@@ -18,9 +18,8 @@ module.exports = function lineDefaults(traceIn, traceOut, defaultColor, layout, 
     coerce('line.color', defaultColor);
 
     if(hasColorscale(traceIn, 'line')) {
-        colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: 'line.', cLetter: 'c'});
-    }
-    else {
+        colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: 'line.', cLetter: 'c', noScale: true});
+    } else {
         var lineColorDflt = (isArrayOrTypedArray(markerColor) ? false : markerColor) || defaultColor;
         coerce('line.color', lineColorDflt);
     }

--- a/src/traces/scatter3d/attributes.js
+++ b/src/traces/scatter3d/attributes.js
@@ -21,6 +21,20 @@ var scatterLineAttrs = scatterAttrs.line;
 var scatterMarkerAttrs = scatterAttrs.marker;
 var scatterMarkerLineAttrs = scatterMarkerAttrs.line;
 
+var lineAttrs = extendFlat({
+    width: scatterLineAttrs.width,
+    dash: {
+        valType: 'enumerated',
+        values: Object.keys(DASHES),
+        dflt: 'solid',
+        role: 'style',
+        description: 'Sets the dash style of the lines.'
+    }
+}, colorAttributes('line'));
+// not yet implemented
+delete lineAttrs.showscale;
+delete lineAttrs.colorbar;
+
 function makeProjectionAttr(axLetter) {
     return {
         show: {
@@ -107,19 +121,10 @@ var attrs = module.exports = overrideAll({
         y: makeProjectionAttr('y'),
         z: makeProjectionAttr('z')
     },
+
     connectgaps: scatterAttrs.connectgaps,
-    line: extendFlat({
-        width: scatterLineAttrs.width,
-        dash: {
-            valType: 'enumerated',
-            values: Object.keys(DASHES),
-            dflt: 'solid',
-            role: 'style',
-            description: 'Sets the dash style of the lines.'
-        }
-    },
-        colorAttributes('line')
-    ),
+    line: lineAttrs,
+
     marker: extendFlat({  // Parity with scatter.js?
         symbol: {
             valType: 'enumerated',

--- a/src/traces/scatter3d/attributes.js
+++ b/src/traces/scatter3d/attributes.js
@@ -155,8 +155,12 @@ var attrs = module.exports = overrideAll({
         colorAttributes('marker')
     ),
 
-    textposition: extendFlat({}, scatterAttrs.textposition, {dflt: 'top center'}),
-    textfont: scatterAttrs.textfont,
+    textposition: extendFlat({}, scatterAttrs.textposition, {dflt: 'top center', arrayOk: false}),
+    textfont: {
+        color: scatterAttrs.textfont.color,
+        size: scatterAttrs.textfont.size,
+        family: extendFlat({}, scatterAttrs.textfont.family, {arrayOk: false})
+    },
 
     hoverinfo: extendFlat({}, baseAttrs.hoverinfo)
 }, 'calc', 'nested');


### PR DESCRIPTION
A few `scatter3d` attributes are not listed properly as mentioned in https://github.com/plotly/plotly.js/issues/2872 and https://github.com/plotly/plotly.js/issues/2862.

This PR corrects them while we wait until https://github.com/plotly/plotly.js/issues/2872 and https://github.com/plotly/plotly.js/issues/2862 get implemented as features.

cc @alexcjohnson 