### PR TITLE
fix #2892 - don't allow auto date ticks < our 100 microseconds limit

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -692,6 +692,9 @@ axes.autoTicks = function(ax, roughDTick) {
             base = getBase(10);
             ax.dtick = roundDTick(roughDTick, base, roundBase10);
         }
+        // ensure we don't try to make ticks below our minimum precision
+        // see https://github.com/plotly/plotly.js/issues/2892
+        if(ax.dtick < 0.1) ax.dtick = 0.1;
     }
     else if(ax.type === 'log') {
         ax.tick0 = 0;

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -503,6 +503,10 @@ axes.prepTicks = function(ax) {
         ax.tick0 = (ax.type === 'date') ? '2000-01-01' : 0;
     }
 
+    // ensure we don't try to make ticks below our minimum precision
+    // see https://github.com/plotly/plotly.js/issues/2892
+    if(ax.type === 'date' && ax.dtick < 0.1) ax.dtick = 0.1;
+
     // now figure out rounding of tick values
     autoTickRound(ax);
 };
@@ -692,9 +696,6 @@ axes.autoTicks = function(ax, roughDTick) {
             base = getBase(10);
             ax.dtick = roundDTick(roughDTick, base, roundBase10);
         }
-        // ensure we don't try to make ticks below our minimum precision
-        // see https://github.com/plotly/plotly.js/issues/2892
-        if(ax.dtick < 0.1) ax.dtick = 0.1;
     }
     else if(ax.type === 'log') {
         ax.tick0 = 0;
@@ -788,6 +789,11 @@ function autoTickRound(ax) {
             // of all possible ticks - so take the max. length of tick0 and the next one
             var tick1len = ax.l2r(tick0ms + dtick).replace(/^-/, '').length;
             ax._tickround = Math.max(tick0len, tick1len) - 20;
+
+            // We shouldn't get here... but in case there's a situation I'm
+            // not thinking of where tick0str and tick1str are identical or
+            // something, fall back on maximum precision
+            if(ax._tickround < 0) ax._tickround = 4;
         }
     }
     else if(isNumeric(dtick) || dtick.charAt(0) === 'L') {

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2057,11 +2057,25 @@ describe('Test axes', function() {
             expect(textOut).toEqual(expectedText);
         });
 
-        it('never gives date dtick < 100 microseconds', function() {
+        it('never gives date dtick < 100 microseconds (autotick case)', function() {
             var ax = {
                 type: 'date',
                 tickmode: 'auto',
                 nticks: '100',
+                range: ['2017-02-08 05:21:18.145', '2017-02-08 05:21:18.1451']
+            };
+
+            var textOut = mockCalc(ax);
+            var expectedText = ['05:21:18.145<br>Feb 8, 2017', '05:21:18.1451'];
+            expect(textOut).toEqual(expectedText);
+        });
+
+        it('never gives date dtick < 100 microseconds (explicit tick case)', function() {
+            var ax = {
+                type: 'date',
+                tickmode: 'linear',
+                tick0: '2000-01-01',
+                dtick: 0.01,
                 range: ['2017-02-08 05:21:18.145', '2017-02-08 05:21:18.1451']
             };
 

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2057,6 +2057,19 @@ describe('Test axes', function() {
             expect(textOut).toEqual(expectedText);
         });
 
+        it('never gives date dtick < 100 microseconds', function() {
+            var ax = {
+                type: 'date',
+                tickmode: 'auto',
+                nticks: '100',
+                range: ['2017-02-08 05:21:18.145', '2017-02-08 05:21:18.1451']
+            };
+
+            var textOut = mockCalc(ax);
+            var expectedText = ['05:21:18.145<br>Feb 8, 2017', '05:21:18.1451'];
+            expect(textOut).toEqual(expectedText);
+        });
+
         it('should handle edge cases with dates and tickvals', function() {
             var ax = {
                 type: 'date',


### PR DESCRIPTION
At least until we do something more substantial in #2893, be more consistent about the 100 microsecond limit.

cc @etpinard 