### PR TITLE
Convert typed array to 'regular' arrays before sendToCloud

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1894,6 +1894,10 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults) {
             return d.map(stripObj);
         }
 
+        if(Lib.isTypedArray(d)) {
+            return Lib.simpleMap(d, Lib.identity);
+        }
+
         // convert native dates to date strings...
         // mostly for external users exporting to plotly
         if(Lib.isJSDate(d)) return Lib.ms2DateTimeLocal(+d);

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -500,6 +500,13 @@ describe('Test Plots', function() {
     });
 
     describe('Plots.graphJson', function() {
+        var gd;
+
+        beforeEach(function() {
+            gd = createGraphDiv();
+        });
+
+        afterEach(destroyGraphDiv);
 
         it('should serialize data, layout and frames', function(done) {
             var mock = {
@@ -533,7 +540,7 @@ describe('Test Plots', function() {
                 }]
             };
 
-            Plotly.plot(createGraphDiv(), mock).then(function(gd) {
+            Plotly.plot(gd, mock).then(function() {
                 var str = Plots.graphJson(gd, false, 'keepdata');
                 var obj = JSON.parse(str);
 
@@ -547,10 +554,38 @@ describe('Test Plots', function() {
                     name: 'garbage'
                 });
             })
-            .then(function() {
-                destroyGraphDiv();
-                done();
-            });
+            .catch(failTest)
+            .then(done);
+        });
+
+        it('should convert typed arrays to regular arrays', function(done) {
+            var trace = {
+                x: new Float32Array([1, 2, 3]),
+                y: new Float32Array([1, 2, 1]),
+                marker: {
+                    size: new Float32Array([20, 30, 10]),
+                    color: new Float32Array([10, 30, 20]),
+                    cmin: 10,
+                    cmax: 30,
+                    colorscale: [
+                        [0, 'rgb(255, 0, 0)'],
+                        [0.5, 'rgb(0, 255, 0)'],
+                        [1, 'rgb(0, 0, 255)']
+                    ]
+                }
+            };
+
+            Plotly.plot(gd, [trace]).then(function() {
+                var str = Plots.graphJson(gd, false, 'keepdata');
+                var obj = JSON.parse(str);
+
+                expect(obj.data[0].x).toEqual([1, 2, 3]);
+                expect(obj.data[0].y).toEqual([1, 2, 1]);
+                expect(obj.data[0].marker.size).toEqual([20, 30, 10]);
+                expect(obj.data[0].marker.color).toEqual([10, 30, 20]);
+            })
+            .catch(failTest)
+            .then(done);
         });
     });
 


### PR DESCRIPTION
- as `JSON.stringify(new Float32Array([1,2,3]))` gives: `"{"0":1,"1":2,"2":3}"`
- use `Lib.simpleMap` as opposed to `Array.prototype.slice.call(d)` to avoid potential 'exceed stack size' errors

![peek 2018-09-11 12-07](https://user-images.githubusercontent.com/6675409/45372590-64d51c80-b5bb-11e8-8ee6-b957dc9698e5.gif)

cc @alexcjohnson 
