### PR TITLE
Apply regl-scatter2d vertex shader simplifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8860,9 +8860,8 @@
       }
     },
     "regl-scatter2d": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.1.0.tgz",
-      "integrity": "sha512-xpjFdNrauLF/343XbAY1Hy0GnCkrOixH4iwNYp2ZpiqMxqnBjIY4vPhfK95YuyNqCXm7sQrjI5dSASyX2nXyPw==",
+      "version": "git://github.com/gl-vis/regl-scatter2d.git#2d5777fe8b1963ec978a3e32a6f7ccec173cc274",
+      "from": "git://github.com/gl-vis/regl-scatter2d.git#2d5777fe8b1963ec978a3e32a6f7ccec173cc274",
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8860,8 +8860,9 @@
       }
     },
     "regl-scatter2d": {
-      "version": "git://github.com/gl-vis/regl-scatter2d.git#2d5777fe8b1963ec978a3e32a6f7ccec173cc274",
-      "from": "git://github.com/gl-vis/regl-scatter2d.git#2d5777fe8b1963ec978a3e32a6f7ccec173cc274",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.1.2.tgz",
+      "integrity": "sha512-tlCWkE42/suXzyRoauTTo36k4Q0KVQOrY7XVov8A28B7JducD8QXGDlapP5M1y0TsBh70etrFABUHxeMLNpVFA==",
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
     "regl-line2d": "^3.0.12",
-    "regl-scatter2d": "^3.1.0",
+    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#2d5777fe8b1963ec978a3e32a6f7ccec173cc274",
     "regl-splom": "^1.0.5",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "regl": "^1.3.7",
     "regl-error2d": "^2.0.5",
     "regl-line2d": "^3.0.12",
-    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#2d5777fe8b1963ec978a3e32a6f7ccec173cc274",
+    "regl-scatter2d": "^3.1.2",
     "regl-splom": "^1.0.5",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",


### PR DESCRIPTION
Bumped `regl-scatter2d` to be at 3.1.2
@etpinard 