### PR TITLE
Draw bar group if there is text

### DIFF
--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -76,9 +76,10 @@ module.exports = function plot(gd, plotinfo, cdbar, barLayer) {
                 di.ct = [(x0 + x1) / 2, y1];
             }
 
+            var text = getText(trace, i);
             if(!isNumeric(x0) || !isNumeric(x1) ||
                     !isNumeric(y0) || !isNumeric(y1) ||
-                    x0 === x1 || y0 === y1) {
+                    ((x0 === x1 || y0 === y1) && !text)) {
                 bar.remove();
                 return;
             }
@@ -120,11 +121,13 @@ module.exports = function plot(gd, plotinfo, cdbar, barLayer) {
                 y1 = fixpx(y1, y0);
             }
 
-            Lib.ensureSingle(bar, 'path')
-                .style('vector-effect', 'non-scaling-stroke')
-                .attr('d',
-                    'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z')
-                .call(Drawing.setClipUrl, plotinfo.layerClipId);
+            if(x0 !== x1 && y0 !== y1) {
+                Lib.ensureSingle(bar, 'path')
+                    .style('vector-effect', 'non-scaling-stroke')
+                    .attr('d',
+                        'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z')
+                    .call(Drawing.setClipUrl, plotinfo.layerClipId);
+            }
 
             appendBarText(gd, bar, cd, i, x0, x1, y0, y1);
 

--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -77,9 +77,10 @@ module.exports = function plot(gd, plotinfo, cdbar, barLayer) {
             }
 
             var text = getText(trace, i);
+            var is_empty = x0 === x1 || y0 === y1;
             if(!isNumeric(x0) || !isNumeric(x1) ||
                     !isNumeric(y0) || !isNumeric(y1) ||
-                    ((x0 === x1 || y0 === y1) && !text)) {
+                    (is_empty && !text)) {
                 bar.remove();
                 return;
             }
@@ -121,7 +122,7 @@ module.exports = function plot(gd, plotinfo, cdbar, barLayer) {
                 y1 = fixpx(y1, y0);
             }
 
-            if(x0 !== x1 && y0 !== y1) {
+            if(!is_empty) {
                 Lib.ensureSingle(bar, 'path')
                     .style('vector-effect', 'non-scaling-stroke')
                     .attr('d',

--- a/test/image/mocks/bar_attrs_relative.json
+++ b/test/image/mocks/bar_attrs_relative.json
@@ -9,7 +9,7 @@
             "type":"bar"
         }, {
             "width":[0.4,0.6,0.8,1],
-            "text":["Three",2,"inside text",''],
+            "text":["Three",2,"inside text",""],
             "textposition":"auto",
             "textfont":{"size":[10]},
             "y":[3,2,1,0],
@@ -23,7 +23,7 @@
             "x":[1,2,3,4],
             "type":"bar"
         }, {
-            "text":['',"outside text",-3,-2],
+            "text":["","outside text",-3,-2],
             "textposition":"auto",
             "y":[0,-0.25,-3,-2],
             "x":[1,2,3,4],

--- a/test/image/mocks/bar_attrs_relative.json
+++ b/test/image/mocks/bar_attrs_relative.json
@@ -9,7 +9,7 @@
             "type":"bar"
         }, {
             "width":[0.4,0.6,0.8,1],
-            "text":["Three",2,"inside text",undefined],
+            "text":["Three",2,"inside text",''],
             "textposition":"auto",
             "textfont":{"size":[10]},
             "y":[3,2,1,0],
@@ -23,7 +23,7 @@
             "x":[1,2,3,4],
             "type":"bar"
         }, {
-            "text":[undefined,"outside text",-3,-2],
+            "text":['',"outside text",-3,-2],
             "textposition":"auto",
             "y":[0,-0.25,-3,-2],
             "x":[1,2,3,4],

--- a/test/image/mocks/bar_attrs_relative.json
+++ b/test/image/mocks/bar_attrs_relative.json
@@ -9,7 +9,7 @@
             "type":"bar"
         }, {
             "width":[0.4,0.6,0.8,1],
-            "text":["Three",2,"inside text",0],
+            "text":["Three",2,"inside text",undefined],
             "textposition":"auto",
             "textfont":{"size":[10]},
             "y":[3,2,1,0],
@@ -23,7 +23,7 @@
             "x":[1,2,3,4],
             "type":"bar"
         }, {
-            "text":[0,"outside text",-3,-2],
+            "text":[undefined,"outside text",-3,-2],
             "textposition":"auto",
             "y":[0,-0.25,-3,-2],
             "x":[1,2,3,4],

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -1428,20 +1428,15 @@ describe('A bar plot', function() {
                 text12 = trace1Bar2.querySelector('text'),
                 trace2Bar0 = getAllBarNodes(traceNodes[2])[0],
                 path20 = trace2Bar0.querySelector('path'),
-                text20 = trace2Bar0.querySelector('text'),
-                trace3Bar0 = getAllBarNodes(traceNodes[3])[0],
-                path30 = trace3Bar0.querySelector('path'),
-                text30 = trace3Bar0.querySelector('text');
+                text20 = trace2Bar0.querySelector('text');
 
             expect(text03.textContent).toBe('4');
             expect(text12.textContent).toBe('inside text');
             expect(text20.textContent).toBe('-1');
-            expect(text30.textContent).toBe('outside text');
 
             assertTextIsAbovePath(text03, path03); // outside
             assertTextIsInsidePath(text12, path12); // inside
             assertTextIsInsidePath(text20, path20); // inside
-            assertTextIsBelowPath(text30, path30); // outside
 
             // clear bounding box cache - somehow when you cache
             // text size too early sometimes it changes later...
@@ -1491,20 +1486,14 @@ describe('A bar plot', function() {
                 text12 = trace1Bar2.querySelector('text'),
                 trace2Bar0 = getAllBarNodes(traceNodes[2])[0],
                 path20 = trace2Bar0.querySelector('path'),
-                text20 = trace2Bar0.querySelector('text'),
-                trace3Bar0 = getAllBarNodes(traceNodes[3])[0],
-                path30 = trace3Bar0.querySelector('path'),
-                text30 = trace3Bar0.querySelector('text');
+                text20 = trace2Bar0.querySelector('text');
 
-            expect(text03.textContent).toBe('4');
             expect(text12.textContent).toBe('inside text');
             expect(text20.textContent).toBe('-1');
-            expect(text30.textContent).toBe('outside text');
 
             assertTextIsInsidePath(text03, path03); // inside
             assertTextIsInsidePath(text12, path12); // inside
             assertTextIsInsidePath(text20, path20); // inside
-            assertTextIsInsidePath(text30, path30); // inside
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
Adresses #3115.

The groups `g.point` contains the path for bars, but also the corresponding
text element. Now, the group is made if it should contain text, even
when it will not contain a path.