### PR TITLE
Shard gl jasmine tests

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -13,12 +13,14 @@ retry () {
     local n=0
 
     until [ $n -ge $MAX_AUTO_RETRY ]; do
+        if [ $n -ge 1 ]; then
+            echo ''
+            echo run $n of $MAX_AUTO_RETRY failed, trying again ...
+            echo ''
+            sleep 15
+        fi
         "$@" && break
         n=$[$n+1]
-        echo ''
-        echo run $n of $MAX_AUTO_RETRY failed, trying again ...
-        echo ''
-        sleep 15
     done
 
     if [ $n -eq $MAX_AUTO_RETRY ]; then

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -40,7 +40,7 @@ case $1 in
         SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --tag=gl))
 
         for s in ${SHARDS[@]}; do
-            retry npm run test-jasmine -- "$s" --tags=gl --skip-tags=noCI,flaky
+            retry npm run test-jasmine -- "$s" --tags=gl --skip-tags=noCI
         done
 
         retry npm run test-jasmine -- --tags=flaky --skip-tags=noCI

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -4,6 +4,7 @@
 set +e
 set +o pipefail
 
+ROOT=$(dirname $0)/..
 EXIT_STATE=0
 MAX_AUTO_RETRY=5
 
@@ -34,7 +35,12 @@ case $1 in
         ;;
 
     jasmine2)
-        retry npm run test-jasmine -- --tags=gl --skip-tags=noCI,flaky
+        SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --tag=gl))
+
+        for s in ${SHARDS[@]}; do
+            retry npm run test-jasmine -- "$s" --tags=gl --skip-tags=noCI,flaky
+        done
+
         retry npm run test-jasmine -- --tags=flaky --skip-tags=noCI
         exit $EXIT_STATE
         ;;

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -8,22 +8,27 @@ ROOT=$(dirname $0)/..
 EXIT_STATE=0
 MAX_AUTO_RETRY=5
 
+log () {
+    echo -e "\n$1"
+}
+
 # inspired by https://unix.stackexchange.com/a/82602
 retry () {
-    local n=0
+    local n=1
 
     until [ $n -ge $MAX_AUTO_RETRY ]; do
-        if [ $n -ge 1 ]; then
-            echo ''
-            echo run $n of $MAX_AUTO_RETRY failed, trying again ...
-            echo ''
-            sleep 15
-        fi
-        "$@" && break
+        "$@" --failFast && break
+        log "run $n of $MAX_AUTO_RETRY failed, trying again ..."
         n=$[$n+1]
     done
 
     if [ $n -eq $MAX_AUTO_RETRY ]; then
+        log "one last time, w/o failing fast"
+        "$@" && n=0
+    fi
+
+    if [ $n -eq $MAX_AUTO_RETRY ]; then
+        log "all $n runs failed, moving on."
         EXIT_STATE=1
     fi
 }

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -32,6 +32,7 @@ case $1 in
 
     jasmine)
         npm run test-jasmine -- --skip-tags=gl,noCI,flaky || EXIT_STATE=$?
+        retry npm run test-jasmine -- --tags=flaky --skip-tags=noCI
         npm run test-bundle || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;
@@ -43,7 +44,6 @@ case $1 in
             retry npm run test-jasmine -- "$s" --tags=gl --skip-tags=noCI
         done
 
-        retry npm run test-jasmine -- --tags=flaky --skip-tags=noCI
         exit $EXIT_STATE
         ;;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6481,6 +6481,12 @@
         "which": "1.3.0"
       }
     },
+    "karma-fail-fast-reporter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/karma-fail-fast-reporter/-/karma-fail-fast-reporter-1.0.5.tgz",
+      "integrity": "sha1-9ScyP5jcXx6oEEfwCkuD7etgv3U=",
+      "dev": true
+    },
     "karma-firefox-launcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "karma": "^3.0.0",
     "karma-browserify": "^5.3.0",
     "karma-chrome-launcher": "^2.0.0",
+    "karma-fail-fast-reporter": "^1.0.5",
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.2",
     "karma-jasmine-spec-tags": "^1.0.1",

--- a/tasks/shard_jasmine_tests.js
+++ b/tasks/shard_jasmine_tests.js
@@ -5,8 +5,8 @@ var falafel = require('falafel');
 var glob = require('glob');
 var minimist = require('minimist');
 
-var constants = require('./util/constants');
-var pathToJasmineTests = constants.pathToJasmineTests;
+var pathToJasmineTests = require('./util/constants').pathToJasmineTests;
+var isJasmineTestIt = require('./util/common').isJasmineTestIt;
 
 var argv = minimist(process.argv.slice(2), {
     string: ['tag', 'limit'],
@@ -32,7 +32,7 @@ glob(path.join(pathToJasmineTests, '*.js'), function(err, files) {
         var bn = path.basename(file);
 
         falafel(code, function(node) {
-            if(isTestDescription(node, tag)) {
+            if(isJasmineTestIt(node, tag)) {
                 if(file2cnt[bn]) {
                     file2cnt[bn]++;
                 } else {
@@ -92,21 +92,3 @@ glob(path.join(pathToJasmineTests, '*.js'), function(err, files) {
     // print result to stdout
     console.log(runs.join('\n'));
 });
-
-function isTestDescription(node, tag) {
-    var isDescription = (
-        node.type === 'Literal' &&
-        node.parent &&
-        node.parent.type === 'CallExpression' &&
-        node.parent.callee &&
-        node.parent.callee.type === 'Identifier' &&
-        node.parent.callee.name === 'it'
-    );
-
-    if(!tag) return isDescription;
-
-    return (
-        isDescription &&
-        node.source().indexOf('@' + tag) !== -1
-    );
-}

--- a/tasks/shard_jasmine_tests.js
+++ b/tasks/shard_jasmine_tests.js
@@ -1,0 +1,112 @@
+var fs = require('fs');
+var path = require('path');
+
+var falafel = require('falafel');
+var glob = require('glob');
+var minimist = require('minimist');
+
+var constants = require('./util/constants');
+var pathToJasmineTests = constants.pathToJasmineTests;
+
+var argv = minimist(process.argv.slice(2), {
+    string: ['tag', 'limit'],
+    alias: {
+        tag: ['t'],
+        limit: ['l'],
+    },
+    default: {
+        limit: 20
+    }
+});
+
+var tag = argv.tag;
+var limit = argv.limit;
+
+glob(path.join(pathToJasmineTests, '*.js'), function(err, files) {
+    if(err) throw err;
+
+    var file2cnt = {};
+
+    files.forEach(function(file) {
+        var code = fs.readFileSync(file, 'utf-8');
+        var bn = path.basename(file);
+
+        falafel(code, function(node) {
+            if(isTestDescription(node, tag)) {
+                if(file2cnt[bn]) {
+                    file2cnt[bn]++;
+                } else {
+                    file2cnt[bn] = 1;
+                }
+            }
+        });
+    });
+
+    var ranking = Object.keys(file2cnt);
+    var runs = [];
+
+    // if 'it' count in file greater than threshold,
+    // run only this file separately,
+    // don't try to shard within file
+    Object.keys(file2cnt).forEach(function(f) {
+        if(file2cnt[f] > limit) {
+            runs.push(f);
+            ranking.splice(ranking.indexOf(f), 1);
+        }
+    });
+
+    // sort ranking in decreasing order
+    ranking.sort(function(a, b) { return file2cnt[b] - file2cnt[a]; });
+
+    var runi;
+    var cnt;
+
+    function newRun() {
+        var r0 = ranking[0];
+        runi = [r0];
+        cnt = file2cnt[r0];
+        ranking.shift();
+    }
+
+    function concat() {
+        runs.push(runi.join(','));
+    }
+
+    // try to match files with many tests with files not-that-many,
+    // by matching first rank with one or multiple trailing ranks.
+    newRun();
+    while(ranking.length) {
+        var rn = ranking[ranking.length - 1];
+
+        if((cnt + file2cnt[rn]) > limit) {
+            concat();
+            newRun();
+        } else {
+            runi.push(rn);
+            cnt += file2cnt[rn];
+            ranking.pop();
+        }
+    }
+    concat();
+
+    // print result to stdout
+    console.log(runs.join('\n'));
+});
+
+function isTestDescription(node, tag) {
+    var isDescription = (
+        node.type === 'Literal' &&
+        node.parent &&
+        node.parent.type === 'CallExpression' &&
+        node.parent.callee &&
+        node.parent.callee.type === 'Identifier' &&
+        node.parent.callee.name === 'it'
+    );
+
+    if(!tag) return isDescription;
+
+    return (
+        isDescription &&
+        node.source().indexOf('@' + tag) !== -1
+    );
+}

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -34,7 +34,10 @@ assertES5();
 function assertJasmineSuites() {
     var BLACK_LIST = ['fdescribe', 'fit', 'xdescribe', 'xit'];
     var TAGS = ['noCI', 'noCIdep', 'gl', 'flaky'];
+    var IT_ONLY_TAGS = ['gl', 'flaky'];
     var logs = [];
+
+    var addTagPrefix = function(t) { return '@' + t; };
 
     glob(combineGlobs([testGlob, bundleTestGlob]), function(err, files) {
         files.forEach(function(file) {
@@ -58,7 +61,7 @@ function assertJasmineSuites() {
                             logs.push([
                                 bn, lineInfo,
                                 'contains an unrecognized tag,',
-                                'not one of: ' + TAGS.map(function(t) { return '\@' + t; }).join(', ')
+                                'not one of: ' + TAGS.map(addTagPrefix).join(', ')
                             ].join(' '));
                         }
                     }
@@ -71,13 +74,15 @@ function assertJasmineSuites() {
                     }
                 }
 
-                if(isJasmineTestDescribe(node, 'gl')) {
-                    logs.push([
-                        bn, lineInfo,
-                        'contains a @gl tag is a *describe* block,',
-                        '@gl tags are allowed only in jasmine *it* blocks.'
-                    ].join(' '));
-                }
+                IT_ONLY_TAGS.forEach(function(t) {
+                    if(isJasmineTestDescribe(node, t)) {
+                        logs.push([
+                            bn, lineInfo,
+                            'contains a', addTagPrefix(t), 'tag is a *describe* block,',
+                            addTagPrefix(t), 'tags are only allowed in jasmine *it* blocks.'
+                        ].join(' '));
+                    }
+                });
             });
         });
 

--- a/tasks/util/common.js
+++ b/tasks/util/common.js
@@ -105,3 +105,30 @@ exports.formatEnumeration = function(list) {
         return '`' + l + '`' + ending;
     }).join(' ');
 };
+
+exports.hasJasmineTestTag = function(node, tag) {
+    var re = tag ?
+        new RegExp('@' + tag + '\\s') :
+        new RegExp('@' + '\\w');
+    return re.test(node.source());
+};
+
+function isJasmineBase(block, node, tag) {
+    return (
+        node.type === 'Literal' &&
+        node.parent &&
+        node.parent.type === 'CallExpression' &&
+        node.parent.callee &&
+        node.parent.callee.type === 'Identifier' &&
+        node.parent.callee.name === block &&
+        (tag === undefined || exports.hasJasmineTestTag(node, tag))
+    );
+}
+
+exports.isJasmineTestIt = function(node, tag) {
+    return isJasmineBase('it', node, tag);
+};
+
+exports.isJasmineTestDescribe = function(node, tag) {
+    return isJasmineBase('describe', node, tag);
+};

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -55,6 +55,7 @@ if(argv.info) {
         '  - `--Chrome` (alias `--chrome`): run test in (our custom) Chrome browser',
         '  - `--Firefox` (alias `--FF`, `--firefox`): run test in (our custom) Firefox browser',
         '  - `--nowatch (dflt: `false`, `true` on CI)`: run karma w/o `autoWatch` / multiple run mode',
+        '  - `--failFast` (dflt: `false`): exit karma upon first test failure',
         '  - `--verbose` (dflt: `false`): show test result using verbose reporter',
         '  - `--tags`: run only test with given tags (using the `jasmine-spec-tags` framework)',
         '  - `--width`(dflt: 1035): set width of the browser window',

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -236,7 +236,10 @@ func.defaultConfig = {
         suppressSkipped: false,
         showSpecTiming: false,
         failFast: false
-    }
+    },
+
+    // e.g. when a test file does not container a given spec tags
+    failOnEmptyTestSuite: false
 };
 
 func.defaultConfig.preprocessors[pathToCustomMatchers] = ['browserify'];

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -7,16 +7,18 @@ var constants = require('../../tasks/util/constants');
 var isCI = !!process.env.CIRCLECI;
 var argv = minimist(process.argv.slice(4), {
     string: ['bundleTest', 'width', 'height'],
-    'boolean': ['info', 'nowatch', 'verbose', 'Chrome', 'Firefox'],
+    'boolean': ['info', 'nowatch', 'failFast', 'verbose', 'Chrome', 'Firefox'],
     alias: {
         'Chrome': 'chrome',
         'Firefox': ['firefox', 'FF'],
         'bundleTest': ['bundletest', 'bundle_test'],
-        'nowatch': 'no-watch'
+        'nowatch': 'no-watch',
+        'failFast': 'fail-fast'
     },
     'default': {
         info: false,
         nowatch: isCI,
+        failFast: false,
         verbose: false,
         width: '1035',
         height: '617'
@@ -105,6 +107,10 @@ var pathToJQuery = path.join(__dirname, 'assets', 'jquery-1.8.3.min.js');
 var pathToIE9mock = path.join(__dirname, 'assets', 'ie9_mock.js');
 var pathToCustomMatchers = path.join(__dirname, 'assets', 'custom_matchers.js');
 
+var reporters = (isFullSuite && !argv.tags) ? ['dots', 'spec'] : ['progress'];
+if(argv.failFast) reporters.push('fail-fast');
+if(argv.verbose) reporters.push('verbose');
+
 function func(config) {
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
@@ -154,7 +160,7 @@ func.defaultConfig = {
     // See note in CONTRIBUTING.md about more verbose reporting via karma-verbose-reporter:
     // https://www.npmjs.com/package/karma-verbose-reporter ('verbose')
     //
-    reporters: (isFullSuite && !argv.tags) ? ['dots', 'spec'] : ['progress'],
+    reporters: reporters,
 
     // web server port
     port: 9876,
@@ -235,6 +241,8 @@ func.defaultConfig = {
         suppressPassed: true,
         suppressSkipped: false,
         showSpecTiming: false,
+        // use 'karma-fail-fast-reporter' to fail fast w/o conflicting
+        // with other karma plugins
         failFast: false
     },
 
@@ -293,10 +301,5 @@ var browsers = func.defaultConfig.browsers;
 if(argv.Chrome) browsers.push('_Chrome');
 if(argv.Firefox) browsers.push('_Firefox');
 if(browsers.length === 0) browsers.push('_Chrome');
-
-// add verbose reporter if specified
-if(argv.verbose) {
-    func.defaultConfig.reporters.push('verbose');
-}
 
 module.exports = func;

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -124,7 +124,7 @@ function func(config) {
     //
     // See https://github.com/karma-runner/karma/commit/89a7a1c#commitcomment-21009216
     func.defaultConfig.browserConsoleLogOptions = {
-        level: 'log'
+        level: 'debug'
     };
 
     config.set(func.defaultConfig);

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -102,7 +102,6 @@ if(isFullSuite) {
 
 var pathToShortcutPath = path.join(__dirname, '..', '..', 'tasks', 'util', 'shortcut_paths.js');
 var pathToStrictD3 = path.join(__dirname, '..', '..', 'tasks', 'util', 'strict_d3.js');
-var pathToMain = path.join(__dirname, '..', '..', 'lib', 'index.js');
 var pathToJQuery = path.join(__dirname, 'assets', 'jquery-1.8.3.min.js');
 var pathToIE9mock = path.join(__dirname, 'assets', 'ie9_mock.js');
 var pathToCustomMatchers = path.join(__dirname, 'assets', 'custom_matchers.js');
@@ -252,10 +251,7 @@ func.defaultConfig = {
 
 func.defaultConfig.preprocessors[pathToCustomMatchers] = ['browserify'];
 
-if(isFullSuite) {
-    func.defaultConfig.files.push(pathToJQuery);
-    func.defaultConfig.preprocessors[testFileGlob] = ['browserify'];
-} else if(isBundleTest) {
+if(isBundleTest) {
     switch(basename(testFileGlob)) {
         case 'requirejs':
             // browserified custom_matchers doesn't work with this route
@@ -282,14 +278,7 @@ if(isFullSuite) {
             break;
     }
 } else {
-    // Add lib/index.js to non-full-suite runs,
-    // to make sure the registry is set-up correctly.
-    func.defaultConfig.files.push(
-        pathToJQuery,
-        pathToMain
-    );
-
-    func.defaultConfig.preprocessors[pathToMain] = ['browserify'];
+    func.defaultConfig.files.push(pathToJQuery);
     func.defaultConfig.preprocessors[testFileGlob] = ['browserify'];
 }
 

--- a/test/jasmine/tests/cone_test.js
+++ b/test/jasmine/tests/cone_test.js
@@ -60,7 +60,7 @@ describe('Test cone defaults', function() {
     });
 });
 
-describe('@gl Test cone autorange:', function() {
+describe('Test cone autorange:', function() {
     var gd;
 
     beforeEach(function() {
@@ -79,7 +79,7 @@ describe('@gl Test cone autorange:', function() {
         expect(sceneLayout.zaxis.range).toBeCloseToArray(zrng, 2, 'zaxis range - ' + msg);
     }
 
-    it('should add pad around cone position to make sure they fit on the scene', function(done) {
+    it('@gl should add pad around cone position to make sure they fit on the scene', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_cone-autorange.json'));
         var rng0 = [0.103, 3.897];
 
@@ -177,7 +177,7 @@ describe('@gl Test cone autorange:', function() {
     });
 });
 
-describe('@gl Test cone interactions', function() {
+describe('Test cone interactions', function() {
     var gd;
 
     beforeEach(function() {
@@ -189,7 +189,7 @@ describe('@gl Test cone interactions', function() {
         destroyGraphDiv();
     });
 
-    it('should add/clear gl objects correctly', function(done) {
+    it('@gl should add/clear gl objects correctly', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_cone-simple.json'));
         // put traces on same subplot
         delete fig.data[1].scene;
@@ -219,7 +219,7 @@ describe('@gl Test cone interactions', function() {
         .then(done);
     });
 
-    it('should not pass zero or infinite `coneSize` to gl-cone3d', function(done) {
+    it('@gl should not pass zero or infinite `coneSize` to gl-cone3d', function(done) {
         var base = {
             type: 'cone',
             x: [1, 2, 3],
@@ -254,7 +254,7 @@ describe('@gl Test cone interactions', function() {
         .then(done);
     });
 
-    it('should display hover labels', function(done) {
+    it('@gl should display hover labels', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_cone-simple.json'));
         // only one trace on one scene
         fig.data = [fig.data[0]];
@@ -302,7 +302,7 @@ describe('@gl Test cone interactions', function() {
         .then(done);
     });
 
-    it('should display hover labels (multi-trace case)', function(done) {
+    it('@gl should display hover labels (multi-trace case)', function(done) {
         function _hover() {
             mouseEvent('mouseover', 282, 240);
             return delay(20)();

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -66,7 +66,7 @@ var mock4 = {
     layout: {}
 };
 
-describe('@gl @flaky Test hover and click interactions', function() {
+describe('@flaky Test hover and click interactions', function() {
     var gd;
 
     function makeHoverFn(gd, x, y) {
@@ -185,7 +185,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         destroyGraphDiv();
     });
 
-    it('should output correct event data for scattergl', function(done) {
+    it('@gl should output correct event data for scattergl', function(done) {
         var _mock = Lib.extendDeep({}, mock1);
 
         _mock.layout.hoverlabel = {
@@ -222,7 +222,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for scattergl in *select* dragmode', function(done) {
+    it('@gl should output correct event data for scattergl in *select* dragmode', function(done) {
         var _mock = Lib.extendDeep({}, mock1);
 
         _mock.layout.dragmode = 'select';
@@ -261,7 +261,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for scattergl in *lasso* dragmode', function(done) {
+    it('@gl should output correct event data for scattergl in *lasso* dragmode', function(done) {
         var _mock = Lib.extendDeep({}, mock1);
 
         _mock.layout.dragmode = 'lasso';
@@ -300,7 +300,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for scattergl with hoverinfo: \'none\'', function(done) {
+    it('@gl should output correct event data for scattergl with hoverinfo: \'none\'', function(done) {
         var _mock = Lib.extendDeep({}, mock1);
         _mock.data[0].hoverinfo = 'none';
 
@@ -320,7 +320,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should show correct label for scattergl when hovertext is set', function(done) {
+    it('@gl should show correct label for scattergl when hovertext is set', function(done) {
         var _mock = Lib.extendDeep({}, mock1);
         _mock.data[0].hovertext = 'text';
         _mock.data[0].hovertext = 'HoVeRtExT';
@@ -347,7 +347,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for pointcloud', function(done) {
+    it('@gl should output correct event data for pointcloud', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
 
         _mock.layout.hoverlabel = { font: {size: 8} };
@@ -375,7 +375,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for heatmapgl', function(done) {
+    it('@gl should output correct event data for heatmapgl', function(done) {
         var _mock = Lib.extendDeep({}, mock3);
         _mock.data[0].type = 'heatmapgl';
 
@@ -408,7 +408,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for heatmapgl (asymmetric case) ', function(done) {
+    it('@gl should output correct event data for heatmapgl (asymmetric case) ', function(done) {
         var _mock = {
             data: [{
                 type: 'heatmapgl',
@@ -441,7 +441,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for scattergl after visibility restyle', function(done) {
+    it('@gl should output correct event data for scattergl after visibility restyle', function(done) {
         var _mock = Lib.extendDeep({}, mock4);
 
         var run = makeRunner([435, 216], {
@@ -483,7 +483,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data for scattergl-fancy', function(done) {
+    it('@gl should output correct event data for scattergl-fancy', function(done) {
         var _mock = Lib.extendDeep({}, mock4);
         _mock.data[0].mode = 'markers+lines';
         _mock.data[1].mode = 'markers+lines';
@@ -531,7 +531,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
         .then(done);
     });
 
-    it('should output correct event data contourgl', function(done) {
+    it('@gl should output correct event data contourgl', function(done) {
         var _mock = Lib.extendDeep({}, mock3);
 
         _mock.data[0].hoverlabel = {
@@ -560,7 +560,7 @@ describe('@gl @flaky Test hover and click interactions', function() {
     });
 });
 
-describe('@noCI @gl Test gl2d lasso/select:', function() {
+describe('@noCI Test gl2d lasso/select:', function() {
     var mockFancy = require('@mocks/gl2d_14.json');
     delete mockFancy.layout.xaxis.autorange;
     delete mockFancy.layout.yaxis.autorange;
@@ -630,7 +630,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
     }
 
 
-    it('should work under fast mode with *select* dragmode', function(done) {
+    it('@gl should work under fast mode with *select* dragmode', function(done) {
         var _mock = Lib.extendDeep({}, mockFast);
         _mock.layout.dragmode = 'select';
         gd = createGraphDiv();
@@ -657,7 +657,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should work under fast mode with *lasso* dragmode', function(done) {
+    it('@gl should work under fast mode with *lasso* dragmode', function(done) {
         var _mock = Lib.extendDeep({}, mockFast);
         _mock.layout.dragmode = 'lasso';
         gd = createGraphDiv();
@@ -681,7 +681,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should work under fancy mode with *select* dragmode', function(done) {
+    it('@gl should work under fancy mode with *select* dragmode', function(done) {
         var _mock = Lib.extendDeep({}, mockFancy);
         _mock.layout.dragmode = 'select';
         gd = createGraphDiv();
@@ -701,7 +701,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should work under fancy mode with *lasso* dragmode', function(done) {
+    it('@gl should work under fancy mode with *lasso* dragmode', function(done) {
         var _mock = Lib.extendDeep({}, mockFancy);
         _mock.layout.dragmode = 'lasso';
         gd = createGraphDiv();
@@ -720,7 +720,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should work on trace with enabled transforms', function(done) {
+    it('@gl should work on trace with enabled transforms', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl2d_transforms.json'));
         fig.layout.dragmode = 'select';
         fig.layout.margin = {t: 0, b: 0, l: 0, r: 0};
@@ -743,7 +743,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should work on gl text charts', function(done) {
+    it('@gl should work on gl text charts', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl2d_text_chart_basic.json'));
         fig.layout.dragmode = 'select';
         fig.layout.margin = {t: 0, b: 0, l: 0, r: 0};
@@ -826,7 +826,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should work on gl text charts with array textfont.color', function(done) {
+    it('@gl should work on gl text charts with array textfont.color', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl2d_text_chart_arrays.json'));
         fig.layout.dragmode = 'select';
         fig.layout.margin = {t: 0, b: 0, l: 0, r: 0};
@@ -906,7 +906,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should work after a width/height relayout', function(done) {
+    it('@gl should work after a width/height relayout', function(done) {
         gd = createGraphDiv();
 
         var w = 500;
@@ -965,7 +965,7 @@ describe('@noCI @gl Test gl2d lasso/select:', function() {
         .then(done);
     });
 
-    it('should behave correctly during select+doubleclick+pan scenarios', function(done) {
+    it('@gl should behave correctly during select+doubleclick+pan scenarios', function(done) {
         gd = createGraphDiv();
 
         // See https://github.com/plotly/plotly.js/issues/2767

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -66,7 +66,7 @@ var mock4 = {
     layout: {}
 };
 
-describe('@flaky Test hover and click interactions', function() {
+describe('Test hover and click interactions', function() {
     var gd;
 
     function makeHoverFn(gd, x, y) {

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -180,9 +180,10 @@ describe('Test hover and click interactions', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(function() {
+    afterEach(function(done) {
         Plotly.purge(gd);
         destroyGraphDiv();
+        setTimeout(done, 1000);
     });
 
     it('@gl should output correct event data for scattergl', function(done) {

--- a/test/jasmine/tests/gl2d_date_axis_render_test.js
+++ b/test/jasmine/tests/gl2d_date_axis_render_test.js
@@ -3,7 +3,7 @@ var Plotly = require('@lib');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 
-describe('@gl date axis', function() {
+describe('date axis', function() {
 
     var gd;
 
@@ -13,7 +13,7 @@ describe('@gl date axis', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('should use the fancy gl-vis/gl-scatter2d', function() {
+    it('@gl should use the fancy gl-vis/gl-scatter2d', function() {
         Plotly.plot(gd, [{
             type: 'scattergl',
             'marker': {
@@ -40,7 +40,7 @@ describe('@gl date axis', function() {
         expect(scene.line2d).not.toBeUndefined();
     });
 
-    it('should use the fancy gl-vis/gl-scatter2d once again', function() {
+    it('@gl should use the fancy gl-vis/gl-scatter2d once again', function() {
         Plotly.plot(gd, [{
             type: 'scattergl',
             'marker': {
@@ -66,7 +66,7 @@ describe('@gl date axis', function() {
         expect(scene.line2d).toBeDefined();
     });
 
-    it('should now use the non-fancy gl-vis/gl-scatter2d', function() {
+    it('@gl should now use the non-fancy gl-vis/gl-scatter2d', function() {
         Plotly.plot(gd, [{
             type: 'scattergl',
             mode: 'markers',
@@ -85,7 +85,7 @@ describe('@gl date axis', function() {
         expect(scene.line2d).toBeDefined();
     });
 
-    it('should use the non-fancy gl-vis/gl-scatter2d with string dates', function() {
+    it('@gl should use the non-fancy gl-vis/gl-scatter2d with string dates', function() {
         Plotly.plot(gd, [{
             type: 'scattergl',
             mode: 'markers',

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -20,7 +20,7 @@ function countCanvases() {
     return d3.selectAll('canvas').size();
 }
 
-describe('@gl Test removal of gl contexts', function() {
+describe('Test removal of gl contexts', function() {
     var gd;
 
     beforeEach(function() {
@@ -29,7 +29,7 @@ describe('@gl Test removal of gl contexts', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('Plots.cleanPlot should remove gl context from the graph div of a gl2d plot', function(done) {
+    it('@gl Plots.cleanPlot should remove gl context from the graph div of a gl2d plot', function(done) {
         Plotly.plot(gd, [{
             type: 'scattergl',
             x: [1, 2, 3],
@@ -44,7 +44,7 @@ describe('@gl Test removal of gl contexts', function() {
         .then(done);
     });
 
-    it('Plotly.newPlot should remove gl context from the graph div of a gl2d plot', function(done) {
+    it('@gl Plotly.newPlot should remove gl context from the graph div of a gl2d plot', function(done) {
         var firstGlplotObject, firstGlContext, firstCanvas;
 
         Plotly.plot(gd, [{
@@ -87,7 +87,7 @@ describe('@gl Test removal of gl contexts', function() {
     });
 });
 
-describe('@gl Test gl plot side effects', function() {
+describe('Test gl plot side effects', function() {
     var gd;
 
     beforeEach(function() {
@@ -99,7 +99,7 @@ describe('@gl Test gl plot side effects', function() {
         destroyGraphDiv();
     });
 
-    it('should not draw the rangeslider', function(done) {
+    it('@gl should not draw the rangeslider', function(done) {
         var data = [{
             x: [1, 2, 3],
             y: [2, 3, 4],
@@ -121,7 +121,7 @@ describe('@gl Test gl plot side effects', function() {
         .then(done);
     });
 
-    it('should be able to replot from a blank graph', function(done) {
+    it('@gl should be able to replot from a blank graph', function(done) {
 
         function countCanvases(cnt) {
             var nodes = d3.selectAll('canvas');
@@ -163,7 +163,7 @@ describe('@gl Test gl plot side effects', function() {
         .then(done);
     });
 
-    it('should be able to switch trace type', function(done) {
+    it('@gl should be able to switch trace type', function(done) {
         Plotly.newPlot(gd, [{
             type: 'parcoords',
             x: [1, 2, 3],
@@ -187,7 +187,7 @@ describe('@gl Test gl plot side effects', function() {
         .then(done);
     });
 
-    it('should be able to resize canvas properly', function(done) {
+    it('@gl should be able to resize canvas properly', function(done) {
         var _mock = Lib.extendDeep({}, require('@mocks/gl2d_10.json'));
         _mock.data[0].line.width = 5;
 
@@ -207,7 +207,7 @@ describe('@gl Test gl plot side effects', function() {
     });
 });
 
-describe('@gl Test gl2d plots', function() {
+describe('Test gl2d plots', function() {
     var gd;
     var mock = require('@mocks/gl2d_10.json');
 
@@ -248,7 +248,7 @@ describe('@gl Test gl2d plots', function() {
         });
     }
 
-    it('@flaky should respond to drag interactions', function(done) {
+    it('@gl @flaky should respond to drag interactions', function(done) {
         var _mock = Lib.extendDeep({}, mock);
 
         var relayoutCallback = jasmine.createSpy('relayoutCallback');
@@ -354,7 +354,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@flaky should be able to toggle visibility', function(done) {
+    it('@gl @flaky should be able to toggle visibility', function(done) {
         var _mock = Lib.extendDeep({}, mock);
         _mock.data[0].line.width = 5;
 
@@ -396,7 +396,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should be able to toggle trace with different modes', function(done) {
+    it('@gl should be able to toggle trace with different modes', function(done) {
         Plotly.newPlot(gd, [{
             // a trace with all regl2d objects
             type: 'scattergl',
@@ -443,7 +443,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@noCI should display selection of big number of regular points', function(done) {
+    it('@noCI @gl should display selection of big number of regular points', function(done) {
         // generate large number of points
         var x = [], y = [], n = 2e2, N = n * n;
         for(var i = 0; i < N; i++) {
@@ -471,7 +471,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@noCI should display selection of big number of miscellaneous points', function(done) {
+    it('@noCI @gl should display selection of big number of miscellaneous points', function(done) {
         var colorList = [
             '#006385', '#F06E75', '#90ed7d', '#f7a35c', '#8085e9',
             '#f15c80', '#e4d354', '#2b908f', '#f45b5b', '#91e8e1',
@@ -510,7 +510,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should be able to toggle from svg to gl', function(done) {
+    it('@gl should be able to toggle from svg to gl', function(done) {
         Plotly.plot(gd, [{
             y: [1, 2, 1],
         }])
@@ -534,7 +534,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@flaky supports 1D and 2D Zoom', function(done) {
+    it('@gl @flaky supports 1D and 2D Zoom', function(done) {
         var centerX;
         var centerY;
 
@@ -587,7 +587,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@flaky supports axis constraints with zoom', function(done) {
+    it('@gl @flaky supports axis constraints with zoom', function(done) {
         var centerX;
         var centerY;
 
@@ -654,7 +654,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@flaky should change plot type with incomplete data', function(done) {
+    it('@gl @flaky should change plot type with incomplete data', function(done) {
         Plotly.plot(gd, [{}]);
         expect(function() {
             Plotly.restyle(gd, {type: 'scattergl', x: [[1]]}, 0);
@@ -667,7 +667,7 @@ describe('@gl Test gl2d plots', function() {
         done();
     });
 
-    it('@flaky data-referenced annotations should update on drag', function(done) {
+    it('@gl @flaky data-referenced annotations should update on drag', function(done) {
         function assertAnnotation(xy) {
             var ann = d3.select('g.annotation-text-g').select('g');
             var translate = Drawing.getTranslate(ann);
@@ -710,7 +710,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@flaky should not scroll document while panning', function(done) {
+    it('@gl @flaky should not scroll document while panning', function(done) {
         var mock = {
             data: [
                 { type: 'scattergl', y: [1, 2, 3], x: [1, 2, 3] }
@@ -764,7 +764,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should restyle opacity', function(done) {
+    it('@gl should restyle opacity', function(done) {
         // #2299
         spyOn(ScatterGl, 'calc');
 
@@ -788,7 +788,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should update selected points', function(done) {
+    it('@gl should update selected points', function(done) {
         // #2298
         var dat = [{
             'x': [1],
@@ -872,7 +872,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@flaky should remove fill2d', function(done) {
+    it('@gl @flaky should remove fill2d', function(done) {
         var mock = require('@mocks/gl2d_axes_labels2.json');
 
         Plotly.plot(gd, mock.data, mock.layout)
@@ -889,7 +889,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should be able to draw more than 4096 colors', function(done) {
+    it('@gl should be able to draw more than 4096 colors', function(done) {
         var x = [];
         var color = [];
         var N = 1e5;
@@ -934,7 +934,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should work with typed array', function(done) {
+    it('@gl should work with typed array', function(done) {
         Plotly.plot(gd, [{
             type: 'scattergl',
             mode: 'markers',
@@ -965,7 +965,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should create two WebGL contexts per graph', function(done) {
+    it('@gl should create two WebGL contexts per graph', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl2d_stacked_subplots.json'));
 
         Plotly.plot(gd, fig).then(function() {
@@ -979,7 +979,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should handle transform traces properly (calcTransform case)', function(done) {
+    it('@gl should handle transform traces properly (calcTransform case)', function(done) {
         spyOn(ScatterGl, 'calc').and.callThrough();
 
         Plotly.plot(gd, [{
@@ -1011,7 +1011,7 @@ describe('@gl Test gl2d plots', function() {
         .then(done);
     });
 
-    it('should handle transform traces properly (default transform case)', function(done) {
+    it('@gl should handle transform traces properly (default transform case)', function(done) {
         spyOn(ScatterGl, 'calc').and.callThrough();
 
         Plotly.plot(gd, [{
@@ -1093,7 +1093,7 @@ describe('Test scattergl autorange:', function() {
         ];
 
         specs.forEach(function(s) {
-            it('- case ' + s.name, function(done) {
+            it('@gl - case ' + s.name, function(done) {
                 var gd = createGraphDiv();
                 var glRangeX;
                 var glRangeY;
@@ -1142,7 +1142,7 @@ describe('Test scattergl autorange:', function() {
             ms[i] = 10 * Lib.pseudoRandom() + 20;
         }
 
-        it('- case scalar marker.size', function(done) {
+        it('@gl - case scalar marker.size', function(done) {
             var gd = createGraphDiv();
 
             Plotly.newPlot(gd, [{
@@ -1160,7 +1160,7 @@ describe('Test scattergl autorange:', function() {
             .then(done);
         });
 
-        it('- case array marker.size', function(done) {
+        it('@gl - case array marker.size', function(done) {
             var gd = createGraphDiv();
 
             Plotly.newPlot(gd, [{

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -27,7 +27,10 @@ describe('Test removal of gl contexts', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(destroyGraphDiv);
+    afterEach(function() {
+        Plotly.purge(gd);
+        destroyGraphDiv();
+    });
 
     it('@gl Plots.cleanPlot should remove gl context from the graph div of a gl2d plot', function(done) {
         Plotly.plot(gd, [{
@@ -41,6 +44,7 @@ describe('Test removal of gl contexts', function() {
 
             expect(!!gd._fullLayout._plots.xy._scene).toBe(false);
         })
+        .catch(failTest)
         .then(done);
     });
 
@@ -83,6 +87,7 @@ describe('Test removal of gl contexts', function() {
                 firstCanvas !== secondCanvas && firstGlContext.isContextLost()
             );
         })
+        .catch(failTest)
         .then(done);
     });
 });
@@ -94,9 +99,10 @@ describe('Test gl plot side effects', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(function() {
+    afterEach(function(done) {
         Plotly.purge(gd);
         destroyGraphDiv();
+        setTimeout(done, 1000);
     });
 
     it('@gl should not draw the rangeslider', function(done) {
@@ -118,6 +124,7 @@ describe('Test gl plot side effects', function() {
             var rangeSlider = document.getElementsByClassName('range-slider')[0];
             expect(rangeSlider).not.toBeDefined();
         })
+        .catch(failTest)
         .then(done);
     });
 
@@ -160,11 +167,12 @@ describe('Test gl plot side effects', function() {
 
             return Plotly.purge(gd);
         })
+        .catch(failTest)
         .then(done);
     });
 
     it('@gl should be able to switch trace type', function(done) {
-        Plotly.newPlot(gd, [{
+        Plotly.plot(gd, [{
             type: 'parcoords',
             x: [1, 2, 3],
             y: [2, 1, 2],
@@ -184,6 +192,7 @@ describe('Test gl plot side effects', function() {
         .then(function() {
             expect(d3.selectAll('canvas').size()).toEqual(0);
         })
+        .catch(failTest)
         .then(done);
     });
 
@@ -197,7 +206,7 @@ describe('Test gl plot side effects', function() {
         .then(function() {
             expect(gd.querySelector('.gl-canvas-context').width).toBe(600);
 
-            Plotly.relayout(gd, {width: 300});
+            return Plotly.relayout(gd, {width: 300});
         })
         .then(function() {
             expect(gd.querySelector('.gl-canvas-context').width).toBe(300);
@@ -216,9 +225,10 @@ describe('Test gl2d plots', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(function() {
+    afterEach(function(done) {
         Plotly.purge(gd);
         destroyGraphDiv();
+        setTimeout(done, 1000);
     });
 
     function mouseTo(p0, p1) {

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -248,7 +248,7 @@ describe('Test gl2d plots', function() {
         });
     }
 
-    it('@gl @flaky should respond to drag interactions', function(done) {
+    it('@gl should respond to drag interactions', function(done) {
         var _mock = Lib.extendDeep({}, mock);
 
         var relayoutCallback = jasmine.createSpy('relayoutCallback');
@@ -354,7 +354,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@gl @flaky should be able to toggle visibility', function(done) {
+    it('@gl should be able to toggle visibility', function(done) {
         var _mock = Lib.extendDeep({}, mock);
         _mock.data[0].line.width = 5;
 
@@ -534,7 +534,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@gl @flaky supports 1D and 2D Zoom', function(done) {
+    it('@gl supports 1D and 2D Zoom', function(done) {
         var centerX;
         var centerY;
 
@@ -587,7 +587,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@gl @flaky supports axis constraints with zoom', function(done) {
+    it('@gl supports axis constraints with zoom', function(done) {
         var centerX;
         var centerY;
 
@@ -654,7 +654,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@gl @flaky should change plot type with incomplete data', function(done) {
+    it('@gl should change plot type with incomplete data', function(done) {
         Plotly.plot(gd, [{}]);
         expect(function() {
             Plotly.restyle(gd, {type: 'scattergl', x: [[1]]}, 0);
@@ -667,7 +667,7 @@ describe('Test gl2d plots', function() {
         done();
     });
 
-    it('@gl @flaky data-referenced annotations should update on drag', function(done) {
+    it('@gl data-referenced annotations should update on drag', function(done) {
         function assertAnnotation(xy) {
             var ann = d3.select('g.annotation-text-g').select('g');
             var translate = Drawing.getTranslate(ann);
@@ -710,7 +710,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@gl @flaky should not scroll document while panning', function(done) {
+    it('@gl should not scroll document while panning', function(done) {
         var mock = {
             data: [
                 { type: 'scattergl', y: [1, 2, 3], x: [1, 2, 3] }
@@ -872,7 +872,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@gl @flaky should remove fill2d', function(done) {
+    it('@gl should remove fill2d', function(done) {
         var mock = require('@mocks/gl2d_axes_labels2.json');
 
         Plotly.plot(gd, mock.data, mock.layout)

--- a/test/jasmine/tests/gl2d_pointcloud_test.js
+++ b/test/jasmine/tests/gl2d_pointcloud_test.js
@@ -138,7 +138,7 @@ var plotData = {
     }
 };
 
-describe('@gl pointcloud traces', function() {
+describe('pointcloud traces', function() {
 
     var gd;
 
@@ -151,13 +151,13 @@ describe('@gl pointcloud traces', function() {
         destroyGraphDiv();
     });
 
-    it('renders without raising an error', function(done) {
+    it('@gl renders without raising an error', function(done) {
         Plotly.plot(gd, plotData)
         .catch(failTest)
         .then(done);
     });
 
-    it('should update properly', function(done) {
+    it('@gl should update properly', function(done) {
         var mock = plotData;
         var scene2d;
 

--- a/test/jasmine/tests/gl2d_scatterplot_contour_test.js
+++ b/test/jasmine/tests/gl2d_scatterplot_contour_test.js
@@ -167,7 +167,7 @@ function makePlot(gd, mock, done) {
         .then(done);
 }
 
-describe('@gl contourgl plots', function() {
+describe('contourgl plots', function() {
 
     var gd;
 
@@ -182,11 +182,11 @@ describe('@gl contourgl plots', function() {
 
     // this first dataset is a special case, very forgiving to the contour renderer, as it's convex,
     // contains no inflexion points etc.
-    it('render without raising an error', function(done) {
+    it('@gl render without raising an error', function(done) {
         makePlot(gd, plotData, done);
     });
 
-    it('render without raising an error', function(done) {
+    it('@gl render without raising an error', function(done) {
         var mock = require('@mocks/simple_contour.json'),
             mockCopy = Lib.extendDeep({}, mock);
 

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -21,7 +21,7 @@ function countCanvases() {
     return d3.selectAll('canvas').size();
 }
 
-describe('@gl Test gl3d plots', function() {
+describe('Test gl3d plots', function() {
     var gd, ptData;
 
     var mock = require('@mocks/gl3d_marker-arrays.json');
@@ -74,7 +74,7 @@ describe('@gl Test gl3d plots', function() {
         destroyGraphDiv();
     });
 
-    it('@noCI should display correct hover labels and emit correct event data (scatter3d case)', function(done) {
+    it('@noCI @gl should display correct hover labels and emit correct event data (scatter3d case)', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
 
         function _hover() {
@@ -217,7 +217,7 @@ describe('@gl Test gl3d plots', function() {
         .then(done);
     });
 
-    it('@noCI should display correct hover labels and emit correct event data (surface case)', function(done) {
+    it('@noCI @gl should display correct hover labels and emit correct event data (surface case)', function(done) {
         var _mock = Lib.extendDeep({}, mock3);
 
         function _hover() {
@@ -313,7 +313,7 @@ describe('@gl Test gl3d plots', function() {
         .then(done);
     });
 
-    it('@noCI should emit correct event data on click (scatter3d case)', function(done) {
+    it('@noCI @gl should emit correct event data on click (scatter3d case)', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
 
         // N.B. gl3d click events are 'mouseover' events
@@ -338,7 +338,7 @@ describe('@gl Test gl3d plots', function() {
         .then(done);
     });
 
-    it('should display correct hover labels (mesh3d case)', function(done) {
+    it('@gl should display correct hover labels (mesh3d case)', function(done) {
         var x = [1, 1, 2, 3, 4, 2];
         var y = [2, 1, 3, 4, 5, 3];
         var z = [3, 7, 4, 5, 3.5, 2];
@@ -392,7 +392,7 @@ describe('@gl Test gl3d plots', function() {
         .then(done);
     });
 
-    it('should be able to reversibly change trace type', function(done) {
+    it('@gl should be able to reversibly change trace type', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
         var sceneLayout = { aspectratio: { x: 1, y: 1, z: 1 } };
 
@@ -430,7 +430,7 @@ describe('@gl Test gl3d plots', function() {
         .then(done);
     });
 
-    it('should be able to delete the last trace', function(done) {
+    it('@gl should be able to delete the last trace', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
 
         Plotly.plot(gd, _mock)
@@ -446,7 +446,7 @@ describe('@gl Test gl3d plots', function() {
         .then(done);
     });
 
-    it('should be able to toggle visibility', function(done) {
+    it('@gl should be able to toggle visibility', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
         _mock.data[0].x = [0, 1, 3];
         _mock.data[0].y = [0, 1, 2];
@@ -512,7 +512,7 @@ describe('@gl Test gl3d plots', function() {
 
 });
 
-describe('@gl Test gl3d modebar handlers', function() {
+describe('Test gl3d modebar handlers', function() {
     var gd, modeBar;
 
     function assertScenes(cont, attr, val) {
@@ -562,7 +562,7 @@ describe('@gl Test gl3d modebar handlers', function() {
         destroyGraphDiv();
     });
 
-    it('button zoom3d should updates the scene dragmode and dragmode button', function() {
+    it('@gl button zoom3d should updates the scene dragmode and dragmode button', function() {
         var buttonTurntable = selectButton(modeBar, 'tableRotation');
         var buttonZoom3d = selectButton(modeBar, 'zoom3d');
 
@@ -583,7 +583,7 @@ describe('@gl Test gl3d modebar handlers', function() {
         expect(buttonZoom3d.isActive()).toBe(false);
     });
 
-    it('button pan3d should updates the scene dragmode and dragmode button', function() {
+    it('@gl button pan3d should updates the scene dragmode and dragmode button', function() {
         var buttonTurntable = selectButton(modeBar, 'tableRotation'),
             buttonPan3d = selectButton(modeBar, 'pan3d');
 
@@ -604,7 +604,7 @@ describe('@gl Test gl3d modebar handlers', function() {
         expect(buttonPan3d.isActive()).toBe(false);
     });
 
-    it('button orbitRotation should updates the scene dragmode and dragmode button', function() {
+    it('@gl button orbitRotation should updates the scene dragmode and dragmode button', function() {
         var buttonTurntable = selectButton(modeBar, 'tableRotation'),
             buttonOrbit = selectButton(modeBar, 'orbitRotation');
 
@@ -625,7 +625,7 @@ describe('@gl Test gl3d modebar handlers', function() {
         expect(buttonOrbit.isActive()).toBe(false);
     });
 
-    it('button hoverClosest3d should update the scene hovermode and spikes', function() {
+    it('@gl button hoverClosest3d should update the scene hovermode and spikes', function() {
         var buttonHover = selectButton(modeBar, 'hoverClosest3d');
 
         assertScenes(gd._fullLayout, 'hovermode', 'closest');
@@ -646,7 +646,7 @@ describe('@gl Test gl3d modebar handlers', function() {
         expect(buttonHover.isActive()).toBe(true);
     });
 
-    it('button resetCameraDefault3d should reset camera to default', function(done) {
+    it('@gl button resetCameraDefault3d should reset camera to default', function(done) {
         var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
 
         expect(gd._fullLayout.scene._scene.cameraInitial.eye).toEqual({ x: 0.1, y: 0.1, z: 1 });
@@ -666,7 +666,7 @@ describe('@gl Test gl3d modebar handlers', function() {
         buttonDefault.click();
     });
 
-    it('button resetCameraLastSave3d should reset camera to default', function(done) {
+    it('@gl button resetCameraLastSave3d should reset camera to default', function(done) {
         var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
         var buttonLastSave = selectButton(modeBar, 'resetCameraLastSave3d');
 
@@ -740,7 +740,7 @@ describe('@gl Test gl3d modebar handlers', function() {
     });
 });
 
-describe('@gl Test gl3d drag and wheel interactions', function() {
+describe('Test gl3d drag and wheel interactions', function() {
     var gd;
 
     function scroll(target, amt) {
@@ -778,7 +778,7 @@ describe('@gl Test gl3d drag and wheel interactions', function() {
         destroyGraphDiv();
     });
 
-    it('should not scroll document while panning', function(done) {
+    it('@gl should not scroll document while panning', function(done) {
         var mock = {
             data: [
                 { type: 'scatter3d' }
@@ -821,7 +821,7 @@ describe('@gl Test gl3d drag and wheel interactions', function() {
         .then(done);
     });
 
-    it('should update the scene camera', function(done) {
+    it('@gl should update the scene camera', function(done) {
         var sceneLayout, sceneLayout2, sceneTarget, sceneTarget2, relayoutCallback;
 
         var mock = {
@@ -913,7 +913,7 @@ describe('@gl Test gl3d drag and wheel interactions', function() {
     });
 });
 
-describe('@gl Test gl3d relayout calls', function() {
+describe('Test gl3d relayout calls', function() {
     var gd;
 
     beforeEach(function() {
@@ -925,7 +925,7 @@ describe('@gl Test gl3d relayout calls', function() {
         destroyGraphDiv();
     });
 
-    it('should be able to adjust margins', function(done) {
+    it('@gl should be able to adjust margins', function(done) {
         var w = 500;
         var h = 500;
 
@@ -960,7 +960,7 @@ describe('@gl Test gl3d relayout calls', function() {
         .then(done);
     });
 
-    it('should skip root-level axis objects', function(done) {
+    it('@gl should skip root-level axis objects', function(done) {
         Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
@@ -979,7 +979,7 @@ describe('@gl Test gl3d relayout calls', function() {
     });
 });
 
-describe('@gl Test gl3d annotations', function() {
+describe('Test gl3d annotations', function() {
     var gd;
 
     beforeEach(function() {
@@ -1029,7 +1029,7 @@ describe('@gl Test gl3d annotations', function() {
         return delay(500)();
     }
 
-    it('should move with camera', function(done) {
+    it('@gl should move with camera', function(done) {
         Plotly.plot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
@@ -1067,7 +1067,7 @@ describe('@gl Test gl3d annotations', function() {
         .then(done);
     });
 
-    it('should be removed when beyond the scene axis ranges', function(done) {
+    it('@gl should be removed when beyond the scene axis ranges', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/gl3d_annotations'));
 
         // replace text with something easier to identify
@@ -1100,7 +1100,7 @@ describe('@gl Test gl3d annotations', function() {
         .then(done);
     });
 
-    it('should be able to add/remove and hide/unhide themselves via relayout', function(done) {
+    it('@gl should be able to add/remove and hide/unhide themselves via relayout', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/gl3d_annotations'));
 
         // replace text with something easier to identify
@@ -1150,7 +1150,7 @@ describe('@gl Test gl3d annotations', function() {
         .then(done);
     });
 
-    it('should work across multiple scenes', function(done) {
+    it('@gl should work across multiple scenes', function(done) {
         function assertAnnotationCntPerScene(id, cnt) {
             expect(d3.selectAll('g.annotation-' + id).size()).toEqual(cnt);
         }
@@ -1203,7 +1203,7 @@ describe('@gl Test gl3d annotations', function() {
         .then(done);
     });
 
-    it('should contribute to scene axis autorange', function(done) {
+    it('@gl should contribute to scene axis autorange', function(done) {
         function assertSceneAxisRanges(xRange, yRange, zRange) {
             var sceneLayout = gd._fullLayout.scene;
 
@@ -1237,7 +1237,7 @@ describe('@gl Test gl3d annotations', function() {
         .then(done);
     });
 
-    it('should allow text and tail position edits under `editable: true`', function(done) {
+    it('@gl should allow text and tail position edits under `editable: true`', function(done) {
         function editText(newText, expectation) {
             return new Promise(function(resolve) {
                 gd.once('plotly_relayout', function(eventData) {
@@ -1306,7 +1306,7 @@ describe('@gl Test gl3d annotations', function() {
         .then(done);
     });
 
-    it('should display hover labels and trigger *plotly_clickannotation* event', function(done) {
+    it('@gl should display hover labels and trigger *plotly_clickannotation* event', function(done) {
         function dispatch(eventType) {
             var target = d3.select('g.annotation-text-g').select('g').node();
             target.dispatchEvent(new MouseEvent(eventType));
@@ -1357,7 +1357,7 @@ describe('@gl Test gl3d annotations', function() {
     });
 });
 
-describe('@gl Test removal of gl contexts', function() {
+describe('Test removal of gl contexts', function() {
     var gd;
 
     beforeEach(function() {
@@ -1366,7 +1366,7 @@ describe('@gl Test removal of gl contexts', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('Plots.cleanPlot should remove gl context from the graph div of a gl3d plot', function(done) {
+    it('@gl Plots.cleanPlot should remove gl context from the graph div of a gl3d plot', function(done) {
         Plotly.plot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
@@ -1382,7 +1382,7 @@ describe('@gl Test removal of gl contexts', function() {
         .then(done);
     });
 
-    it('Plotly.newPlot should remove gl context from the graph div of a gl3d plot', function(done) {
+    it('@gl Plotly.newPlot should remove gl context from the graph div of a gl3d plot', function(done) {
         var firstGlplotObject, firstGlContext, firstCanvas;
 
         Plotly.plot(gd, [{

--- a/test/jasmine/tests/gl_plot_interact_basic_test.js
+++ b/test/jasmine/tests/gl_plot_interact_basic_test.js
@@ -55,7 +55,7 @@ function testEvents(plot) {
     });
 }
 
-describe('@gl gl3d plots', function() {
+describe('gl3d plots', function() {
 
     var gd;
 
@@ -68,13 +68,13 @@ describe('@gl gl3d plots', function() {
         destroyGraphDiv();
     });
 
-    it('should respond to drag interactions with mock of unset camera', function(done) {
+    it('@gl should respond to drag interactions with mock of unset camera', function(done) {
         testEvents(makePlot(gd, require('@mocks/gl3d_scatter3d-connectgaps.json')))
             .catch(failTest)
             .then(done);
     });
 
-    it('should respond to drag interactions with mock of partially set camera', function(done) {
+    it('@gl should respond to drag interactions with mock of partially set camera', function(done) {
         testEvents(makePlot(gd, require('@mocks/gl3d_errorbars_zx.json')))
             .catch(failTest)
             .then(done);

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -1014,7 +1014,7 @@ describe('parcoords basic use', function() {
         .then(done);
     });
 
-    it('@gl @flaky Calling `Plotly.animate` with patches targeting `dimensions` attributes should do the right thing', function(done) {
+    it('@gl Calling `Plotly.animate` with patches targeting `dimensions` attributes should do the right thing', function(done) {
         Plotly.react(gd, [{
             type: 'parcoords',
             line: {color: 'blue'},

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -301,7 +301,7 @@ describe('parcoords initialization tests', function() {
     });
 });
 
-describe('@gl parcoords edge cases', function() {
+describe('parcoords edge cases', function() {
     var gd;
     beforeEach(function() {
         gd = createGraphDiv();
@@ -309,7 +309,7 @@ describe('@gl parcoords edge cases', function() {
 
     afterEach(purgeGraphDiv);
 
-    it('Works fine with one panel only', function(done) {
+    it('@gl Works fine with one panel only', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock2);
         Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
@@ -329,7 +329,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('Do something sensible if there is no panel i.e. dimension count is less than 2', function(done) {
+    it('@gl Do something sensible if there is no panel i.e. dimension count is less than 2', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
@@ -347,7 +347,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('Does not error with zero dimensions', function(done) {
+    it('@gl Does not error with zero dimensions', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock0);
 
@@ -361,7 +361,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('Works with duplicate dimension labels', function(done) {
+    it('@gl Works with duplicate dimension labels', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock2);
 
@@ -378,7 +378,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('Works with a single line; also, use a longer color array than the number of lines', function(done) {
+    it('@gl Works with a single line; also, use a longer color array than the number of lines', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock2);
         var dim, i, j;
@@ -405,7 +405,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('Does not raise an error with zero lines and no specified range', function(done) {
+    it('@gl Does not raise an error with zero lines and no specified range', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock2);
         var dim, i;
@@ -429,7 +429,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('Works with non-finite `values` elements', function(done) {
+    it('@gl Works with non-finite `values` elements', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock2);
         var dim, i, j;
@@ -457,7 +457,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('@noCI Works with 60 dimensions', function(done) {
+    it('@noCI @gl Works with 60 dimensions', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         var newDimension, i, j;
@@ -487,7 +487,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('@noCI Truncates 60+ dimensions to 60', function(done) {
+    it('@noCI @gl Truncates 60+ dimensions to 60', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         var newDimension, i, j;
@@ -515,7 +515,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('@noCI Truncates dimension values to the shortest array, retaining only 3 lines', function(done) {
+    it('@noCI @gl Truncates dimension values to the shortest array, retaining only 3 lines', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         var newDimension, i, j;
@@ -544,7 +544,7 @@ describe('@gl parcoords edge cases', function() {
         .then(done);
     });
 
-    it('Skip dimensions which are not plain objects or whose `values` is not an array', function(done) {
+    it('@gl Skip dimensions which are not plain objects or whose `values` is not an array', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         var newDimension, i, j;
@@ -578,7 +578,7 @@ describe('@gl parcoords edge cases', function() {
     });
 });
 
-describe('@gl parcoords Lifecycle methods', function() {
+describe('parcoords Lifecycle methods', function() {
     afterEach(purgeGraphDiv);
 
     it('Plotly.deleteTraces with one trace removes the plot', function(done) {
@@ -601,7 +601,7 @@ describe('@gl parcoords Lifecycle methods', function() {
         .then(done);
     });
 
-    it('Plotly.deleteTraces with two traces removes the deleted plot', function(done) {
+    it('@gl Plotly.deleteTraces with two traces removes the deleted plot', function(done) {
 
         var gd = createGraphDiv();
         var mockCopy = Lib.extendDeep({}, mock);
@@ -635,7 +635,7 @@ describe('@gl parcoords Lifecycle methods', function() {
             .then(done);
     });
 
-    it('Calling `Plotly.restyle` with zero panels left should erase lines', function(done) {
+    it('@gl Calling `Plotly.restyle` with zero panels left should erase lines', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock2);
         var gd = createGraphDiv();
@@ -668,7 +668,7 @@ describe('@gl parcoords Lifecycle methods', function() {
 
     describe('Having two datasets', function() {
 
-        it('Two subsequent calls to Plotly.plot should create two parcoords rows', function(done) {
+        it('@gl Two subsequent calls to Plotly.plot should create two parcoords rows', function(done) {
 
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
@@ -698,7 +698,7 @@ describe('@gl parcoords Lifecycle methods', function() {
                 .then(done);
         });
 
-        it('Plotly.addTraces should add a new parcoords row', function(done) {
+        it('@gl Plotly.addTraces should add a new parcoords row', function(done) {
 
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
@@ -725,7 +725,7 @@ describe('@gl parcoords Lifecycle methods', function() {
                 .then(done);
         });
 
-        it('Plotly.restyle should update the existing parcoords row', function(done) {
+        it('@gl Plotly.restyle should update the existing parcoords row', function(done) {
 
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
@@ -775,7 +775,7 @@ describe('@gl parcoords Lifecycle methods', function() {
     });
 });
 
-describe('@gl parcoords basic use', function() {
+describe('parcoords basic use', function() {
     var mockCopy;
     var gd;
 
@@ -795,7 +795,7 @@ describe('@gl parcoords basic use', function() {
 
     afterAll(purgeGraphDiv);
 
-    it('should create three WebGL contexts per graph', function() {
+    it('@gl should create three WebGL contexts per graph', function() {
         var cnt = 0;
         d3.select(gd).selectAll('canvas').each(function(d) {
             if(d.regl) cnt++;
@@ -803,7 +803,7 @@ describe('@gl parcoords basic use', function() {
         expect(cnt).toBe(3);
     });
 
-    it('`Plotly.plot` should have proper fields on `gd.data` on initial rendering', function() {
+    it('@gl `Plotly.plot` should have proper fields on `gd.data` on initial rendering', function() {
 
         expect(gd.data.length).toEqual(1);
         expect(gd.data[0].dimensions.length).toEqual(11);
@@ -821,7 +821,7 @@ describe('@gl parcoords basic use', function() {
 
     });
 
-    it('Calling `Plotly.plot` again should add the new parcoords', function(done) {
+    it('@gl Calling `Plotly.plot` again should add the new parcoords', function(done) {
 
         var reversedMockCopy = Lib.extendDeep({}, mockCopy);
         reversedMockCopy.data[0].dimensions = reversedMockCopy.data[0].dimensions.slice().reverse();
@@ -851,7 +851,7 @@ describe('@gl parcoords basic use', function() {
 
     });
 
-    it('Calling `Plotly.restyle` with a string path should amend the preexisting parcoords', function(done) {
+    it('@gl Calling `Plotly.restyle` with a string path should amend the preexisting parcoords', function(done) {
 
         expect(gd.data.length).toEqual(1);
 
@@ -871,7 +871,7 @@ describe('@gl parcoords basic use', function() {
 
     });
 
-    it('Calling `Plotly.restyle` for a dimension should amend the preexisting dimension', function(done) {
+    it('@gl Calling `Plotly.restyle` for a dimension should amend the preexisting dimension', function(done) {
 
         function restyleDimension(key, setterValue) {
 
@@ -897,7 +897,7 @@ describe('@gl parcoords basic use', function() {
             .then(done);
     });
 
-    it('Calling `Plotly.restyle` with an object should amend the preexisting parcoords', function(done) {
+    it('@gl Calling `Plotly.restyle` with an object should amend the preexisting parcoords', function(done) {
 
         var newStyle = Lib.extendDeep({}, mockCopy.data[0].line);
         newStyle.colorscale = 'Viridis';
@@ -919,7 +919,7 @@ describe('@gl parcoords basic use', function() {
         .then(done);
     });
 
-    it('Should emit a \'plotly_restyle\' event', function(done) {
+    it('@gl Should emit a \'plotly_restyle\' event', function(done) {
 
         var tester = (function() {
 
@@ -945,7 +945,7 @@ describe('@gl parcoords basic use', function() {
 
     });
 
-    it('Should emit a \'plotly_hover\' event', function(done) {
+    it('@gl Should emit a \'plotly_hover\' event', function(done) {
         var hoverCalls = 0;
         var unhoverCalls = 0;
 
@@ -974,7 +974,7 @@ describe('@gl parcoords basic use', function() {
 
     });
 
-    it('Calling `Plotly.relayout` with string should amend the preexisting parcoords', function(done) {
+    it('@gl Calling `Plotly.relayout` with string should amend the preexisting parcoords', function(done) {
 
         expect(gd.layout.width).toEqual(1184);
 
@@ -994,7 +994,7 @@ describe('@gl parcoords basic use', function() {
         .then(done);
     });
 
-    it('Calling `Plotly.relayout`with object should amend the preexisting parcoords', function(done) {
+    it('@gl Calling `Plotly.relayout`with object should amend the preexisting parcoords', function(done) {
 
         expect(gd.layout.width).toEqual(1184);
 
@@ -1014,7 +1014,7 @@ describe('@gl parcoords basic use', function() {
         .then(done);
     });
 
-    it('@flaky Calling `Plotly.animate` with patches targeting `dimensions` attributes should do the right thing', function(done) {
+    it('@gl @flaky Calling `Plotly.animate` with patches targeting `dimensions` attributes should do the right thing', function(done) {
         Plotly.react(gd, [{
             type: 'parcoords',
             line: {color: 'blue'},
@@ -1054,7 +1054,7 @@ describe('@gl parcoords basic use', function() {
     });
 });
 
-describe('@gl @noCI parcoords constraint interactions', function() {
+describe('@noCI parcoords constraint interactions', function() {
     var gd, initialDashArray0, initialDashArray1;
 
     function initialFigure() {
@@ -1138,7 +1138,7 @@ describe('@gl @noCI parcoords constraint interactions', function() {
         expect(dashArray.length).toBe(segmentCount, dashArray);
     }
 
-    it('snaps ordinal constraints', function(done) {
+    it('@gl snaps ordinal constraints', function(done) {
         // first: drag almost to 2 but not quite - constraint will snap back to [2.75, 4]
         mostOfDrag(105, 165, 105, 190);
         var newDashArray = getDashArray(0);
@@ -1216,7 +1216,7 @@ describe('@gl @noCI parcoords constraint interactions', function() {
         .then(done);
     });
 
-    it('updates continuous constraints with no snap', function(done) {
+    it('@gl updates continuous constraints with no snap', function(done) {
         // first: extend 7 to 5
         mostOfDrag(295, 160, 295, 200);
         var newDashArray = getDashArray(1);
@@ -1258,7 +1258,7 @@ describe('@gl @noCI parcoords constraint interactions', function() {
         .then(done);
     });
 
-    it('will only select one region when multiselect is disabled', function(done) {
+    it('@gl will only select one region when multiselect is disabled', function(done) {
         var newDashArray;
 
         Plotly.restyle(gd, {'dimensions[1].multiselect': false})

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -1077,7 +1077,7 @@ describe('Test polar interactions:', function() {
         .then(done);
     });
 
-    describe('@gl should update scene during drag interactions on radial and angular drag area', function() {
+    describe('should update scene during drag interactions on radial and angular drag area', function() {
         var objs = ['scatter2d', 'line2d'];
         var scene, gl, nTraces;
 
@@ -1132,7 +1132,7 @@ describe('Test polar interactions:', function() {
         }];
 
         specs.forEach(function(s) {
-            it('- ' + s.desc, function(done) {
+            it('@gl - ' + s.desc, function(done) {
                 var fig = Lib.extendDeep({}, require('@mocks/glpolar_scatter.json'));
                 scene = null;
                 gl = null;

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -109,7 +109,7 @@ var BOXEVENTS = [1, 2, 1];
 // assumes 5 points in the lasso path
 var LASSOEVENTS = [4, 2, 1];
 
-describe('@flaky Test select box and lasso in general:', function() {
+describe('Test select box and lasso in general:', function() {
     var mock = require('@mocks/14.json');
     var selectPath = [[93, 193], [143, 193]];
     var lassoPath = [[316, 171], [318, 239], [335, 243], [328, 169]];
@@ -157,7 +157,7 @@ describe('@flaky Test select box and lasso in general:', function() {
                 .then(done);
         });
 
-        it('should trigger selecting/selected/deselect events', function(done) {
+        it('@flaky should trigger selecting/selected/deselect events', function(done) {
             resetEvents(gd);
 
             drag(selectPath);
@@ -196,7 +196,7 @@ describe('@flaky Test select box and lasso in general:', function() {
             .then(done);
         });
 
-        it('should handle add/sub selection', function(done) {
+        it('@flaky should handle add/sub selection', function(done) {
             resetEvents(gd);
 
             drag(selectPath);
@@ -303,7 +303,7 @@ describe('@flaky Test select box and lasso in general:', function() {
                 .then(done);
         });
 
-        it('should trigger selecting/selected/deselect events', function(done) {
+        it('@flaky should trigger selecting/selected/deselect events', function(done) {
             resetEvents(gd);
 
             drag(lassoPath);
@@ -342,7 +342,7 @@ describe('@flaky Test select box and lasso in general:', function() {
             .then(done);
         });
 
-        it('should set selected points in graph data', function(done) {
+        it('@flaky should set selected points in graph data', function(done) {
             resetEvents(gd);
 
             drag(lassoPath);
@@ -361,7 +361,7 @@ describe('@flaky Test select box and lasso in general:', function() {
             .then(done);
         });
 
-        it('should set selected points in full data', function(done) {
+        it('@flaky should set selected points in full data', function(done) {
             resetEvents(gd);
 
             drag(lassoPath);
@@ -380,7 +380,7 @@ describe('@flaky Test select box and lasso in general:', function() {
             .then(done);
         });
 
-        it('should trigger selecting/selected/deselect events for touches', function(done) {
+        it('@flaky should trigger selecting/selected/deselect events for touches', function(done) {
             resetEvents(gd);
 
             drag(lassoPath, {type: 'touch'});
@@ -415,7 +415,7 @@ describe('@flaky Test select box and lasso in general:', function() {
         });
     });
 
-    it('should skip over non-visible traces', function(done) {
+    it('@flaky should skip over non-visible traces', function(done) {
         // note: this tests a mock with one or several invisible traces
         // the invisible traces in the other tests test for multiple
         // traces, with some visible and some not.
@@ -494,7 +494,7 @@ describe('@flaky Test select box and lasso in general:', function() {
         .then(done);
     });
 
-    it('should skip over BADNUM items', function(done) {
+    it('@flaky should skip over BADNUM items', function(done) {
         var data = [{
             mode: 'markers',
             x: [null, undefined, NaN, 0, 'NA'],
@@ -533,7 +533,7 @@ describe('@flaky Test select box and lasso in general:', function() {
         .then(done);
     });
 
-    it('scroll zoom should clear selection regions', function(done) {
+    it('@flaky scroll zoom should clear selection regions', function(done) {
         var gd = createGraphDiv();
         var mockCopy = Lib.extendDeep({}, mock);
         mockCopy.layout.dragmode = 'select';
@@ -566,7 +566,7 @@ describe('@flaky Test select box and lasso in general:', function() {
         .then(done);
     });
 
-    it('should select the right data with the corresponding select direction', function(done) {
+    it('@flaky should select the right data with the corresponding select direction', function(done) {
 
         var gd = createGraphDiv();
 
@@ -627,7 +627,7 @@ describe('@flaky Test select box and lasso in general:', function() {
         .then(done);
     });
 
-    it('should clear selected points on double click only on pan/lasso modes', function(done) {
+    it('@flaky should clear selected points on double click only on pan/lasso modes', function(done) {
         var gd = createGraphDiv();
         var fig = Lib.extendDeep({}, require('@mocks/0.json'));
         fig.data = [fig.data[0]];
@@ -735,7 +735,7 @@ describe('@flaky Test select box and lasso in general:', function() {
         .then(done);
     });
 
-    it('should remember selection polygons from previous select/lasso mode', function(done) {
+    it('@flaky should remember selection polygons from previous select/lasso mode', function(done) {
         var gd = createGraphDiv();
         var path1 = [[150, 150], [170, 170]];
         var path2 = [[193, 193], [213, 193]];
@@ -872,7 +872,7 @@ describe('@flaky Test select box and lasso in general:', function() {
     });
 });
 
-describe('@flaky Test select box and lasso per trace:', function() {
+describe('Test select box and lasso per trace:', function() {
     var gd;
 
     beforeEach(function() {
@@ -999,7 +999,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
             });
     }
 
-    it('should work on scatterternary traces', function(done) {
+    it('@flaky should work on scatterternary traces', function(done) {
         var assertPoints = makeAssertPoints(['a', 'b', 'c']);
         var assertSelectedPoints = makeAssertSelectedPoints();
 
@@ -1052,7 +1052,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('should work on scattercarpet traces', function(done) {
+    it('@flaky should work on scattercarpet traces', function(done) {
         var assertPoints = makeAssertPoints(['a', 'b']);
         var assertSelectedPoints = makeAssertSelectedPoints();
 
@@ -1088,7 +1088,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('@noCI should work on scattermapbox traces', function(done) {
+    it('@noCI @flaky should work on scattermapbox traces', function(done) {
         var assertPoints = makeAssertPoints(['lon', 'lat']);
         var assertRanges = makeAssertRanges('mapbox');
         var assertLassoPoints = makeAssertLassoPoints('mapbox');
@@ -1145,7 +1145,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     }, LONG_TIMEOUT_INTERVAL);
 
-    it('should work on scattergeo traces', function(done) {
+    it('@flaky should work on scattergeo traces', function(done) {
         var assertPoints = makeAssertPoints(['lon', 'lat']);
         var assertSelectedPoints = makeAssertSelectedPoints();
         var assertRanges = makeAssertRanges('geo');
@@ -1244,7 +1244,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     }, LONG_TIMEOUT_INTERVAL);
 
-    it('should work on scatterpolar traces', function(done) {
+    it('@flaky should work on scatterpolar traces', function(done) {
         var assertPoints = makeAssertPoints(['r', 'theta']);
         var assertSelectedPoints = makeAssertSelectedPoints();
 
@@ -1282,7 +1282,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('should work on choropleth traces', function(done) {
+    it('@flaky should work on choropleth traces', function(done) {
         var assertPoints = makeAssertPoints(['location', 'z']);
         var assertSelectedPoints = makeAssertSelectedPoints();
         var assertRanges = makeAssertRanges('geo', -0.5);
@@ -1345,7 +1345,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     }, LONG_TIMEOUT_INTERVAL);
 
-    it('should work for bar traces', function(done) {
+    it('@flaky should work for bar traces', function(done) {
         var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
         var assertSelectedPoints = makeAssertSelectedPoints();
         var assertRanges = makeAssertRanges();
@@ -1418,7 +1418,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('should work for date/category traces', function(done) {
+    it('@flaky should work for date/category traces', function(done) {
         var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
         var assertSelectedPoints = makeAssertSelectedPoints();
 
@@ -1478,7 +1478,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('should work for histogram traces', function(done) {
+    it('@flaky should work for histogram traces', function(done) {
         var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y', 'pointIndices']);
         var assertSelectedPoints = makeAssertSelectedPoints();
         var assertRanges = makeAssertRanges();
@@ -1527,7 +1527,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('should work for box traces', function(done) {
+    it('@flaky should work for box traces', function(done) {
         var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
         var assertSelectedPoints = makeAssertSelectedPoints();
         var assertRanges = makeAssertRanges();
@@ -1591,7 +1591,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('should work for violin traces', function(done) {
+    it('@flaky should work for violin traces', function(done) {
         var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
         var assertSelectedPoints = makeAssertSelectedPoints();
         var assertRanges = makeAssertRanges();
@@ -1655,7 +1655,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
     });
 
     ['ohlc', 'candlestick'].forEach(function(type) {
-        it('should work for ' + type + ' traces', function(done) {
+        it('@flaky should work for ' + type + ' traces', function(done) {
             var assertPoints = makeAssertPoints(['curveNumber', 'x', 'open', 'high', 'low', 'close']);
             var assertSelectedPoints = makeAssertSelectedPoints();
             var assertRanges = makeAssertRanges();
@@ -1731,7 +1731,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         });
     });
 
-    it('should work on traces with enabled transforms', function(done) {
+    it('@flaky should work on traces with enabled transforms', function(done) {
         var assertSelectedPoints = makeAssertSelectedPoints();
 
         Plotly.plot(gd, [{
@@ -1774,7 +1774,7 @@ describe('@flaky Test select box and lasso per trace:', function() {
         .then(done);
     });
 
-    it('should work on scatter/bar traces with text nodes', function(done) {
+    it('@flaky should work on scatter/bar traces with text nodes', function(done) {
         var assertSelectedPoints = makeAssertSelectedPoints();
 
         function assertFillOpacity(exp) {

--- a/test/jasmine/tests/shapes_test.js
+++ b/test/jasmine/tests/shapes_test.js
@@ -1072,9 +1072,9 @@ describe('A fixed size shape', function() {
     // and (ii) line has a different resize behavior.
     var shapeAndResizeTypes = combinations([{type: 'rect'}, {type: 'circle'}], resizeTypes);
     shapeAndResizeTypes.forEach(function(testCase) {
-        describe('@flaky of type ' + testCase.type + ' can be ' + testCase.resizeDisplayName, function() {
+        describe('of type ' + testCase.type + ' can be ' + testCase.resizeDisplayName, function() {
             resizeDirections.forEach(function(direction) {
-                it('over direction ' + direction, function(done) {
+                it('@flaky over direction ' + direction, function(done) {
                     layout.shapes[0].type = testCase.type;
 
                     Plotly.plot(gd, data, layout, {editable: true})
@@ -1102,14 +1102,14 @@ describe('A fixed size shape', function() {
         });
     });
 
-    describe('@flaky of type line', function() {
+    describe('of type line', function() {
         beforeEach(function() {
             layout.shapes[0].type = 'line';
             layout.shapes[0].yanchor = 3;
 
         });
 
-        it('can be moved by dragging the middle', function(done) {
+        it('@flaky can be moved by dragging the middle', function(done) {
             Plotly.plot(gd, data, layout, {editable: true})
               .then(function() {
                   var shapeNodeBeforeDrag = getFirstShapeNode();
@@ -1130,7 +1130,7 @@ describe('A fixed size shape', function() {
               });
         });
 
-        it('can be resized by dragging the start point', function(done) {
+        it('@flaky can be resized by dragging the start point', function(done) {
             Plotly.plot(gd, data, layout, {editable: true})
               .then(function() {
                   var shapeNodeBeforeDrag = getFirstShapeNode();
@@ -1153,7 +1153,7 @@ describe('A fixed size shape', function() {
               });
         });
 
-        it('can be resized by dragging the end point', function(done) {
+        it('@flaky can be resized by dragging the end point', function(done) {
             Plotly.plot(gd, data, layout, {editable: true})
               .then(function() {
                   var shapeNodeBeforeDrag = getFirstShapeNode();
@@ -1266,7 +1266,7 @@ describe('A fixed size shape', function() {
     });
 });
 
-describe('@flaky Test shapes', function() {
+describe('Test shapes', function() {
     'use strict';
 
     var gd, data, layout, config;
@@ -1308,7 +1308,7 @@ describe('@flaky Test shapes', function() {
     ];
 
     testCases.forEach(function(testCase) {
-        it(testCase.title + ' should be draggable', function(done) {
+        it('@flaky ' + testCase.title + ' should be draggable', function(done) {
             setupLayout(testCase, [{type: 'line'}, {type: 'rect'}, {type: 'circle'}, {type: 'path'}]);
             testDragEachShape(done);
         });
@@ -1319,7 +1319,7 @@ describe('@flaky Test shapes', function() {
             var testTitle = testCase.title +
                 ' should be resizeable over direction ' +
                 direction;
-            it(testTitle, function(done) {
+            it('@flaky ' + testTitle, function(done) {
                 // Exclude line because it has a different resize behavior
                 setupLayout(testCase, [{type: 'rect'}, {type: 'circle'}, {type: 'path'}]);
                 testResizeEachShape(direction, done);
@@ -1331,7 +1331,7 @@ describe('@flaky Test shapes', function() {
         ['start', 'end'].forEach(function(linePoint) {
             var testTitle = 'Line shape ' + testCase.title +
               ' should be resizable by dragging the ' + linePoint + ' point';
-            it(testTitle, function(done) {
+            it('@flaky ' + testTitle, function(done) {
                 setupLayout(testCase, [{type: 'line'}]);
                 testLineResize(linePoint, done);
             });

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -431,7 +431,7 @@ describe('Test splom trace calc step:', function() {
     });
 });
 
-describe('@gl Test splom interactions:', function() {
+describe('Test splom interactions:', function() {
     var gd;
 
     beforeEach(function() {
@@ -443,7 +443,7 @@ describe('@gl Test splom interactions:', function() {
         destroyGraphDiv();
     });
 
-    it('should destroy gl objects on Plots.cleanPlot', function(done) {
+    it('@gl should destroy gl objects on Plots.cleanPlot', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_large.json'));
 
         Plotly.plot(gd, fig).then(function() {
@@ -460,7 +460,7 @@ describe('@gl Test splom interactions:', function() {
         .then(done);
     });
 
-    it('when hasOnlyLargeSploms, should create correct regl-line2d data for grid', function(done) {
+    it('@gl when hasOnlyLargeSploms, should create correct regl-line2d data for grid', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_large.json'));
         var cnt = 1;
 
@@ -514,7 +514,7 @@ describe('@gl Test splom interactions:', function() {
         .then(done);
     });
 
-    it('should update properly in-and-out of hasOnlyLargeSploms regime', function(done) {
+    it('@gl should update properly in-and-out of hasOnlyLargeSploms regime', function(done) {
         var figLarge = Lib.extendDeep({}, require('@mocks/splom_large.json'));
         var dimsLarge = figLarge.data[0].dimensions;
         var dimsSmall = dimsLarge.slice(0, 5);
@@ -597,7 +597,7 @@ describe('@gl Test splom interactions:', function() {
         .then(done);
     });
 
-    it('should correctly move axis layers when relayouting *grid.(x|y)side*', function(done) {
+    it('@gl should correctly move axis layers when relayouting *grid.(x|y)side*', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_upper-nodiag.json'));
 
         function _assert(exp) {
@@ -639,7 +639,7 @@ describe('@gl Test splom interactions:', function() {
         .then(done);
     });
 
-    it('should work with typed arrays', function(done) {
+    it('@gl should work with typed arrays', function(done) {
         Plotly.plot(gd, [{
             type: 'splom',
             dimensions: [{
@@ -654,7 +654,7 @@ describe('@gl Test splom interactions:', function() {
         .then(done);
     });
 
-    it('should toggle trace correctly', function(done) {
+    it('@gl should toggle trace correctly', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_iris.json'));
 
         function _assert(msg, exp) {
@@ -684,7 +684,7 @@ describe('@gl Test splom interactions:', function() {
     });
 });
 
-describe('@gl Test splom hover:', function() {
+describe('Test splom hover:', function() {
     var gd;
 
     afterEach(function() {
@@ -792,13 +792,13 @@ describe('@gl Test splom hover:', function() {
     }];
 
     specs.forEach(function(s) {
-        it('should generate correct hover labels ' + s.desc, function(done) {
+        it('@gl should generate correct hover labels ' + s.desc, function(done) {
             run(s, done);
         });
     });
 });
 
-describe('@gl Test splom drag:', function() {
+describe('Test splom drag:', function() {
     var gd;
 
     beforeEach(function() {
@@ -817,7 +817,7 @@ describe('@gl Test splom drag:', function() {
         return drag(node, dx, dy, null, p0[0], p0[1]);
     }
 
-    it('should update scattermatrix ranges on pan', function(done) {
+    it('@gl should update scattermatrix ranges on pan', function(done) {
         var fig = require('@mocks/splom_iris.json');
         fig.layout.dragmode = 'pan';
 
@@ -877,7 +877,7 @@ describe('@gl Test splom drag:', function() {
     });
 });
 
-describe('@gl Test splom select:', function() {
+describe('Test splom select:', function() {
     var gd;
     var ptData;
     var subplot;
@@ -922,7 +922,7 @@ describe('@gl Test splom select:', function() {
         });
     }
 
-    it('should emit correct event data and draw selection outlines', function(done) {
+    it('@gl should emit correct event data and draw selection outlines', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_0.json'));
         fig.layout = {
             dragmode: 'select',
@@ -1007,7 +1007,7 @@ describe('@gl Test splom select:', function() {
         .then(done);
     });
 
-    it('should redraw splom traces before scattergl trace (if any)', function(done) {
+    it('@gl should redraw splom traces before scattergl trace (if any)', function(done) {
         var fig = require('@mocks/splom_with-cartesian.json');
         fig.layout.dragmode = 'select';
         fig.layout.width = 400;
@@ -1045,7 +1045,7 @@ describe('@gl Test splom select:', function() {
         .then(done);
     });
 
-    it('should behave correctly during select->dblclick->pan scenarios', function(done) {
+    it('@gl should behave correctly during select->dblclick->pan scenarios', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_0.json'));
         fig.layout = {
             width: 400,

--- a/test/jasmine/tests/streamtube_test.js
+++ b/test/jasmine/tests/streamtube_test.js
@@ -61,7 +61,7 @@ describe('Test streamtube defaults', function() {
     });
 });
 
-describe('@gl Test streamtube autorange', function() {
+describe('Test streamtube autorange', function() {
     var gd;
 
     beforeEach(function() {
@@ -80,7 +80,7 @@ describe('@gl Test streamtube autorange', function() {
         expect(sceneLayout.zaxis.range).toBeCloseToArray(zrng, 2, 'zaxis range - ' + msg);
     }
 
-    it('should add pad around tubes to make sure they fit on the scene', function(done) {
+    it('@gl should add pad around tubes to make sure they fit on the scene', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_streamtube-first'));
 
         Plotly.plot(gd, fig).then(function() {
@@ -105,7 +105,7 @@ describe('@gl Test streamtube autorange', function() {
     });
 });
 
-describe('@gl Test streamtube starting positions defaults:', function() {
+describe('Test streamtube starting positions defaults:', function() {
     var gd;
 
     beforeEach(function() {
@@ -147,7 +147,7 @@ describe('@gl Test streamtube starting positions defaults:', function() {
         expect(exp.cellsLength).toBe(obj.cells.length, 'cells length');
     }
 
-    it('should cut xz at min-y and take all x/y/z pts on that plane except those on the edges', function(done) {
+    it('@gl should cut xz at min-y and take all x/y/z pts on that plane except those on the edges', function(done) {
         Plotly.plot(gd, makeFigure(3, 3, 3)).then(function() {
             _assert({
                 positionsLength: 1536,
@@ -158,7 +158,7 @@ describe('@gl Test streamtube starting positions defaults:', function() {
         .then(done);
     });
 
-    it('should take middle pt if mesh vector has length 2', function(done) {
+    it('@gl should take middle pt if mesh vector has length 2', function(done) {
         Plotly.plot(gd, makeFigure(3, 3, 2)).then(function() {
             _assert({
                 positionsLength: 1200,
@@ -169,7 +169,7 @@ describe('@gl Test streamtube starting positions defaults:', function() {
         .then(done);
     });
 
-    it('should take pt if mesh vector has length 1', function(done) {
+    it('@gl should take pt if mesh vector has length 1', function(done) {
         Plotly.plot(gd, makeFigure(1, 3, 2)).then(function() {
             _assert({
                 positionsLength: 720,
@@ -181,7 +181,7 @@ describe('@gl Test streamtube starting positions defaults:', function() {
     });
 });
 
-describe('@gl Test streamtube interactions', function() {
+describe('Test streamtube interactions', function() {
     var gd;
 
     beforeEach(function() {
@@ -193,7 +193,7 @@ describe('@gl Test streamtube interactions', function() {
         destroyGraphDiv();
     });
 
-    it('overspecified meshgrid should return blank mesh grid', function(done) {
+    it('@gl overspecified meshgrid should return blank mesh grid', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_streamtube-simple.json'));
         var trace = fig.data[0];
         var x = trace.x.slice();
@@ -228,7 +228,7 @@ describe('@gl Test streamtube interactions', function() {
         .then(done);
     });
 
-    it('should add/clear gl objects correctly', function(done) {
+    it('@gl should add/clear gl objects correctly', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_streamtube-simple.json'));
         var trace = Lib.extendDeep({}, fig.data[0]);
 
@@ -261,7 +261,7 @@ describe('@gl Test streamtube interactions', function() {
         .then(done);
     });
 
-    it('should be able to restyle to a cone trace and back', function(done) {
+    it('@gl should be able to restyle to a cone trace and back', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_cone-autorange.json'));
         var trace1 = Lib.extendDeep({}, fig.data[0]);
         trace1.type = 'streamtube';
@@ -295,7 +295,7 @@ describe('@gl Test streamtube interactions', function() {
     });
 });
 
-describe('@gl Test streamtube hover', function() {
+describe('Test streamtube hover', function() {
     var gd;
 
     beforeEach(function() {
@@ -307,7 +307,7 @@ describe('@gl Test streamtube hover', function() {
         destroyGraphDiv();
     });
 
-    it('should display hover labels', function(done) {
+    it('@gl should display hover labels', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_streamtube-simple.json'));
         fig.data[0].showscale = false;
         fig.layout.margin = {l: 0, t: 0, r: 0, b: 0};
@@ -364,7 +364,7 @@ describe('@gl Test streamtube hover', function() {
         .then(done);
     });
 
-    it('should display hover labels (multi-trace case)', function(done) {
+    it('@gl should display hover labels (multi-trace case)', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_streamtube-simple.json'));
         var trace0 = fig.data[0];
         trace0.showscale = false;
@@ -400,7 +400,7 @@ describe('@gl Test streamtube hover', function() {
         .then(done);
     });
 
-    it('should emit correct event data', function(done) {
+    it('@gl should emit correct event data', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_streamtube-simple.json'));
         fig.data[0].showscale = false;
         fig.layout.margin = {l: 0, t: 0, r: 0, b: 0};


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/2922 (hopefully)

This PR adds a _sharding_ script that splits our jasmine test suites into groups of a given number of `it` blocks. We use it here to shard jasmine tests with tag `@gl`, but the same logic could eventually be used in other jasmine tests.

To make the sharding logic simple and predictable, we enforce the following jasmine test tag _rules_:

- `@gl`, `@noCI`, `@noCIdep` and `@flaky` are the only allowed tags
- `@gl` and `@flaky` can't be set in `describe` blocks, only in `it` blocks
- a given `it` block can't have both a`@gl` and a `@flaky` tag (i.e. all `@gl` are _flaky_ and are in runned in retry loop on ci, setting both tags is redundant)

Along the way, commit 77125072d0f568f4f0726f87680b9de84e5e88ed made `gl2d_plot_interact_test.js` and `gl2d_click_test.js` more robust and bdf468ee77546661d306d91618edad9d6e4931ab  moved the `@flaky` test run from `jasmine)` to `jasmine2)` on CI. Things appear to be working fine: [many :green_book: runs are occuring in succession on CI](https://circleci.com/gh/plotly/workflows/plotly.js/tree/shard-gl-tests).

cc @alexcjohnson hopefully this will be enough to not have to worry about intermittent failures for a while.