### PR TITLE
Parcoords issues with extra update call

### DIFF
--- a/src/traces/parcoords/parcoords.js
+++ b/src/traces/parcoords/parcoords.js
@@ -457,8 +457,7 @@ module.exports = function(root, svg, parcoordsLineLayers, styledData, layout, ca
     parcoordsLineLayer
         .each(function(d) {
             if(d.viewModel) {
-                if(d.lineLayer) d.lineLayer.update(d);
-                else d.lineLayer = lineLayerMaker(this, d);
+                d.lineLayer = lineLayerMaker(this, d);
 
                 d.viewModel[d.key] = d.lineLayer;
                 d.lineLayer.render(d.viewModel.panels, !d.context);


### PR DESCRIPTION
Regarding issues #3099 and #3101 this patch removed an extra update call which may be the source of this problem. Please notice that lineLayerMaker itself also calls the update method to redraw.

@alexcjohnson 