### PR TITLE
Update package-lock for pr #3171

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4770,8 +4770,9 @@
       }
     },
     "gl-scatter3d": {
-      "version": "git://github.com/gl-vis/gl-scatter3d.git#8915d2ec6a89b7dc76e216487e82143dbc165c6f",
-      "from": "git://github.com/gl-vis/gl-scatter3d.git#8915d2ec6a89b7dc76e216487e82143dbc165c6f",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.0.13.tgz",
+      "integrity": "sha512-p9vsC5PTuMFJj8qcMRVYeS/pwqG+0w8E8AmkKXtSmAY4YJ7uZNlyRylojYIwxfI6vTwWMaTqYnPiWrfkBXvwqw==",
       "requires": {
         "gl-buffer": "^2.0.6",
         "gl-mat4": "^1.0.0",


### PR DESCRIPTION
fixup for commit https://github.com/plotly/plotly.js/pull/3171/commits/513461a7c0d8e5215fe9fc7ec9a4a3c220dbd76c - where @archmoj wasn't using the correct npm version.