### PR TITLE
prevent vertical modebar from overflowing

### DIFF
--- a/build/plotcss.js
+++ b/build/plotcss.js
@@ -37,7 +37,7 @@ var rules = {
     "X .modebar-group": "float:left;display:inline-block;box-sizing:border-box;margin-left:8px;position:relative;vertical-align:middle;white-space:nowrap;",
     "X .modebar-btn": "position:relative;font-size:16px;padding:3px 4px;height:22px;cursor:pointer;line-height:normal;box-sizing:border-box;",
     "X .modebar-btn svg": "position:relative;top:2px;",
-    "X .modebar.vertical": "top:-1px;",
+    "X .modebar.vertical": "top:-1px;display:flex;flex-direction:column;flex-wrap:wrap;height:100%;align-content:flex-end;",
     "X .modebar.vertical .modebar-group": "display:block;float:none;margin-left:0px;margin-bottom:8px;",
     "X .modebar.vertical .modebar-group .modebar-btn": "display:block;text-align:center;",
     "X [data-title]:before,X [data-title]:after": "position:absolute;-webkit-transform:translate3d(0, 0, 0);-moz-transform:translate3d(0, 0, 0);-ms-transform:translate3d(0, 0, 0);-o-transform:translate3d(0, 0, 0);transform:translate3d(0, 0, 0);display:none;opacity:0;z-index:1001;pointer-events:none;top:110%;right:50%;",

--- a/src/css/_modebar.scss
+++ b/src/css/_modebar.scss
@@ -46,6 +46,11 @@
 
 .modebar.vertical {
     top: -1px;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    height: 100%;
+    align-content: flex-end;
     .modebar-group {
         display: block;
         float: none;


### PR DESCRIPTION
This PR makes vertical modebars behave like horizontal ones.

Previously, a vertical modebar could overflow the figure's container:
<img width="154" alt="sharex_2018-10-10_14-06-36" src="https://user-images.githubusercontent.com/301546/46757432-25701d80-cc98-11e8-8737-56e241d0b5b7.png">

With this PR, it doesn't and wrap the items:
<img width="154" alt="2018-10-10_14-22-36" src="https://user-images.githubusercontent.com/301546/46757459-36209380-cc98-11e8-896c-6024e29c3ffd.png">

This patch relies on `display:flex` which is used on plotly's official webpage and is now [very well supported](https://caniuse.com/#search=flex).

