### PR TITLE
Don't skip over dtick and tick0 in geo subplot in diffLayout

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2444,14 +2444,15 @@ function getDiffFlags(oldContainer, newContainer, outerparts, opts) {
 
         if(key.charAt(0) === '_' || typeof oldVal === 'function' || oldVal === newVal) continue;
 
-        // FIXME: ax.tick0 and dtick get filled in during plotting, and unlike other auto values
-        // they don't make it back into the input, so newContainer won't have them.
-        // similar for axis ranges for 3D
-        // contourcarpet doesn't HAVE zmin/zmax, they're just auto-added. It needs them.
-        if(key === 'tick0' || key === 'dtick') {
+        // FIXME: ax.tick0 and dtick get filled in during plotting (except for geo subplots),
+        // and unlike other auto values they don't make it back into the input,
+        // so newContainer won't have them.
+        if((key === 'tick0' || key === 'dtick') && outerparts[0] !== 'geo') {
             var tickMode = newContainer.tickmode;
             if(tickMode === 'auto' || tickMode === 'array' || !tickMode) continue;
         }
+        // FIXME: Similarly for axis ranges for 3D
+        // contourcarpet doesn't HAVE zmin/zmax, they're just auto-added. It needs them.
         if(key === 'range' && newContainer.autorange) continue;
         if((key === 'zmin' || key === 'zmax') && newContainer.type === 'contourcarpet') continue;
 

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -2784,6 +2784,37 @@ describe('Test plot api', function() {
             .then(done);
         });
 
+        it('picks up special dtick geo case', function(done) {
+            var data = [{type: 'scattergeo'}];
+            var layout = {};
+
+            function countLines() {
+                var path = d3.select(gd).select('.lataxis > path');
+                return path.attr('d').split('M').length;
+            }
+
+            Plotly.react(gd, data)
+            .then(countPlots)
+            .then(function() {
+                layout.geo = {lataxis: {showgrid: true, dtick: 10}};
+                return Plotly.react(gd, data, layout);
+            })
+            .then(function() {
+                countCalls({plot: 1});
+                expect(countLines()).toBe(18);
+            })
+            .then(function() {
+                layout.geo.lataxis.dtick = 30;
+                return Plotly.react(gd, data, layout);
+            })
+            .then(function() {
+                countCalls({plot: 1});
+                expect(countLines()).toBe(6);
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
         it('picks up minimal sequence for cartesian axis range updates', function(done) {
             var data = [{y: [1, 2, 1]}];
             var layout = {xaxis: {range: [1, 2]}};


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/2898, a better fix would be to make `dtick` and `tick0` for all axes _just work_ with `Plotly.react` with no added logic (that's one of the items in https://github.com/plotly/plotly.js/issues/2353), but that will be for another day.

cc @alexcjohnson @antoinerg 