### PR TITLE
support dom element as argument to Plotly.makeTemplate

### DIFF
--- a/src/plot_api/template_api.js
+++ b/src/plot_api/template_api.js
@@ -31,7 +31,7 @@ var dfltConfig = require('./plot_config');
  *     `layout.template` in another figure.
  */
 exports.makeTemplate = function(figure) {
-    figure = Lib.extendDeep({_context: dfltConfig}, figure);
+    figure = Lib.extendDeep({_context: dfltConfig}, {data: figure.data, layout: figure.layout});
     Plots.supplyDefaults(figure);
     var data = figure.data || [];
     var layout = figure.layout || {};

--- a/test/jasmine/tests/template_test.js
+++ b/test/jasmine/tests/template_test.js
@@ -141,6 +141,33 @@ describe('makeTemplate', function() {
 
         expect(template).toEqual(expected);
     });
+
+    it('works on DOM element', function(done) {
+        var mock = Lib.extendDeep({}, scatterFillMock);
+        var gd = createGraphDiv();
+
+        Plotly.newPlot(gd, mock)
+      .then(function() {
+          var template = Plotly.makeTemplate(gd);
+          delete(template.layout.xaxis);
+          delete(template.layout.yaxis);
+          expect(template).toEqual({
+              data: {scatter: [
+                {fill: 'tonext', line: {shape: 'spline'}},
+                {fill: 'tonext'},
+                {fill: 'toself'}
+              ] },
+              layout: {
+                  title: 'Fill toself and tonext',
+                  width: 400,
+                  height: 400
+              }
+          });
+      })
+      .catch(failTest)
+      .then(destroyGraphDiv)
+      .then(done);
+    });
 });
 
 // statics of template application are all covered by the template mock

--- a/test/jasmine/tests/template_test.js
+++ b/test/jasmine/tests/template_test.js
@@ -147,23 +147,23 @@ describe('makeTemplate', function() {
         var gd = createGraphDiv();
 
         Plotly.newPlot(gd, mock)
-      .then(function() {
-          var template = Plotly.makeTemplate(gd);
-          delete(template.layout.xaxis);
-          delete(template.layout.yaxis);
-          expect(template).toEqual({
-              data: {scatter: [
-                {fill: 'tonext', line: {shape: 'spline'}},
-                {fill: 'tonext'},
-                {fill: 'toself'}
-              ] },
-              layout: {
-                  title: 'Fill toself and tonext',
-                  width: 400,
-                  height: 400
-              }
-          });
-      })
+        .then(function() {
+            var template = Plotly.makeTemplate(gd);
+            delete(template.layout.xaxis);
+            delete(template.layout.yaxis);
+            expect(template).toEqual({
+                data: {scatter: [
+                  {fill: 'tonext', line: {shape: 'spline'}},
+                  {fill: 'tonext'},
+                  {fill: 'toself'}
+                ] },
+                layout: {
+                    title: 'Fill toself and tonext',
+                    width: 400,
+                    height: 400
+                }
+            });
+        })
       .catch(failTest)
       .then(destroyGraphDiv)
       .then(done);


### PR DESCRIPTION
As a first-time user of templates, I expected the following to just work:
```
var.gd = document.getElementById('graph');
Plotly.plot(gd,{...});2,3], y:[4,9,3], line: {color: 'red'}}
...
var layout = Plotly.makeTemplate(gd);
```

This PR enables calling `makeTemplate` with a DOM element.