### PR TITLE
prune global-level trace attributes that are already defined in a trace

### DIFF
--- a/src/plot_api/plot_schema.js
+++ b/src/plot_api/plot_schema.js
@@ -112,6 +112,7 @@ exports.get = function() {
  *          @param {String} attrName name string
  *          @param {object[]} attrs all the attributes
  *          @param {Number} level the recursion level, 0 at the root
+ *          @param {String} fullAttrString full attribute name (ie 'marker.line')
  * @param {Number} [specifiedLevel]
  *  The level in the tree, in order to let the callback function detect descend or backtrack,
  *  typically unsupplied (implied 0), just used by the self-recursive call.
@@ -466,9 +467,9 @@ function getTraceAttributes(type) {
 
     // prune global-level trace attributes that are already defined in a trace
     exports.crawl(copyModuleAttributes, function(attr, attrName, attrs, level, fullAttrString) {
-        delete copyBaseAttributes[fullAttrString];
+        Lib.nestedProperty(copyBaseAttributes, fullAttrString).set(undefined);
         // Prune undefined attributes
-        if(attr === undefined) delete copyModuleAttributes[fullAttrString];
+        if(attr === undefined) Lib.nestedProperty(copyModuleAttributes, fullAttrString).set(undefined);
     });
 
     // base attributes (same for all trace types)

--- a/src/plot_api/plot_schema.js
+++ b/src/plot_api/plot_schema.js
@@ -460,11 +460,22 @@ function getTraceAttributes(type) {
     // make 'type' the first attribute in the object
     attributes.type = null;
 
+
+    var copyBaseAttributes = extendDeepAll({}, baseAttributes),
+        copyModuleAttributes = extendDeepAll({}, _module.attributes);
+
+    // prune global-level trace attributes that are already defined in a trace
+    exports.crawl(copyModuleAttributes, function(attr, attrName, attrs, level, fullAttrString) {
+        delete copyBaseAttributes[fullAttrString];
+        // Prune undefined attributes
+        if(attr === undefined) delete copyModuleAttributes[fullAttrString];
+    });
+
     // base attributes (same for all trace types)
-    extendDeepAll(attributes, baseAttributes);
+    extendDeepAll(attributes, copyBaseAttributes);
 
     // module attributes
-    extendDeepAll(attributes, _module.attributes);
+    extendDeepAll(attributes, copyModuleAttributes);
 
     // subplot attributes
     if(basePlotModule.attributes) {

--- a/src/plot_api/plot_schema.js
+++ b/src/plot_api/plot_schema.js
@@ -461,8 +461,8 @@ function getTraceAttributes(type) {
     attributes.type = null;
 
 
-    var copyBaseAttributes = extendDeepAll({}, baseAttributes),
-        copyModuleAttributes = extendDeepAll({}, _module.attributes);
+    var copyBaseAttributes = extendDeepAll({}, baseAttributes);
+    var copyModuleAttributes = extendDeepAll({}, _module.attributes);
 
     // prune global-level trace attributes that are already defined in a trace
     exports.crawl(copyModuleAttributes, function(attr, attrName, attrs, level, fullAttrString) {

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1172,8 +1172,8 @@ plots.supplyTraceDefaults = function(traceIn, traceOut, colorIndex, layout, trac
     }
 
     if(visible) {
-        coerceUnlessPruned('customdata');
-        coerceUnlessPruned('ids');
+        coerce('customdata');
+        coerce('ids');
 
         if(Registry.traceIs(traceOut, 'showLegend')) {
             traceOut._dfltShowLegend = true;

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1171,7 +1171,9 @@ plots.supplyTraceDefaults = function(traceIn, traceOut, colorIndex, layout, trac
             traceOut._dfltShowLegend = false;
         }
 
-        if(_module && _module.attributes.hoverlabel !== undefined) {
+        if(_module && ('hoverlabel' in _module.attributes) && _module.attributes.hoverlabel === undefined) {
+            // Do not coerce hoverlabel
+        } else {
             Registry.getComponentMethod(
                 'fx',
                 'supplyDefaults'

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1184,7 +1184,7 @@ plots.supplyTraceDefaults = function(traceIn, traceOut, colorIndex, layout, trac
             traceOut._dfltShowLegend = false;
         }
 
-        coerceUnlessPruned('hoverlabel','',function() {
+        coerceUnlessPruned('hoverlabel', '', function() {
             Registry.getComponentMethod(
                 'fx',
                 'supplyDefaults'

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1171,10 +1171,12 @@ plots.supplyTraceDefaults = function(traceIn, traceOut, colorIndex, layout, trac
             traceOut._dfltShowLegend = false;
         }
 
-        Registry.getComponentMethod(
-            'fx',
-            'supplyDefaults'
-        )(traceIn, traceOut, defaultColor, layout);
+        if(_module && _module.attributes.hoverlabel !== undefined) {
+            Registry.getComponentMethod(
+                'fx',
+                'supplyDefaults'
+            )(traceIn, traceOut, defaultColor, layout);
+        }
 
         // TODO add per-base-plot-module trace defaults step
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1125,6 +1125,7 @@ plots.supplyTraceDefaults = function(traceIn, traceOut, colorIndex, layout, trac
     // we want even invisible traces to make their would-be subplots visible
     // so coerce the subplot id(s) now no matter what
     var _module = plots.getModule(traceOut);
+
     traceOut._module = _module;
     if(_module) {
         var basePlotModule = _module.basePlotModule;
@@ -1158,9 +1159,21 @@ plots.supplyTraceDefaults = function(traceIn, traceOut, colorIndex, layout, trac
         }
     }
 
+    function coerceUnlessPruned(attr, dflt, cb) {
+        if(_module && (attr in _module.attributes) && _module.attributes[attr] === undefined) {
+            // Pruned
+        } else {
+            if(cb && typeof cb === 'function') {
+                cb();
+            } else {
+                coerce(attr, dflt);
+            }
+        }
+    }
+
     if(visible) {
-        coerce('customdata');
-        coerce('ids');
+        coerceUnlessPruned('customdata');
+        coerceUnlessPruned('ids');
 
         if(Registry.traceIs(traceOut, 'showLegend')) {
             traceOut._dfltShowLegend = true;
@@ -1171,14 +1184,12 @@ plots.supplyTraceDefaults = function(traceIn, traceOut, colorIndex, layout, trac
             traceOut._dfltShowLegend = false;
         }
 
-        if(_module && ('hoverlabel' in _module.attributes) && _module.attributes.hoverlabel === undefined) {
-            // Do not coerce hoverlabel
-        } else {
+        coerceUnlessPruned('hoverlabel','',function() {
             Registry.getComponentMethod(
                 'fx',
                 'supplyDefaults'
             )(traceIn, traceOut, defaultColor, layout);
-        }
+        });
 
         // TODO add per-base-plot-module trace defaults step
 

--- a/src/traces/carpet/attributes.js
+++ b/src/traces/carpet/attributes.js
@@ -127,4 +127,5 @@ module.exports = {
             'Individual pieces can override this.'
         ].join(' ')
     },
+    transforms: undefined
 };

--- a/src/traces/cone/attributes.js
+++ b/src/traces/cone/attributes.js
@@ -180,4 +180,6 @@ attrs.hoverinfo = extendFlat({}, baseAttrs.hoverinfo, {
     dflt: 'x+y+z+norm+text+name'
 });
 
+attrs.transforms = undefined;
+
 module.exports = attrs;

--- a/src/traces/contourcarpet/attributes.js
+++ b/src/traces/contourcarpet/attributes.js
@@ -90,7 +90,8 @@ module.exports = extendFlat({
             ].join(' ')
         }),
         editType: 'plot'
-    }
+    },
+    transforms: undefined
 },
 
     colorscaleAttrs('', {

--- a/src/traces/heatmap/attributes.js
+++ b/src/traces/heatmap/attributes.js
@@ -111,6 +111,7 @@ module.exports = extendFlat({
             'https://github.com/d3/d3-format/blob/master/README.md#locale_format'
         ].join(' ')
     },
+    transforms: undefined
 },
     colorscaleAttrs('', {
         cLetter: 'z',

--- a/src/traces/mesh3d/attributes.js
+++ b/src/traces/mesh3d/attributes.js
@@ -165,6 +165,7 @@ module.exports = extendFlat({
             'Overrides *color* and *vertexcolor*.'
         ].join(' ')
     },
+    transforms: undefined
 },
 
 colorscaleAttrs('', {

--- a/src/traces/parcoords/attributes.js
+++ b/src/traces/parcoords/attributes.js
@@ -20,6 +20,8 @@ var templatedArray = require('../../plot_api/plot_template').templatedArray;
 module.exports = {
     domain: domainAttrs({name: 'parcoords', trace: true, editType: 'calc'}),
 
+    hoverlabel: undefined,
+
     labelfont: fontAttrs({
         editType: 'calc',
         description: 'Sets the font for the `dimension` labels.'

--- a/src/traces/pointcloud/attributes.js
+++ b/src/traces/pointcloud/attributes.js
@@ -141,5 +141,6 @@ module.exports = {
             editType: 'calc'
         },
         editType: 'calc'
-    }
+    },
+    transforms: undefined
 };

--- a/src/traces/sankey/attributes.js
+++ b/src/traces/sankey/attributes.js
@@ -17,7 +17,7 @@ var domainAttrs = require('../../plots/domain').attributes;
 var extendFlat = require('../../lib/extend').extendFlat;
 var overrideAll = require('../../plot_api/edit_types').overrideAll;
 
-module.exports = overrideAll({
+var attrs = module.exports = overrideAll({
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {
         flags: [],
         arrayOk: false,
@@ -219,3 +219,4 @@ module.exports = overrideAll({
         description: 'The links of the Sankey plot.'
     }
 }, 'calc', 'nested');
+attrs.transforms = undefined;

--- a/src/traces/streamtube/attributes.js
+++ b/src/traces/streamtube/attributes.js
@@ -152,4 +152,6 @@ attrs.hoverinfo = extendFlat({}, baseAttrs.hoverinfo, {
     dflt: 'x+y+z+norm+text+name'
 });
 
+attrs.transforms = undefined;
+
 module.exports = attrs;

--- a/src/traces/surface/attributes.js
+++ b/src/traces/surface/attributes.js
@@ -256,3 +256,4 @@ colorscaleAttrs('', {
 }), 'calc', 'nested');
 
 attrs.x.editType = attrs.y.editType = attrs.z.editType = 'calc+clearAxisTypes';
+attrs.transforms = undefined;

--- a/src/traces/table/attributes.js
+++ b/src/traces/table/attributes.js
@@ -14,7 +14,7 @@ var overrideAll = require('../../plot_api/edit_types').overrideAll;
 var fontAttrs = require('../../plots/font_attributes');
 var domainAttrs = require('../../plots/domain').attributes;
 
-module.exports = overrideAll({
+var attrs = module.exports = overrideAll({
     domain: domainAttrs({name: 'table', trace: true}),
 
     columnwidth: {
@@ -198,3 +198,4 @@ module.exports = overrideAll({
         font: extendFlat({}, fontAttrs({arrayOk: true}))
     }
 }, 'calc', 'from-root');
+attrs.transforms = undefined;

--- a/test/jasmine/bundle_tests/plotschema_test.js
+++ b/test/jasmine/bundle_tests/plotschema_test.js
@@ -362,6 +362,11 @@ describe('plot schema', function() {
         expect(typeof splomAttrs.yaxes.items.regex).toBe('string');
         expect(splomAttrs.yaxes.items.regex).toBe('/^y([2-9]|[1-9][0-9]+)?$/');
     });
+
+    it('should prune unsupported global-level trace attributes', function() {
+        expect(Plotly.PlotSchema.get().traces.sankey.attributes.hoverinfo.flags.length).toBe(0);
+    });
+
 });
 
 describe('getTraceValObject', function() {

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -79,6 +79,14 @@ describe('parcoords initialization tests', function() {
             expect(gd._fullData[0].tickfont).toEqual(expected);
             expect(gd._fullData[0].rangefont).toEqual(expected);
         });
+
+        it('should not coerce hoverlabel', function() {
+            var gd = Lib.extendDeep({}, mock1);
+
+            supplyAllDefaults(gd);
+
+            expect(gd._fullData[0].hoverlabel).toBeUndefined();
+        });
     });
 
     describe('parcoords defaults', function() {


### PR DESCRIPTION
Fixes #3058 

Prune unsupported global-level trace attributes from
- [x]  `Plotly.PlotSchema`
- [x] `_fulldata`