### PR TITLE
Fix `toSVG` for graphs that call `Drawing.gradient`

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -334,11 +334,7 @@ drawing.gradient = function(sel, gd, gradientID, type, colorscale, prop) {
             });
         });
 
-    // Set url to gradient definition as an 'attribute', so that
-    // we don't have to fiddle with quotes inside of quotes in Snapshot.toSVG.
-    // Clear corresponding 'style' setting to avoid potential conflicts.
-    sel.attr(prop, 'url(#' + fullID + ')')
-        .style(prop, null)
+    sel.style(prop, 'url(#' + fullID + ')')
         .style(prop + '-opacity', null);
 };
 

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -334,7 +334,11 @@ drawing.gradient = function(sel, gd, gradientID, type, colorscale, prop) {
             });
         });
 
-    sel.style(prop, 'url(#' + fullID + ')')
+    // Set url to gradient definition as an 'attribute', so that
+    // we don't have to fiddle with quotes inside of quotes in Snapshot.toSVG.
+    // Clear corresponding 'style' setting to avoid potential conflicts.
+    sel.attr(prop, 'url(#' + fullID + ')')
+        .style(prop, null)
         .style(prop + '-opacity', null);
 };
 

--- a/src/snapshot/tosvg.js
+++ b/src/snapshot/tosvg.js
@@ -116,6 +116,22 @@ module.exports = function toSVG(gd, format, scale) {
             }
         });
 
+    svg.selectAll('.point, .scatterpts, .legendfill>path, .legendlines>path, .cbfill').each(function() {
+        var pt = d3.select(this);
+
+        // similar to font family styles above,
+        // we must remove " after the SVG DOM has been serialized
+        var fill = this.style.fill;
+        if(fill && fill.indexOf('url(') !== -1) {
+            pt.style('fill', fill.replace(DOUBLEQUOTE_REGEX, DUMMY_SUB));
+        }
+
+        var stroke = this.style.stroke;
+        if(stroke && stroke.indexOf('url(') !== -1) {
+            pt.style('stroke', stroke.replace(DOUBLEQUOTE_REGEX, DUMMY_SUB));
+        }
+    });
+
     if(format === 'pdf' || format === 'eps') {
         // these formats make the extra line MathJax adds around symbols look super thick in some cases
         // it looks better if this is removed entirely.

--- a/src/snapshot/tosvg.js
+++ b/src/snapshot/tosvg.js
@@ -116,22 +116,6 @@ module.exports = function toSVG(gd, format, scale) {
             }
         });
 
-    svg.selectAll('.point, .scatterpts, .legendfill>path, .legendlines>path, .cbfill').each(function() {
-        var pt = d3.select(this);
-
-        // similar to font family styles above,
-        // we must remove " after the SVG DOM has been serialized
-        var fill = this.style.fill;
-        if(fill && fill.indexOf('url(') !== -1) {
-            pt.style('fill', fill.replace(DOUBLEQUOTE_REGEX, DUMMY_SUB));
-        }
-
-        var stroke = this.style.stroke;
-        if(stroke && stroke.indexOf('url(') !== -1) {
-            pt.style('stroke', stroke.replace(DOUBLEQUOTE_REGEX, DUMMY_SUB));
-        }
-    });
-
     if(format === 'pdf' || format === 'eps') {
         // these formats make the extra line MathJax adds around symbols look super thick in some cases
         // it looks better if this is removed entirely.

--- a/src/snapshot/tosvg.js
+++ b/src/snapshot/tosvg.js
@@ -116,14 +116,19 @@ module.exports = function toSVG(gd, format, scale) {
             }
         });
 
-    svg.selectAll('.point,.scatterpts').each(function() {
+    svg.selectAll('.point, .scatterpts, .legendfill>path, .legendlines>path, .cbfill').each(function() {
         var pt = d3.select(this);
-        var fill = this.style.fill;
 
         // similar to font family styles above,
         // we must remove " after the SVG DOM has been serialized
+        var fill = this.style.fill;
         if(fill && fill.indexOf('url(') !== -1) {
             pt.style('fill', fill.replace(DOUBLEQUOTE_REGEX, DUMMY_SUB));
+        }
+
+        var stroke = this.style.stroke;
+        if(stroke && stroke.indexOf('url(') !== -1) {
+            pt.style('stroke', stroke.replace(DOUBLEQUOTE_REGEX, DUMMY_SUB));
         }
     });
 

--- a/tasks/noci_test.sh
+++ b/tasks/noci_test.sh
@@ -1,12 +1,25 @@
 #! /bin/bash
+#
+# Run tests that aren't ran on CI (yet)
+#
+# to run all no-ci tests
+# $ (plotly.js) ./tasks/noci_test.sh
+#
+# to run jasmine no-ci tests
+# $ (plotly.js) ./tasks/noci_test.sh jasmine
+
+# to run image no-ci tests
+# $ (plotly.js) ./tasks/noci_test.sh image
+#
+# -----------------------------------------------
 
 EXIT_STATE=0
 root=$(dirname $0)/..
 
-# tests that aren't run on CI (yet)
-
 # jasmine specs with @noCI tag
-npm run test-jasmine -- --tags=noCI,noCIdep --nowatch || EXIT_STATE=$?
+test_jasmine () {
+    npm run test-jasmine -- --tags=noCI,noCIdep --nowatch || EXIT_STATE=$?
+}
 
 # mapbox image tests take too much resources on CI
 #
@@ -15,12 +28,27 @@ npm run test-jasmine -- --tags=noCI,noCIdep --nowatch || EXIT_STATE=$?
 # 'old' image server
 #
 # cone traces don't render correctly in the imagetest container
-$root/../orca/bin/orca.js graph \
-    $root/test/image/mocks/mapbox_* \
-    $root/test/image/mocks/gl3d_cone* \
-    --plotly $root/build/plotly.js \
-    --mapbox-access-token "pk.eyJ1IjoiZXRwaW5hcmQiLCJhIjoiY2luMHIzdHE0MGFxNXVubTRxczZ2YmUxaCJ9.hwWZful0U2CQxit4ItNsiQ" \
-    --output-dir $root/test/image/baselines/ \
-    --verbose
+test_image () {
+    $root/../orca/bin/orca.js graph \
+        $root/test/image/mocks/mapbox_* \
+        $root/test/image/mocks/gl3d_cone* \
+        --plotly $root/build/plotly.js \
+        --mapbox-access-token "pk.eyJ1IjoiZXRwaW5hcmQiLCJhIjoiY2luMHIzdHE0MGFxNXVubTRxczZ2YmUxaCJ9.hwWZful0U2CQxit4ItNsiQ" \
+        --output-dir $root/test/image/baselines/ \
+        --verbose || EXIT_STATE=$?
+}
+
+case $1 in
+    jasmine)
+        test_jasmine
+        ;;
+    image)
+        test_image
+        ;;
+    *)
+        test_jasmine
+        test_image
+        ;;
+esac
 
 exit $EXIT_STATE

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -3,7 +3,7 @@ var Plotly = require('@lib/index');
 var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
-var fail = require('../assets/fail_test');
+var failTest = require('../assets/fail_test');
 
 var subplotMock = require('../../image/mocks/multiple_subplots.json');
 var annotationMock = require('../../image/mocks/annotations.json');
@@ -297,7 +297,7 @@ describe('Plotly.Snapshot', function() {
                 expect(legendPointElements.length).toEqual(1);
                 expect(legendPointElements[0].style.fill.substr(0, 6)).toEqual('url(\"#');
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
 
@@ -317,7 +317,7 @@ describe('Plotly.Snapshot', function() {
                 expect(el.getAttribute('height')).toBe('1000', 'height');
                 expect(el.getAttribute('viewBox')).toBe('0 0 300 400', 'viewbox');
             })
-            .catch(fail)
+            .catch(failTest)
             .then(done);
         });
     });

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -1,4 +1,5 @@
 var Plotly = require('@lib/index');
+var Lib = require('@src/lib');
 
 var d3 = require('d3');
 var createGraphDiv = require('../assets/create_graph_div');
@@ -250,55 +251,101 @@ describe('Plotly.Snapshot', function() {
             });
         });
 
-        it('should handle quoted style properties', function(done) {
-            Plotly.plot(gd, [{
-                y: [1, 2, 1],
-                marker: {
-                    gradient: {
-                        type: 'radial',
-                        color: '#fff'
-                    },
-                    color: ['red', 'blue', 'green']
-                }
-            }], {
-                font: { family: 'Times New Roman' },
-                showlegend: true
-            })
-            .then(function() {
-                d3.selectAll('text').each(function() {
-                    expect(this.style.fontFamily).toEqual('\"Times New Roman\"');
-                });
+        describe('should handle quoted style properties', function() {
+            function checkURL(actual, msg) {
+                // which is enough tot check that toSVG did its job right
+                expect((actual || '').substr(0, 6)).toBe('url(\"#', msg);
+            }
 
-                d3.selectAll('.point,.scatterpts').each(function() {
-                    expect(this.style.fill.substr(0, 6)).toEqual('url(\"#');
-                });
+            it('- marker-gradient case', function(done) {
+                Plotly.plot(gd, [{
+                    y: [1, 2, 1],
+                    marker: {
+                        gradient: {
+                            type: 'radial',
+                            color: '#fff'
+                        },
+                        color: ['red', 'blue', 'green']
+                    }
+                }], {
+                    font: { family: 'Times New Roman' },
+                    showlegend: true
+                })
+                .then(function() {
+                    d3.selectAll('text').each(function() {
+                        expect(this.style.fontFamily).toEqual('\"Times New Roman\"');
+                    });
 
-                return Plotly.Snapshot.toSVG(gd);
-            })
-            .then(function(svg) {
-                var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
-                var i;
+                    d3.selectAll('.point,.scatterpts').each(function() {
+                        checkURL(this.style.fill);
+                    });
 
-                var textElements = svgDOM.getElementsByTagName('text');
-                expect(textElements.length).toEqual(12);
+                    return Plotly.Snapshot.toSVG(gd);
+                })
+                .then(function(svg) {
+                    var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
+                    var i;
 
-                for(i = 0; i < textElements.length; i++) {
-                    expect(textElements[i].style.fontFamily).toEqual('\"Times New Roman\"');
-                }
+                    var textElements = svgDOM.getElementsByTagName('text');
+                    expect(textElements.length).toEqual(12);
 
-                var pointElements = svgDOM.getElementsByClassName('point');
-                expect(pointElements.length).toEqual(3);
+                    for(i = 0; i < textElements.length; i++) {
+                        expect(textElements[i].style.fontFamily).toEqual('\"Times New Roman\"');
+                    }
 
-                for(i = 0; i < pointElements.length; i++) {
-                    expect(pointElements[i].style.fill.substr(0, 6)).toEqual('url(\"#');
-                }
+                    var pointElements = svgDOM.getElementsByClassName('point');
+                    expect(pointElements.length).toEqual(3);
 
-                var legendPointElements = svgDOM.getElementsByClassName('scatterpts');
-                expect(legendPointElements.length).toEqual(1);
-                expect(legendPointElements[0].style.fill.substr(0, 6)).toEqual('url(\"#');
-            })
-            .catch(failTest)
-            .then(done);
+                    for(i = 0; i < pointElements.length; i++) {
+                        checkURL(pointElements[i].style.fill);
+                    }
+
+                    var legendPointElements = svgDOM.getElementsByClassName('scatterpts');
+                    expect(legendPointElements.length).toEqual(1);
+                    checkURL(legendPointElements[0].style.fill);
+                })
+                .catch(failTest)
+                .then(done);
+            });
+
+            it('- legend with contour items case', function(done) {
+                var fig = Lib.extendDeep({}, require('@mocks/contour_legend.json'));
+                var fillItemIndices = [0, 4, 5];
+
+                Plotly.plot(gd, fig)
+                .then(function() { return Plotly.Snapshot.toSVG(gd); })
+                .then(function(svg) {
+                    var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
+
+                    var fillItems = svgDOM.getElementsByClassName('legendfill');
+                    for(var i = 0; i < fillItemIndices.length; i++) {
+                        checkURL(fillItems[fillItemIndices[i]].firstChild.style.fill, 'fill gradient ' + i);
+                    }
+
+                    var lineItems = svgDOM.getElementsByClassName('legendlines');
+                    checkURL(lineItems[1].firstChild.style.stroke, 'stroke gradient');
+                })
+                .catch(failTest)
+                .then(done);
+            });
+
+            it('- colorbar case', function(done) {
+                var fig = Lib.extendDeep({}, require('@mocks/16.json'));
+
+                Plotly.plot(gd, fig)
+                .then(function() { return Plotly.Snapshot.toSVG(gd); })
+                .then(function(svg) {
+                    var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
+
+                    var fillItems = svgDOM.getElementsByClassName('cbfill');
+                    expect(fillItems.length).toBe(1, '# of colorbars');
+                    for(var i = 0; i < fillItems.length; i++) {
+                        checkURL(fillItems[i].style.fill, 'fill gradient ' + i);
+                    }
+                })
+                .catch(failTest)
+                .then(done);
+            });
         });
 
         it('should adapt *viewBox* attribute under *scale* option', function(done) {

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -254,7 +254,7 @@ describe('Plotly.Snapshot', function() {
         describe('should handle quoted style properties', function() {
             function checkURL(actual, msg) {
                 // which is enough tot check that toSVG did its job right
-                expect((actual || '').substr(0, 6)).toBe('url(\"#', msg);
+                expect((actual || '').substr(0, 5)).toBe('url(#', msg);
             }
 
             it('- marker-gradient case', function(done) {
@@ -277,7 +277,7 @@ describe('Plotly.Snapshot', function() {
                     });
 
                     d3.selectAll('.point,.scatterpts').each(function() {
-                        checkURL(this.style.fill);
+                        checkURL(d3.select(this).attr('fill'));
                     });
 
                     return Plotly.Snapshot.toSVG(gd);
@@ -297,12 +297,12 @@ describe('Plotly.Snapshot', function() {
                     expect(pointElements.length).toEqual(3);
 
                     for(i = 0; i < pointElements.length; i++) {
-                        checkURL(pointElements[i].style.fill);
+                        checkURL(pointElements[i].getAttribute('fill'));
                     }
 
                     var legendPointElements = svgDOM.getElementsByClassName('scatterpts');
                     expect(legendPointElements.length).toEqual(1);
-                    checkURL(legendPointElements[0].style.fill);
+                    checkURL(legendPointElements[0].getAttribute('fill'));
                 })
                 .catch(failTest)
                 .then(done);
@@ -319,11 +319,12 @@ describe('Plotly.Snapshot', function() {
 
                     var fillItems = svgDOM.getElementsByClassName('legendfill');
                     for(var i = 0; i < fillItemIndices.length; i++) {
-                        checkURL(fillItems[fillItemIndices[i]].firstChild.style.fill, 'fill gradient ' + i);
+                        var path = fillItems[fillItemIndices[i]].firstChild;
+                        checkURL(path.getAttribute('fill'), 'fill gradient ' + i);
                     }
 
                     var lineItems = svgDOM.getElementsByClassName('legendlines');
-                    checkURL(lineItems[1].firstChild.style.stroke, 'stroke gradient');
+                    checkURL(lineItems[1].firstChild.getAttribute('stroke'), 'stroke gradient');
                 })
                 .catch(failTest)
                 .then(done);
@@ -340,7 +341,7 @@ describe('Plotly.Snapshot', function() {
                     var fillItems = svgDOM.getElementsByClassName('cbfill');
                     expect(fillItems.length).toBe(1, '# of colorbars');
                     for(var i = 0; i < fillItems.length; i++) {
-                        checkURL(fillItems[i].style.fill, 'fill gradient ' + i);
+                        checkURL(fillItems[i].getAttribute('fill'), 'fill gradient ' + i);
                     }
                 })
                 .catch(failTest)

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -254,7 +254,7 @@ describe('Plotly.Snapshot', function() {
         describe('should handle quoted style properties', function() {
             function checkURL(actual, msg) {
                 // which is enough tot check that toSVG did its job right
-                expect((actual || '').substr(0, 5)).toBe('url(#', msg);
+                expect((actual || '').substr(0, 6)).toBe('url(\"#', msg);
             }
 
             it('- marker-gradient case', function(done) {
@@ -277,7 +277,7 @@ describe('Plotly.Snapshot', function() {
                     });
 
                     d3.selectAll('.point,.scatterpts').each(function() {
-                        checkURL(d3.select(this).attr('fill'));
+                        checkURL(this.style.fill);
                     });
 
                     return Plotly.Snapshot.toSVG(gd);
@@ -297,12 +297,12 @@ describe('Plotly.Snapshot', function() {
                     expect(pointElements.length).toEqual(3);
 
                     for(i = 0; i < pointElements.length; i++) {
-                        checkURL(pointElements[i].getAttribute('fill'));
+                        checkURL(pointElements[i].style.fill);
                     }
 
                     var legendPointElements = svgDOM.getElementsByClassName('scatterpts');
                     expect(legendPointElements.length).toEqual(1);
-                    checkURL(legendPointElements[0].getAttribute('fill'));
+                    checkURL(legendPointElements[0].style.fill);
                 })
                 .catch(failTest)
                 .then(done);
@@ -319,12 +319,11 @@ describe('Plotly.Snapshot', function() {
 
                     var fillItems = svgDOM.getElementsByClassName('legendfill');
                     for(var i = 0; i < fillItemIndices.length; i++) {
-                        var path = fillItems[fillItemIndices[i]].firstChild;
-                        checkURL(path.getAttribute('fill'), 'fill gradient ' + i);
+                        checkURL(fillItems[fillItemIndices[i]].firstChild.style.fill, 'fill gradient ' + i);
                     }
 
                     var lineItems = svgDOM.getElementsByClassName('legendlines');
-                    checkURL(lineItems[1].firstChild.getAttribute('stroke'), 'stroke gradient');
+                    checkURL(lineItems[1].firstChild.style.stroke, 'stroke gradient');
                 })
                 .catch(failTest)
                 .then(done);
@@ -341,7 +340,7 @@ describe('Plotly.Snapshot', function() {
                     var fillItems = svgDOM.getElementsByClassName('cbfill');
                     expect(fillItems.length).toBe(1, '# of colorbars');
                     for(var i = 0; i < fillItems.length; i++) {
-                        checkURL(fillItems[i].getAttribute('fill'), 'fill gradient ' + i);
+                        checkURL(fillItems[i].style.fill, 'fill gradient ' + i);
                     }
                 })
                 .catch(failTest)


### PR DESCRIPTION
This PR fixes `toSVG` (and hence `toImage` and `downloadImage`) for graphs with filled colorbars (from https://github.com/plotly/plotly.js/pull/2910) and contour legend items (added in https://github.com/plotly/plotly.js/pull/2891) in "newer" browsers.

These bugs are related to double-nested `"` inside svg node `style` - which browsers have a hard time serializing (cc https://github.com/plotly/plotly.js/issues/1697). Why were they unnoticed in their respective PRs: our old nw.js image-server doesn't care about those double-nested `"`. 

What saved us from releasing these bugs in 1.40.0 is `./tasks/noci_test.sh` which test mapbox and cone mocks using orca (which relies on a much newer version of Chromium) where the mocks with colorbars failed to export.

Now, this PR offers two solutions:

- in https://github.com/plotly/plotly.js/commit/b32aac06ce2033224f76931e216f41a609f1b286, which implements a solution very similar to https://github.com/plotly/plotly.js/pull/1928
- another in https://github.com/plotly/plotly.js/commit/1c8017ef88c3a04d1bbc555b72a4a42ca0848847, where we take a different approach: setting gradient URLs as node attribute, not node style as @alexcjohnson suggested in a private convo.

The second solution seems to work well, and it leads to :hocho: a fairly big hacky block in `toSVG`. Thoughts?


