### PR TITLE
Replot when webgl buffer dims don't match canvas dims

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -242,6 +242,24 @@ exports.plot = function(gd, data, layout, config) {
             fullLayout._glcanvas
                 .attr('width', fullLayout.width)
                 .attr('height', fullLayout.height);
+
+
+            var regl = fullLayout._glcanvas.data()[0].regl;
+            if(regl) {
+                if(
+                    fullLayout.width !== regl._gl.drawingBufferWidth ||
+                    fullLayout.height !== regl._gl.drawingBufferHeight
+                 ) {
+                    // Unfortunately, this can happen when relayouting to large
+                    // width/height on some browsers.
+                    Lib.log([
+                        'WebGL context buffer and canvas dimensions do not match,',
+                        'due to browser/WebGL bug.',
+                        'Clearing graph and plotting again.'
+                    ].join(' '));
+                    exports.newPlot(gd, gd.data, gd.layout);
+                }
+            }
         }
 
         return Plots.previousPromises(gd);

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -255,9 +255,12 @@ exports.plot = function(gd, data, layout, config) {
                         Lib.error(msg);
                     } else {
                         Lib.log(msg + ' Clearing graph and plotting again.');
-                        fullLayout._redrawFromWrongGlDimensions = 1;
                         Plots.cleanPlot([], {}, gd._fullData, fullLayout, gd.calcdata);
-                        exports.plot(gd, gd.data, gd.layout);
+                        Plots.supplyDefaults(gd);
+                        fullLayout = gd._fullLayout;
+                        Plots.doCalcdata(gd);
+                        fullLayout._redrawFromWrongGlDimensions = 1;
+                        return drawFramework();
                     }
                 }
             }

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -199,6 +199,7 @@ exports.plot = function(gd, data, layout, config) {
 
     // draw framework first so that margin-pushing
     // components can position themselves correctly
+    var drawFrameworkCalls = 0;
     function drawFramework() {
         var basePlotModules = fullLayout._basePlotModules;
 
@@ -251,7 +252,7 @@ exports.plot = function(gd, data, layout, config) {
                     fullLayout.height !== regl._gl.drawingBufferHeight
                  ) {
                     var msg = 'WebGL context buffer and canvas dimensions do not match due to browser/WebGL bug.';
-                    if(fullLayout._redrawFromWrongGlDimensions) {
+                    if(drawFrameworkCalls) {
                         Lib.error(msg);
                     } else {
                         Lib.log(msg + ' Clearing graph and plotting again.');
@@ -259,7 +260,7 @@ exports.plot = function(gd, data, layout, config) {
                         Plots.supplyDefaults(gd);
                         fullLayout = gd._fullLayout;
                         Plots.doCalcdata(gd);
-                        fullLayout._redrawFromWrongGlDimensions = 1;
+                        drawFrameworkCalls++;
                         return drawFramework();
                     }
                 }

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -243,21 +243,22 @@ exports.plot = function(gd, data, layout, config) {
                 .attr('width', fullLayout.width)
                 .attr('height', fullLayout.height);
 
-
             var regl = fullLayout._glcanvas.data()[0].regl;
             if(regl) {
-                if(
-                    fullLayout.width !== regl._gl.drawingBufferWidth ||
+                // Unfortunately, this can happen when relayouting to large
+                // width/height on some browsers.
+                if(fullLayout.width !== regl._gl.drawingBufferWidth ||
                     fullLayout.height !== regl._gl.drawingBufferHeight
                  ) {
-                    // Unfortunately, this can happen when relayouting to large
-                    // width/height on some browsers.
-                    Lib.log([
-                        'WebGL context buffer and canvas dimensions do not match,',
-                        'due to browser/WebGL bug.',
-                        'Clearing graph and plotting again.'
-                    ].join(' '));
-                    exports.newPlot(gd, gd.data, gd.layout);
+                    var msg = 'WebGL context buffer and canvas dimensions do not match due to browser/WebGL bug.';
+                    if(fullLayout._redrawFromWrongGlDimensions) {
+                        Lib.error(msg);
+                    } else {
+                        Lib.log(msg + ' Clearing graph and plotting again.');
+                        fullLayout._redrawFromWrongGlDimensions = 1;
+                        Plots.cleanPlot([], {}, gd._fullData, fullLayout, gd.calcdata);
+                        exports.plot(gd, gd.data, gd.layout);
+                    }
                 }
             }
         }

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -717,7 +717,6 @@ describe('Test splom interactions:', function() {
             });
             assertDims('base', 600, 500);
             expect(Lib.log).toHaveBeenCalledTimes(0);
-            expect(gd._fullLayout._redrawFromWrongGlDimensions).toBeUndefined();
 
             spyOn(gd._fullData[0]._module, 'plot').and.callThrough();
 
@@ -732,7 +731,6 @@ describe('Test splom interactions:', function() {
             assertDims('after', 4810, 3656);
             expect(Lib.log)
                 .toHaveBeenCalledWith('WebGL context buffer and canvas dimensions do not match due to browser/WebGL bug. Clearing graph and plotting again.');
-            expect(gd._fullLayout._redrawFromWrongGlDimensions).toBe(1);
         })
         .catch(failTest)
         .then(done);

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -697,20 +697,22 @@ describe('Test splom interactions:', function() {
             expect(gl.drawingBufferHeight).toBe(h, msg);
         }
 
-        spyOn(plotApi, 'newPlot').and.callThrough();
+        spyOn(plotApi, 'plot').and.callThrough();
         spyOn(Lib, 'log');
 
         Plotly.plot(gd, fig).then(function() {
-            expect(plotApi.newPlot).toHaveBeenCalledTimes(0);
+            expect(plotApi.plot).toHaveBeenCalledTimes(0);
             expect(Lib.log).toHaveBeenCalledTimes(0);
+            expect(gd._fullLayout._redrawFromWrongGlDimensions).toBeUndefined();
             assertDims('base', 600, 500);
 
             return Plotly.relayout(gd, {width: 4810, height: 3656});
         })
         .then(function() {
-            expect(plotApi.newPlot).toHaveBeenCalledTimes(1);
+            expect(plotApi.plot).toHaveBeenCalledTimes(1);
             expect(Lib.log)
-                .toHaveBeenCalledWith('WebGL context buffer and canvas dimensions do not match, due to browser/WebGL bug. Clearing graph and plotting again.');
+                .toHaveBeenCalledWith('WebGL context buffer and canvas dimensions do not match due to browser/WebGL bug. Clearing graph and plotting again.');
+            expect(gd._fullLayout._redrawFromWrongGlDimensions).toBe(1);
             assertDims('base', 4810, 3656);
         })
         .catch(failTest)


### PR DESCRIPTION
... as this can unfortunately happen when relayouting to large width/height on some browsers e.g. Chrome 68 and Chrome 64 (that we use on CI).

Note that this doesn't just affect sploms, but all regl-based trace type and presumably all WebGL-trace types.

cc @alexcjohnson 