### PR TITLE
add support for responsive charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,28 @@
         "d3-interpolate": "1"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.24",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
+      "integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg==",
+      "dev": true
+    },
+    "@types/karma": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@types/karma/-/karma-1.7.6.tgz",
+      "integrity": "sha512-VLyBOU0SmMjGTUpuZvPOzoR0GIKMGcYueGz803V55lbkI4oGsLG03rYP43kJowh9vNNkVERrDYYoFoTbMftzFw==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
+      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
@@ -6187,6 +6209,12 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6306,6 +6334,16 @@
       "dev": true,
       "requires": {
         "colors": ">=1.0"
+      }
+    },
+    "karma-viewport": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/karma-viewport/-/karma-viewport-1.0.2.tgz",
+      "integrity": "sha512-rvzY9UTVXHPt9QRwawyh1D50qzqtxRsoPe5svgOY5kvV7eigv8e5dcW3RSmPZ6m/3Hx+QwJEMY+kLhCmamKJ6A==",
+      "dev": true,
+      "requires": {
+        "@types/karma": "^1.7.3",
+        "jsonschema": "^1.1.1"
       }
     },
     "kdbush": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "karma-jasmine-spec-tags": "^1.0.1",
     "karma-spec-reporter": "0.0.32",
     "karma-verbose-reporter": "0.0.6",
+    "karma-viewport": "^1.0.2",
     "madge": "^3.2.0",
     "minify-stream": "^1.2.0",
     "minimist": "^1.2.0",

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -385,6 +385,15 @@ function emitAfterPlot(gd) {
         fullLayout._redrawFromAutoMarginCount--;
     } else {
         gd.emit('plotly_afterplot');
+
+        // make the figure responsive
+        if(gd._context.responsive && !gd._responsiveChartHandler) {
+            // Keep a reference to the resize handler to purge it down the road
+            gd._responsiveChartHandler = function() {Plots.resize(gd);};
+
+            // Listen to window resize
+            window.addEventListener('resize', gd._responsiveChartHandler);
+        }
     }
 }
 
@@ -3154,6 +3163,11 @@ exports.purge = function purge(gd) {
     var fullLayout = gd._fullLayout || {};
     var fullData = gd._fullData || [];
     var calcdata = gd.calcdata || [];
+
+    // remove responsive handler
+    if(gd._responsiveChartHandler) {
+        window.removeEventListener('resize', gd._responsiveChartHandler);
+    }
 
     // remove gl contexts
     Plots.cleanPlot([], {}, fullData, fullLayout, calcdata);

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -57,6 +57,9 @@ module.exports = {
      */
     autosizable: false,
 
+    // responsive: determines whether to change the layout size when window is resized
+    responsive: false,
+
     // set the length of the undo/redo queue
     queueLength: 0,
 

--- a/test/jasmine/.eslintrc
+++ b/test/jasmine/.eslintrc
@@ -3,5 +3,8 @@
   "env": {
     "browser": true,
     "jasmine": true
+  },
+  "globals": {
+    "viewport": true
   }
 }

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -137,7 +137,7 @@ func.defaultConfig = {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine', 'jasmine-spec-tags', 'browserify'],
+    frameworks: ['jasmine', 'jasmine-spec-tags', 'browserify', 'viewport'],
 
     // list of files / patterns to load in the browser
     //

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -6,6 +6,7 @@ var destroyGraphDiv = require('../assets/destroy_graph_div');
 var click = require('../assets/click');
 var mouseEvent = require('../assets/mouse_event');
 var failTest = require('../assets/fail_test');
+var delay = require('../assets/delay');
 
 describe('config argument', function() {
 
@@ -527,6 +528,52 @@ describe('config argument', function() {
                 delete window.PLOTLY_ENV;
                 done();
             });
+        });
+    });
+
+    describe('responsive figure', function() {
+        var gd;
+        var data = [{x: [1, 2, 3, 4], y: [5, 10, 2, 8]}];
+
+        beforeEach(function() {
+            viewport.reset();
+            gd = createGraphDiv();
+
+            // Make the graph fill the parent
+            gd.style.width = '100%';
+            gd.style.height = '100%';
+        });
+
+        afterEach(function() {
+            destroyGraphDiv();
+            // Reset window size
+            viewport.reset();
+        });
+
+        function checkLayoutSize(width, height) {
+            expect(gd._fullLayout.width).toBe(width);
+            expect(gd._fullLayout.height).toBe(height);
+
+            var svg = document.getElementsByClassName('main-svg')[0];
+            expect(+svg.getAttribute('width')).toBe(width);
+            expect(+svg.getAttribute('height')).toBe(height);
+        }
+
+        it('should resize when the viewport width/height changes', function(done) {
+            var newWidth = 400, newHeight = 700;
+            Plotly.newPlot(gd, data, {}, {responsive: true})
+            // Resize viewport
+            .then(function() {
+                viewport.set(newWidth, newHeight);
+            })
+            // Wait for resize to happen (Plotly.resize has a 100ms timeout)
+            .then(delay(200))
+            // Check final figure size
+            .then(function() {
+                checkLayoutSize(newWidth, newHeight);
+            })
+            .catch(failTest)
+            .then(done);
         });
     });
 });


### PR DESCRIPTION
Initial implementation of responsive charts as proposed in #2969.

By setting `{responsive:true}` in a plot's config, it will be automatically resized when the window size changes. For now it only reacts to window's resize but could be improved by using `ResizeObserver` down the road.

Viewing a responsive chart on a phone going from landscape to portrait now results in the following experience:
![after](https://user-images.githubusercontent.com/301546/45111166-44681680-b112-11e8-95d4-ddab215dae4e.gif)
