### PR TITLE
Publish `plotly.js-locales` to npm

### DIFF
--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -205,6 +205,7 @@ function syncLocalesPkg(d) {
             '',
             '// then',
             'Plotly.register(locale);',
+            'Plotly.setPlotConfig({locale: \'fr\'})',
             '```',
             '',
             copyrightAndLicense

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs = require('fs-extra');
 var exec = require('child_process').exec;
 var runSeries = require('run-series');
+var glob = require('glob');
 
 var common = require('./util/common');
 var constants = require('./util/constants');
@@ -19,7 +20,9 @@ var copyrightAndLicense = [
     'Docs released under the [Creative Commons license](https://github.com/plotly/documentation/blob/source/LICENSE).',
     ''
 ].join('\n');
-var packagesSpecs = constants.partialBundlePaths
+
+// sync "partial bundle" packages
+constants.partialBundlePaths
     .map(function(d) {
         return {
             name: 'plotly.js-' + d.name + '-dist',
@@ -35,18 +38,21 @@ var packagesSpecs = constants.partialBundlePaths
         main: 'plotly.js',
         dist: constants.pathToPlotlyDist,
         desc: 'Ready-to-use plotly.js distributed bundle.',
-    }]);
+    }])
+    .forEach(syncPartialBundlePkg);
 
-packagesSpecs.forEach(function(d) {
+// sync "locales" package
+syncLocalesPkg({
+    name: 'plotly.js-locales',
+    dir: path.join(constants.pathToLib, 'locales'),
+    main: 'index.js',
+    desc: 'Ready-to-use plotly.js locales',
+});
+
+function syncPartialBundlePkg(d) {
     var pkgPath = path.join(constants.pathToBuild, d.name);
 
-    function initDirectory(cb) {
-        if(common.doesDirExist(pkgPath)) {
-            cb();
-        } else {
-            fs.mkdir(pkgPath, cb);
-        }
-    }
+    var initDirectory = _initDirectory(d, pkgPath);
 
     function writePackageJSON(cb) {
         var cnt = {
@@ -72,6 +78,7 @@ packagesSpecs.forEach(function(d) {
             cb
         );
     }
+
 
     function writeREADME(cb) {
         var moduleList = common.findModuleList(d.index);
@@ -114,22 +121,9 @@ packagesSpecs.forEach(function(d) {
         fs.copy(d.dist, path.join(pkgPath, d.main), cb);
     }
 
-    function copyLicense(cb) {
-        fs.copy(
-            path.join(constants.pathToRoot, 'LICENSE'),
-            path.join(pkgPath, 'LICENSE'),
-            cb
-        );
-    }
+    var copyLicense = _copyLicense(d, pkgPath);
 
-    function publishToNPM(cb) {
-        if(process.env.DRYRUN) {
-            console.log('dry run, did not publish ' + d.name);
-            cb();
-            return;
-        }
-        exec('npm publish', {cwd: pkgPath}, cb).stdout.pipe(process.stdout);
-    }
+    var publishToNPM = _publishToNPM(d, pkgPath);
 
     runSeries([
         initDirectory,
@@ -141,4 +135,156 @@ packagesSpecs.forEach(function(d) {
     ], function(err) {
         if(err) throw err;
     });
-});
+}
+
+function syncLocalesPkg(d) {
+    var pkgPath = path.join(constants.pathToBuild, d.name);
+
+    var initDirectory = _initDirectory(d, pkgPath);
+
+    var localeFiles;
+    function listLocalFiles(cb) {
+        var localeGlob = path.join(constants.pathToLib, 'locales', '*.js');
+        glob(localeGlob, function(err, _localeFiles) {
+            if(err) cb(null);
+            localeFiles = _localeFiles;
+            cb();
+        });
+    }
+
+    function writePackageJSON(cb) {
+        var cnt = {
+            name: d.name,
+            version: pkg.version,
+            description: d.desc,
+            license: pkg.license,
+            main: d.main,
+            repository: pkg.repository,
+            bugs: pkg.bugs,
+            author: pkg.author,
+            keywords: pkg.keywords,
+            files: [
+                'LICENSE',
+                'README.md',
+                d.main
+            ].concat(localeFiles.map(function(f) { return path.basename(f); }))
+        };
+
+        fs.writeFile(
+            path.join(pkgPath, 'package.json'),
+            JSON.stringify(cnt, null, 2) + '\n',
+            cb
+        );
+    }
+
+    function writeREADME(cb) {
+        var cnt = [
+            '# ' + d.name,
+            '',
+            d.desc,
+            '',
+            'For more info on plotly.js, go to https://github.com/plotly/plotly.js',
+            '',
+            '## Installation',
+            '',
+            '```',
+            'npm install ' + d.name,
+            '```',
+            '## Usage',
+            '',
+            'For example to setup the `fr` locale:',
+            '',
+            '```js',
+            '// ES6 module',
+            'import Plotly from \'plotly.js\';',
+            'import locale from \'' + d.name + '/fr' + '\';',
+            '',
+            '// CommonJS',
+            'var Plotly = require(\'plotly.js\');',
+            'var locale = require(\'' + d.name + '/fr\');',
+            '',
+            '// then',
+            'Plotly.register(locale);',
+            '```',
+            '',
+            copyrightAndLicense
+        ];
+
+        fs.writeFile(
+            path.join(pkgPath, 'README.md'),
+            cnt.join('\n'),
+            cb
+        );
+    }
+
+    function writeMain(cb) {
+        var cnt = [constants.licenseSrc, ''];
+        localeFiles.forEach(function(f) {
+            var n = path.basename(f, '.js');
+            cnt.push('exports[\'' + n + '\'] = require(\'./' + n + '.js\');');
+        });
+        cnt.push('');
+
+        fs.writeFile(
+            path.join(pkgPath, d.main),
+            cnt.join('\n'),
+            cb
+        );
+    }
+
+    function copyLocaleFiles(cb) {
+        runSeries(localeFiles.map(function(f) {
+            return function(cb) {
+                fs.copy(f, path.join(pkgPath, path.basename(f)), cb);
+            };
+        }), cb);
+    }
+
+    var copyLicense = _copyLicense(d, pkgPath);
+
+    var publishToNPM = _publishToNPM(d, pkgPath);
+
+    runSeries([
+        initDirectory,
+        listLocalFiles,
+        writePackageJSON,
+        writeREADME,
+        writeMain,
+        copyLocaleFiles,
+        copyLicense,
+        publishToNPM
+    ], function(err) {
+        if(err) throw err;
+    });
+}
+
+function _initDirectory(d, pkgPath) {
+    return function(cb) {
+        if(common.doesDirExist(pkgPath)) {
+            cb();
+        } else {
+            fs.mkdir(pkgPath, cb);
+        }
+    };
+}
+
+function _copyLicense(d, pkgPath) {
+    return function(cb) {
+        fs.copy(
+            path.join(constants.pathToRoot, 'LICENSE'),
+            path.join(pkgPath, 'LICENSE'),
+            cb
+        );
+    };
+}
+
+function _publishToNPM(d, pkgPath) {
+    return function(cb) {
+        if(process.env.DRYRUN) {
+            console.log('dry run, did not publish ' + d.name);
+            cb();
+            return;
+        }
+        exec('npm publish', {cwd: pkgPath}, cb).stdout.pipe(process.stdout);
+    };
+}

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -7,6 +7,18 @@ var common = require('./util/common');
 var constants = require('./util/constants');
 var pkg = require('../package.json');
 
+var year = (new Date()).getFullYear();
+
+var copyrightAndLicense = [
+    '## Copyright and license',
+    '',
+    'Code and documentation copyright ' + year + ' Plotly, Inc.',
+    '',
+    'Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/master/LICENSE).',
+    '',
+    'Docs released under the [Creative Commons license](https://github.com/plotly/documentation/blob/source/LICENSE).',
+    ''
+].join('\n');
 var packagesSpecs = constants.partialBundlePaths
     .map(function(d) {
         return {
@@ -88,14 +100,7 @@ packagesSpecs.forEach(function(d) {
             'var Plotly = require(\'' + d.name + '\');',
             '```',
             '',
-            '## Copyright and license',
-            '',
-            'Code and documentation copyright 2018 Plotly, Inc.',
-            '',
-            'Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/master/LICENSE).',
-            '',
-            'Docs released under the [Creative Commons license](https://github.com/plotly/documentation/blob/source/LICENSE).',
-            ''
+            copyrightAndLicense
         ];
 
         fs.writeFile(


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/3083, a continuation from https://github.com/plotly/plotly.js/pull/2670 (the partial-bundle-pkgs PR)

As locale files are fairly small, I decided to publish only one `plotly.js-locales` package (as opposed to one per locale) and ask users (in the `plotly.js-locales` README) to grab to relevant locale as:

```js
// ES6 module
import Plotly from 'plotly.js';
import locale from 'plotly.js-locales/fr';

// CommonJS
var Plotly = require('plotly.js');
var locale = require('plotly.js-locales/fr');

// then
Plotly.register(locale);
```

that is, users would npm-download all the locales, but only bundle the locale(s) they need.

Reviewers can look at:

https://github.com/plotly/plotly.js/compare/publish-locales...publish-locales-build

to see to generated git-ignored files in `build/`.

cc @plotly/plotly_js and @nicolaskruchten who may find this useful for RCE and dash users.

