### PR TITLE
add cors support for devtools http server

### DIFF
--- a/devtools/test_dashboard/server.js
+++ b/devtools/test_dashboard/server.js
@@ -16,7 +16,8 @@ var PORT = process.argv[2] || 3000;
 var server = http.createServer(ecstatic({
     root: constants.pathToRoot,
     cache: 0,
-    gzip: true
+    gzip: true,
+    cors: true
 }));
 
 // Make watchified bundle for plotly.js


### PR DESCRIPTION
This allows talking to the devtools http server from any webpage. This enables my prototype image viewer (hosted on another domain) to retrieve mocks and images from localhost!