### PR TITLE
Improvements for CI build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,8 +162,4 @@ workflows:
             - build
       - publish:
           requires:
-            - test-jasmine
-            - test-jasmine2
-            - test-image
-            - test-image2
-            - test-syntax
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,13 @@ jobs:
       - store_artifacts:
           path: dist/plot-schema.json
           destination: /plot-schema.json
+      - run:
+          name: Show URLs to build files
+          command: |
+            PROJECT_NUM=45646037
+            echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/plotly.js
+            echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/plotly.min.js
+            echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/plot-schema.json
 
 workflows:
   version: 2


### PR DESCRIPTION
I'm a <strike>big</strike> huge fan of @antoinerg 's https://github.com/plotly/plotly.js/pull/3136, so I couldn't resist improving it slightly.

This PR:
- makes the build artifacts get "published" even when the tests fail (which can be useful in some situations)
- echoes the artifact URLs in the publish step using Circle's [built-in environment variables](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables), which can serve as an easier click-to alternative to @antoinerg's [fancy shell footwork](https://github.com/plotly/plotly.js/pull/3136#issuecomment-432059992).

cc @plotly/plotly_js 