### PR TITLE
882 - Chart Title Alignment

### DIFF
--- a/src/components/colorbar/draw.js
+++ b/src/components/colorbar/draw.js
@@ -184,7 +184,6 @@ module.exports = function draw(gd, id) {
                 showticksuffix: opts.showticksuffix,
                 ticksuffix: opts.ticksuffix,
                 title: opts.title,
-                titlefont: opts.titlefont,
                 showline: true,
                 anchor: 'free',
                 side: 'right',
@@ -290,7 +289,7 @@ module.exports = function draw(gd, id) {
             // when we squish the axis. This one only applies to
             // top or bottom titles, not right side.
             var x = gs.l + (opts.x + xpadFrac) * gs.w,
-                fontSize = cbAxisOut.titlefont.size,
+                fontSize = cbAxisOut.title.font.size,
                 y;
 
             if(opts.titleside === 'top') {
@@ -460,7 +459,7 @@ module.exports = function draw(gd, id) {
                 },
                 function() {
                     if(['top', 'bottom'].indexOf(opts.titleside) === -1) {
-                        var fontSize = cbAxisOut.titlefont.size,
+                        var fontSize = cbAxisOut.title.font.size,
                             y = cbAxisOut._offset + cbAxisOut._length / 2,
                             x = gs.l + (cbAxisOut.position || 0) * gs.w + ((cbAxisOut.side === 'right') ?
                                 10 + fontSize * ((cbAxisOut.showticklabels ? 1 : 0.5)) :

--- a/src/components/colorbar/draw.js
+++ b/src/components/colorbar/draw.js
@@ -183,7 +183,15 @@ module.exports = function draw(gd, id) {
                 tickprefix: opts.tickprefix,
                 showticksuffix: opts.showticksuffix,
                 ticksuffix: opts.ticksuffix,
-                title: opts.title,
+
+                // Plot and axes titles have a different, nested attribute structure
+                // for defining title attributes. Since the `titles` component
+                // assumes that nested structure, let's adapt to it without breaking
+                // the existing colorbar API.
+                title: {
+                    text: opts.title,
+                    font: opts.titlefont
+                },
                 showline: true,
                 anchor: 'free',
                 side: 'right',

--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -172,7 +172,7 @@ module.exports = function(gd) {
                 placeholder: fullLayout._dfltTitle.x,
                 attributes: {
                     x: axisOpts._offset + axisOpts._length / 2,
-                    y: y + opts._height + opts._offsetShift + 10 + 1.5 * axisOpts.titlefont.size,
+                    y: y + opts._height + opts._offsetShift + 10 + 1.5 * axisOpts.title.font.size,
                     'text-anchor': 'middle'
                 }
             });

--- a/src/components/sliders/attributes.js
+++ b/src/components/sliders/attributes.js
@@ -133,7 +133,7 @@ module.exports = overrideAll(templatedArray('slider', {
         role: 'style',
         description: 'Sets the x position (in normalized coordinates) of the slider.'
     },
-    pad: extendDeepAll({}, padAttrs, {
+    pad: extendDeepAll(padAttrs({editType: 'arraydraw'}), {
         description: 'Set the padding of the slider component along each side.'
     }, {t: {dflt: 20}}),
     xanchor: {

--- a/src/components/titles/index.js
+++ b/src/components/titles/index.js
@@ -81,7 +81,7 @@ function draw(gd, titleClass, options) {
     // only make this title editable if we positively identify its property
     // as one that has editing enabled.
     var editAttr;
-    // TODO 882 Probably compare against 'title.text'
+    // TODO 882 Probably compare against 'title.text' and may also adapt calling code?
     if(prop === 'title') editAttr = 'titleText';
     else if(prop.indexOf('axis') !== -1) editAttr = 'axisTitleText';
     else if(prop.indexOf('colorbar' !== -1)) editAttr = 'colorbarTitleText';

--- a/src/components/titles/index.js
+++ b/src/components/titles/index.js
@@ -74,7 +74,8 @@ function draw(gd, titleClass, options) {
 
     var opacity = 1;
     var isplaceholder = false;
-    var txt = (cont.title || '').trim();
+    var title = cont.title;
+    var txt = (title && title.text ? title.text : '').trim();
 
     // only make this title editable if we positively identify its property
     // as one that has editing enabled.

--- a/src/components/titles/index.js
+++ b/src/components/titles/index.js
@@ -67,19 +67,21 @@ function draw(gd, titleClass, options) {
     var group = options.containerGroup;
 
     var fullLayout = gd._fullLayout;
-    var titlefont = cont.titlefont || {};
-    var font = titlefont.family;
-    var fontSize = titlefont.size;
-    var fontColor = titlefont.color;
 
     var opacity = 1;
     var isplaceholder = false;
     var title = cont.title;
     var txt = (title && title.text ? title.text : '').trim();
 
+    var font = title && title.font ? title.font : {};
+    var fontFamily = font.family;
+    var fontSize = font.size;
+    var fontColor = font.color;
+
     // only make this title editable if we positively identify its property
     // as one that has editing enabled.
     var editAttr;
+    // TODO 882 Probably compare against 'title.text'
     if(prop === 'title') editAttr = 'titleText';
     else if(prop.indexOf('axis') !== -1) editAttr = 'axisTitleText';
     else if(prop.indexOf('colorbar' !== -1)) editAttr = 'colorbarTitleText';
@@ -138,7 +140,7 @@ function draw(gd, titleClass, options) {
         titleEl.attr('transform', transformVal);
 
         titleEl.style({
-            'font-family': font,
+            'font-family': fontFamily,
             'font-size': d3.round(fontSize, 2) + 'px',
             fill: Color.rgb(fontColor),
             opacity: opacity * Color.opacity(fontColor),

--- a/src/components/titles/index.js
+++ b/src/components/titles/index.js
@@ -81,8 +81,7 @@ function draw(gd, titleClass, options) {
     // only make this title editable if we positively identify its property
     // as one that has editing enabled.
     var editAttr;
-    // TODO 882 Probably compare against 'title.text' and may also adapt calling code?
-    if(prop === 'title') editAttr = 'titleText';
+    if(prop === 'title.text') editAttr = 'titleText';
     else if(prop.indexOf('axis') !== -1) editAttr = 'axisTitleText';
     else if(prop.indexOf('colorbar' !== -1)) editAttr = 'colorbarTitleText';
     var editable = gd._context.edits[editAttr];

--- a/src/components/updatemenus/attributes.js
+++ b/src/components/updatemenus/attributes.js
@@ -162,7 +162,7 @@ module.exports = overrideAll(templatedArray('updatemenu', {
         ].join(' ')
     },
 
-    pad: extendFlat({}, padAttrs, {
+    pad: extendFlat(padAttrs({editType: 'arraydraw'}), {
         description: 'Sets the padding around the buttons or dropdown menu.'
     }),
 

--- a/src/constants/alignment.js
+++ b/src/constants/alignment.js
@@ -41,12 +41,17 @@ module.exports = {
     // multiple of fontSize to get the vertical offset between lines
     LINE_SPACING: 1.3,
 
-    // multiple of fontSize to shift from the baseline to the midline
+    // multiple of fontSize to shift from the baseline
+    // to the cap (captical letter) line
     // (to use when we don't calculate this shift from Drawing.bBox)
-    // To be precise this should be half the cap height (capital letter)
-    // of the font, and according to wikipedia:
+    // This is an approximation since in reality cap height can differ
+    // from font to font. However, according to Wikipedia
     //   an "average" font might have a cap height of 70% of the em
     // https://en.wikipedia.org/wiki/Em_(typography)#History
+    CAP_SHIFT: 0.70,
+
+    // half the cap height (distance between baseline and cap line)
+    // of an "average" font (for more info see above).
     MID_SHIFT: 0.35,
 
     OPPOSITE_SIDE: {

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -91,6 +91,19 @@ exports.cleanLayout = function(layout) {
                 }
                 delete ax.autotick;
             }
+
+            // title -> title.text
+            if(!Lib.isPlainObject(ax.title)) {
+                ax.title = {
+                    text: ax.title
+                };
+            }
+
+            // titlefont -> title.font
+            if(Lib.isPlainObject(ax.titlefont) && !Lib.isPlainObject(ax.title.font)) {
+                ax.title.font = ax.titlefont;
+                delete ax.titlefont;
+            }
         }
 
         // modifications for 3D scenes
@@ -176,20 +189,10 @@ exports.cleanLayout = function(layout) {
         }
     }
 
-    // Check for old-style title definitions
+    // Check for old-style title definition
     if(!Lib.isPlainObject(layout.title)) {
         layout.title = {
             text: layout.title
-        };
-    }
-    if(layout.xaxis && !Lib.isPlainObject(layout.xaxis.title)) {
-        layout.xaxis.title = {
-            text: layout.xaxis.title
-        };
-    }
-    if(layout.yaxis && !Lib.isPlainObject(layout.yaxis.title)) {
-        layout.yaxis.title = {
-            text: layout.yaxis.title
         };
     }
 
@@ -197,16 +200,6 @@ exports.cleanLayout = function(layout) {
     if(Lib.isPlainObject(layout.titlefont) && !Lib.isPlainObject(layout.title.font)) {
         layout.title.font = layout.titlefont;
         delete layout.titlefont;
-    }
-    if(layout.xaxis &&
-      Lib.isPlainObject(layout.xaxis.titlefont) && !Lib.isPlainObject(layout.xaxis.title.font)) {
-        layout.xaxis.title.font = layout.xaxis.titlefont;
-        delete layout.xaxis.titlefont;
-    }
-    if(layout.yaxis &&
-      Lib.isPlainObject(layout.yaxis.titlefont) && !Lib.isPlainObject(layout.yaxis.title.font)) {
-        layout.yaxis.title.font = layout.yaxis.titlefont;
-        delete layout.yaxis.titlefont;
     }
 
     /*

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -137,6 +137,11 @@ exports.cleanLayout = function(layout) {
 
                 delete scene.cameraposition;
             }
+
+            // clean axis titles
+            cleanTitle(scene.xaxis);
+            cleanTitle(scene.yaxis);
+            cleanTitle(scene.zaxis);
         }
     }
 

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -176,6 +176,23 @@ exports.cleanLayout = function(layout) {
         }
     }
 
+    // Check for old-style title definitions
+    if(!Lib.isPlainObject(layout.title)) {
+        layout.title = {
+            text: layout.title
+        };
+    }
+    if(layout.xaxis && !Lib.isPlainObject(layout.xaxis.title)) {
+        layout.xaxis.title = {
+            text: layout.xaxis.title
+        };
+    }
+    if(layout.yaxis && !Lib.isPlainObject(layout.yaxis.title)) {
+        layout.yaxis.title = {
+            text: layout.yaxis.title
+        };
+    }
+
     /*
      * Moved from rotate -> orbit for dragmode
      */

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -193,6 +193,22 @@ exports.cleanLayout = function(layout) {
         };
     }
 
+    // Check for old-style title font definitions
+    if(Lib.isPlainObject(layout.titlefont) && !Lib.isPlainObject(layout.title.font)) {
+        layout.title.font = layout.titlefont;
+        delete layout.titlefont;
+    }
+    if(layout.xaxis &&
+      Lib.isPlainObject(layout.xaxis.titlefont) && !Lib.isPlainObject(layout.xaxis.title.font)) {
+        layout.xaxis.title.font = layout.xaxis.titlefont;
+        delete layout.xaxis.titlefont;
+    }
+    if(layout.yaxis &&
+      Lib.isPlainObject(layout.yaxis.titlefont) && !Lib.isPlainObject(layout.yaxis.title.font)) {
+        layout.yaxis.title.font = layout.yaxis.titlefont;
+        delete layout.yaxis.titlefont;
+    }
+
     /*
      * Moved from rotate -> orbit for dragmode
      */

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -100,12 +100,14 @@ exports.cleanLayout = function(layout) {
         // modifications for polar
         else if(polarAttrRegex && polarAttrRegex.test(key)) {
             var polar = layout[key];
+
             cleanTitle(polar.radialaxis);
         }
 
         // modifications for ternary
         else if(ternaryAttrRegex && ternaryAttrRegex.test(key)) {
             var ternary = layout[key];
+
             cleanTitle(ternary.aaxis);
             cleanTitle(ternary.baxis);
             cleanTitle(ternary.caxis);
@@ -199,7 +201,7 @@ exports.cleanLayout = function(layout) {
         }
     }
 
-    // Check for old-style title definition
+    // clean plot title
     cleanTitle(layout);
 
     /*
@@ -211,7 +213,7 @@ exports.cleanLayout = function(layout) {
     // supported, but new tinycolor does not because they're not valid css
     Color.clean(layout);
 
-    // also clean the layout container in layout.template
+    // clean the layout container in layout.template
     if(layout.template && layout.template.layout) {
         exports.cleanLayout(layout.template.layout);
     }
@@ -229,6 +231,8 @@ function cleanAxRef(container, attr) {
 
 function cleanTitle(titleContainer) {
     if(titleContainer) {
+
+        // title -> title.text
         if(typeof titleContainer.title === 'string') {
             titleContainer.title = {
                 text: titleContainer.title
@@ -236,9 +240,13 @@ function cleanTitle(titleContainer) {
         }
 
         // titlefont -> title.font
-        if(titleContainer.title &&
-          Lib.isPlainObject(titleContainer.titlefont) &&
-          !Lib.isPlainObject(titleContainer.title.font)) {
+        var oldFontAttrSet = Lib.isPlainObject(titleContainer.titlefont);
+        var newFontAttrSet = titleContainer.title && Lib.isPlainObject(titleContainer.title.font);
+        if(oldFontAttrSet && !newFontAttrSet) {
+            if(!titleContainer.title) {
+                titleContainer.title = {};
+            }
+
             titleContainer.title.font = titleContainer.titlefont;
             delete titleContainer.titlefont;
         }

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -53,6 +53,7 @@ exports.cleanLayout = function(layout) {
     }
 
     var axisAttrRegex = (Plots.subplotsRegistry.cartesian || {}).attrRegex;
+    var polarAttrRegex = (Plots.subplotsRegistry.polar || {}).attrRegex;
     var sceneAttrRegex = (Plots.subplotsRegistry.gl3d || {}).attrRegex;
 
     var keys = Object.keys(layout);
@@ -92,6 +93,9 @@ exports.cleanLayout = function(layout) {
                 delete ax.autotick;
             }
 
+            // TODO Should this be done with typeof as well (see radialaxes)?
+            // At least code would be more obvious!
+
             // title -> title.text
             if(!Lib.isPlainObject(ax.title)) {
                 ax.title = {
@@ -103,6 +107,28 @@ exports.cleanLayout = function(layout) {
             if(Lib.isPlainObject(ax.titlefont) && !Lib.isPlainObject(ax.title.font)) {
                 ax.title.font = ax.titlefont;
                 delete ax.titlefont;
+            }
+        }
+
+        // modifications for radial axes
+        else if(polarAttrRegex && polarAttrRegex.test(key)) {
+            var polar = layout[key];
+
+            if(polar.radialaxis) {
+
+                // title -> title.text
+                if(typeof polar.radialaxis.title === 'string') {
+                    polar.radialaxis.title = {
+                        text: polar.radialaxis.title
+                    };
+                }
+
+                // titlefont -> title.font
+                if(Lib.isPlainObject(polar.radialaxis.titlefont) &&
+                  !Lib.isPlainObject(polar.radialaxis.title.font)) {
+                    polar.radialaxis.title.font = polar.radialaxis.titlefont;
+                    delete polar.radialaxis.titlefont;
+                }
             }
         }
 

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -211,6 +211,11 @@ exports.cleanLayout = function(layout) {
     // supported, but new tinycolor does not because they're not valid css
     Color.clean(layout);
 
+    // also clean the layout container in layout.template
+    if(layout.template && layout.template.layout) {
+        exports.cleanLayout(layout.template.layout);
+    }
+
     return layout;
 };
 

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -34,7 +34,7 @@ exports.clearPromiseQueue = function(gd) {
 // before it gets used for anything
 // backward compatibility and cleanup of nonstandard options
 exports.cleanLayout = function(layout) {
-    var i, j;
+    var i, j, k;
 
     if(!layout) layout = {};
 
@@ -54,6 +54,7 @@ exports.cleanLayout = function(layout) {
 
     var axisAttrRegex = (Plots.subplotsRegistry.cartesian || {}).attrRegex;
     var polarAttrRegex = (Plots.subplotsRegistry.polar || {}).attrRegex;
+    var ternaryAttrRegex = (Plots.subplotsRegistry.ternary || {}).attrRegex;
     var sceneAttrRegex = (Plots.subplotsRegistry.gl3d || {}).attrRegex;
 
     var keys = Object.keys(layout);
@@ -128,6 +129,38 @@ exports.cleanLayout = function(layout) {
                   !Lib.isPlainObject(polar.radialaxis.title.font)) {
                     polar.radialaxis.title.font = polar.radialaxis.titlefont;
                     delete polar.radialaxis.titlefont;
+                }
+            }
+        }
+
+        // modifications for ternary
+        else if(ternaryAttrRegex && ternaryAttrRegex.test(key)) {
+            var ternary = layout[key];
+
+            var ternaryKeys = Object.keys(ternary);
+            for(k = 0; k < ternaryKeys.length; k++) {
+                var ternaryKey = ternaryKeys[k];
+                if(
+                  ternaryKey === 'aaxis' ||
+                  ternaryKey === 'baxis' ||
+                  ternaryKey === 'caxis'
+                ) {
+                    var ternaryAxis = ternary[ternaryKey];
+
+                    // TODO 882 DRY that up with polar, axes and main title
+                    // title -> title.text
+                    if(typeof ternaryAxis.title === 'string') {
+                        ternaryAxis.title = {
+                            text: ternaryAxis.title
+                        };
+                    }
+
+                    // titlefont -> title.font
+                    if(Lib.isPlainObject(ternaryAxis.titlefont) &&
+                      !Lib.isPlainObject(ternaryAxis.title.font)) {
+                        ternaryAxis.title.font = ternaryAxis.titlefont;
+                        delete ternaryAxis.titlefont;
+                    }
                 }
             }
         }

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -34,7 +34,7 @@ exports.clearPromiseQueue = function(gd) {
 // before it gets used for anything
 // backward compatibility and cleanup of nonstandard options
 exports.cleanLayout = function(layout) {
-    var i, j, k;
+    var i, j;
 
     if(!layout) layout = {};
 
@@ -94,75 +94,21 @@ exports.cleanLayout = function(layout) {
                 delete ax.autotick;
             }
 
-            // TODO Should this be done with typeof as well (see radialaxes)?
-            // At least code would be more obvious!
-
-            // title -> title.text
-            if(!Lib.isPlainObject(ax.title)) {
-                ax.title = {
-                    text: ax.title
-                };
-            }
-
-            // titlefont -> title.font
-            if(Lib.isPlainObject(ax.titlefont) && !Lib.isPlainObject(ax.title.font)) {
-                ax.title.font = ax.titlefont;
-                delete ax.titlefont;
-            }
+            cleanTitle(ax);
         }
 
-        // modifications for radial axes
+        // modifications for polar
         else if(polarAttrRegex && polarAttrRegex.test(key)) {
             var polar = layout[key];
-
-            if(polar.radialaxis) {
-
-                // title -> title.text
-                if(typeof polar.radialaxis.title === 'string') {
-                    polar.radialaxis.title = {
-                        text: polar.radialaxis.title
-                    };
-                }
-
-                // titlefont -> title.font
-                if(Lib.isPlainObject(polar.radialaxis.titlefont) &&
-                  !Lib.isPlainObject(polar.radialaxis.title.font)) {
-                    polar.radialaxis.title.font = polar.radialaxis.titlefont;
-                    delete polar.radialaxis.titlefont;
-                }
-            }
+            cleanTitle(polar.radialaxis);
         }
 
         // modifications for ternary
         else if(ternaryAttrRegex && ternaryAttrRegex.test(key)) {
             var ternary = layout[key];
-
-            var ternaryKeys = Object.keys(ternary);
-            for(k = 0; k < ternaryKeys.length; k++) {
-                var ternaryKey = ternaryKeys[k];
-                if(
-                  ternaryKey === 'aaxis' ||
-                  ternaryKey === 'baxis' ||
-                  ternaryKey === 'caxis'
-                ) {
-                    var ternaryAxis = ternary[ternaryKey];
-
-                    // TODO 882 DRY that up with polar, axes and main title
-                    // title -> title.text
-                    if(typeof ternaryAxis.title === 'string') {
-                        ternaryAxis.title = {
-                            text: ternaryAxis.title
-                        };
-                    }
-
-                    // titlefont -> title.font
-                    if(Lib.isPlainObject(ternaryAxis.titlefont) &&
-                      !Lib.isPlainObject(ternaryAxis.title.font)) {
-                        ternaryAxis.title.font = ternaryAxis.titlefont;
-                        delete ternaryAxis.titlefont;
-                    }
-                }
-            }
+            cleanTitle(ternary.aaxis);
+            cleanTitle(ternary.baxis);
+            cleanTitle(ternary.caxis);
         }
 
         // modifications for 3D scenes
@@ -249,17 +195,7 @@ exports.cleanLayout = function(layout) {
     }
 
     // Check for old-style title definition
-    if(!Lib.isPlainObject(layout.title)) {
-        layout.title = {
-            text: layout.title
-        };
-    }
-
-    // Check for old-style title font definitions
-    if(Lib.isPlainObject(layout.titlefont) && !Lib.isPlainObject(layout.title.font)) {
-        layout.title.font = layout.titlefont;
-        delete layout.titlefont;
-    }
+    cleanTitle(layout);
 
     /*
      * Moved from rotate -> orbit for dragmode
@@ -278,6 +214,24 @@ function cleanAxRef(container, attr) {
         axLetter = attr.charAt(0);
     if(valIn && valIn !== 'paper') {
         container[attr] = cleanId(valIn, axLetter);
+    }
+}
+
+function cleanTitle(titleContainer) {
+    if(titleContainer) {
+        if(typeof titleContainer.title === 'string') {
+            titleContainer.title = {
+                text: titleContainer.title
+            };
+        }
+
+        // titlefont -> title.font
+        if(titleContainer.title &&
+          Lib.isPlainObject(titleContainer.titlefont) &&
+          !Lib.isPlainObject(titleContainer.title.font)) {
+            titleContainer.title.font = titleContainer.titlefont;
+            delete titleContainer.titlefont;
+        }
     }
 }
 

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1687,12 +1687,12 @@ function _restyle(gd, aobj, traces) {
 }
 
 /**
- * Maps deprecated layout attributes that need to be converted
- * to the current API at this stage to ensure backwards compatibility.
+ * Converts deprecated layout attributes to the current API
+ * to ensure backwards compatibility.
  *
  * @param layoutObj
  */
-function mapDeprecatedLayoutAttributes(layoutObj) {
+function cleanDeprecatedLayoutAttributes(layoutObj) {
 
     // Support old-style update of the title's font
     var isTitlefontSet = layoutObj.titlefont;
@@ -1715,14 +1715,14 @@ function mapDeprecatedLayoutAttributes(layoutObj) {
 }
 
 /**
- * Maps deprecated layout "string attributes" to
+ * Converts deprecated layout "string attributes" to
  * "string attributes" of the current API to ensure backwards compatibility.
  *
  * E.g. Maps {'xaxis.title': 'A chart'} to {'xaxis.title.text': 'A chart'}
  *
  * @param layoutObj
  */
-function mapDeprecatedLayoutAttributeStrings(layoutObj) {
+function cleanDeprecatedLayoutAttributeStrings(layoutObj) {
     var oldAxisTitleRegExp = /axis\d{0,2}.title$/;
     var keys, i, key, value;
 
@@ -1748,11 +1748,9 @@ function mapDeprecatedLayoutAttributeStrings(layoutObj) {
         }
     }
 
-    function replace(oldKey, newKey) {
-        if(layoutObj[oldKey] !== undefined) {
-            layoutObj[newKey] = layoutObj[oldKey];
-            delete layoutObj[oldKey];
-        }
+    function replace(oldAttrStr, newAttrStr) {
+        layoutObj[newAttrStr] = layoutObj[oldAttrStr];
+        delete layoutObj[oldAttrStr];
     }
 }
 
@@ -1796,8 +1794,8 @@ exports.relayout = function relayout(gd, astr, val) {
 
     if(Object.keys(aobj).length) gd.changed = true;
 
-    mapDeprecatedLayoutAttributes(aobj);
-    mapDeprecatedLayoutAttributeStrings(aobj);
+    cleanDeprecatedLayoutAttributes(aobj);
+    cleanDeprecatedLayoutAttributeStrings(aobj);
 
     var specs = _relayout(gd, aobj);
     var flags = specs.flags;
@@ -2276,8 +2274,8 @@ exports.update = function update(gd, traceUpdate, layoutUpdate, _traces) {
     var restyleSpecs = _restyle(gd, Lib.extendFlat({}, traceUpdate), traces);
     var restyleFlags = restyleSpecs.flags;
 
-    mapDeprecatedLayoutAttributes(layoutUpdate);
-    mapDeprecatedLayoutAttributeStrings(layoutUpdate);
+    cleanDeprecatedLayoutAttributes(layoutUpdate);
+    cleanDeprecatedLayoutAttributeStrings(layoutUpdate);
 
     var relayoutSpecs = _relayout(gd, Lib.extendFlat({}, layoutUpdate));
     var relayoutFlags = relayoutSpecs.flags;

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1687,6 +1687,28 @@ function _restyle(gd, aobj, traces) {
 }
 
 /**
+ * Maps deprecated layout "string attributes" to
+ * "string attributes" of the current API to ensure backwards compatibility.
+ *
+ * E.g. Maps {'xaxis.title': 'A chart'} to {'xaxis.title.text': 'A chart'}
+ *
+ * @param layoutObj
+ */
+function mapDeprecatedLayoutAttributeStrings(layoutObj) {
+    if(layoutObj.title && !Lib.isPlainObject(layoutObj.title)) {
+        layoutObj.title = {text: layoutObj.title};
+    }
+    if(layoutObj['xaxis.title'] !== undefined) {
+        layoutObj['xaxis.title.text'] = layoutObj['xaxis.title'];
+        delete layoutObj['xaxis.title'];
+    }
+    if(layoutObj['yaxis.title'] !== undefined) {
+        layoutObj['yaxis.title.text'] = layoutObj['yaxis.title'];
+        delete layoutObj['yaxis.title'];
+    }
+}
+
+/**
  * relayout: update layout attributes of an existing plot
  *
  * Can be called two ways:
@@ -1725,6 +1747,8 @@ exports.relayout = function relayout(gd, astr, val) {
     }
 
     if(Object.keys(aobj).length) gd.changed = true;
+
+    mapDeprecatedLayoutAttributeStrings(aobj);
 
     var specs = _relayout(gd, aobj);
     var flags = specs.flags;
@@ -2202,6 +2226,8 @@ exports.update = function update(gd, traceUpdate, layoutUpdate, _traces) {
 
     var restyleSpecs = _restyle(gd, Lib.extendFlat({}, traceUpdate), traces);
     var restyleFlags = restyleSpecs.flags;
+
+    mapDeprecatedLayoutAttributeStrings(layoutUpdate);
 
     var relayoutSpecs = _relayout(gd, Lib.extendFlat({}, layoutUpdate));
     var relayoutFlags = relayoutSpecs.flags;

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -157,7 +157,7 @@ exports.plot = function(gd, data, layout, config) {
     // Legacy polar plots
     if(!fullLayout._has('polar') && data && data[0] && data[0].r) {
         Lib.log('Legacy polar charts are deprecated!');
-        return plotPolar(gd, data, layout);
+        return plotLegacyPolar(gd, data, layout);
     }
 
     // so we don't try to re-call Plotly.plot from inside
@@ -494,7 +494,7 @@ function setPlotContext(gd, config) {
     context._hasZeroWidth = context._hasZeroWidth || gd.clientWidth === 0;
 }
 
-function plotPolar(gd, data, layout) {
+function plotLegacyPolar(gd, data, layout) {
     // build or reuse the container skeleton
     var plotContainer = d3.select(gd).selectAll('.plot-container')
         .data([0]);
@@ -535,7 +535,7 @@ function plotPolar(gd, data, layout) {
 
     // editable title
     var opacity = 1;
-    var txt = gd._fullLayout.title;
+    var txt = gd._fullLayout.title ? gd._fullLayout.title.text : '';
     if(txt === '' || !txt) opacity = 0;
 
     var titleLayout = function() {
@@ -569,7 +569,7 @@ function plotPolar(gd, data, layout) {
         var setContenteditable = function() {
             this.call(svgTextUtils.makeEditable, {gd: gd})
                 .on('edit', function(text) {
-                    gd.framework({layout: {title: text}});
+                    gd.framework({layout: {title: {text: text}}});
                     this.text(text)
                         .call(titleLayout);
                     this.call(setContenteditable);

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1723,29 +1723,30 @@ function mapDeprecatedLayoutAttributes(layoutObj) {
  * @param layoutObj
  */
 function mapDeprecatedLayoutAttributeStrings(layoutObj) {
-    if(layoutObj.title && !Lib.isPlainObject(layoutObj.title)) {
+    var oldAxisTitleRegExp = /axis\d{0,2}.title$/;
+    var keys, i, key, value;
+
+    if(typeof layoutObj.title === 'string') {
         layoutObj.title = {text: layoutObj.title};
     }
-    replace('xaxis.title', 'xaxis.title.text');
-    replace('yaxis.title', 'yaxis.title.text');
 
     // Note: Only "nested" (dot notation) attributes
-    // need to be converted. For example 'titlefont'
+    // need to be converted. For example 'layout.titlefont'
     // was a top-level attribute and thus is covered by
     // the general compatibility layer.
-    replace('titlefont.color', 'title.font.color');
-    replace('titlefont.family', 'title.font.family');
-    replace('titlefont.size', 'title.font.size');
+    keys = Object.keys(layoutObj);
+    for(i = 0; i < keys.length; i++) {
+        key = keys[i];
+        value = layoutObj[key];
 
-    replace('xaxis.titlefont', 'xaxis.title.font');
-    replace('xaxis.titlefont.color', 'xaxis.title.font.color');
-    replace('xaxis.titlefont.family', 'xaxis.title.font.family');
-    replace('xaxis.titlefont.size', 'xaxis.title.font.size');
+        if(key.indexOf('titlefont') > -1) {
+            replace(key, key.replace('titlefont', 'title.font'));
+        }
 
-    replace('yaxis.titlefont', 'yaxis.title.font');
-    replace('yaxis.titlefont.color', 'yaxis.title.font.color');
-    replace('yaxis.titlefont.family', 'yaxis.title.font.family');
-    replace('yaxis.titlefont.size', 'yaxis.title.font.size');
+        if(typeof value === 'string' && oldAxisTitleRegExp.test(key)) {
+            replace(key, key.replace('title', 'title.text'));
+        }
+    }
 
     function replace(oldKey, newKey) {
         if(layoutObj[oldKey] !== undefined) {

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -452,7 +452,7 @@ exports.drawMainTitle = function(gd) {
 
     Titles.draw(gd, 'gtitle', {
         propContainer: fullLayout,
-        propName: 'title',
+        propName: 'title.text',
         placeholder: fullLayout._dfltTitle.plot,
         attributes: {
             x: fullLayout.width / 2,

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -27,6 +27,10 @@ var enforceAxisConstraints = axisConstraints.enforce;
 var cleanAxisConstraints = axisConstraints.clean;
 var doAutoRange = require('../plots/cartesian/autorange').doAutoRange;
 
+var SVG_TEXT_ANCHOR_START = 'start';
+var SVG_TEXT_ANCHOR_MIDDLE = 'middle';
+var SVG_TEXT_ANCHOR_END = 'end';
+
 exports.layoutStyles = function(gd) {
     return Lib.syncOrAsync([Plots.doAutoMargin, lsInner], gd);
 };
@@ -450,45 +454,62 @@ function findCounterAxisLineWidth(ax, side, counterAx, axList) {
 exports.drawMainTitle = function(gd) {
     var fullLayout = gd._fullLayout;
 
+    var textAnchor = getMainTitleTextAnchor(fullLayout);
+    var dy = getMainTitleDy(fullLayout);
+
     Titles.draw(gd, 'gtitle', {
         propContainer: fullLayout,
         propName: 'title.text',
         placeholder: fullLayout._dfltTitle.plot,
         attributes: {
-            x: getMainTitleX(fullLayout),
-            y: getMainTitleY(fullLayout),
-            'text-anchor': getMainTitleTextAnchor(fullLayout),
-            dy: getMainTitleDy(fullLayout)
+            x: getMainTitleX(fullLayout, textAnchor),
+            y: getMainTitleY(fullLayout, dy),
+            'text-anchor': textAnchor,
+            dy: dy
         }
     });
 };
 
-function getMainTitleX(fullLayout) {
+function getMainTitleX(fullLayout, textAnchor) {
     var title = fullLayout.title;
     var _size = fullLayout._size;
+    var hPadShift = 0;
+
+    if(textAnchor === SVG_TEXT_ANCHOR_START) {
+        hPadShift = title.pad.l;
+    } else if(textAnchor === SVG_TEXT_ANCHOR_END) {
+        hPadShift = -title.pad.r;
+    }
 
     switch(title.xref) {
         case 'paper':
-            return _size.l + _size.w * title.x;
+            return _size.l + _size.w * title.x + hPadShift;
         case 'container':
         default:
-            return fullLayout.width * title.x;
+            return fullLayout.width * title.x + hPadShift;
     }
 }
 
-function getMainTitleY(fullLayout) {
+function getMainTitleY(fullLayout, dy) {
     var title = fullLayout.title;
     var _size = fullLayout._size;
+    var vPadShift = 0;
+
+    if(dy === '0em' || !dy) {
+        vPadShift = -title.pad.b;
+    } else if(dy === alignmentConstants.CAP_SHIFT + 'em') {
+        vPadShift = title.pad.t;
+    }
 
     if(title.y === 'auto') {
         return _size.t / 2;
     } else {
         switch(title.yref) {
             case 'paper':
-                return _size.t + _size.h - _size.h * title.y;
+                return _size.t + _size.h - _size.h * title.y + vPadShift;
             case 'container':
             default:
-                return fullLayout.height - fullLayout.height * title.y;
+                return fullLayout.height - fullLayout.height * title.y + vPadShift;
         }
     }
 }
@@ -500,22 +521,22 @@ function getMainTitleTextAnchor(fullLayout) {
         case 'auto':
             return calcTextAnchor(fullLayout.title.x);
         case 'left':
-            return 'start';
+            return SVG_TEXT_ANCHOR_START;
         case 'right':
-            return 'end';
+            return SVG_TEXT_ANCHOR_END;
         case 'center':
         default:
-            return 'middle';
+            return SVG_TEXT_ANCHOR_MIDDLE;
     }
 
     function calcTextAnchor(x) {
         if(x < 1 / 3) {
-            return 'start';
+            return SVG_TEXT_ANCHOR_START;
         } else if(x > 2 / 3) {
-            return 'end';
+            return SVG_TEXT_ANCHOR_END;
         }
 
-        return 'middle';
+        return SVG_TEXT_ANCHOR_MIDDLE;
     }
 }
 

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -449,17 +449,6 @@ function findCounterAxisLineWidth(ax, side, counterAx, axList) {
 
 exports.drawMainTitle = function(gd) {
     var fullLayout = gd._fullLayout;
-    var textAnchorDict = {
-        'left': 'start',
-        'center': 'middle',
-        'right': 'end',
-        'auto': 'middle' // TODO That needs to be calculated based on x
-    };
-    var dyDict = {
-        'top': alignmentConstants.CAP_SHIFT + 'em',
-        'middle': alignmentConstants.MID_SHIFT + 'em',
-        'bottom': '0em',
-    };
 
     Titles.draw(gd, 'gtitle', {
         propContainer: fullLayout,
@@ -468,8 +457,8 @@ exports.drawMainTitle = function(gd) {
         attributes: {
             x: getMainTitleX(fullLayout),
             y: getMainTitleY(fullLayout),
-            'text-anchor': textAnchorDict[fullLayout.title.xanchor],
-            dy: dyDict[fullLayout.title.yanchor]
+            'text-anchor': getMainTitleTextAnchor(fullLayout),
+            dy: getMainTitleDy(fullLayout)
         }
     });
 };
@@ -501,6 +490,65 @@ function getMainTitleY(fullLayout) {
             default:
                 return fullLayout.height - fullLayout.height * title.y;
         }
+    }
+}
+
+function getMainTitleTextAnchor(fullLayout) {
+    var xanchor = fullLayout.title.xanchor;
+
+    switch(xanchor) {
+        case 'auto':
+            return calcTextAnchor(fullLayout.title.x);
+        case 'left':
+            return 'start';
+        case 'right':
+            return 'end';
+        case 'center':
+        default:
+            return 'middle';
+    }
+
+    function calcTextAnchor(x) {
+        if(x < 1 / 3) {
+            return 'start';
+        } else if(x > 2 / 3) {
+            return 'end';
+        }
+
+        return 'middle';
+    }
+}
+
+function getMainTitleDy(fullLayout) {
+    var yanchor = fullLayout.title.yanchor;
+    switch(yanchor) {
+        case 'auto':
+            return calcDy(fullLayout.title.y);
+        case 'middle':
+            return alignmentConstants.MID_SHIFT + 'em';
+        case 'top':
+            return alignmentConstants.CAP_SHIFT + 'em';
+        case 'bottom':
+        default:
+            return '0em';
+    }
+
+    function calcDy(y) {
+
+        // Imitate behavior before "chart title alignment" was introduced
+        if(y === 'auto') {
+            return '0em';
+        } else if(typeof y === 'number') {
+            if(y < 1 / 3) {
+                return '0em';
+            } else if(y > 2 / 3) {
+                return alignmentConstants.CAP_SHIFT + 'em';
+            } else {
+                return alignmentConstants.MID_SHIFT + 'em';
+            }
+        }
+
+        return 0;
     }
 }
 

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -449,18 +449,60 @@ function findCounterAxisLineWidth(ax, side, counterAx, axList) {
 
 exports.drawMainTitle = function(gd) {
     var fullLayout = gd._fullLayout;
+    var textAnchorDict = {
+        'left': 'start',
+        'center': 'middle',
+        'right': 'end',
+        'auto': 'middle' // TODO That needs to be calculated based on x
+    };
+    var dyDict = {
+        'top': alignmentConstants.CAP_SHIFT + 'em',
+        'middle': alignmentConstants.MID_SHIFT + 'em',
+        'bottom': '0em',
+    };
 
     Titles.draw(gd, 'gtitle', {
         propContainer: fullLayout,
         propName: 'title.text',
         placeholder: fullLayout._dfltTitle.plot,
         attributes: {
-            x: fullLayout.width / 2,
-            y: fullLayout._size.t / 2,
-            'text-anchor': 'middle'
+            x: getMainTitleX(fullLayout),
+            y: getMainTitleY(fullLayout),
+            'text-anchor': textAnchorDict[fullLayout.title.xanchor],
+            dy: dyDict[fullLayout.title.yanchor]
         }
     });
 };
+
+function getMainTitleX(fullLayout) {
+    var title = fullLayout.title;
+    var _size = fullLayout._size;
+
+    switch(title.xref) {
+        case 'paper':
+            return _size.l + _size.w * title.x;
+        case 'container':
+        default:
+            return fullLayout.width * title.x;
+    }
+}
+
+function getMainTitleY(fullLayout) {
+    var title = fullLayout.title;
+    var _size = fullLayout._size;
+
+    if(title.y === 'auto') {
+        return _size.t / 2;
+    } else {
+        switch(title.yref) {
+            case 'paper':
+                return _size.t + _size.h - _size.h * title.y;
+            case 'container':
+            default:
+                return fullLayout.height - fullLayout.height * title.y;
+        }
+    }
+}
 
 exports.doTraceStyle = function(gd) {
     var calcdata = gd.calcdata;

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -564,9 +564,9 @@ function getMainTitleDy(fullLayout) {
                 return '0em';
             } else if(y > 2 / 3) {
                 return alignmentConstants.CAP_SHIFT + 'em';
-            } else {
-                return alignmentConstants.MID_SHIFT + 'em';
             }
+
+            return alignmentConstants.MID_SHIFT + 'em';
         }
 
         return 0;

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -2640,11 +2640,11 @@ function swapAxisAttrs(layout, key, xFullAxes, yFullAxes, dfltTitle) {
         i;
     if(key === 'title') {
         // special handling of placeholder titles
-        if(xVal === dfltTitle.x) {
-            xVal = dfltTitle.y;
+        if(xVal && xVal.text === dfltTitle.x) {
+            xVal.text = dfltTitle.y;
         }
-        if(yVal === dfltTitle.y) {
-            yVal = dfltTitle.x;
+        if(yVal && yVal.text === dfltTitle.y) {
+            yVal.text = dfltTitle.x;
         }
     }
 

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -2387,7 +2387,7 @@ axes.drawTitle = function(gd, ax) {
 
     Titles.draw(gd, axId + 'title', {
         propContainer: ax,
-        propName: ax._name + '.title',
+        propName: ax._name + '.title.text',
         placeholder: fullLayout._dfltTitle[axLetter],
         avoid: avoid,
         transform: transform,

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -2337,7 +2337,7 @@ axes.drawTitle = function(gd, ax) {
     var axLetter = axId.charAt(0);
     var offsetBase = 1.5;
     var gs = fullLayout._size;
-    var fontSize = ax.titlefont.size;
+    var fontSize = ax.title.font.size;
 
     var transform, counterAxis, x, y;
 

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1825,8 +1825,8 @@ axes.drawOne = function(gd, ax, opts) {
             push[s] += ax._boundingBox.width;
         }
 
-        if(ax.title !== fullLayout._dfltTitle[axLetter]) {
-            push[s] += ax.titlefont.size;
+        if(ax.title.text !== fullLayout._dfltTitle[axLetter]) {
+            push[s] += ax.title.font.size;
         }
 
         Plots.autoMargin(gd, pushKey, push);

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -69,7 +69,7 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
     var dfltTitle = splomStash.label || layoutOut._dfltTitle[letter];
 
     coerce('title.text', dfltTitle);
-    Lib.coerceFont(coerce, 'titlefont', {
+    Lib.coerceFont(coerce, 'title.font', {
         family: font.family,
         size: Math.round(font.size * 1.2),
         color: dfltFontColor

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -68,7 +68,7 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
     // try to get default title from splom trace, fallback to graph-wide value
     var dfltTitle = splomStash.label || layoutOut._dfltTitle[letter];
 
-    coerce('title', dfltTitle);
+    coerce('title.text', dfltTitle);
     Lib.coerceFont(coerce, 'titlefont', {
         family: font.family,
         size: Math.round(font.size * 1.2),

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -41,10 +41,12 @@ module.exports = {
         ].join(' ')
     },
     title: {
-        valType: 'string',
-        role: 'info',
-        editType: 'ticks',
-        description: 'Sets the title of this axis.'
+        text: {
+            valType: 'string',
+            role: 'info',
+            editType: 'ticks',
+            description: 'Sets the title of this axis.'
+        }
     },
     titlefont: fontAttrs({
         editType: 'ticks',

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -46,7 +46,8 @@ module.exports = {
             role: 'info',
             editType: 'ticks',
             description: 'Sets the title of this axis.'
-        }
+        },
+        editType: 'ticks'
     },
     titlefont: fontAttrs({
         editType: 'ticks',

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -47,14 +47,14 @@ module.exports = {
             editType: 'ticks',
             description: 'Sets the title of this axis.'
         },
+        font: fontAttrs({
+            editType: 'ticks',
+            description: [
+                'Sets this axis\' title font.'
+            ].join(' ')
+        }),
         editType: 'ticks'
     },
-    titlefont: fontAttrs({
-        editType: 'ticks',
-        description: [
-            'Sets this axis\' title font.'
-        ].join(' ')
-    }),
     type: {
         valType: 'enumerated',
         // '-' means we haven't yet run autotype or couldn't find any data

--- a/src/plots/gl2d/convert.js
+++ b/src/plots/gl2d/convert.js
@@ -113,14 +113,14 @@ proto.merge = function(options) {
         // '_name' is e.g. xaxis, xaxis2, yaxis, yaxis4 ...
         ax = options[this.scene[axisName]._name];
 
-        axTitle = ax.title === this.scene.fullLayout._dfltTitle[axisLetter] ? '' : ax.title;
+        axTitle = ax.title.text === this.scene.fullLayout._dfltTitle[axisLetter] ? '' : ax.title.text;
 
         for(j = 0; j <= 2; j += 2) {
             this.labelEnable[i + j] = false;
             this.labels[i + j] = axTitle;
-            this.labelColor[i + j] = str2RGBArray(ax.titlefont.color);
-            this.labelFont[i + j] = ax.titlefont.family;
-            this.labelSize[i + j] = ax.titlefont.size;
+            this.labelColor[i + j] = str2RGBArray(ax.title.font.color);
+            this.labelFont[i + j] = ax.title.font.family;
+            this.labelSize[i + j] = ax.title.font.size;
             this.labelPad[i + j] = this.getLabelPad(axisName, ax);
 
             this.tickEnable[i + j] = false;
@@ -208,7 +208,7 @@ proto.hasAxisInAltrPos = function(axisName, ax) {
 
 proto.getLabelPad = function(axisName, ax) {
     var offsetBase = 1.5,
-        fontSize = ax.titlefont.size,
+        fontSize = ax.title.font.size,
         showticklabels = ax.showticklabels;
 
     if(axisName === 'xaxis') {

--- a/src/plots/gl3d/layout/axis_attributes.js
+++ b/src/plots/gl3d/layout/axis_attributes.js
@@ -73,7 +73,6 @@ module.exports = overrideAll({
     categoryorder: axesAttrs.categoryorder,
     categoryarray: axesAttrs.categoryarray,
     title: axesAttrs.title,
-    titlefont: axesAttrs.titlefont,
     type: axesAttrs.type,
     autorange: axesAttrs.autorange,
     rangemode: axesAttrs.rangemode,

--- a/src/plots/gl3d/layout/axis_defaults.js
+++ b/src/plots/gl3d/layout/axis_defaults.js
@@ -56,7 +56,15 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, options) {
             options.fullLayout);
 
         coerce('gridcolor', colorMix(containerOut.color, options.bgColor, gridLightness).toRgbString());
-        coerce('title', axName[0]);  // shouldn't this be on-par with 2D?
+        coerce('title.text', axName[0]);  // shouldn't this be on-par with 2D?
+
+        // TODO 882 coercing old 'titlefont' was missing. Why? Activating the below would break a lot image tests...
+        // Lib.coerceFont(coerce, 'title.font', {
+        //     family: options.font.family,
+        //     size: Math.round(options.font.size),
+        //     color: options.font.color
+        // });
+
 
         containerOut.setScale = Lib.noop;
 

--- a/src/plots/gl3d/layout/convert.js
+++ b/src/plots/gl3d/layout/convert.js
@@ -84,7 +84,7 @@ proto.merge = function(sceneLayout) {
 
         // Axes labels
         opts.labels[i] = axes.title.text;
-        if('title' in axes && 'font' in axes.title) {
+        if('font' in axes.title) {
             if(axes.title.font.color) opts.labelColor[i] = str2RgbaArray(axes.title.font.color);
             if(axes.title.font.family) opts.labelFont[i] = axes.title.font.family;
             if(axes.title.font.size) opts.labelSize[i] = axes.title.font.size;

--- a/src/plots/gl3d/layout/convert.js
+++ b/src/plots/gl3d/layout/convert.js
@@ -83,11 +83,11 @@ proto.merge = function(sceneLayout) {
         }
 
         // Axes labels
-        opts.labels[i] = axes.title;
-        if('titlefont' in axes) {
-            if(axes.titlefont.color) opts.labelColor[i] = str2RgbaArray(axes.titlefont.color);
-            if(axes.titlefont.family) opts.labelFont[i] = axes.titlefont.family;
-            if(axes.titlefont.size) opts.labelSize[i] = axes.titlefont.size;
+        opts.labels[i] = axes.title.text;
+        if('title' in axes && 'font' in axes.title) {
+            if(axes.title.font.color) opts.labelColor[i] = str2RgbaArray(axes.title.font.color);
+            if(axes.title.font.family) opts.labelFont[i] = axes.title.font.family;
+            if(axes.title.font.size) opts.labelSize[i] = axes.title.font.size;
         }
 
         // Lines

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -34,12 +34,12 @@ module.exports = {
                 'Sets the plot\'s title.'
             ].join(' ')
         },
+        font: fontAttrs({
+            editType: 'layoutstyle',
+            description: 'Sets the title font.'
+        }),
         editType: 'layoutstyle'
     },
-    titlefont: fontAttrs({
-        editType: 'layoutstyle',
-        description: 'Sets the title font.'
-    }),
     autosize: {
         valType: 'boolean',
         role: 'info',

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -64,7 +64,9 @@ module.exports = {
         },
         x: {
             valType: 'number',
-            dflt: '0.5',
+            min: 0,
+            max: 1,
+            dflt: 0.5,
             role: 'style',
             editType: 'layoutstyle',
             description: [
@@ -78,7 +80,7 @@ module.exports = {
             role: 'style',
             editType: 'layoutstyle',
             description: [
-                'Some',
+                'Some', // TODO document
                 'docu',
             ].join(' ')
         },

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -38,6 +38,70 @@ module.exports = {
             editType: 'layoutstyle',
             description: 'Sets the title font.'
         }),
+        xref: {
+            valType: 'enumerated',
+            dflt: 'container',
+            values: ['container', 'paper'],
+            role: 'info',
+            editType: 'layoutstyle',
+            description: [
+                'Some',
+                'docu', // TODO document
+            ].join(' ')
+        },
+        yref: {
+            valType: 'enumerated',
+            dflt: 'container',
+            values: ['container', 'paper'],
+            role: 'info',
+            editType: 'layoutstyle',
+            description: [
+                'Some',
+                'docu', // TODO document
+            ].join(' ')
+        },
+        x: {
+            valType: 'number',
+            dflt: '0.5',
+            role: 'style',
+            editType: 'layoutstyle',
+            description: [
+                'Some',
+                'docu', // TODO document
+            ].join(' ')
+        },
+        y: {
+            valType: 'any',
+            dflt: 'auto',
+            role: 'style',
+            editType: 'layoutstyle',
+            description: [
+                'Some',
+                'docu',
+            ].join(' ')
+        },
+        xanchor: {
+            valType: 'enumerated',
+            dflt: 'auto',
+            values: ['auto', 'left', 'center', 'right'],
+            role: 'info',
+            editType: 'layoutstyle',
+            description: [
+                'Some',
+                'docu', // TODO document
+            ].join(' ')
+        },
+        yanchor: {
+            valType: 'enumerated',
+            dflt: 'auto',
+            values: ['auto', 'top', 'middle', 'bottom'],
+            role: 'info',
+            editType: 'layoutstyle',
+            description: [
+                'Some',
+                'docu', // TODO document
+            ].join(' ')
+        },
         editType: 'layoutstyle'
     },
     autosize: {

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -10,6 +10,8 @@
 
 var fontAttrs = require('./font_attributes');
 var colorAttrs = require('../components/color/attributes');
+var padAttrs = require('./pad_attributes');
+var extendFlat = require('../lib/extend').extendFlat;
 
 var globalFont = fontAttrs({
     editType: 'calc',
@@ -102,6 +104,16 @@ module.exports = {
                 'docu', // TODO document
             ].join(' ')
         },
+        pad: extendFlat(padAttrs({editType: 'layoutstyle'}), {
+            description: [
+                'Sets the padding of the title.',
+                'Each padding value only applies when the corresponding',
+                'xanchor / yanchor value is set accordingly. E.g. for left',
+                'padding to take effect, xanchor must be set to left.',
+                'The same rule applies if xanchor/yanchor is determined automatically.',
+                'Padding is muted if respective anchor value is middle/center.'
+            ].join(' ')
+        }),
         editType: 'layoutstyle'
     },
     autosize: {

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -33,7 +33,8 @@ module.exports = {
             description: [
                 'Sets the plot\'s title.'
             ].join(' ')
-        }
+        },
+        editType: 'layoutstyle'
     },
     titlefont: fontAttrs({
         editType: 'layoutstyle',

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -26,12 +26,14 @@ globalFont.color.dflt = colorAttrs.defaultLine;
 module.exports = {
     font: globalFont,
     title: {
-        valType: 'string',
-        role: 'info',
-        editType: 'layoutstyle',
-        description: [
-            'Sets the plot\'s title.'
-        ].join(' ')
+        text: {
+            valType: 'string',
+            role: 'info',
+            editType: 'layoutstyle',
+            description: [
+                'Sets the plot\'s title.'
+            ].join(' ')
+        }
     },
     titlefont: fontAttrs({
         editType: 'layoutstyle',

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -47,8 +47,9 @@ module.exports = {
             role: 'info',
             editType: 'layoutstyle',
             description: [
-                'Some',
-                'docu', // TODO document
+                'Sets the container `x` refers to.',
+                '*container* spans the entire `width` of the plot.',
+                '*paper* refers to the width of the plotting area only.'
             ].join(' ')
         },
         yref: {
@@ -58,8 +59,9 @@ module.exports = {
             role: 'info',
             editType: 'layoutstyle',
             description: [
-                'Some',
-                'docu', // TODO document
+                'Sets the container `y` refers to.',
+                '*container* spans the entire `height` of the plot.',
+                '*paper* refers to the height of the plotting area only.'
             ].join(' ')
         },
         x: {
@@ -70,8 +72,8 @@ module.exports = {
             role: 'style',
             editType: 'layoutstyle',
             description: [
-                'Some',
-                'docu', // TODO document
+                'Sets the x position with respect to `xref` in normalized',
+                'coordinates from *0* (left) to *1* (right).'
             ].join(' ')
         },
         y: {
@@ -80,8 +82,10 @@ module.exports = {
             role: 'style',
             editType: 'layoutstyle',
             description: [
-                'Some', // TODO document
-                'docu',
+                'Sets the y position with respect to `yref` in normalized',
+                'coordinates from *0* (bottom) to *1* (top).',
+                '*auto* places the baseline of the title onto the',
+                'vertical center of the top margin.'
             ].join(' ')
         },
         xanchor: {
@@ -91,8 +95,12 @@ module.exports = {
             role: 'info',
             editType: 'layoutstyle',
             description: [
-                'Some',
-                'docu', // TODO document
+                'Sets the title\'s horizontal alignment with respect to its x position.',
+                '*left* means that the title starts at x,',
+                '*right* means that the title ends at x',
+                'and *center* means that the title\'s center is at x.',
+                '*auto* divides `xref` by three and calculates the `xanchor`',
+                'value automatically based on the value of `x`.'
             ].join(' ')
         },
         yanchor: {
@@ -102,18 +110,22 @@ module.exports = {
             role: 'info',
             editType: 'layoutstyle',
             description: [
-                'Some',
-                'docu', // TODO document
+                'Sets the title\'s vertical alignment with respect to its y position.',
+                '*top* means that the title\'s cap line is at y,',
+                '*bottom* means that the title\'s baseline is at y',
+                'and *middle* means that the title\'s midline is at y.',
+                '*auto* divides `yref` by three and calculates the `yanchor`',
+                'value automatically based on the value of `y`.'
             ].join(' ')
         },
         pad: extendFlat(padAttrs({editType: 'layoutstyle'}), {
             description: [
                 'Sets the padding of the title.',
                 'Each padding value only applies when the corresponding',
-                'xanchor / yanchor value is set accordingly. E.g. for left',
-                'padding to take effect, xanchor must be set to left.',
-                'The same rule applies if xanchor/yanchor is determined automatically.',
-                'Padding is muted if respective anchor value is middle/center.'
+                '`xanchor`/`yanchor` value is set accordingly. E.g. for left',
+                'padding to take effect, `xanchor` must be set to *left*.',
+                'The same rule applies if `xanchor`/`yanchor` is determined automatically.',
+                'Padding is muted if the respective anchor value is *middle*/*center*.'
             ].join(' ')
         }),
         editType: 'layoutstyle'

--- a/src/plots/pad_attributes.js
+++ b/src/plots/pad_attributes.js
@@ -8,37 +8,46 @@
 
 'use strict';
 
-// This is used exclusively by components inside component arrays,
-// hence the 'arraydraw' editType. If this ever gets used elsewhere
-// we could generalize it as a function ala font_attributes
-module.exports = {
-    t: {
-        valType: 'number',
-        dflt: 0,
-        role: 'style',
-        editType: 'arraydraw',
-        description: 'The amount of padding (in px) along the top of the component.'
-    },
-    r: {
-        valType: 'number',
-        dflt: 0,
-        role: 'style',
-        editType: 'arraydraw',
-        description: 'The amount of padding (in px) on the right side of the component.'
-    },
-    b: {
-        valType: 'number',
-        dflt: 0,
-        role: 'style',
-        editType: 'arraydraw',
-        description: 'The amount of padding (in px) along the bottom of the component.'
-    },
-    l: {
-        valType: 'number',
-        dflt: 0,
-        role: 'style',
-        editType: 'arraydraw',
-        description: 'The amount of padding (in px) on the left side of the component.'
-    },
-    editType: 'arraydraw'
+/**
+ * Creates a set of padding attributes.
+ *
+ * @param {object} opts
+ *   @param {string} editType:
+ *     the editType for all pieces of this padding definition
+ *
+ * @return {object} attributes object containing {t, r, b, l} as specified
+ */
+module.exports = function(opts) {
+    var editType = opts.editType;
+    return {
+        t: {
+            valType: 'number',
+            dflt: 0,
+            role: 'style',
+            editType: editType,
+            description: 'The amount of padding (in px) along the top of the component.'
+        },
+        r: {
+            valType: 'number',
+            dflt: 0,
+            role: 'style',
+            editType: editType,
+            description: 'The amount of padding (in px) on the right side of the component.'
+        },
+        b: {
+            valType: 'number',
+            dflt: 0,
+            role: 'style',
+            editType: editType,
+            description: 'The amount of padding (in px) along the bottom of the component.'
+        },
+        l: {
+            valType: 'number',
+            dflt: 0,
+            role: 'style',
+            editType: editType,
+            description: 'The amount of padding (in px) on the left side of the component.'
+        },
+        editType: editType
+    };
 };

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1315,6 +1315,19 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut, formatObj) {
         return Lib.coerce(layoutIn, layoutOut, plots.layoutAttributes, attr, dflt);
     }
 
+    // Special treatment for title.y that can be 'auto'
+    // or a number between 0 and 1.
+    function coerceTitleY() {
+        if(layoutIn.title && isNumeric(layoutIn.title.y)) {
+            var propOut = Lib.nestedProperty(layoutOut, 'title.y');
+            var opts = Lib.nestedProperty(plots.layoutAttributes, 'title.y').get();
+
+            Lib.valObjectMeta.number.coerceFunction(layoutIn.title.y, propOut, 'auto', opts);
+        } else {
+            coerce('title.y');
+        }
+    }
+
     var template = layoutIn.template;
     if(Lib.isPlainObject(template)) {
         layoutOut.template = template;
@@ -1334,8 +1347,8 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut, formatObj) {
 
     coerce('title.xref');
     coerce('title.yref');
-    coerce('title.x'); // TODO restrict to [-2, 3]?
-    coerce('title.y'); // TODO restrict to [-2, 3]?
+    coerce('title.x');
+    coerceTitleY();
     coerce('title.xanchor');
     coerce('title.yanchor');
     coerce('title.pad.t');

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1326,7 +1326,7 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut, formatObj) {
 
     coerce('title.text', layoutOut._dfltTitle.plot);
 
-    Lib.coerceFont(coerce, 'titlefont', {
+    Lib.coerceFont(coerce, 'title.font', {
         family: globalFont.family,
         size: Math.round(globalFont.size * 1.4),
         color: globalFont.color

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1332,6 +1332,13 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut, formatObj) {
         color: globalFont.color
     });
 
+    coerce('title.xref');
+    coerce('title.yref');
+    coerce('title.x'); // TODO restrict to [-2, 3]?
+    coerce('title.y'); // TODO restrict to [-2, 3]?
+    coerce('title.xanchor');
+    coerce('title.yanchor');
+
     // Make sure that autosize is defaulted to *true*
     // on layouts with no set width and height for backward compatibly,
     // in particular https://plot.ly/javascript/responsive-fluid-layout/

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1324,7 +1324,7 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut, formatObj) {
 
     var globalFont = Lib.coerceFont(coerce, 'font');
 
-    coerce('title', layoutOut._dfltTitle.plot);
+    coerce('title.text', layoutOut._dfltTitle.plot);
 
     Lib.coerceFont(coerce, 'titlefont', {
         family: globalFont.family,

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1338,6 +1338,10 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut, formatObj) {
     coerce('title.y'); // TODO restrict to [-2, 3]?
     coerce('title.xanchor');
     coerce('title.yanchor');
+    coerce('title.pad.t');
+    coerce('title.pad.r');
+    coerce('title.pad.b');
+    coerce('title.pad.l');
 
     // Make sure that autosize is defaulted to *true*
     // on layouts with no set width and height for backward compatibly,

--- a/src/plots/polar/layout_attributes.js
+++ b/src/plots/polar/layout_attributes.js
@@ -112,8 +112,7 @@ var radialAxisAttrs = {
     },
 
 
-    title: extendFlat({}, axesAttrs.title, {editType: 'plot', dflt: ''}),
-    titlefont: overrideAll(axesAttrs.titlefont, 'plot', 'from-root'),
+    title: overrideAll(axesAttrs.title, 'plot', 'from-root'),
     // might need a 'titleside' and even 'titledirection' down the road
 
     hoverformat: axesAttrs.hoverformat,

--- a/src/plots/polar/layout_defaults.js
+++ b/src/plots/polar/layout_defaults.js
@@ -100,8 +100,8 @@ function handleDefaults(contIn, contOut, coerce, opts) {
                     coerceAxis('side');
                     coerceAxis('angle', sector[0]);
 
-                    coerceAxis('title');
-                    Lib.coerceFont(coerceAxis, 'titlefont', {
+                    coerceAxis('title.text');
+                    Lib.coerceFont(coerceAxis, 'title.font', {
                         family: opts.font.family,
                         size: Math.round(opts.font.size * 1.2),
                         color: dfltFontColor

--- a/src/plots/polar/legacy/micropolar.js
+++ b/src/plots/polar/legacy/micropolar.js
@@ -215,8 +215,8 @@ var µ = module.exports = { version: '0.2.2' };
             centeringOffset[0] = Math.max(0, centeringOffset[0]);
             centeringOffset[1] = Math.max(0, centeringOffset[1]);
             svg.select('.outer-group').attr('transform', 'translate(' + centeringOffset + ')');
-            if (axisConfig.title) {
-                var title = svg.select('g.title-group text').style(fontStyle).text(axisConfig.title);
+            if (axisConfig.title && axisConfig.title.text) {
+                var title = svg.select('g.title-group text').style(fontStyle).text(axisConfig.title.text);
                 var titleBBox = title.node().getBBox();
                 title.attr({
                     x: chartCenter[0] - titleBBox.width / 2,

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -483,9 +483,12 @@ proto.updateRadialAxisTitle = function(fullLayout, polarLayout, _angle) {
     var sina = Math.sin(angleRad);
 
     var pad = 0;
+
+    // Hint: no need to check if there is in fact a title.text set
+    // because if plot is editable, pad needs to be calculated anyways.
     if(radialLayout.title) {
         var h = Drawing.bBox(_this.layers['radial-axis'].node()).height;
-        var ts = radialLayout.titlefont.size;
+        var ts = radialLayout.title.font.size;
         pad = radialLayout.side === 'counterclockwise' ?
             -h - ts * 0.4 :
             h + ts * 0.8;

--- a/src/plots/ternary/layout_attributes.js
+++ b/src/plots/ternary/layout_attributes.js
@@ -17,7 +17,6 @@ var extendFlat = require('../../lib/extend').extendFlat;
 
 var ternaryAxesAttrs = {
     title: axesAttrs.title,
-    titlefont: axesAttrs.titlefont,
     color: axesAttrs.color,
     // ticks
     tickmode: axesAttrs.tickmode,

--- a/src/plots/ternary/layout_defaults.js
+++ b/src/plots/ternary/layout_defaults.js
@@ -83,10 +83,10 @@ function handleAxisDefaults(containerIn, containerOut, options) {
         letterUpper = axName.charAt(0).toUpperCase(),
         dfltTitle = 'Component ' + letterUpper;
 
-    var title = coerce('title', dfltTitle);
+    var title = coerce('title.text', dfltTitle);
     containerOut._hovertitle = title === dfltTitle ? title : letterUpper;
 
-    Lib.coerceFont(coerce, 'titlefont', {
+    Lib.coerceFont(coerce, 'title.font', {
         family: options.font.family,
         size: Math.round(options.font.size * 1.2),
         color: dfltFontColor

--- a/src/plots/ternary/ternary.js
+++ b/src/plots/ternary/ternary.js
@@ -375,7 +375,7 @@ proto.drawAxes = function(doTitles) {
             placeholder: _(gd, 'Click to enter Component A title'),
             attributes: {
                 x: _this.x0 + _this.w / 2,
-                y: _this.y0 - aaxis.titlefont.size / 3 - apad,
+                y: _this.y0 - aaxis.title.font.size / 3 - apad,
                 'text-anchor': 'middle'
             }
         });
@@ -385,7 +385,7 @@ proto.drawAxes = function(doTitles) {
             placeholder: _(gd, 'Click to enter Component B title'),
             attributes: {
                 x: _this.x0 - bpad,
-                y: _this.y0 + _this.h + baxis.titlefont.size * 0.83 + bpad,
+                y: _this.y0 + _this.h + baxis.title.font.size * 0.83 + bpad,
                 'text-anchor': 'middle'
             }
         });
@@ -395,7 +395,7 @@ proto.drawAxes = function(doTitles) {
             placeholder: _(gd, 'Click to enter Component C title'),
             attributes: {
                 x: _this.x0 + _this.w + bpad,
-                y: _this.y0 + _this.h + caxis.titlefont.size * 0.83 + bpad,
+                y: _this.y0 + _this.h + caxis.title.font.size * 0.83 + bpad,
                 'text-anchor': 'middle'
             }
         });

--- a/src/snapshot/cloneplot.js
+++ b/src/snapshot/cloneplot.js
@@ -24,7 +24,7 @@ function cloneLayoutOverride(tileClass) {
                 autosize: true,
                 width: 150,
                 height: 150,
-                title: '',
+                title: {text: ''},
                 showlegend: false,
                 margin: {l: 5, r: 5, t: 5, b: 5, pad: 0},
                 annotations: []
@@ -33,7 +33,7 @@ function cloneLayoutOverride(tileClass) {
 
         case 'thumbnail':
             override = {
-                title: '',
+                title: {text: ''},
                 hidesources: true,
                 showlegend: false,
                 borderwidth: 0,
@@ -81,9 +81,11 @@ module.exports = function clonePlot(graphObj, options) {
 
         for(i = 0; i < keys.length; i++) {
             if(keyIsAxis(keys[i])) {
-                newLayout[keys[i]].title = '';
+                newLayout[keys[i]].title = {text: ''};
             }
         }
+
+        // TODO 882 Shouldn't ternary and polar axis titles be thrown away as well?
 
         // kill colorbar and pie labels
         for(i = 0; i < newData.length; i++) {
@@ -109,7 +111,7 @@ module.exports = function clonePlot(graphObj, options) {
         var axesImageOverride = {};
         if(options.tileClass === 'thumbnail') {
             axesImageOverride = {
-                title: '',
+                title: {text: ''},
                 showaxeslabels: false,
                 showticklabels: false,
                 linetickenable: false

--- a/test/image/mocks/shapes.json
+++ b/test/image/mocks/shapes.json
@@ -12,10 +12,10 @@
         "yaxis":"y2"
     }],
     "layout": {
-        "xaxis":{"title":"linear","range":[0,1],"domain":[0.35,0.65],"type":"linear","showgrid":false,"zeroline":false,"showticklabels":false},
-        "yaxis":{"title":"log","range":[0,1],"domain":[0.6,1],"type":"log","showgrid":false,"zeroline":false,"showticklabels":false},
-        "xaxis2":{"title":"date","range":["2000-01-01","2000-01-02"],"domain":[0.7,1],"anchor":"y2","type":"date","showgrid":false,"zeroline":false,"showticklabels":false},
-        "yaxis2":{"title":"category","range":[0,1],"domain":[0.6,1],"anchor":"x2","type":"category","showgrid":false,"zeroline":false,"showticklabels":false},
+        "xaxis":{"title":{"text":"linear"},"range":[0,1],"domain":[0.35,0.65],"type":"linear","showgrid":false,"zeroline":false,"showticklabels":false},
+        "yaxis":{"title":{"text":"log"},"range":[0,1],"domain":[0.6,1],"type":"log","showgrid":false,"zeroline":false,"showticklabels":false},
+        "xaxis2":{"title":{"text":"date"},"range":["2000-01-01","2000-01-02"],"domain":[0.7,1],"anchor":"y2","type":"date","showgrid":false,"zeroline":false,"showticklabels":false},
+        "yaxis2":{"title":{"text":"category"},"range":[0,1],"domain":[0.6,1],"anchor":"x2","type":"category","showgrid":false,"zeroline":false,"showticklabels":false},
         "height":400,
         "width":800,
         "margin": {"l":20,"r":20,"pad":0},

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -29,7 +29,9 @@ describe('Test axes', function() {
                 data: [{x: [1, 2, 3], y: [1, 2, 3]}],
                 layout: {
                     xaxis: {
-                        title: 'A Title!!!',
+                        title: {
+                            text: 'A Title!!!'
+                        },
                         type: 'log',
                         autorange: 'reversed',
                         rangemode: 'tozero',
@@ -42,14 +44,18 @@ describe('Test axes', function() {
                         tickcolor: '#f00'
                     },
                     yaxis: {
-                        title: 'Click to enter Y axis title',
+                        title: {
+                            text: 'Click to enter Y axis title'
+                        },
                         type: 'date'
                     }
                 }
             };
             var expectedYaxis = Lib.extendDeep({}, gd.layout.xaxis),
                 expectedXaxis = {
-                    title: 'Click to enter X axis title',
+                    title: {
+                        text: 'Click to enter X axis title'
+                    },
                     type: 'date'
                 };
 

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -345,11 +345,11 @@ describe('Test axes', function() {
             expect(layoutOut.xaxis.zerolinecolor).toBe(undefined);
         });
 
-        it('should use \'axis.color\' as default for \'axis.titlefont.color\'', function() {
+        it('should use \'axis.color\' as default for \'axis.title.font.color\'', function() {
             layoutIn = {
                 xaxis: { color: 'red' },
                 yaxis: {},
-                yaxis2: { titlefont: { color: 'yellow' } }
+                yaxis2: { title: { font: { color: 'yellow' } } }
             };
 
             layoutOut.font = { color: 'blue' };
@@ -357,9 +357,9 @@ describe('Test axes', function() {
             layoutOut._subplots.yaxis.push('y2');
 
             supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-            expect(layoutOut.xaxis.titlefont.color).toEqual('red');
-            expect(layoutOut.yaxis.titlefont.color).toEqual('blue');
-            expect(layoutOut.yaxis2.titlefont.color).toEqual('yellow');
+            expect(layoutOut.xaxis.title.font.color).toEqual('red');
+            expect(layoutOut.yaxis.title.font.color).toEqual('blue');
+            expect(layoutOut.yaxis2.title.font.color).toEqual('yellow');
         });
 
         it('should use \'axis.color\' as default for \'axis.linecolor\'', function() {
@@ -2882,14 +2882,14 @@ describe('Test axes', function() {
                 expect(size.t).toBe(previousSize.t);
 
                 previousSize = Lib.extendDeep({}, size);
-                return Plotly.relayout(gd, {'yaxis.titlefont.size': 30});
+                return Plotly.relayout(gd, {'yaxis.title.font.size': 30});
             })
             .then(function() {
                 var size = gd._fullLayout._size;
                 expect(size).toEqual(previousSize);
 
                 previousSize = Lib.extendDeep({}, size);
-                return Plotly.relayout(gd, {'yaxis.title': 'hello'});
+                return Plotly.relayout(gd, {'yaxis.title.text': 'hello'});
             })
             .then(function() {
                 var size = gd._fullLayout._size;

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -1655,7 +1655,8 @@ describe('hover info', function() {
 
         it('should contain the axis names', function(done) {
             var gd = document.getElementById('graph');
-            Plotly.restyle(gd, 'hovertemplate', '%{yaxis.title}:%{y:$.2f}<br>%{xaxis.title}:%{x:0.4f}<extra></extra>')
+            Plotly.restyle(gd, 'hovertemplate',
+              '%{yaxis.title.text}:%{y:$.2f}<br>%{xaxis.title.text}:%{x:0.4f}<extra></extra>')
             .then(function() {
                 Fx.hover('graph', evt, 'xy');
 

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -1431,7 +1431,7 @@ describe('legend interaction', function() {
                     });
                     gd.on('plotly_relayout', function(d) {
                         expect(typeof d).toBe('object');
-                        expect(d.title).toBe('just clicked on trace #2');
+                        expect(d.title.text).toBe('just clicked on trace #2');
                         done();
                     });
                     gd.on('plotly_restyle', function() {
@@ -1451,7 +1451,7 @@ describe('legend interaction', function() {
                     });
                     gd.on('plotly_relayout', function(d) {
                         expect(typeof d).toBe('object');
-                        expect(d.title).toBe('just double clicked on trace #0');
+                        expect(d.title.text).toBe('just double clicked on trace #0');
                         done();
                     });
                     gd.on('plotly_restyle', function() {

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -2658,7 +2658,7 @@ describe('Queue', function() {
         .then(function() {
             expect(gd.undoQueue.index).toEqual(2);
             expect(gd.undoQueue.queue[1].undo.args[0][1].title).toEqual(null);
-            expect(gd.undoQueue.queue[1].redo.args[0][1].title).toEqual('A title');
+            expect(gd.undoQueue.queue[1].redo.args[0][1].title.text).toEqual('A title');
 
             return Plotly.restyle(gd, 'mode', 'markers');
         })
@@ -2670,7 +2670,7 @@ describe('Queue', function() {
             expect(gd.undoQueue.queue[1].redo.args[0][1].mode).toEqual('markers');
 
             expect(gd.undoQueue.queue[0].undo.args[0][1].title).toEqual(null);
-            expect(gd.undoQueue.queue[0].redo.args[0][1].title).toEqual('A title');
+            expect(gd.undoQueue.queue[0].redo.args[0][1].title.text).toEqual('A title');
 
             return Plotly.restyle(gd, 'transforms[0]', { type: 'filter' });
         })

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -134,7 +134,7 @@ describe('Test polar plots defaults:', function() {
         expect(layoutOut.polar.angularaxis.linecolor).toBe('red');
         expect(layoutOut.polar.angularaxis.gridcolor).toBe('rgb(255, 153, 153)', 'blend by 60% with bgcolor');
 
-        expect(layoutOut.polar.radialaxis.titlefont.color).toBe('blue');
+        expect(layoutOut.polar.radialaxis.title.font.color).toBe('blue');
         expect(layoutOut.polar.radialaxis.linecolor).toBe('blue');
         expect(layoutOut.polar.radialaxis.gridcolor).toBe('rgb(153, 153, 255)', 'blend by 60% with bgcolor');
     });

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -36,19 +36,19 @@ describe('Plotly.Snapshot', function() {
 
         data = [dummyTrace1, dummyTrace2];
         layout = {
-            title: 'Chart Title',
+            title: {text: 'Chart Title'},
             showlegend: true,
             autosize: true,
             width: 688,
             height: 460,
             xaxis: {
-                title: 'xaxis title',
+                title: {text: 'xaxis title'},
                 range: [-0.323374917925, 5.32337491793],
                 type: 'linear',
                 autorange: true
             },
             yaxis: {
-                title: 'yaxis title',
+                title: {text: 'yaxis title'},
                 range: [1.41922290389, 10.5807770961],
                 type: 'linear',
                 autorange: true
@@ -70,7 +70,7 @@ describe('Plotly.Snapshot', function() {
                 autosize: true,
                 width: 150,
                 height: 150,
-                title: '',
+                title: {text: ''},
                 showlegend: false,
                 margin: {'l': 5, 'r': 5, 't': 5, 'b': 5, 'pad': 0},
                 annotations: []
@@ -100,7 +100,7 @@ describe('Plotly.Snapshot', function() {
             };
 
             var THUMBNAIL_DEFAULT_LAYOUT = {
-                'title': '',
+                'title': {text: ''},
                 'hidesources': true,
                 'showlegend': false,
                 'hovermode': false,
@@ -117,6 +117,7 @@ describe('Plotly.Snapshot', function() {
             expect(thumbTile.layout.showlegend).toEqual(THUMBNAIL_DEFAULT_LAYOUT.showlegend);
             expect(thumbTile.layout.borderwidth).toEqual(THUMBNAIL_DEFAULT_LAYOUT.borderwidth);
             expect(thumbTile.layout.annotations).toEqual(THUMBNAIL_DEFAULT_LAYOUT.annotations);
+            expect(thumbTile.layout.title).toEqual(THUMBNAIL_DEFAULT_LAYOUT.title);
         });
 
         it('should create a 3D thumbnail with limited attributes', function() {
@@ -142,7 +143,7 @@ describe('Plotly.Snapshot', function() {
             };
 
             var AXIS_OVERRIDE = {
-                title: '',
+                title: {text: ''},
                 showaxeslabels: false,
                 showticklabels: false,
                 linetickenable: false

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -325,10 +325,10 @@ describe('Test splom trace defaults:', function() {
         });
 
         var fullLayout = gd._fullLayout;
-        expect(fullLayout.xaxis.title).toBe('A');
-        expect(fullLayout.yaxis.title).toBe('A');
-        expect(fullLayout.xaxis2.title).toBe('B');
-        expect(fullLayout.yaxis2.title).toBe('B');
+        expect(fullLayout.xaxis.title.text).toBe('A');
+        expect(fullLayout.yaxis.title.text).toBe('A');
+        expect(fullLayout.xaxis2.title.text).toBe('B');
+        expect(fullLayout.yaxis2.title.text).toBe('B');
     });
 
     it('should set axis title default using dimensions *label* (even visible false dimensions)', function() {
@@ -346,12 +346,12 @@ describe('Test splom trace defaults:', function() {
         });
 
         var fullLayout = gd._fullLayout;
-        expect(fullLayout.xaxis.title).toBe('A');
-        expect(fullLayout.yaxis.title).toBe('A');
-        expect(fullLayout.xaxis2.title).toBe('B');
-        expect(fullLayout.yaxis2.title).toBe('B');
-        expect(fullLayout.xaxis3.title).toBe('C');
-        expect(fullLayout.yaxis3.title).toBe('C');
+        expect(fullLayout.xaxis.title.text).toBe('A');
+        expect(fullLayout.yaxis.title.text).toBe('A');
+        expect(fullLayout.xaxis2.title.text).toBe('B');
+        expect(fullLayout.yaxis2.title.text).toBe('B');
+        expect(fullLayout.xaxis3.title.text).toBe('C');
+        expect(fullLayout.yaxis3.title.text).toBe('C');
     });
 
     it('should ignore (x|y)axes values beyond dimensions length', function() {
@@ -382,12 +382,12 @@ describe('Test splom trace defaults:', function() {
             'x2y', 'x2y2', 'x2y3',
             'x3y', 'x3y2', 'x3y3'
         ]);
-        expect(fullLayout.xaxis.title).toBe('A');
-        expect(fullLayout.yaxis.title).toBe('A');
-        expect(fullLayout.xaxis2.title).toBe('B');
-        expect(fullLayout.yaxis2.title).toBe('B');
-        expect(fullLayout.xaxis3.title).toBe('C');
-        expect(fullLayout.yaxis3.title).toBe('C');
+        expect(fullLayout.xaxis.title.text).toBe('A');
+        expect(fullLayout.yaxis.title.text).toBe('A');
+        expect(fullLayout.xaxis2.title.text).toBe('B');
+        expect(fullLayout.yaxis2.title.text).toBe('B');
+        expect(fullLayout.xaxis3.title.text).toBe('C');
+        expect(fullLayout.yaxis3.title.text).toBe('C');
         expect(fullLayout.xaxis4).toBe(undefined);
         expect(fullLayout.yaxis4).toBe(undefined);
     });
@@ -422,12 +422,12 @@ describe('Test splom trace defaults:', function() {
         ]);
         expect(fullLayout.xaxis).toBe(undefined);
         expect(fullLayout.yaxis).toBe(undefined);
-        expect(fullLayout.xaxis2.title).toBe('A');
-        expect(fullLayout.yaxis2.title).toBe('A');
-        expect(fullLayout.xaxis3.title).toBe('B');
-        expect(fullLayout.yaxis3.title).toBe('B');
-        expect(fullLayout.xaxis4.title).toBe('C');
-        expect(fullLayout.yaxis4.title).toBe('C');
+        expect(fullLayout.xaxis2.title.text).toBe('A');
+        expect(fullLayout.yaxis2.title.text).toBe('A');
+        expect(fullLayout.xaxis3.title.text).toBe('B');
+        expect(fullLayout.yaxis3.title.text).toBe('B');
+        expect(fullLayout.xaxis4.title.text).toBe('C');
+        expect(fullLayout.yaxis4.title.text).toBe('C');
         expect(fullLayout.xaxis5).toBe(undefined);
         expect(fullLayout.yaxis5).toBe(undefined);
     });

--- a/test/jasmine/tests/template_test.js
+++ b/test/jasmine/tests/template_test.js
@@ -158,7 +158,9 @@ describe('makeTemplate', function() {
                   {fill: 'toself'}
                 ] },
                 layout: {
-                    title: 'Fill toself and tonext',
+                    title: {
+                        text: 'Fill toself and tonext'
+                    },
                     width: 400,
                     height: 400
                 }

--- a/test/jasmine/tests/ternary_test.js
+++ b/test/jasmine/tests/ternary_test.js
@@ -1,5 +1,6 @@
 var Plotly = require('@lib');
 var Lib = require('@src/lib');
+var rgb = require('@src/components/color').rgb;
 
 var supplyLayoutDefaults = require('@src/plots/ternary/layout_defaults');
 
@@ -382,6 +383,55 @@ describe('ternary plots', function() {
         .then(done);
     });
 
+    it('should be able to relayout axis title attributes', function(done) {
+        var gd = createGraphDiv();
+        var fig = Lib.extendDeep({}, require('@mocks/ternary_simple.json'));
+
+        function _assert(axisPrefix, title, family, color, size) {
+            var titleSel = d3.select('.' + axisPrefix + 'title');
+            var titleNode = titleSel.node();
+
+            var msg = 'for ' + axisPrefix + 'axis title';
+            expect(titleSel.text()).toBe(title, 'title ' + msg);
+            expect(titleNode.style['font-family']).toBe(family, 'font family ' + msg);
+            expect(parseFloat(titleNode.style['font-size'])).toBe(size, 'font size ' + msg);
+            expect(titleNode.style.fill).toBe(color, 'font color ' + msg);
+        }
+
+        Plotly.plot(gd, fig).then(function() {
+            _assert('a', 'Component A', '"Open Sans", verdana, arial, sans-serif', rgb('#ccc'), 14);
+            _assert('b', 'chocolate', '"Open Sans", verdana, arial, sans-serif', rgb('#0f0'), 14);
+            _assert('c', 'Component C', '"Open Sans", verdana, arial, sans-serif', rgb('#444'), 14);
+
+            // Note: Different update notations to also test legacy title structures
+            return Plotly.relayout(gd, {
+                'ternary.aaxis.title.text': 'chips',
+                'ternary.aaxis.title.font.color': 'yellow',
+                'ternary.aaxis.titlefont.family': 'monospace',
+                'ternary.aaxis.titlefont.size': 16,
+                'ternary.baxis.title': 'white chocolate',
+                'ternary.baxis.title.font.color': 'blue',
+                'ternary.baxis.titlefont.family': 'sans-serif',
+                'ternary.baxis.titlefont.size': 10,
+                'ternary.caxis.title': {
+                    text: 'candy',
+                    font: {
+                        color: 'pink',
+                        family: 'serif',
+                        size: 30
+                    }
+                }
+            });
+        })
+          .then(function() {
+              _assert('a', 'chips', 'monospace', rgb('yellow'), 16);
+              _assert('b', 'white chocolate', 'sans-serif', rgb('blue'), 10);
+              _assert('c', 'candy', 'serif', rgb('pink'), 30);
+          })
+          .catch(failTest)
+          .then(done);
+    });
+
     it('should be able to hide/show ticks and tick labels', function(done) {
         var gd = createGraphDiv();
         var fig = Lib.extendDeep({}, require('@mocks/ternary_simple.json'));
@@ -546,9 +596,9 @@ describe('ternary defaults', function() {
         layoutIn = {};
 
         supplyLayoutDefaults(layoutIn, layoutOut, fullData);
-        expect(layoutOut.ternary.aaxis.title).toEqual('Component A');
-        expect(layoutOut.ternary.baxis.title).toEqual('Component B');
-        expect(layoutOut.ternary.caxis.title).toEqual('Component C');
+        expect(layoutOut.ternary.aaxis.title.text).toEqual('Component A');
+        expect(layoutOut.ternary.baxis.title.text).toEqual('Component B');
+        expect(layoutOut.ternary.caxis.title.text).toEqual('Component C');
     });
 
     it('should default \'gricolor\' to 60% dark', function() {

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -1,6 +1,7 @@
 var d3 = require('d3');
 
 var Plotly = require('@lib/index');
+var alignmentConstants = require('@src/constants/alignment');
 var interactConstants = require('@src/constants/interactions');
 var Lib = require('@src/lib');
 var rgb = require('@src/components/color').rgb;
@@ -13,11 +14,6 @@ describe('Plot title', function() {
     'use strict';
 
     var data = [{x: [1, 2, 3], y: [1, 2, 3]}];
-    var layout = {
-        title: {
-            text: 'Plotly line chart'
-        }
-    };
     var gd;
 
     beforeEach(function() {
@@ -26,8 +22,25 @@ describe('Plot title', function() {
 
     afterEach(destroyGraphDiv);
 
+    var containerElemSelector = {
+        desc: 'container',
+        select: function() {
+            return d3.selectAll('.svg-container').node();
+        }
+    };
+
+    var paperElemSelector = {
+        desc: 'plot area',
+        select: function() {
+            var bgLayer = d3.selectAll('.bglayer .bg');
+            expect(bgLayer.empty()).toBe(false,
+              'No background layer found representing the size of the plot area');
+            return bgLayer.node();
+        }
+    };
+
     it('is centered horizontally and vertically above the plot by default', function() {
-        Plotly.plot(gd, data, layout);
+        Plotly.plot(gd, data, {title: {text: 'Plotly line chart'}});
 
         expectDefaultCenteredPosition(gd);
     });
@@ -50,6 +63,98 @@ describe('Plot title', function() {
           .then(done);
     });
 
+    // Horizontal alignment
+    [
+        {
+            selector: containerElemSelector,
+            xref: 'container'
+        },
+        {
+            selector: paperElemSelector,
+            xref: 'paper'
+        }
+    ].forEach(function(testCase) {
+        it('can be placed at the left edge of the ' + testCase.selector.desc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                xref: testCase.xref,
+                x: 0,
+                xanchor: 'left'
+            }));
+
+            expectLeftEdgeAlignedTo(testCase.selector);
+        });
+
+        it('can be placed at the right edge of the ' + testCase.selector.desc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                xref: testCase.xref,
+                x: 1,
+                xanchor: 'right'
+            }));
+
+            expectRightEdgeAlignedTo(testCase.selector);
+        });
+
+        it('can be placed at the center of the ' + testCase.selector.desc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                xref: testCase.xref,
+                x: 0.5,
+                xanchor: 'center'
+            }));
+
+            expectCenteredWithin(testCase.selector);
+        });
+    });
+
+    // Vertical alignment
+    [
+        {
+            selector: containerElemSelector,
+            yref: 'container'
+        },
+        {
+            selector: paperElemSelector,
+            yref: 'paper'
+        }
+    ].forEach(function(testCase) {
+        it('can be placed at the top edge of the ' + testCase.selector.desc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                yref: testCase.yref,
+                y: 1,
+                yanchor: 'top'
+            }));
+
+            expectCapLineAlignsWithTopEdgeOf(testCase.selector);
+        });
+
+        it('can be placed at the bottom edge of the ' + testCase.selector.desc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                yref: testCase.yref,
+                y: 0,
+                yanchor: 'bottom'
+            }));
+
+            expectBaselineAlignsWithBottomEdgeOf(testCase.selector);
+        });
+
+        it('can be placed in the vertical center of the ' + testCase.selector.desc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                yref: testCase.yref,
+                y: 0.5,
+                yanchor: 'middle'
+            }));
+
+            expectCenteredVerticallyWithin(testCase.selector);
+        });
+    });
+
+    // TODO y set to `auto` to ensure current behavior is still supported
+
+    // TODO x-anchor auto
+
+    // TODO y-anchor auto
+
+    // TODO padding
+
     it('preserves alignment when text is updated via `Plotly.relayout` using an attribute string', function() {
         // TODO implement once alignment is implemented
     });
@@ -65,6 +170,145 @@ describe('Plot title', function() {
     it('discards alignment when text is updated via `Plotly.update` by passing a new title object', function() {
         // TODO implement once alignment is implemented
     });
+
+    function extendLayout(titleAttrs) {
+        return {
+            title: Lib.extendFlat({text: 'A Chart Title'}, titleAttrs),
+
+            // This needs to be set to have a DOM element that represents the
+            // exact size of the plot area.
+            plot_bgcolor: '#f9f9f9',
+        };
+    }
+
+    function expectLeftEdgeAlignedTo(elemSelector) {
+        expectHorizontalEdgeAligned(elemSelector, 'left');
+    }
+
+    function expectRightEdgeAlignedTo(elemSelector) {
+        expectHorizontalEdgeAligned(elemSelector, 'right');
+    }
+
+    function expectHorizontalEdgeAligned(elemSelector, edgeKey) {
+        var refElem = elemSelector.select();
+        var titleElem = titleSel().node();
+        var refElemBB = refElem.getBoundingClientRect();
+        var titleBB = titleElem.getBoundingClientRect();
+
+        var tolerance = 1.1;
+        var msg = 'Title ' + edgeKey + ' of ' + elemSelector.desc;
+        expect(titleBB[edgeKey] - refElemBB[edgeKey]).toBeWithin(0, tolerance, msg);
+    }
+
+    function expectCapLineAlignsWithTopEdgeOf(elemSelector) {
+        var refElem = elemSelector.select();
+        var refElemBB = refElem.getBoundingClientRect();
+
+        // Note: getBoundingClientRect of an SVG <text> element
+        // doesn't return the tightest bounding box of the current text
+        // but a rectangle that is wide enough to contain any
+        // possible character even though something like 'Ö' isn't
+        // in the current title string. Moreover getBoundingClientRect
+        // (with respect to SVG <text> elements) differs from browser to
+        // browser and thus is unreliable for testing vertical alignment
+        // of SVG text. Because of that the cap line is calculated based on the
+        // element properties.
+        var capLineY = calcTextCapLineY(titleSel());
+
+        var msg = 'Title\'s cap line y is same as the top of ' + elemSelector.desc;
+        expect(capLineY).toBeWithin(refElemBB.top, 1.1, msg);
+    }
+
+    function expectBaselineAlignsWithBottomEdgeOf(elemSelector) {
+        var refElem = elemSelector.select();
+        var refElemBB = refElem.getBoundingClientRect();
+
+        // Note: using getBoundingClientRect is not reliable, see
+        // comment in `expectCapLineAlignsWithTopEdgeOf` for more info.
+        var baselineY = calcTextBaselineY(titleSel());
+
+        var msg = 'Title baseline sits on the bottom of ' + elemSelector.desc;
+        expect(baselineY).toBeWithin(refElemBB.bottom, 1.1, msg);
+    }
+
+    function calcTextCapLineY(textSel) {
+        var baselineY = calcTextBaselineY(textSel);
+        var fontSize = textSel.node().style.fontSize;
+        var fontSizeVal = parseFontSizeAttr(fontSize).val;
+
+        // CAP_SHIFT is assuming a cap height of an average font.
+        // One would have to analyze the font metrics of the
+        // used font to determine an accurate cap shift factor.
+        return baselineY - fontSizeVal * alignmentConstants.CAP_SHIFT;
+    }
+
+    function calcTextBaselineY(textSel) {
+        var y = Number.parseFloat(textSel.attr('y'));
+        var dy = textSel.attr('dy');
+        var parsedDy = /^([0-9.]*)(\w*)$/.exec(dy);
+        var dyNumValue, dyUnit;
+        var fontSize, parsedFontSize;
+        var yShift;
+
+        if(parsedDy) {
+            dyUnit = parsedDy[2];
+            dyNumValue = Number.parseFloat(parsedDy[1]);
+
+            if(dyUnit === 'em') {
+                fontSize = textSel.node().style.fontSize;
+                parsedFontSize = parseFontSizeAttr(fontSize);
+
+                yShift = dyNumValue * Number.parseFloat(parsedFontSize.val);
+            } else if(dyUnit === '') {
+                yShift = dyNumValue;
+            } else {
+                fail('Calculating y-shift for unit ' + dyUnit + ' not implemented in test');
+            }
+        } else {
+            fail('dy value \'' + dy + '\' could not be parsed by test');
+        }
+
+        return y + yShift;
+    }
+
+    function parseFontSizeAttr(fontSizeAttr) {
+        var parsedFontSize = /^([0-9.]*)px$/.exec(fontSizeAttr);
+        var isFontSizeInPx = !!parsedFontSize;
+        expect(isFontSizeInPx).toBe(true, 'Tests assumes font-size is set in pixel');
+
+        return {
+            val: parsedFontSize[1],
+            unit: parsedFontSize[2]
+        };
+    }
+
+    function expectCenteredWithin(elemSelector) {
+        var refElem = elemSelector.select();
+        var titleElem = titleSel().node();
+        var refElemBB = refElem.getBoundingClientRect();
+        var titleBB = titleElem.getBoundingClientRect();
+
+        var leftDistance = titleBB.left - refElemBB.left;
+        var rightDistance = refElemBB.right - titleBB.right;
+
+        var tolerance = 1.1;
+        var msg = 'Title in center of ' + elemSelector.desc;
+        expect(leftDistance).toBeWithin(rightDistance, tolerance, msg);
+    }
+
+    function expectCenteredVerticallyWithin(elemSelector) {
+        var refElem = elemSelector.select();
+        var titleElem = titleSel().node();
+        var refElemBB = refElem.getBoundingClientRect();
+        var titleBB = titleElem.getBoundingClientRect();
+
+        var topDistance = titleBB.top - refElemBB.top;
+        var bottomDistance = refElemBB.bottom - titleBB.bottom;
+
+        var tolerance = 1.1;
+        var msg = 'Title centered vertically within ' + elemSelector.desc;
+        expect(topDistance).toBeWithin(bottomDistance, tolerance, msg);
+    }
 });
 
 describe('Titles can be updated', function() {

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -656,6 +656,93 @@ describe('Title fonts can be updated', function() {
     }
 });
 
+describe('Titles for multiple axes', function() {
+    'use strict';
+
+    var data = [
+      {x: [1, 2, 3], y: [1, 2, 3], xaxis: 'x', yaxis: 'y'},
+      {x: [1, 2, 3], y: [3, 2, 1], xaxis: 'x2', yaxis: 'y2'}
+    ];
+    var multiAxesLayout = {
+        xaxis: {
+            title: 'X-Axis 1',
+            titlefont: {
+                size: 30
+            }
+        },
+        xaxis2: {
+            title: 'X-Axis 2',
+            titlefont: {
+                family: 'serif'
+            },
+            side: 'top'
+        },
+        yaxis: {
+            title: 'Y-Axis 1',
+            titlefont: {
+                family: 'Roboto'
+            },
+        },
+        yaxis2: {
+            title: 'Y-Axis 2',
+            titlefont: {
+                color: 'blue'
+            },
+            side: 'right'
+        }
+    };
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('still support deprecated `title` and `titlefont` syntax (backwards-compatibility)', function() {
+        Plotly.plot(gd, data, multiAxesLayout);
+
+        expect(xTitleSel(1).text()).toBe('X-Axis 1');
+        expect(xTitleSel(1).node().style.fontSize).toBe('30px');
+
+        expect(xTitleSel(2).text()).toBe('X-Axis 2');
+        expect(xTitleSel(2).node().style.fontFamily).toBe('serif');
+
+        expect(yTitleSel(1).text()).toBe('Y-Axis 1');
+        expect(yTitleSel(1).node().style.fontFamily).toBe('Roboto');
+
+        expect(yTitleSel(2).text()).toBe('Y-Axis 2');
+        expect(yTitleSel(2).node().style.fill).toBe(rgb('blue'));
+    });
+
+    it('can be updated using deprecated `title` and `titlefont` syntax (backwards-compatibility)', function() {
+        Plotly.plot(gd, data, multiAxesLayout);
+
+        Plotly.relayout(gd, {
+            'xaxis2.title': '2nd X-Axis',
+            'xaxis2.titlefont.color': 'pink',
+            'xaxis2.titlefont.family': 'sans-serif',
+            'xaxis2.titlefont.size': '14',
+            'yaxis2.title': '2nd Y-Axis',
+            'yaxis2.titlefont.color': 'yellow',
+            'yaxis2.titlefont.family': 'monospace',
+            'yaxis2.titlefont.size': '5'
+        });
+
+        var x2Style = xTitleSel(2).node().style;
+        expect(xTitleSel(2).text()).toBe('2nd X-Axis');
+        expect(x2Style.fill).toBe(rgb('pink'));
+        expect(x2Style.fontFamily).toBe('sans-serif');
+        expect(x2Style.fontSize).toBe('14px');
+
+        var y2Style = yTitleSel(2).node().style;
+        expect(yTitleSel(2).text()).toBe('2nd Y-Axis');
+        expect(y2Style.fill).toBe(rgb('yellow'));
+        expect(y2Style.fontFamily).toBe('monospace');
+        expect(y2Style.fontSize).toBe('5px');
+    });
+});
+
 function expectTitle(expTitle) {
     expectTitleFn(expTitle)();
 }
@@ -762,15 +849,17 @@ function titleSel() {
     return titleSel;
 }
 
-function xTitleSel() {
-    var xTitleSel = d3.select('.xtitle');
-    expect(xTitleSel.empty()).toBe(false, 'X-axis title element missing');
+function xTitleSel(num) {
+    var axIdx = num === 1 ? '' : (num || '');
+    var xTitleSel = d3.select('.x' + axIdx + 'title');
+    expect(xTitleSel.empty()).toBe(false, 'X-axis ' + axIdx + ' title element missing');
     return xTitleSel;
 }
 
-function yTitleSel() {
-    var yTitleSel = d3.select('.ytitle');
-    expect(yTitleSel.empty()).toBe(false, 'Y-axis title element missing');
+function yTitleSel(num) {
+    var axIdx = num === 1 ? '' : (num || '');
+    var yTitleSel = d3.select('.y' + axIdx + 'title');
+    expect(yTitleSel.empty()).toBe(false, 'Y-axis ' + axIdx + ' title element missing');
     return yTitleSel;
 }
 

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -12,7 +12,11 @@ describe('Plot title', function() {
     'use strict';
 
     var data = [{x: [1, 2, 3], y: [1, 2, 3]}];
-    var layout = {title: 'Plotly line chart'};
+    var layout = {
+        title: {
+            text: 'Plotly line chart'
+        }
+    };
     var gd;
 
     beforeEach(function() {
@@ -24,11 +28,22 @@ describe('Plot title', function() {
     it('is centered horizontally and vertically above the plot by default', function() {
         Plotly.plot(gd, data, layout);
 
+        expectDefaultCenteredPosition();
+    });
+
+    it('can still be defined as `layout.title` to ensure backwards-compatibility', function() {
+        Plotly.plot(gd, data, {title: 'Plotly line chart'});
+
+        expect(titleSel().text()).toBe('Plotly line chart');
+        expectDefaultCenteredPosition();
+    });
+
+    function expectDefaultCenteredPosition() {
         var containerBB = gd.getBoundingClientRect();
 
         expect(titleX()).toBe(containerBB.width / 2);
         expect(titleY()).toBe(gd._fullLayout.margin.t / 2);
-    });
+    }
 
     function titleX() {
         return Number.parseFloat(titleSel().attr('x'));
@@ -39,7 +54,9 @@ describe('Plot title', function() {
     }
 
     function titleSel() {
-        return d3.select('.infolayer .g-gtitle .gtitle');
+        var titleSel = d3.select('.infolayer .g-gtitle .gtitle');
+        expect(titleSel.empty()).toBe(false, 'Title element missing');
+        return titleSel;
     }
 });
 
@@ -117,9 +134,9 @@ describe('editable titles', function() {
 
     it('has hover effects for blank titles', function(done) {
         Plotly.plot(gd, data, {
-            xaxis: {title: ''},
-            yaxis: {title: ''},
-            title: ''
+            xaxis: {title: {text: ''}},
+            yaxis: {title: {text: ''}},
+            title: {text: ''}
         }, {editable: true})
         .then(function() {
             return Promise.all([
@@ -133,18 +150,18 @@ describe('editable titles', function() {
 
     it('has no hover effects for titles that used to be blank', function(done) {
         Plotly.plot(gd, data, {
-            xaxis: {title: ''},
-            yaxis: {title: ''},
-            title: ''
+            xaxis: {title: {text: ''}},
+            yaxis: {title: {text: ''}},
+            title: {text: ''}
         }, {editable: true})
         .then(function() {
-            return editTitle('x', 'xaxis.title', 'XXX');
+            return editTitle('x', 'xaxis.title.text', 'XXX');
         })
         .then(function() {
-            return editTitle('y', 'yaxis.title', 'YYY');
+            return editTitle('y', 'yaxis.title.text', 'YYY');
         })
         .then(function() {
-            return editTitle('g', 'title', 'TTT');
+            return editTitle('g', 'title.text', 'TTT');
         })
         .then(function() {
             return Promise.all([

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -170,15 +170,13 @@ describe('Plot title', function() {
 
     // xanchor 'auto' test
     [
-        {x: -0.5, expAlignment: 'start'},
         {x: 0, expAlignment: 'start'},
         {x: 0.3, expAlignment: 'start'},
         {x: 0.4, expAlignment: 'middle'},
         {x: 0.5, expAlignment: 'middle'},
         {x: 0.6, expAlignment: 'middle'},
         {x: 0.7, expAlignment: 'end'},
-        {x: 1, expAlignment: 'end'},
-        {x: 1.5, expAlignment: 'end'}
+        {x: 1, expAlignment: 'end'}
     ].forEach(function(testCase) {
         runXAnchorAutoTest(testCase, 'container');
         runXAnchorAutoTest(testCase, 'paper');

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -147,6 +147,7 @@ describe('Plot title', function() {
         });
     });
 
+    // y 'auto' value
     it('provides a y \'auto\' value putting title baseline in middle ' +
       'of top margin irrespective of `yref`', function() {
 
@@ -164,9 +165,76 @@ describe('Plot title', function() {
         expectBaselineInMiddleOfTopMargin(gd);
     });
 
-    // TODO x-anchor auto
+    // xanchor 'auto' test
+    [
+        {x: -0.5, expAlignment: 'start'},
+        {x: 0, expAlignment: 'start'},
+        {x: 0.3, expAlignment: 'start'},
+        {x: 0.4, expAlignment: 'middle'},
+        {x: 0.5, expAlignment: 'middle'},
+        {x: 0.6, expAlignment: 'middle'},
+        {x: 0.7, expAlignment: 'end'},
+        {x: 1, expAlignment: 'end'},
+        {x: 1.5, expAlignment: 'end'}
+    ].forEach(function(testCase) {
+        runXAnchorAutoTest(testCase, 'container');
+        runXAnchorAutoTest(testCase, 'paper');
+    });
 
-    // TODO y-anchor auto
+    function runXAnchorAutoTest(testCase, xref) {
+        var testDesc = 'with {xanchor: \'auto\', x: ' + testCase.x + ', xref: \'' + xref +
+          '\'} expected to be aligned ' + testCase.expAlignment;
+        it(testDesc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                xref: xref,
+                x: testCase.x,
+                xanchor: 'auto'
+            }));
+
+            var textAnchor = titleSel().attr('text-anchor');
+            expect(textAnchor).toBe(testCase.expAlignment, testDesc);
+        });
+    }
+
+    // yanchor 'auto' test
+    //
+    // Note: in contrast to xanchor, there's no SVG attribute like
+    // text-anchor we can safely assume to work in all browsers. Thus the
+    // dy attribute has to be used and as a consequence it's much harder to test
+    // arbitrary vertical alignment options. Because of that only the
+    // most common use cases are tested in this regard.
+    [
+        {y: 0, expAlignment: 'bottom', expFn: expectBaselineAlignsWithBottomEdgeOf},
+        {y: 0.5, expAlignment: 'middle', expFn: expectCenteredVerticallyWithin},
+        {y: 1, expAlignment: 'top', expFn: expectCapLineAlignsWithTopEdgeOf},
+    ].forEach(function(testCase) {
+        runYAnchorAutoTest(testCase, 'container', containerElemSelector);
+        runYAnchorAutoTest(testCase, 'paper', paperElemSelector);
+    });
+
+    function runYAnchorAutoTest(testCase, yref, elemSelector) {
+        var testDesc = 'with {yanchor: \'auto\', y: ' + testCase.y + ', yref: \'' + yref +
+          '\'} expected to be aligned ' + testCase.expAlignment;
+        it(testDesc, function() {
+            Plotly.plot(gd, data, extendLayout({
+                yref: yref,
+                y: testCase.y,
+                yanchor: 'auto'
+            }));
+
+            testCase.expFn(elemSelector);
+        });
+    }
+
+    it('{y: \'auto\'} overrules {yanchor: \'auto\'} to support behavior ' +
+      'before chart title alignment was introduced', function() {
+        Plotly.plot(gd, data, extendLayout({
+            y: 'auto',
+            yanchor: 'auto'
+        }));
+
+        expectDefaultCenteredPosition(gd);
+    });
 
     // TODO padding
 

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -3,6 +3,7 @@ var d3 = require('d3');
 var Plotly = require('@lib/index');
 var interactConstants = require('@src/constants/interactions');
 var Lib = require('@src/lib');
+var rgb = require('@src/components/color').rgb;
 
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
@@ -144,13 +145,238 @@ describe('Titles can be updated', function() {
     function expectTitles(expTitle, expXTitle, expYTitle) {
         expectTitle(expTitle);
 
-        var xTitleSel = d3.select('.xtitle');
-        expect(xTitleSel.empty()).toBe(false, 'X-axis title element missing');
-        expect(xTitleSel.text()).toBe(expXTitle);
+        var xSel = xTitleSel();
+        expect(xSel.empty()).toBe(false, 'X-axis title element missing');
+        expect(xSel.text()).toBe(expXTitle);
 
-        var yTitleSel = d3.select('.ytitle');
-        expect(yTitleSel.empty()).toBe(false, 'Y-axis title element missing');
-        expect(yTitleSel.text()).toBe(expYTitle);
+        var ySel = yTitleSel();
+        expect(ySel.empty()).toBe(false, 'Y-axis title element missing');
+        expect(ySel.text()).toBe(expYTitle);
+    }
+});
+
+describe('Titles support setting custom font properties', function() {
+    'use strict';
+
+    var data = [{x: [1, 2, 3], y: [1, 2, 3]}];
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('through defining a `font` property in the respective title attribute', function() {
+        var layout = {
+            title: {
+                text: 'Plotly line chart',
+                font: {
+                    color: 'blue',
+                    family: 'serif',
+                    size: 24
+                }
+            },
+            xaxis: {
+                title: {
+                    text: 'X-Axis',
+                    font: {
+                        color: '#333',
+                        family: 'sans-serif',
+                        size: 20
+                    }
+                }
+            },
+            yaxis: {
+                title: {
+                    text: 'Y-Axis',
+                    font: {
+                        color: '#666',
+                        family: 'Arial',
+                        size: 16
+                    }
+                }
+            }
+        };
+        Plotly.plot(gd, data, layout);
+
+        expectTitleFont('blue', 'serif', 24);
+        expectXAxisTitleFont('#333', 'sans-serif', 20);
+        expectYAxisTitleFont('#666', 'Arial', 16);
+    });
+
+    it('through using the deprecated `titlefont` properties (backwards-compatibility)', function() {
+        var layout = {
+            title: {
+                text: 'Plotly line chart',
+            },
+            titlefont: {
+                color: 'blue',
+                family: 'serif',
+                size: 24
+            },
+            xaxis: {
+                title: {
+                    text: 'X-Axis',
+                },
+                titlefont: {
+                    color: '#333',
+                    family: 'sans-serif',
+                    size: 20
+                }
+            },
+            yaxis: {
+                title: {
+                    text: 'Y-Axis',
+                },
+                titlefont: {
+                    color: '#666',
+                    family: 'Arial',
+                    size: 16
+                }
+            }
+        };
+        Plotly.plot(gd, data, layout);
+
+        expectTitleFont('blue', 'serif', 24);
+        expectXAxisTitleFont('#333', 'sans-serif', 20);
+        expectYAxisTitleFont('#666', 'Arial', 16);
+    });
+});
+
+describe('Title fonts can be updated', function() {
+    'use strict';
+
+    var data = [{x: [1, 2, 3], y: [1, 2, 3]}];
+    var NEW_TITLE = 'Weight over years';
+    var NEW_XTITLE = 'Age in years';
+    var NEW_YTITLE = 'Average weight';
+    var NEW_TITLE_FONT = {color: '#333', family: 'serif', size: 28};
+    var NEW_XTITLE_FONT = {color: '#666', family: 'sans-serif', size: 18};
+    var NEW_YTITLE_FONT = {color: '#999', family: 'serif', size: 12};
+    var gd;
+
+    beforeEach(function() {
+        var layout = {
+            title: {
+                text: 'Plotly line chart',
+                font: {color: 'black', family: 'sans-serif', size: 24}
+            },
+            xaxis: {
+                title: {
+                    text: 'Age',
+                    font: {color: 'red', family: 'serif', size: 20}
+                }
+            },
+            yaxis: {
+                title: {
+                    text: 'Weight',
+                    font: {color: 'green', family: 'monospace', size: 16}
+                }
+            }
+        };
+        gd = createGraphDiv();
+        Plotly.plot(gd, data, Lib.extendDeep({}, layout));
+
+        expectTitleFont('black', 'sans-serif', 24);
+        expectXAxisTitleFont('red', 'serif', 20);
+        expectYAxisTitleFont('green', 'monospace', 16);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    [
+        {
+            desc: 'by replacing the entire title objects',
+            update: {
+                title: {
+                    text: NEW_TITLE,
+                    font: NEW_TITLE_FONT
+                },
+                xaxis: {
+                    title: {
+                        text: NEW_XTITLE,
+                        font: NEW_XTITLE_FONT
+                    }
+                },
+                yaxis: {
+                    title: {
+                        text: NEW_YTITLE,
+                        font: NEW_YTITLE_FONT
+                    }
+                }
+            }
+        },
+        {
+            desc: 'by using attribute strings',
+            update: {
+                'title.font.color': NEW_TITLE_FONT.color,
+                'title.font.family': NEW_TITLE_FONT.family,
+                'title.font.size': NEW_TITLE_FONT.size,
+                'xaxis.title.font.color': NEW_XTITLE_FONT.color,
+                'xaxis.title.font.family': NEW_XTITLE_FONT.family,
+                'xaxis.title.font.size': NEW_XTITLE_FONT.size,
+                'yaxis.title.font.color': NEW_YTITLE_FONT.color,
+                'yaxis.title.font.family': NEW_YTITLE_FONT.family,
+                'yaxis.title.font.size': NEW_YTITLE_FONT.size
+            }
+        },
+        {
+            desc: 'despite passing deprecated `titlefont` properties (backwards-compatibility)',
+            update: {
+                titlefont: NEW_TITLE_FONT,
+                xaxis: {
+                    title: NEW_XTITLE,
+                    titlefont: NEW_XTITLE_FONT
+                },
+                yaxis: {
+                    title: NEW_YTITLE,
+                    titlefont: NEW_YTITLE_FONT
+                }
+            }
+        },
+        {
+            desc: 'despite using string attributes representing the deprecated structure ' +
+            '(backwards-compatibility)',
+            update: {
+                'titlefont.color': NEW_TITLE_FONT.color,
+                'titlefont.family': NEW_TITLE_FONT.family,
+                'titlefont.size': NEW_TITLE_FONT.size,
+                'xaxis.titlefont.color': NEW_XTITLE_FONT.color,
+                'xaxis.titlefont.family': NEW_XTITLE_FONT.family,
+                'xaxis.titlefont.size': NEW_XTITLE_FONT.size,
+                'yaxis.titlefont.color': NEW_YTITLE_FONT.color,
+                'yaxis.titlefont.family': NEW_YTITLE_FONT.family,
+                'yaxis.titlefont.size': NEW_YTITLE_FONT.size
+            }
+        },
+        {
+            desc: 'despite using string attributes replacing deprecated `titlefont` attributes ' +
+            '(backwards-compatibility)',
+            update: {
+                'titlefont': NEW_TITLE_FONT,
+                'xaxis.titlefont': NEW_XTITLE_FONT,
+                'yaxis.titlefont': NEW_YTITLE_FONT
+            }
+        }
+    ].forEach(function(testCase) {
+        it('via `Plotly.relayout` ' + testCase.desc, function() {
+            Plotly.relayout(gd, testCase.update);
+
+            expectChangedTitleFonts();
+        });
+
+        it('via `Plotly.update` ' + testCase.desc, function() {
+            Plotly.update(gd, {}, testCase.update);
+
+            expectChangedTitleFonts();
+        });
+    });
+
+    function expectChangedTitleFonts() {
+        expectTitleFont(NEW_TITLE_FONT.color, NEW_TITLE_FONT.family, NEW_TITLE_FONT.size);
+        expectXAxisTitleFont(NEW_XTITLE_FONT.color, NEW_XTITLE_FONT.family, NEW_XTITLE_FONT.size);
+        expectYAxisTitleFont(NEW_YTITLE_FONT.color, NEW_YTITLE_FONT.family, NEW_YTITLE_FONT.size);
     }
 });
 
@@ -162,6 +388,25 @@ function expectTitleFn(expTitle) {
     return function() {
         expect(titleSel().text()).toBe(expTitle);
     };
+}
+
+function expectTitleFont(color, family, size) {
+    expectFont(titleSel(), color, family, size);
+}
+
+function expectXAxisTitleFont(color, family, size) {
+    expectFont(xTitleSel(), color, family, size);
+}
+
+function expectYAxisTitleFont(color, family, size) {
+    expectFont(yTitleSel(), color, family, size);
+}
+
+function expectFont(sel, color, family, size) {
+    var node = sel.node();
+    expect(node.style.fill).toBe(rgb(color));
+    expect(node.style.fontFamily).toBe(family);
+    expect(node.style.fontSize).toBe(size + 'px');
 }
 
 function expectDefaultCenteredPosition(gd) {
@@ -181,8 +426,20 @@ function titleY() {
 
 function titleSel() {
     var titleSel = d3.select('.infolayer .g-gtitle .gtitle');
-    expect(titleSel.empty()).toBe(false, 'Title element missing');
+    expect(titleSel.empty()).toBe(false, 'Plot title element missing');
     return titleSel;
+}
+
+function xTitleSel() {
+    var xTitleSel = d3.select('.xtitle');
+    expect(xTitleSel.empty()).toBe(false, 'X-axis title element missing');
+    return xTitleSel;
+}
+
+function yTitleSel() {
+    var yTitleSel = d3.select('.ytitle');
+    expect(yTitleSel.empty()).toBe(false, 'Y-axis title element missing');
+    return yTitleSel;
 }
 
 describe('Editable titles', function() {

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -7,6 +7,42 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var mouseEvent = require('../assets/mouse_event');
 
+
+describe('Plot title', function() {
+    'use strict';
+
+    var data = [{x: [1, 2, 3], y: [1, 2, 3]}];
+    var layout = {title: 'Plotly line chart'};
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('is centered horizontally and vertically above the plot by default', function() {
+        Plotly.plot(gd, data, layout);
+
+        var containerBB = gd.getBoundingClientRect();
+
+        expect(titleX()).toBe(containerBB.width / 2);
+        expect(titleY()).toBe(gd._fullLayout.margin.t / 2);
+    });
+
+    function titleX() {
+        return Number.parseFloat(titleSel().attr('x'));
+    }
+
+    function titleY() {
+        return Number.parseFloat(titleSel().attr('y'));
+    }
+
+    function titleSel() {
+        return d3.select('.infolayer .g-gtitle .gtitle');
+    }
+});
+
 describe('editable titles', function() {
     'use strict';
 

--- a/test/jasmine/tests/validate_test.js
+++ b/test/jasmine/tests/validate_test.js
@@ -18,7 +18,9 @@ describe('Plotly.validate', function() {
             type: 'scatter',
             x: [1, 2, 3]
         }], {
-            title: 'my simple graph'
+            title: {
+                text: 'my simple graph'
+            }
         });
 
         expect(out).toBeUndefined();
@@ -371,7 +373,9 @@ describe('Plotly.validate', function() {
                 }]
             }),
         ], {
-            title: 'my transformed graph'
+            title: {
+                text: 'my transformed graph'
+            }
         });
 
         expect(out.length).toEqual(5);


### PR DESCRIPTION
This PR adds the capability to **align the main plot title** as requested in issue #882.

**New title attributes structure**
Besides the introduction of the discussed alignment options, this PR also transitions to a new `title` attribute structure. `layout.title` has become `layout.title.text` and `layout.titlefont` has become `layout.title.font`. The same goes for any other title definitions within `layout`, e.g.  `xaxis`, `yaxis`, `polar.radialaxis` and so on.

The structure of title attributes within `data` remains unchanged as it won't have added any significant value to users compared to the additional effort this would have taken (e.g. transitioning `pie`).

**To be discussed**
- Two new `TODO`s were added that probably need a closer look by a core maintainer.
- The new title structure has changed event data of `plotly_relayout` which especially showed in two broken and thus updated tests in `legend_test.js`. Users are still able to use the old attributes structure as an input to `Plotly.relayout` and `Plotly.update`. But any handlers listening on `plotly_relayout` events, that assume the old title structure, need to be updated.
- `Lib.warn` calls in `cleanLayout` have not been added so far since the original issue is about two years old as of writing and every other clean-up code in `cleanLayout` does not yet emit warnings.