### PR TITLE
#2371: Not disabling scrollZoom when page (plot) has scroll bar

### DIFF
--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -434,13 +434,6 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
         recomputeAxisLists();
 
-        // if the plot has scrollbars (more than a tiny excess)
-        // disable scrollzoom too.
-        if(pc.scrollHeight - pc.clientHeight > 10 ||
-                pc.scrollWidth - pc.clientWidth > 10) {
-            return;
-        }
-
         clearTimeout(redrawTimer);
 
         var wheelDelta = -e.deltaY;


### PR DESCRIPTION
Used to disable scrollzoom when the plot had scrollbars. Ended up with a plot which is not zoomable with mouse scroll on a page which had additional content (had a scrollbar).