### PR TITLE
fix #3339 - typed arrays support for ohlc / candlestick traces

### DIFF
--- a/src/traces/ohlc/calc.js
+++ b/src/traces/ohlc/calc.js
@@ -92,7 +92,7 @@ function calcCommon(gd, trace, x, ya, ptFunc) {
         }
     }
 
-    trace._extremes[ya._id] = Axes.findExtremes(ya, l.concat(h), {padded: true});
+    trace._extremes[ya._id] = Axes.findExtremes(ya, Lib.concat(l, h), {padded: true});
 
     if(cd.length) {
         cd[0].t = {

--- a/test/jasmine/tests/finance_test.js
+++ b/test/jasmine/tests/finance_test.js
@@ -983,6 +983,37 @@ describe('finance charts updates:', function() {
         .then(done);
     });
 
+    it('should work with typed array', function(done) {
+        var mockTA = {
+            open: new Float32Array(mock0.open),
+            high: new Float32Array(mock0.high),
+            low: new Float32Array(mock0.low),
+            close: new Float32Array(mock0.close)
+        };
+
+        var dataTA = [
+            Lib.extendDeep({}, mockTA, {type: 'ohlc'}),
+            Lib.extendDeep({}, mockTA, {type: 'candlestick'}),
+        ];
+
+        var data0 = [
+            Lib.extendDeep({}, mock0, {type: 'ohlc'}),
+            Lib.extendDeep({}, mock0, {type: 'candlestick'}),
+        ];
+
+        Plotly.plot(gd, dataTA)
+        .then(function() {
+            expect(countOHLCTraces()).toBe(1, '# of ohlc traces');
+            expect(countBoxTraces()).toBe(1, '# of candlestick traces');
+        })
+        .then(function() { return Plotly.react(gd, data0); })
+        .then(function() {
+            expect(countOHLCTraces()).toBe(1, '# of ohlc traces');
+            expect(countBoxTraces()).toBe(1, '# of candlestick traces');
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('finance charts *special* handlers:', function() {


### PR DESCRIPTION
cc @plotly/plotly_js - easy fix before we tackle https://github.com/plotly/plotly.js/issues/3215 (which would be a nice holiday project :thinking: )