### PR TITLE
Fix gl3d subplots on tablets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4723,9 +4723,9 @@
       }
     },
     "gl-plot3d": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-1.5.5.tgz",
-      "integrity": "sha512-pmpIVJ/otokKSdUrpT0a0YjT1B0qdrH3qFO7LcuCSV/8YIo0ybYbXAoYacksgbiJehVVxvnN1ZMCkDIl1uFh4w==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-1.5.6.tgz",
+      "integrity": "sha512-wui+rl9mCOA4k7A6dMTkKYmmZyYCvMA9LC4WjSyiH7pJxcSDqpLFwfZoGhbsv9ucgb0NeCeW+0iWGOM8fH90YQ==",
       "requires": {
         "3d-view-controls": "^2.2.0",
         "a-big-triangle": "^1.0.0",
@@ -4736,7 +4736,7 @@
         "gl-shader": "^4.2.1",
         "gl-spikes3d": "^1.0.3",
         "glslify": "^6.1.0",
-        "is-mobile": "^0.2.2",
+        "is-mobile": "^2.0.0",
         "mouse-change": "^1.1.1",
         "ndarray": "^1.0.16"
       }
@@ -5909,9 +5909,9 @@
       "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY="
     },
     "is-mobile": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-0.2.2.tgz",
-      "integrity": "sha1-Di4AbZntLCFVt2HfgPKjYZrirZ8="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.0.0.tgz",
+      "integrity": "sha512-k2+p7BBCzhqHMdYJwGUNNo+6zegGiMIVbM6bEPzxWXpQV6BUzV892UW0oDFgqxT6DygO7LdxRbwC0xmOhJdbew=="
     },
     "is-number": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.0.0",
     "gl-plot2d": "^1.3.1",
-    "gl-plot3d": "^1.5.5",
+    "gl-plot3d": "^1.5.6",
     "gl-pointcloud2d": "^1.0.1",
     "gl-scatter3d": "^1.0.11",
     "gl-select-box": "^1.0.2",


### PR DESCRIPTION
by bumping gl-plot3d to 1.5.6 which includes @dy's https://github.com/gl-vis/gl-plot3d/pull/11 that closed https://github.com/plotly/plotly.js/issues/280

cc @nicolaskruchten @plotly/plotly_js 