### PR TITLE
fixes #3336 - don't try to makeCalcdata on visible:false traces

### DIFF
--- a/src/traces/histogram/calc.js
+++ b/src/traces/histogram/calc.js
@@ -251,16 +251,18 @@ function calcAllAutoBins(gd, trace, pa, mainData, _overlayEdgeCase) {
         var isFirstVisible = true;
         for(i = 0; i < traces.length; i++) {
             tracei = traces[i];
-            pos0 = tracei._pos0 = pa.makeCalcdata(tracei, mainData);
-            allPos = Lib.concat(allPos, pos0);
-            delete tracei._autoBinFinished;
-            if(trace.visible === true) {
-                if(isFirstVisible) {
-                    isFirstVisible = false;
-                }
-                else {
-                    delete tracei._autoBin;
-                    tracei._autoBinFinished = 1;
+            if(tracei.visible) {
+                pos0 = tracei._pos0 = pa.makeCalcdata(tracei, mainData);
+                allPos = Lib.concat(allPos, pos0);
+                delete tracei._autoBinFinished;
+                if(trace.visible === true) {
+                    if(isFirstVisible) {
+                        isFirstVisible = false;
+                    }
+                    else {
+                        delete tracei._autoBin;
+                        tracei._autoBinFinished = 1;
+                    }
                 }
             }
         }

--- a/test/jasmine/tests/histogram_test.js
+++ b/test/jasmine/tests/histogram_test.js
@@ -796,6 +796,8 @@ describe('Test histogram', function() {
                 x: [1, 2, 3], type: 'histogram'
             }, {
                 x: [1, 2, 3], type: 'histogram'
+            }, {
+                type: 'histogram'
             }])
             .then(function() {
                 assertTraceCount(3);
@@ -834,32 +836,33 @@ describe('Test histogram', function() {
             Plotly.newPlot(gd, [
                 {type: 'histogram', x: [1]},
                 {type: 'histogram', x: [10, 10.1, 10.2, 10.3]},
-                {type: 'histogram', x: [20, 20, 20, 20, 20, 20, 20, 20, 20, 21]}
+                {type: 'histogram', x: [20, 20, 20, 20, 20, 20, 20, 20, 20, 21]},
+                {type: 'histogram'}
             ])
             .then(function() {
-                _assertBinCenters([[0], [10], [20]]);
+                _assertBinCenters([[0], [10], [20], hidden]);
                 return Plotly.restyle(gd, 'visible', 'legendonly', [1, 2]);
             })
             .then(function() {
-                _assertBinCenters([[0], hidden, hidden]);
+                _assertBinCenters([[0], hidden, hidden, hidden]);
                 return Plotly.restyle(gd, 'visible', false, [1, 2]);
             })
             .then(function() {
-                _assertBinCenters([[1], hidden, hidden]);
+                _assertBinCenters([[1], hidden, hidden, hidden]);
                 return Plotly.restyle(gd, 'visible', [false, false, true]);
             })
             .then(function() {
-                _assertBinCenters([hidden, hidden, [20, 21]]);
+                _assertBinCenters([hidden, hidden, [20, 21], hidden]);
                 return Plotly.restyle(gd, 'visible', [false, true, false]);
             })
             .then(function() {
-                _assertBinCenters([hidden, [10.1, 10.3], hidden]);
+                _assertBinCenters([hidden, [10.1, 10.3], hidden, hidden]);
                 // only one trace is visible, despite traces being grouped
                 expect(gd._fullLayout.bargap).toBe(0);
                 return Plotly.restyle(gd, 'visible', ['legendonly', true, 'legendonly']);
             })
             .then(function() {
-                _assertBinCenters([hidden, [10], hidden]);
+                _assertBinCenters([hidden, [10], hidden, hidden]);
                 // legendonly traces still flip us back to gapped
                 expect(gd._fullLayout.bargap).toBe(0.2);
             })


### PR DESCRIPTION
... in `Histogram.calc` loop looking for `isFirstVisible` traces.

cc @plotly/plotly_js - a follow-up of https://github.com/plotly/plotly.js/pull/3044

cc @nicolaskruchten 

![peek 2018-12-17 14-01](https://user-images.githubusercontent.com/6675409/50108837-3f802c00-0204-11e9-904c-7c137963ac1f.gif)