### PR TITLE
Reset updates object on every zoomDone

### DIFF
--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -85,6 +85,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     var editX, editY;
     // graph-wide optimization flags
     var hasScatterGl, hasOnlyLargeSploms, hasSplom, hasSVG;
+    // collected changes to be made to the plot by relayout at the end
+    var updates;
 
     function recomputeAxisLists() {
         xa0 = plotinfo.xaxis;
@@ -291,9 +293,6 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     // zoom takes over minDrag, so it also has to take over gd._dragged
     var zoomDragged;
 
-    // collected changes to be made to the plot by relayout at the end
-    var updates = {};
-
     function zoomPrep(e, startX, startY) {
         var dragBBox = dragger.getBoundingClientRect();
         x0 = startX - dragBBox.left;
@@ -386,6 +385,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     }
 
     function zoomDone() {
+        updates = {};
+
         // more strict than dragged, which allows you to come back to where you started
         // and still count as dragged
         if(Math.min(box.h, box.w) < MINDRAG * 2) {
@@ -936,6 +937,7 @@ function zoomAxRanges(axList, r0Fraction, r1Fraction, updates, linkedAxes) {
             axi.l2r(axRangeLinear0 + axRangeLinearSpan * r0Fraction),
             axi.l2r(axRangeLinear0 + axRangeLinearSpan * r1Fraction)
         ];
+
         updates[axi._name + '.range[0]'] = axi.range[0];
         updates[axi._name + '.range[1]'] = axi.range[1];
     }

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -654,6 +654,25 @@ describe('axis zoom/pan and main plot zoom', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('handles xy, x-only and y-only zoombox updates', function(done) {
+        function _assert(msg, xrng, yrng) {
+            expect(gd.layout.xaxis.range).toBeCloseToArray(xrng, 2, 'xrng - ' + msg);
+            expect(gd.layout.yaxis.range).toBeCloseToArray(yrng, 2, 'yrng - ' + msg);
+        }
+
+        Plotly.plot(gd, [{ y: [1, 2, 1] }])
+        .then(doDrag('xy', 'nsew', 50, 50))
+        .then(function() { _assert('after xy drag', [1, 1.208], [1.287, 1.5]); })
+        .then(doDblClick('xy', 'nsew'))
+        .then(doDrag('xy', 'nsew', 50, 0))
+        .then(function() { _assert('after x-only drag', [1, 1.208], [0.926, 2.073]); })
+        .then(doDblClick('xy', 'nsew'))
+        .then(doDrag('xy', 'nsew', 0, 50))
+        .then(function() { _assert('after y-only drag', [-0.128, 2.128], [1.287, 1.5]); })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('Event data:', function() {


### PR DESCRIPTION
... so that 'old' keys from two-sided zoomboxes don't trickle into single-side zoombox updates.

Fixes https://github.com/plotly/plotly.js/issues/3026, which was made apparent staring from `v1.40.0` (and PR https://github.com/plotly/plotly.js/pull/2823), as we no longer run a `calc` edit when autoranging cartesian axes (e.g on double-click).

This one is fairly bad bug, so I'll make a release as soon as this thing is merged.

cc @alexcjohnson @antoinerg 