### PR TITLE
issue #2904

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8861,8 +8861,8 @@
       }
     },
     "regl-line2d": {
-      "version": "git://github.com/archmoj/regl-line2d.git#506970ff38c2e55419aaf95f5f816fba4d3d3073",
-      "from": "git://github.com/archmoj/regl-line2d.git#506970ff38c2e55419aaf95f5f816fba4d3d3073",
+      "version": "git://github.com/archmoj/regl-line2d.git#e613c7f11907fea6bc533d970203d3396b0ef651",
+      "from": "git://github.com/archmoj/regl-line2d.git#e613c7f11907fea6bc533d970203d3396b0ef651",
       "requires": {
         "array-bounds": "^1.0.0",
         "array-normalize": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8861,8 +8861,8 @@
       }
     },
     "regl-line2d": {
-      "version": "git://github.com/archmoj/regl-line2d.git#e613c7f11907fea6bc533d970203d3396b0ef651",
-      "from": "git://github.com/archmoj/regl-line2d.git#e613c7f11907fea6bc533d970203d3396b0ef651",
+      "version": "git://github.com/archmoj/regl-line2d.git#87dbc502d0a22611ed135b6d525e7bc7bad3932f",
+      "from": "git://github.com/archmoj/regl-line2d.git#87dbc502d0a22611ed135b6d525e7bc7bad3932f",
       "requires": {
         "array-bounds": "^1.0.0",
         "array-normalize": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8861,8 +8861,8 @@
       }
     },
     "regl-line2d": {
-      "version": "git://github.com/archmoj/regl-line2d.git#87dbc502d0a22611ed135b6d525e7bc7bad3932f",
-      "from": "git://github.com/archmoj/regl-line2d.git#87dbc502d0a22611ed135b6d525e7bc7bad3932f",
+      "version": "git://github.com/archmoj/regl-line2d.git#c5856f8d71f246532f11cb48e20aad30fa773652",
+      "from": "git://github.com/archmoj/regl-line2d.git#c5856f8d71f246532f11cb48e20aad30fa773652",
       "requires": {
         "array-bounds": "^1.0.0",
         "array-normalize": "^1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8861,9 +8861,8 @@
       }
     },
     "regl-line2d": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.11.tgz",
-      "integrity": "sha512-nf0Ftpf6boR0oJ24Gs77J8pQE0wet59T1TkrK1f0TWKJgWgRXByxRHDD92m/KZ2dpl+XTvCORk2NRqitSJGwWw==",
+      "version": "git://github.com/archmoj/regl-line2d.git#506970ff38c2e55419aaf95f5f816fba4d3d3073",
+      "from": "git://github.com/archmoj/regl-line2d.git#506970ff38c2e55419aaf95f5f816fba4d3d3073",
       "requires": {
         "array-bounds": "^1.0.0",
         "array-normalize": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "polybooljs": "^1.2.0",
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
-    "regl-line2d": "git://github.com/archmoj/regl-line2d.git#e613c7f11907fea6bc533d970203d3396b0ef651",
+    "regl-line2d": "git://github.com/archmoj/regl-line2d.git#87dbc502d0a22611ed135b6d525e7bc7bad3932f",
     "regl-scatter2d": "^3.0.6",
     "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "polybooljs": "^1.2.0",
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
-    "regl-line2d": "git://github.com/archmoj/regl-line2d.git#506970ff38c2e55419aaf95f5f816fba4d3d3073",
+    "regl-line2d": "git://github.com/archmoj/regl-line2d.git#e613c7f11907fea6bc533d970203d3396b0ef651",
     "regl-scatter2d": "^3.0.6",
     "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "polybooljs": "^1.2.0",
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
-    "regl-line2d": "^3.0.11",
+    "regl-line2d": "git://github.com/archmoj/regl-line2d.git#506970ff38c2e55419aaf95f5f816fba4d3d3073",
     "regl-scatter2d": "^3.0.6",
     "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "polybooljs": "^1.2.0",
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
-    "regl-line2d": "git://github.com/archmoj/regl-line2d.git#87dbc502d0a22611ed135b6d525e7bc7bad3932f",
+    "regl-line2d": "git://github.com/archmoj/regl-line2d.git#c5856f8d71f246532f11cb48e20aad30fa773652",
     "regl-scatter2d": "^3.0.6",
     "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",


### PR DESCRIPTION
Bug fix for 2D line plots.
Negative scales are handled in the webgl vertex shader so that the line plots would be displayed in layouts with reversed ranges.
@etpinard 
@alexcjohnson 