### PR TITLE
Do not to look for 'add' or 'remove' when replacing array containers

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1979,9 +1979,10 @@ function _relayout(gd, aobj) {
             var obji = (componentArray || [])[i] || {};
             var updateValObject = valObject || {editType: 'calc'};
 
-            if(propStr === '') {
+            if(i !== '' && propStr === '') {
                 // special handling of undoit if we're adding or removing an element
-                // ie 'annotations[2]' which can be {...} (add) or null (remove)
+                // ie 'annotations[2]' which can be {...} (add) or null,
+                // does not work when replacing the entire array
                 if(manageArrays.isAddVal(vi)) {
                     undoit[ai] = null;
                 } else if(manageArrays.isRemoveVal(vi)) {
@@ -1990,7 +1991,6 @@ function _relayout(gd, aobj) {
                     Lib.warn('unrecognized full object value', aobj);
                 }
             }
-
             editTypes.update(flags, updateValObject);
 
             // prepare the edits object we'll send to applyContainerArrayChanges

--- a/test/jasmine/tests/shapes_test.js
+++ b/test/jasmine/tests/shapes_test.js
@@ -367,6 +367,8 @@ describe('Test shapes:', function() {
         });
 
         it('can replace the shapes array', function(done) {
+            spyOn(Lib, 'warn');
+
             Plotly.relayout(gd, { shapes: [
                 getRandomShape(),
                 getRandomShape()
@@ -375,6 +377,7 @@ describe('Test shapes:', function() {
                 expect(countShapePathsInLowerLayer()).toEqual(0);
                 expect(countShapePathsInSubplots()).toEqual(0);
                 expect(gd.layout.shapes.length).toBe(2);
+                expect(Lib.warn).not.toHaveBeenCalled();
             })
             .catch(failTest)
             .then(done);


### PR DESCRIPTION
fixes an issue brought up in https://community.plot.ly/t/posible-issue-in-plotly-relayout-and-passing-in-an-update-object-with-a-shapes-array/13975 - which didn't lead to any bugs (as the correct `editType` was still resolved), but lead to a false `Lib.warn` message in the console.

This PR is essentially a small fixup of commit https://github.com/plotly/plotly.js/commit/138a84f613c7c6185c6c1d1d3978fda4754f76e5#diff-2941ab69a12080c0633ff4ac8ea3aa83 from PR https://github.com/plotly/plotly.js/pull/2823 (fast axis autorange).

@alexcjohnson @antoinerg @archmoj 