### PR TITLE
Fix to enable switching modes using plotly react method on scattergl traces

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -261,8 +261,8 @@ exports.plot = function(gd, data, layout, config) {
             if(regl) {
                 // Unfortunately, this can happen when relayouting to large
                 // width/height on some browsers.
-                if(fullLayout.width !== regl._gl.drawingBufferWidth ||
-                    fullLayout.height !== regl._gl.drawingBufferHeight
+                if(Math.floor(fullLayout.width) !== regl._gl.drawingBufferWidth ||
+                    Math.floor(fullLayout.height) !== regl._gl.drawingBufferHeight
                  ) {
                     var msg = 'WebGL context buffer and canvas dimensions do not match due to browser/WebGL bug.';
                     if(drawFrameworkCalls) {

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -296,25 +296,24 @@ function sceneUpdate(gd, subplot) {
         // remove scene resources
         scene.destroy = function destroy() {
             if((scene.fill2d) &&
-               (scene.fill2d.destroy))
-                scene.fill2d.destroy();
+               (scene.fill2d.destroy)) {
+                scene.fill2d.destroy();}
             if((scene.scatter2d) &&
-               (scene.scatter2d.destroy))
-                scene.scatter2d.destroy();
+               (scene.scatter2d.destroy)) {
+                scene.scatter2d.destroy();}
             if((scene.error2d) &&
-               (scene.error2d.destroy))
-                scene.error2d.destroy();
+               (scene.error2d.destroy)) {
+                scene.error2d.destroy();}
             if((scene.line2d) &&
-               (scene.line2d.destroy))
-                scene.line2d.destroy();
+               (scene.line2d.destroy)) {
+                scene.line2d.destroy();}
             if((scene.select2d) &&
-               (scene.select2d.destroy))
-                scene.select2d.destroy();
+               (scene.select2d.destroy)) {
+                scene.select2d.destroy();}
             if(scene.glText) {
                 scene.glText.forEach(
                     function(text) {
-                        if(text.destroy)
-                            text.destroy();
+                        if(text.destroy) text.destroy();
                     }
                 );
             }

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -295,27 +295,15 @@ function sceneUpdate(gd, subplot) {
 
         // remove scene resources
         scene.destroy = function destroy() {
-            if((scene.fill2d) &&
-               (scene.fill2d.destroy)) {
-                scene.fill2d.destroy();}
-            if((scene.scatter2d) &&
-               (scene.scatter2d.destroy)) {
-                scene.scatter2d.destroy();}
-            if((scene.error2d) &&
-               (scene.error2d.destroy)) {
-                scene.error2d.destroy();}
-            if((scene.line2d) &&
-               (scene.line2d.destroy)) {
-                scene.line2d.destroy();}
-            if((scene.select2d) &&
-               (scene.select2d.destroy)) {
-                scene.select2d.destroy();}
+            if(scene.fill2d && scene.fill2d.destroy) scene.fill2d.destroy();
+            if(scene.scatter2d && scene.scatter2d.destroy) scene.scatter2d.destroy();
+            if(scene.error2d && scene.error2d.destroy) scene.error2d.destroy();
+            if(scene.line2d && scene.line2d.destroy) scene.line2d.destroy();
+            if(scene.select2d && scene.select2d.destroy) scene.select2d.destroy();
             if(scene.glText) {
-                scene.glText.forEach(
-                    function(text) {
-                        if(text.destroy) text.destroy();
-                    }
-                );
+                scene.glText.forEach(function(text) {
+                    if(text.destroy) text.destroy();
+                });
             }
 
             scene.lineOptions = null;

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -295,13 +295,28 @@ function sceneUpdate(gd, subplot) {
 
         // remove scene resources
         scene.destroy = function destroy() {
-            if(scene.fill2d) scene.fill2d.destroy();
-            if(scene.scatter2d) scene.scatter2d.destroy();
-            if(scene.error2d) scene.error2d.destroy();
-            if(scene.line2d) scene.line2d.destroy();
-            if(scene.select2d) scene.select2d.destroy();
+            if((scene.fill2d) &&
+               (scene.fill2d.destroy))
+                scene.fill2d.destroy();
+            if((scene.scatter2d) &&
+               (scene.scatter2d.destroy))
+                scene.scatter2d.destroy();
+            if((scene.error2d) &&
+               (scene.error2d.destroy))
+                scene.error2d.destroy();
+            if((scene.line2d) &&
+               (scene.line2d.destroy))
+                scene.line2d.destroy();
+            if((scene.select2d) &&
+               (scene.select2d.destroy))
+                scene.select2d.destroy();
             if(scene.glText) {
-                scene.glText.forEach(function(text) { text.destroy(); });
+                scene.glText.forEach(
+                    function(text) {
+                        if (text.destroy)
+                            text.destroy();
+                    }
+                );
             }
 
             scene.lineOptions = null;

--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -313,7 +313,7 @@ function sceneUpdate(gd, subplot) {
             if(scene.glText) {
                 scene.glText.forEach(
                     function(text) {
-                        if (text.destroy)
+                        if(text.destroy)
                             text.destroy();
                     }
                 );


### PR DESCRIPTION
This PR resolves the issue #2999 by providing additional checks before calling destroy functions of scattergl. Without these checks in scenarios namely switching back and forth between different modes e.g. `markers` to `lines` and  then back to `markers` the program (depending on the device/browser) may complain and/or stop.
@alexcjohnson 