### PR TITLE
Add (some) IE11 testing on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+environment:
+  nodejs_version: "10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  # faster than `npm install`
+  - npm ci
+
+test_script:
+  - node --version
+  - npm --version
+  - npm run test-jasmine -- lib --IE11
+
+build: off

--- a/package-lock.json
+++ b/package-lock.json
@@ -6335,6 +6335,15 @@
       "integrity": "sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==",
       "dev": true
     },
+    "karma-ie-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz",
+      "integrity": "sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.6.1"
+      }
+    },
     "karma-jasmine": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-fail-fast-reporter": "^1.0.5",
     "karma-firefox-launcher": "^1.0.1",
+    "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^1.1.2",
     "karma-jasmine-spec-tags": "^1.0.1",
     "karma-spec-reporter": "0.0.32",

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -7,10 +7,11 @@ var constants = require('../../tasks/util/constants');
 var isCI = !!process.env.CIRCLECI;
 var argv = minimist(process.argv.slice(4), {
     string: ['bundleTest', 'width', 'height'],
-    'boolean': ['info', 'nowatch', 'failFast', 'verbose', 'Chrome', 'Firefox'],
+    'boolean': ['info', 'nowatch', 'failFast', 'verbose', 'Chrome', 'Firefox', 'IE11'],
     alias: {
         'Chrome': 'chrome',
         'Firefox': ['firefox', 'FF'],
+        'IE11': ['ie11'],
         'bundleTest': ['bundletest', 'bundle_test'],
         'nowatch': 'no-watch',
         'failFast': 'fail-fast'
@@ -54,6 +55,7 @@ if(argv.info) {
         '  - `--info`: show this info message',
         '  - `--Chrome` (alias `--chrome`): run test in (our custom) Chrome browser',
         '  - `--Firefox` (alias `--FF`, `--firefox`): run test in (our custom) Firefox browser',
+        '  - `--IE11` (alias -- `ie11`)`: run test in IE11 browser',
         '  - `--nowatch (dflt: `false`, `true` on CI)`: run karma w/o `autoWatch` / multiple run mode',
         '  - `--failFast` (dflt: `false`): exit karma upon first test failure',
         '  - `--verbose` (dflt: `false`): show test result using verbose reporter',
@@ -302,6 +304,7 @@ func.defaultConfig.files.push(testFileGlob);
 var browsers = func.defaultConfig.browsers;
 if(argv.Chrome) browsers.push('_Chrome');
 if(argv.Firefox) browsers.push('_Firefox');
+if(argv.IE11) browsers.push('IE');
 if(browsers.length === 0) browsers.push('_Chrome');
 
 module.exports = func;

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -4,7 +4,7 @@ var path = require('path');
 var minimist = require('minimist');
 var constants = require('../../tasks/util/constants');
 
-var isCI = !!process.env.CIRCLECI;
+var isCI = !!process.env.CI;
 var argv = minimist(process.argv.slice(4), {
     string: ['bundleTest', 'width', 'height'],
     'boolean': ['info', 'nowatch', 'failFast', 'verbose', 'Chrome', 'Firefox', 'IE11'],

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -1558,12 +1558,16 @@ describe('Test lib.js:', function() {
 
     describe('cleanNumber', function() {
         it('should return finite numbers untouched', function() {
-            [
-                0, 1, 2, 1234.567,
-                -1, -100, -999.999,
-                Number.MAX_VALUE, Number.MIN_VALUE, Number.EPSILON,
-                -Number.MAX_VALUE, -Number.MIN_VALUE, -Number.EPSILON
-            ].forEach(function(v) {
+            var vals = [0, 1, 2, 1234.567, -1, -100, -999.999];
+
+            if(!Lib.isIE()) {
+                vals.push(
+                    Number.MAX_VALUE, Number.MIN_VALUE, Number.EPSILON,
+                    -Number.MAX_VALUE, -Number.MIN_VALUE, -Number.EPSILON
+                );
+            }
+
+            vals.forEach(function(v) {
                 expect(Lib.cleanNumber(v)).toBe(v);
             });
         });

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -1558,13 +1558,14 @@ describe('Test lib.js:', function() {
 
     describe('cleanNumber', function() {
         it('should return finite numbers untouched', function() {
-            var vals = [0, 1, 2, 1234.567, -1, -100, -999.999];
+            var vals = [
+                0, 1, 2, 1234.567, -1, -100, -999.999,
+                Number.MAX_VALUE, Number.MIN_VALUE,
+                -Number.MAX_VALUE, -Number.MIN_VALUE
+            ];
 
             if(!Lib.isIE()) {
-                vals.push(
-                    Number.MAX_VALUE, Number.MIN_VALUE, Number.EPSILON,
-                    -Number.MAX_VALUE, -Number.MIN_VALUE, -Number.EPSILON
-                );
+                vals.push(Number.EPSILON, -Number.EPSILON);
             }
 
             vals.forEach(function(v) {


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/431

Looks like AppVeyor has gotten a lot better in the last three years, adding IE11 tests was relatively easy.

Note that this iteration only tests the `lib_test.js` suite. We should add more IE11 tests eventually, perhaps by adding a specialty suite in `test/jasmine/bundle_tests/ie11_test.js` or by adding a `@ie11` jasmine tag.

But as discussed in https://github.com/plotly/plotly.js/issues/431#issuecomment-435079403, adapting all our jasmine tests (especially our pixel-based tests) might be too much of a pain for little benefit.

cc @plotly/plotly_js 