### PR TITLE
Emit 'plotly_webglcontextlost' event on WebGL context lost

### DIFF
--- a/src/lib/prepare_regl.js
+++ b/src/lib/prepare_regl.js
@@ -48,6 +48,15 @@ module.exports = function prepareRegl(gd, extensions) {
         } catch(e) {
             success = false;
         }
+
+        if(success) {
+            this.addEventListener('webglcontextlost', function(event) {
+                gd.emit('plotly_webglcontextlost', {
+                    event: event,
+                    layer: d.key
+                });
+            }, false);
+        }
     });
 
     if(!success) {

--- a/src/lib/prepare_regl.js
+++ b/src/lib/prepare_regl.js
@@ -51,10 +51,12 @@ module.exports = function prepareRegl(gd, extensions) {
 
         if(success) {
             this.addEventListener('webglcontextlost', function(event) {
-                gd.emit('plotly_webglcontextlost', {
-                    event: event,
-                    layer: d.key
-                });
+                if(gd && gd.emit) {
+                    gd.emit('plotly_webglcontextlost', {
+                        event: event,
+                        layer: d.key
+                    });
+                }
             }, false);
         }
     });

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -170,6 +170,8 @@ function render(scene) {
 }
 
 function initializeGLPlot(scene, fullLayout, canvas, gl) {
+    var gd = scene.graphDiv;
+
     var glplotOptions = {
         canvas: canvas,
         gl: gl,
@@ -220,7 +222,7 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
 
         var update = {};
         update[scene.id + '.camera'] = getLayoutCamera(scene.camera);
-        scene.saveCamera(scene.graphDiv.layout);
+        scene.saveCamera(gd.layout);
         scene.graphDiv.emit('plotly_relayout', update);
     };
 
@@ -228,10 +230,14 @@ function initializeGLPlot(scene, fullLayout, canvas, gl) {
     scene.glplot.canvas.addEventListener('wheel', relayoutCallback.bind(null, scene), passiveSupported ? {passive: false} : false);
 
     if(!scene.staticMode) {
-        scene.glplot.canvas.addEventListener('webglcontextlost', function(ev) {
-            Lib.warn('Lost WebGL context.');
-            ev.preventDefault();
-        });
+        scene.glplot.canvas.addEventListener('webglcontextlost', function(event) {
+            if(gd && gd.emit) {
+                gd.emit('plotly_webglcontextlost', {
+                    event: event,
+                    layer: scene.id
+                });
+            }
+        }, false);
     }
 
     if(!scene.camera) {

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -214,6 +214,27 @@ describe('Test gl plot side effects', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('@gl should fire *plotly_webglcontextlost* when on webgl context lost', function(done) {
+        var _mock = Lib.extendDeep({}, require('@mocks/gl2d_12.json'));
+
+        Plotly.plot(gd, _mock).then(function() {
+            return new Promise(function(resolve, reject) {
+                gd.on('plotly_webglcontextlost', resolve);
+                setTimeout(reject, 10);
+
+                var ev = new window.WebGLContextEvent('webglcontextlost');
+                var canvas = gd.querySelector('.gl-canvas-context');
+                canvas.dispatchEvent(ev);
+            });
+        })
+        .then(function(eventData) {
+            expect((eventData || {}).event).toBeDefined();
+            expect((eventData || {}).layer).toBe('contextLayer');
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('Test gl2d plots', function() {

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -220,7 +220,7 @@ describe('Test gl plot side effects', function() {
 
         Plotly.plot(gd, _mock).then(function() {
             return new Promise(function(resolve, reject) {
-                gd.on('plotly_webglcontextlost', resolve);
+                gd.once('plotly_webglcontextlost', resolve);
                 setTimeout(reject, 10);
 
                 var ev = new window.WebGLContextEvent('webglcontextlost');
@@ -231,6 +231,20 @@ describe('Test gl plot side effects', function() {
         .then(function(eventData) {
             expect((eventData || {}).event).toBeDefined();
             expect((eventData || {}).layer).toBe('contextLayer');
+        })
+        .then(function() {
+            return new Promise(function(resolve, reject) {
+                gd.once('plotly_webglcontextlost', resolve);
+                setTimeout(reject, 10);
+
+                var ev = new window.WebGLContextEvent('webglcontextlost');
+                var canvas = gd.querySelector('.gl-canvas-focus');
+                canvas.dispatchEvent(ev);
+            });
+        })
+        .then(function(eventData) {
+            expect((eventData || {}).event).toBeDefined();
+            expect((eventData || {}).layer).toBe('focusLayer');
         })
         .catch(failTest)
         .then(done);

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -1425,4 +1425,25 @@ describe('Test removal of gl contexts', function() {
         })
         .then(done);
     });
+
+    it('@gl should fire *plotly_webglcontextlost* when on webgl context lost', function(done) {
+        var _mock = Lib.extendDeep({}, require('@mocks/gl3d_marker-arrays.json'));
+
+        Plotly.plot(gd, _mock).then(function() {
+            return new Promise(function(resolve, reject) {
+                gd.on('plotly_webglcontextlost', resolve);
+                setTimeout(reject, 10);
+
+                var ev = new window.WebGLContextEvent('webglcontextlost');
+                var canvas = gd.querySelector('div#scene > canvas');
+                canvas.dispatchEvent(ev);
+            });
+        })
+        .then(function(eventData) {
+            expect((eventData || {}).event).toBeDefined();
+            expect((eventData || {}).layer).toBe('scene');
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -1052,6 +1052,36 @@ describe('parcoords basic use', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('@gl should fire *plotly_webglcontextlost* when on webgl context lost', function() {
+        var eventData;
+        var cnt = 0;
+        gd.on('plotly_webglcontextlost', function(d) {
+            eventData = d;
+            cnt++;
+        });
+
+        function trigger(name) {
+            var ev = new window.WebGLContextEvent('webglcontextlost');
+            var canvas = gd.querySelector('.gl-canvas-' + name);
+            canvas.dispatchEvent(ev);
+        }
+
+        function _assert(d, c) {
+            expect((eventData || {}).event).toBeDefined();
+            expect((eventData || {}).layer).toBe(d);
+            expect(cnt).toBe(c);
+        }
+
+        trigger('context');
+        _assert('contextLayer', 1);
+
+        trigger('focus');
+        _assert('focusLayer', 2);
+
+        trigger('pick');
+        _assert('pickLayer', 3);
+    });
 });
 
 describe('@noCI parcoords constraint interactions', function() {


### PR DESCRIPTION
cc @alexcjohnson 

I'm not sure if there's a way to actually test this.

This PR makes regl-based graphs emit an event on WebGL context lost from one of our canvases.

Note that gl3 already sort of does this:

https://github.com/plotly/plotly.js/blob/ff3c324bc09029766b9e4b7ab517b83166a7e363/src/plots/gl3d/scene.js#L231-L234

but logs something instead of emitting an event. Personally, I think emitting an event is better, but maybe consistency with gl3d is best (this is, before the v2 push).