### PR TITLE
Fix horizontal box/violin hover label misalignment under hovermode:'closest'

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1080,7 +1080,6 @@ function createHoverText(hoverData, opts, gd) {
 // information then.
 function hoverAvoidOverlaps(hoverData, ax, fullLayout) {
     var nummoves = 0;
-
     var axSign = 1;
 
     // make groups of touching points
@@ -1326,7 +1325,7 @@ function cleanPoint(d, hovermode) {
     fill('fontColor', 'htc', 'hoverlabel.font.color');
     fill('nameLength', 'hnl', 'hoverlabel.namelength');
 
-    d.posref = hovermode === 'y' ?
+    d.posref = (hovermode === 'y' || (hovermode === 'closest' && trace.orientation === 'h')) ?
         (d.xa._offset + (d.x0 + d.x1) / 2) :
         (d.ya._offset + (d.y0 + d.y1) / 2);
 

--- a/test/jasmine/tests/box_test.js
+++ b/test/jasmine/tests/box_test.js
@@ -312,6 +312,29 @@ describe('Test box hover:', function() {
         },
         nums: 'look:0.7',
         name: ''
+    }, {
+        desc: 'orientation:h | hovermode;y',
+        mock: require('@mocks/box_grouped_horz.json'),
+        pos: [430, 130],
+        nums: [
+            'max: 1', 'mean ± σ: 0.6833333 ± 0.2409472', 'min: 0.3',
+            'q1: 0.5', 'q3: 0.9', 'median: 0.7'],
+        name: ['', '', '', '', '', 'carrots'],
+        axis: 'day 2',
+        hOrder: [0, 4, 5, 1, 3, 2]
+    }, {
+        desc: 'orientation:h | hovermode:closest',
+        mock: require('@mocks/box_grouped_horz.json'),
+        patch: function(fig) {
+            fig.layout.hovermode = 'closest';
+            return fig;
+        },
+        pos: [430, 130],
+        nums: [
+            '(max: 1, day 2)', '(mean ± σ: 0.6833333 ± 0.2409472, day 2)', '(min: 0.3, day 2)',
+            '(q1: 0.5, day 2)', '(q3: 0.9, day 2)', '(median: 0.7, day 2)'],
+        name: ['', '', '', '', '', 'carrots'],
+        hOrder: [0, 4, 5, 1, 3, 2]
     }].forEach(function(specs) {
         it('should generate correct hover labels ' + specs.desc, function(done) {
             run(specs).catch(failTest).then(done);

--- a/test/jasmine/tests/box_test.js
+++ b/test/jasmine/tests/box_test.js
@@ -313,7 +313,7 @@ describe('Test box hover:', function() {
         nums: 'look:0.7',
         name: ''
     }, {
-        desc: 'orientation:h | hovermode;y',
+        desc: 'orientation:h | hovermode:y',
         mock: require('@mocks/box_grouped_horz.json'),
         pos: [430, 130],
         nums: [

--- a/test/jasmine/tests/violin_test.js
+++ b/test/jasmine/tests/violin_test.js
@@ -490,7 +490,7 @@ describe('Test violin hover:', function() {
         name: '',
         isRotated: false
     }, {
-        desc: 'orientation:h | hovermode;y',
+        desc: 'orientation:h | hovermode:y',
         mock: require('@mocks/violin_grouped_horz-multicategory.json'),
         patch: function(fig) {
             // don't hover on kde, to avoid local vs CI discrepancies

--- a/test/jasmine/tests/violin_test.js
+++ b/test/jasmine/tests/violin_test.js
@@ -489,6 +489,29 @@ describe('Test violin hover:', function() {
         nums: '(96, Old Faithful)',
         name: '',
         isRotated: false
+    }, {
+        desc: 'orientation:h | hovermode;y',
+        mock: require('@mocks/violin_grouped_horz-multicategory.json'),
+        pos: [430, 130],
+        nums: ['max: 0.9', 'min: 0.1', 'q1: 0.2', 'q3: 0.7', 'x: 0.7963605, kde: 0.445', 'median: 0.4'],
+        name: ['', '', '', '', '', 'kale'],
+        axis: '2018 - day 2',
+        hOrder: [0, 4, 3, 5, 2, 1]
+    }, {
+        desc: 'orientation:h | hovermode:closest',
+        mock: require('@mocks/violin_grouped_horz-multicategory.json'),
+        patch: function(fig) {
+            fig.layout.hovermode = 'closest';
+            return fig;
+        },
+        pos: [430, 130],
+        nums: [
+            '(max: 0.9, 2018 - day 2)', '(min: 0.1, 2018 - day 2)',
+            '(q1: 0.2, 2018 - day 2)', '(q3: 0.7, 2018 - day 2)',
+            '(x: 0.7963605, kde: 0.445, 2018 - day 2)', '(median: 0.4, 2018 - day 2)'
+        ],
+        name: ['', '', '', '', '', 'kale'],
+        hOrder: [0, 4, 3, 5, 2, 1]
     }]
     .forEach(function(specs) {
         it('should generate correct hover labels ' + specs.desc, function(done) {

--- a/test/jasmine/tests/violin_test.js
+++ b/test/jasmine/tests/violin_test.js
@@ -492,15 +492,26 @@ describe('Test violin hover:', function() {
     }, {
         desc: 'orientation:h | hovermode;y',
         mock: require('@mocks/violin_grouped_horz-multicategory.json'),
+        patch: function(fig) {
+            // don't hover on kde, to avoid local vs CI discrepancies
+            fig.data.forEach(function(t) {
+                t.hoveron = 'violins';
+            });
+            return fig;
+        },
         pos: [430, 130],
-        nums: ['max: 0.9', 'min: 0.1', 'q1: 0.2', 'q3: 0.7', 'x: 0.7963605, kde: 0.445', 'median: 0.4'],
-        name: ['', '', '', '', '', 'kale'],
+        nums: ['max: 0.9', 'min: 0.1', 'q1: 0.2', 'q3: 0.7', 'median: 0.4'],
+        name: ['', '', '', '', 'kale'],
         axis: '2018 - day 2',
-        hOrder: [0, 4, 3, 5, 2, 1]
+        hOrder: [0, 3, 4, 2, 1]
     }, {
         desc: 'orientation:h | hovermode:closest',
         mock: require('@mocks/violin_grouped_horz-multicategory.json'),
         patch: function(fig) {
+            // don't hover on kde, to avoid local vs CI discrepancies
+            fig.data.forEach(function(t) {
+                t.hoveron = 'violins';
+            });
             fig.layout.hovermode = 'closest';
             return fig;
         },
@@ -508,10 +519,10 @@ describe('Test violin hover:', function() {
         nums: [
             '(max: 0.9, 2018 - day 2)', '(min: 0.1, 2018 - day 2)',
             '(q1: 0.2, 2018 - day 2)', '(q3: 0.7, 2018 - day 2)',
-            '(x: 0.7963605, kde: 0.445, 2018 - day 2)', '(median: 0.4, 2018 - day 2)'
+            '(median: 0.4, 2018 - day 2)'
         ],
-        name: ['', '', '', '', '', 'kale'],
-        hOrder: [0, 4, 3, 5, 2, 1]
+        name: ['', '', '', '', 'kale'],
+        hOrder: [0, 3, 4, 2, 1]
     }]
     .forEach(function(specs) {
         it('should generate correct hover labels ' + specs.desc, function(done) {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3050 (although it might worth moving https://github.com/plotly/plotly.js/issues/3050#issuecomment-424508921 into a new issue).

The idea behind this patch came from @nicolaskruchten 's https://github.com/plotly/plotly.js/pull/3396 - which revealed that something was wrong with how box/violin horizontal hover labels were sorted before the avoid-overlap algo. This PR is essentially a continuation of https://github.com/plotly/plotly.js/pull/3043

I have to add some tolerance in the kde hover label text assertion, but other than that this PR is ready to review cc @plotly/plotly_js 