### PR TITLE
update Lib.sort comment and relax its tests

### DIFF
--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -118,6 +118,10 @@ exports.roundUp = function(val, arrayIn, reverse) {
 /**
  * Tweak to Array.sort(sortFn) that improves performance for pre-sorted arrays
  *
+ * Note that newer browsers (such as Chrome v70+) are starting to pick up
+ * on pre-sorted arrays which may render the following optimization unnecessary
+ * in the future.
+ *
  * Motivation: sometimes we need to sort arrays but the input is likely to
  * already be sorted. Browsers don't seem to pick up on pre-sorted arrays,
  * and in fact Chrome is actually *slower* sorting pre-sorted arrays than purely

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -2329,10 +2329,6 @@ describe('Test lib.js:', function() {
                 .toEqual(dupes());
 
             expect(callCount).toEqual(18);
-
-            callCount = 0;
-            dupes().sort(sortCounter);
-            expect(callCount).toBeGreaterThan(18);
         });
 
         it('still short-circuits reversed with duplicates', function() {
@@ -2340,10 +2336,6 @@ describe('Test lib.js:', function() {
                 .toEqual(dupes().reverse());
 
             expect(callCount).toEqual(18);
-
-            callCount = 0;
-            dupes().sort(sortCounterReversed);
-            expect(callCount).toBeGreaterThan(18);
         });
     });
 


### PR DESCRIPTION
Fix `Lib.sort`'s tests which are failing in Chrome v70+.

Background:
Chrome v70+ introduces a new implementation of ` Array.prototype.sort` which optimizes sorting pre-sorted arrays. Our own `Lib.sort` doesn't win the shootout anymore so the tests have to be relaxed to reflect that. Beating the browser was only gravy anyway.

Thanks to @Marc-Andre-Rivet for pointing this out to me :)