### PR TITLE
fix support for typed arrays in bar 'width' and 'offset'

### DIFF
--- a/src/traces/bar/cross_trace_calc.js
+++ b/src/traces/bar/cross_trace_calc.js
@@ -356,7 +356,7 @@ function applyAttributes(sieve) {
 
         if(isArrayOrTypedArray(offset)) {
             // if offset is an array, then clone it into t.poffset.
-            newPoffset = offset.slice(0, calcTrace.length);
+            newPoffset = Array.prototype.slice.call(offset, 0, calcTrace.length);
 
             // guard against non-numeric items
             for(j = 0; j < newPoffset.length; j++) {
@@ -377,12 +377,12 @@ function applyAttributes(sieve) {
             t.poffset = offset;
         }
 
-        var width = fullTrace._width || fullTrace.width,
-            initialBarwidth = t.barwidth;
+        var width = fullTrace._width || fullTrace.width;
+        var initialBarwidth = t.barwidth;
 
         if(isArrayOrTypedArray(width)) {
             // if width is an array, then clone it into t.barwidth.
-            var newBarwidth = width.slice(0, calcTrace.length);
+            var newBarwidth = Array.prototype.slice.call(width, 0, calcTrace.length);
 
             // guard against non-numeric items
             for(j = 0; j < newBarwidth.length; j++) {

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -398,6 +398,46 @@ describe('Bar.crossTraceCalc (formerly known as setPositions)', function() {
     });
 
     it('should guard against invalid width items', function() {
+        var w = [0.1, 0.4, 0.7];
+
+        var gd = mockBarPlot([{
+            width: w,
+            y: [1, 2, 3]
+        }, {
+            width: new Float32Array(w),
+            y: [1, 2, 3]
+        }]);
+
+        var cd = gd.calcdata;
+        assertArrayField(cd[0][0], 't.barwidth', w);
+        assertArrayField(cd[1][0], 't.barwidth', w);
+        assertPointField(cd, 'x', [
+            [-0.2, 0.8, 1.8],
+            [0.2, 1.2, 2.2]
+        ]);
+    });
+
+    it('should work with width typed arrays', function() {
+        var o = [0.1, 0.4, 0.7];
+
+        var gd = mockBarPlot([{
+            offset: o,
+            y: [1, 2, 3]
+        }, {
+            offset: new Float32Array(o),
+            y: [1, 2, 3]
+        }]);
+
+        var cd = gd.calcdata;
+        assertArrayField(cd[0][0], 't.poffset', o);
+        assertArrayField(cd[1][0], 't.poffset', o);
+        assertPointField(cd, 'x', [
+            [0.5, 1.8, 3.1],
+            [0.5, 1.8, 3.099]
+        ]);
+    });
+
+    it('should guard against invalid width items', function() {
         var gd = mockBarPlot([{
             width: [null, 1, 0.8],
             y: [1, 2, 3]

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -397,7 +397,7 @@ describe('Bar.crossTraceCalc (formerly known as setPositions)', function() {
         assertArrayField(cd[2][0], 't.poffset', [-0.4]);
     });
 
-    it('should guard against invalid width items', function() {
+    it('should work with *width* typed arrays', function() {
         var w = [0.1, 0.4, 0.7];
 
         var gd = mockBarPlot([{
@@ -417,7 +417,7 @@ describe('Bar.crossTraceCalc (formerly known as setPositions)', function() {
         ]);
     });
 
-    it('should work with width typed arrays', function() {
+    it('should work with *offset* typed arrays', function() {
         var o = [0.1, 0.4, 0.7];
 
         var gd = mockBarPlot([{


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3142 and a similar unlisted bug for bar `offset`.

cc @plotly/plotly_js 