### PR TITLE
Bump regl trace deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,29 +35,6 @@
         "commander": "^2.15.1"
       }
     },
-    "@etpinard/gl-text": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@etpinard/gl-text/-/gl-text-1.1.6.tgz",
-      "integrity": "sha512-sN007FwlqdSKJt2/cnGZu3jsAN7G4R/wxk/D6ZivPuQtrwJ42B68iuAqysJPgFepUTAsDRtGAOd1U7tZxfDJwA==",
-      "requires": {
-        "color-normalize": "^1.1.0",
-        "css-font": "^1.2.0",
-        "detect-kerning": "^2.1.2",
-        "es6-weak-map": "^2.0.2",
-        "flatten-vertex-data": "^1.0.2",
-        "font-atlas": "^2.1.0",
-        "font-measure": "^1.2.2",
-        "gl-util": "^3.0.7",
-        "is-plain-obj": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "parse-unit": "^1.0.1",
-        "pick-by-alias": "^1.2.0",
-        "regl": "^1.3.6",
-        "to-px": "^1.0.1",
-        "typedarray-pool": "^1.1.0"
-      }
-    },
     "@mapbox/geojson-area": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
@@ -4865,6 +4842,30 @@
         "ndarray-scratch": "^1.1.1",
         "surface-nets": "^1.0.2",
         "typedarray-pool": "^1.0.0"
+      }
+    },
+    "gl-text": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.6.tgz",
+      "integrity": "sha512-OB+Nc5JKO1gyYYqBOJrYvCvRXIecfVpIKP7AviQNY63jrWPM9hUFSwZG7sH/paVnR1yCZBVirqOPfiFeF1Qo4g==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.1.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.2",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.0.7",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^1.3.6",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-texture2d": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8863,9 +8863,9 @@
       }
     },
     "regl-splom": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.3.tgz",
-      "integrity": "sha512-3oJT26xm91p303Jb3jMI7PptHYMSbR2/ZnTLolYGnC42jVp/e+xbbik1pTNFyeS5WiaE0M+Ssl3tUC6zgQ8nOw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.4.tgz",
+      "integrity": "sha512-+iq/RJAJdHCp48wPbEGQ5qw29OXFVF/m7CzcuLZxwptjdkB/FHGKiMuyqclOSNQcEKFxQTvRRJMJJ6brd8VvrA==",
       "requires": {
         "array-bounds": "^1.0.1",
         "array-range": "^1.0.1",
@@ -8878,7 +8878,7 @@
         "pick-by-alias": "^1.2.0",
         "point-cluster": "^1.0.2",
         "raf": "^3.4.0",
-        "regl-scatter2d": "^3.0.0"
+        "regl-scatter2d": "^3.0.6"
       },
       "dependencies": {
         "binary-search-bounds": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "regl-error2d": "^2.0.5",
     "regl-line2d": "^3.0.9",
     "regl-scatter2d": "^3.0.6",
-    "regl-splom": "^1.0.3",
+    "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",
     "sane-topojson": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "3d-view": "^2.0.0",
-    "@etpinard/gl-text": "^1.1.6",
     "@plotly/d3-sankey": "^0.5.0",
     "alpha-shape": "^1.0.0",
     "array-range": "^1.0.1",
@@ -85,6 +84,7 @@
     "gl-spikes2d": "^1.0.1",
     "gl-streamtube3d": "^1.0.0",
     "gl-surface3d": "^1.3.5",
+    "gl-text": "^1.1.6",
     "glslify": "^6.2.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -13,7 +13,7 @@ var createLine = require('regl-line2d');
 var createError = require('regl-error2d');
 var cluster = require('point-cluster');
 var arrayRange = require('array-range');
-var Text = require('@etpinard/gl-text');
+var Text = require('gl-text');
 
 var Registry = require('../../registry');
 var Lib = require('../../lib');


### PR DESCRIPTION
cc @alexcjohnson 

The first commits applies https://github.com/a-vis/regl-splom/pull/9 and the other essentially reverts https://github.com/plotly/plotly.js/pull/2783

Note that `gl-text@1.1.6` includes an additional commit (-> https://github.com/a-vis/gl-text/commit/95036634910f6801b0eb583a58ab286c98b0c500) that wasn't bundled before. @dy do you remember what https://github.com/a-vis/gl-text/commit/95036634910f6801b0eb583a58ab286c98b0c500 was for?