### PR TITLE
Fix scatter fill regression

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -198,13 +198,7 @@ drawing.fillGroupStyle = function(s) {
     s.style('stroke-width', 0)
     .each(function(d) {
         var shape = d3.select(this);
-        try {
-            shape.call(Color.fill, d[0].trace.fillcolor);
-        }
-        catch(e) {
-            Lib.error(e, s);
-            shape.remove();
-        }
+        shape.call(Color.fill, d[0].trace.fillcolor);
     });
 };
 

--- a/src/traces/scatter/link_traces.js
+++ b/src/traces/scatter/link_traces.js
@@ -75,12 +75,11 @@ module.exports = function linkTraces(gd, plotinfo, cdscatter) {
                 }
             }
 
-            if(trace.fill && (
-                trace.fill.substr(0, 6) === 'tozero' || trace.fill === 'toself' ||
-                (trace.fill.substr(0, 2) === 'to' && !trace._prevtrace))
-            ) {
-                trace._ownfill = true;
-            }
+            trace._ownfill = (trace.fill && (
+                trace.fill.substr(0, 6) === 'tozero' ||
+                trace.fill === 'toself' ||
+                (trace.fill.substr(0, 2) === 'to' && !trace._prevtrace)
+            ));
 
             prevtraces[group] = trace;
         } else {

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -658,10 +658,6 @@ describe('end-to-end scatter tests', function() {
         // from any case to any other case.
         var indices = transitions(cases.length);
 
-        // Drawing.fillGroupStyle logs an error in a try-catch when
-        // things go wrong
-        spyOn(Lib, 'error');
-
         var p = Plotly.plot(gd, [
             {y: [1, 2], text: 'a'},
             {y: [2, 3], text: 'b'},
@@ -711,7 +707,6 @@ describe('end-to-end scatter tests', function() {
             var msg = i ? ('from ' + cases[indices[i - 1]].name + ' to ') : 'from default to ';
             msg += name;
             assertMultiNodeOrder(selectorArray, msg);
-            expect(Lib.error).not.toHaveBeenCalled();
         }; }
 
         for(i = 0; i < indices.length; i++) {

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -658,6 +658,10 @@ describe('end-to-end scatter tests', function() {
         // from any case to any other case.
         var indices = transitions(cases.length);
 
+        // Drawing.fillGroupStyle logs an error in a try-catch when
+        // things go wrong
+        spyOn(Lib, 'error');
+
         var p = Plotly.plot(gd, [
             {y: [1, 2], text: 'a'},
             {y: [2, 3], text: 'b'},
@@ -707,6 +711,7 @@ describe('end-to-end scatter tests', function() {
             var msg = i ? ('from ' + cases[indices[i - 1]].name + ' to ') : 'from default to ';
             msg += name;
             assertMultiNodeOrder(selectorArray, msg);
+            expect(Lib.error).not.toHaveBeenCalled();
         }; }
 
         for(i = 0; i < indices.length; i++) {


### PR DESCRIPTION
This PR fixes an unreleased regression originating from https://github.com/plotly/plotly.js/pull/3087. I'd like to get this in before the 1.42.0 release.

Scatter fills on master currently do not restyle correctly and lead to these logs:

![image](https://user-images.githubusercontent.com/6675409/47579989-99a6f400-d91b-11e8-827d-a2c9b2d65e7c.png)

but **no** failed tests. That's because those logs come from:

https://github.com/plotly/plotly.js/blob/0a310c99455bf7389f4bb891392c806b59d93d47/src/components/drawing/index.js#L201-L207

which do **not** make `failTest` throw, leading to false-positive tests.

----------

The first commit fixes and :lock:s the bug, and the second commit :hocho:s that try-catch (which is at least 4 years old) which is probably a bit more dangerous, but I'm willing to take that chance. I hope @plotly/plotly_js agrees.