### PR TITLE
fix for transforms operating on auto-invisible traces

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -951,6 +951,8 @@ plots.supplyDataDefaults = function(dataIn, dataOut, layout, fullLayout) {
         fullTrace._expandedIndex = cnt;
 
         if(fullTrace.transforms && fullTrace.transforms.length) {
+            var sdInvisible = trace.visible !== false && fullTrace.visible === false;
+
             var expandedTraces = applyTransforms(fullTrace, dataOut, layout, fullLayout);
 
             for(var j = 0; j < expandedTraces.length; j++) {
@@ -964,6 +966,17 @@ plots.supplyDataDefaults = function(dataIn, dataOut, layout, fullLayout) {
                     // to promote consistency between update calls
                     uid: fullTrace.uid + j
                 };
+
+                // If the first supplyDefaults created `visible: false`,
+                // clear it before running supplyDefaults a second time,
+                // because sometimes there are items we still want to coerce
+                // inside trace modules before determining that the trace is
+                // again `visible: false`, for example partial visibilities
+                // in `splom` traces.
+                if(sdInvisible && expandedTrace.visible === false) {
+                    delete expandedTrace.visible;
+                }
+
                 plots.supplyTraceDefaults(expandedTrace, fullExpandedTrace, cnt, fullLayout, i);
 
                 // relink private (i.e. underscore) keys expanded trace to full expanded trace so

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -49,6 +49,37 @@ describe('Test splom trace defaults:', function() {
         });
 
         expect(gd._fullData[0].visible).toBe(false);
+
+        // make sure these are still coerced - so you can get back via GUI!
+        expect(gd._fullData[0].showupperhalf).toBe(false);
+        expect(gd._fullData[0].showlowerhalf).toBe(false);
+        expect(gd._fullData[0].diagonal.visible).toBe(false);
+    });
+
+    it('still coerces partial visibilities even if all are false with transforms', function() {
+        _supply({
+            dimensions: [{
+                values: [1, 2, 3]
+            }],
+            showupperhalf: false,
+            showlowerhalf: false,
+            diagonal: {visible: false},
+            transforms: [{
+                type: 'filter',
+                target: 'dimensions[0].values',
+                operation: '>',
+                value: 2
+            }]
+        });
+
+        expect(gd._fullData[0].visible).toBe(false);
+
+        expect(gd._fullData[0].transforms[0].enabled).toBe(true);
+
+        // make sure these are still coerced - so you can get back via GUI!
+        expect(gd._fullData[0].showupperhalf).toBe(false);
+        expect(gd._fullData[0].showlowerhalf).toBe(false);
+        expect(gd._fullData[0].diagonal.visible).toBe(false);
     });
 
     it('should set `visible: false` to values-less dimensions', function() {


### PR DESCRIPTION
Transforms mean `supplyDefaults` gets run twice. This is mostly fine, but there are some unwanted effects from running it on a trace object that has already had its defaults filled in. The one I'm concerned with here is that if a trace is explicitly `visible: false` we don't even run the module defaults, but occasionally there are things that automatically trigger `visible: false` in the module defaults, after we've already set some properties in `fullTrace`. Because the `visible: false` only makes sense based on those properties, we still want them to be part of the final trace (for example, to make RCE and toolpanel happy). So in this PR I detect this situation and clear `expandedTrace.visible` so that the original logic will run again the second time through `supplyDefaults`.

@etpinard can you think of any unwanted consequences of this? cc @antoinerg @archmoj - one of the darker, dingier corners of plotly.js...