### PR TITLE
add build artifact to CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
           command: |
             npm run pretest
             npm run cibuild
+      - run:
+          name: Save build artifact
+          command: cp build/plotly.js $CIRCLE_ARTIFACTS/
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,8 @@ jobs:
           command: ./.circleci/test.sh syntax
 
   publish:
+    docker:
+      - image: circleci/node:10.9.0    
     working_directory: ~/plotly.js
     steps:
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ jobs:
             npm run cibuild
       - store_artifacts:
           path: ~/plotly.js/build/plotly.js
-      - run:
-          name: Save build artifact
-          command: cp build/plotly.js $CIRCLE_ARTIFACTS/
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,8 @@ jobs:
             npm run pretest
             npm run cibuild
       - store_artifacts:
-          path: ~/plotly.js/build/plotly.js
+          path: build/plotly.js
+          destination: /plotly.js
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
           command: ./.circleci/test.sh image
       - store_artifacts:
           path: build
+          destination: /
 
   test-image2:
     docker:
@@ -107,6 +108,7 @@ jobs:
           command: ./.circleci/test.sh image2
       - store_artifacts:
           path: build
+          destination: /
 
   test-syntax:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,12 @@ jobs:
 
   publish:
     docker:
-      - image: circleci/node:10.9.0    
+      - image: circleci/node:10.9.0
     working_directory: ~/plotly.js
     steps:
+      - checkout
+      - attach_workspace:
+          at: ~/plotly.js
       - store_artifacts:
           path: build/plotly.js
           destination: /plotly.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           destination: /plotly.js
       - store_artifacts:
           path: dist/plotly.min.js
-          destinatin: /plotly.min.js
+          destination: /plotly.min.js
       - store_artifacts:
           path: dist/plot-schema.json
           destination: /plot-schema.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,6 @@ jobs:
           command: |
             npm run pretest
             npm run cibuild
-      - store_artifacts:
-          path: build/plotly.js
-          destination: /plotly.js
       - save_cache:
           paths:
             - node_modules
@@ -123,6 +120,19 @@ jobs:
           name: Run syntax tests
           command: ./.circleci/test.sh syntax
 
+  publish:
+    working_directory: ~/plotly.js
+    steps:
+      - store_artifacts:
+          path: build/plotly.js
+          destination: /plotly.js
+      - store_artifacts:
+          path: dist/plotly.min.js
+          destinatin: /plotly.min.js
+      - store_artifacts:
+          path: dist/plot-schema.json
+          destination: /plot-schema.json
+
 workflows:
   version: 2
   build-and-test:
@@ -141,5 +151,8 @@ workflows:
           requires:
             - build
       - test-syntax:
+          requires:
+            - build
+      - publish:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
           command: |
             npm run pretest
             npm run cibuild
+      - store_artifacts:
+          path: ~/plotly.js/build/plotly.js
       - run:
           name: Save build artifact
           command: cp build/plotly.js $CIRCLE_ARTIFACTS/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,4 +160,8 @@ workflows:
             - build
       - publish:
           requires:
-            - build
+            - test-jasmine
+            - test-jasmine2
+            - test-image
+            - test-image2
+            - test-syntax


### PR DESCRIPTION
Testing the artifacts features of circleCI. 

The idea is to store the `plotly.js` that gets built for each commit/branch. This way, it would be extremely easy to test a particular branch without having to checkout, build and serve over HTTP locally. Moreover, if the artifacts are served by circleCI over HTTPS, it will be easy to test them out in Codepen and quickly swap between versions to check whether it correctly fixes a given issue.