### PR TITLE
Regression bug fix of scatter2d traces not to change other traces colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8780,9 +8780,8 @@
       }
     },
     "regl-scatter2d": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.0.6.tgz",
-      "integrity": "sha512-l2/OcCRKTxsCtrGtb2TKUKYnDHzI07qOm2eK2kiRYKyDwiWiGyiLC6p3SlOxDoqhQ/8gbIue9BABPXuCJ0lpRQ==",
+      "version": "git://github.com/gl-vis/regl-scatter2d.git#22c218464af8a50a0fbbd8e6a983edb24f21fdab",
+      "from": "git://github.com/gl-vis/regl-scatter2d.git#22c218464af8a50a0fbbd8e6a983edb24f21fdab",
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8780,24 +8780,31 @@
       }
     },
     "regl-scatter2d": {
-      "version": "git://github.com/gl-vis/regl-scatter2d.git#39382a1dbdbf3c58cab5210f5d52505ba52e732f",
-      "from": "git://github.com/gl-vis/regl-scatter2d.git#39382a1dbdbf3c58cab5210f5d52505ba52e732f",
+      "version": "git://github.com/gl-vis/regl-scatter2d.git#1cb7d93015e164d83d9beabaedcb5f56fe4cb00c",
+      "from": "git://github.com/gl-vis/regl-scatter2d.git#1cb7d93015e164d83d9beabaedcb5f56fe4cb00c",
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",
-        "bubleify": "^1.0.0",
+        "bubleify": "^1.2.0",
         "clamp": "^1.0.1",
         "color-id": "^1.1.0",
-        "color-normalize": "^1.0.3",
-        "flatten-vertex-data": "^1.0.0",
-        "glslify": "^6.1.1",
+        "color-normalize": "^1.3.0",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^6.3.1",
         "is-iexplorer": "^1.0.0",
         "object-assign": "^4.1.1",
-        "parse-rect": "^1.1.0",
-        "pick-by-alias": "^1.0.0",
-        "point-cluster": "^3.1.2",
-        "to-float32": "^1.0.0",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "point-cluster": "^3.1.4",
+        "to-float32": "^1.0.1",
         "update-diff": "^1.1.0"
+      },
+      "dependencies": {
+        "to-float32": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.0.1.tgz",
+          "integrity": "sha512-nOy2WSwae3xhZbc+05xiCuU3ZPPmH0L4Rg4Q1qiOGFSuNSCTB9nVJaGgGl3ZScxAclX/L8hJuDHJGDAzbfuKCQ=="
+        }
       }
     },
     "regl-splom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8780,8 +8780,8 @@
       }
     },
     "regl-scatter2d": {
-      "version": "git://github.com/gl-vis/regl-scatter2d.git#22c218464af8a50a0fbbd8e6a983edb24f21fdab",
-      "from": "git://github.com/gl-vis/regl-scatter2d.git#22c218464af8a50a0fbbd8e6a983edb24f21fdab",
+      "version": "git://github.com/gl-vis/regl-scatter2d.git#39382a1dbdbf3c58cab5210f5d52505ba52e732f",
+      "from": "git://github.com/gl-vis/regl-scatter2d.git#39382a1dbdbf3c58cab5210f5d52505ba52e732f",
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",
@@ -8834,6 +8834,47 @@
             "binary-search-bounds": "^2.0.4",
             "clamp": "^1.0.1",
             "parse-rect": "^1.1.1"
+          }
+        },
+        "regl-scatter2d": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.0.6.tgz",
+          "integrity": "sha512-l2/OcCRKTxsCtrGtb2TKUKYnDHzI07qOm2eK2kiRYKyDwiWiGyiLC6p3SlOxDoqhQ/8gbIue9BABPXuCJ0lpRQ==",
+          "requires": {
+            "array-range": "^1.0.1",
+            "array-rearrange": "^2.2.2",
+            "bubleify": "^1.0.0",
+            "clamp": "^1.0.1",
+            "color-id": "^1.1.0",
+            "color-normalize": "^1.0.3",
+            "flatten-vertex-data": "^1.0.0",
+            "glslify": "^6.1.1",
+            "is-iexplorer": "^1.0.0",
+            "object-assign": "^4.1.1",
+            "parse-rect": "^1.1.0",
+            "pick-by-alias": "^1.0.0",
+            "point-cluster": "^3.1.2",
+            "to-float32": "^1.0.0",
+            "update-diff": "^1.1.0"
+          },
+          "dependencies": {
+            "point-cluster": {
+              "version": "3.1.4",
+              "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.4.tgz",
+              "integrity": "sha512-jVjzC1vYoZlvcLWi170i41he5LhJTncOgFPaZx1uoqNn+8q+24xjLS9yG68XfN6/U1F52kliD6a3oXjJduerTQ==",
+              "requires": {
+                "array-bounds": "^1.0.1",
+                "array-normalize": "^1.1.3",
+                "binary-search-bounds": "^2.0.4",
+                "bubleify": "^1.1.0",
+                "clamp": "^1.0.1",
+                "dtype": "^2.0.0",
+                "flatten-vertex-data": "^1.0.0",
+                "is-obj": "^1.0.1",
+                "math-log2": "^1.0.1",
+                "parse-rect": "^1.2.0"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
     "regl-line2d": "^3.0.12",
-    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#22c218464af8a50a0fbbd8e6a983edb24f21fdab",
+    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#39382a1dbdbf3c58cab5210f5d52505ba52e732f",
     "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
     "regl-line2d": "^3.0.12",
-    "regl-scatter2d": "^3.0.6",
+    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#22c218464af8a50a0fbbd8e6a983edb24f21fdab",
     "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
     "regl-line2d": "^3.0.12",
-    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#39382a1dbdbf3c58cab5210f5d52505ba52e732f",
+    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#1cb7d93015e164d83d9beabaedcb5f56fe4cb00c",
     "regl-splom": "^1.0.4",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",


### PR DESCRIPTION
Fixes #3232 and https://github.com/plotly/phoenix-integration/issues/232 by disabling unstable palette color algorithm in regl-scatter2d.
Although some improvements are made in another branch and [PR](https://github.com/plotly/plotly.js/pull/3242); that still requires more rewrites and possibly passing two palettes to the shaders.
While this could be a very annoying bug for Plotly users, this PR disabled the buggy palette mechanism in the module so that it may be fixed in the next minor version. 
Also few other minor improvements are made in the `regl-scatter2d` module.  
@etpinard 
@alexcjohnson 
