### PR TITLE
Renaming old attributes should not replace existing current attributes if both provided 

### DIFF
--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -319,11 +319,11 @@ exports.cleanData = function(data) {
 
         // scl->scale, reversescl->reversescale
         if('scl' in trace) {
-            trace.colorscale = trace.scl;
+            if(!('colorscale' in trace)) { trace.colorscale = trace.scl; }
             delete trace.scl;
         }
         if('reversescl' in trace) {
-            trace.reversescale = trace.reversescl;
+            if(!('reversescale' in trace)) { trace.reversescale = trace.reversescl; }
             delete trace.reversescl;
         }
 

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -318,12 +318,12 @@ exports.cleanData = function(data) {
         }
 
         // scl->scale, reversescl->reversescale
-        if('scl' in trace) {
-            if(!('colorscale' in trace)) { trace.colorscale = trace.scl; }
+        if('scl' in trace && !('colorscale' in trace)) {
+            trace.colorscale = trace.scl;
             delete trace.scl;
         }
-        if('reversescl' in trace) {
-            if(!('reversescale' in trace)) { trace.reversescale = trace.reversescl; }
+        if('reversescl' in trace && !('reversescale' in trace)) {
+            trace.reversescale = trace.reversescl;
             delete trace.reversescl;
         }
 

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -2254,6 +2254,52 @@ describe('Test plot api', function() {
 
         afterEach(destroyGraphDiv);
 
+        it('should rename \'scl\' to \'colorscale\' when colorscale is not defined', function() {
+            var data = [{
+                type: 'heatmap',
+                scl: 'Blues'
+            }];
+
+            Plotly.plot(gd, data);
+            expect(gd.data[0].colorscale).toBe('Blues');
+            expect(gd.data[0].scl).toBe(undefined);
+        });
+
+        it('should not rename \'scl\' to \'colorscale\' when colorscale is defined ', function() {
+            var data = [{
+                type: 'heatmap',
+                colorscale: 'Greens',
+                scl: 'Reds'
+            }];
+
+            Plotly.plot(gd, data);
+            expect(gd.data[0].colorscale).toBe('Greens');
+            expect(gd.data[0].scl).toBe(undefined);
+        });
+
+        it('should rename \'reversescl\' to \'reversescale\' when colorscale is not defined', function() {
+            var data = [{
+                type: 'heatmap',
+                reversescl: true
+            }];
+
+            Plotly.plot(gd, data);
+            expect(gd.data[0].reversescale).toBe(true);
+            expect(gd.data[0].reversescl).toBe(undefined);
+        });
+
+        it('should not rename \'scl\' to \'colorscale\' when colorscale is defined ', function() {
+            var data = [{
+                type: 'heatmap',
+                reversescale: true,
+                reversescl: false
+            }];
+
+            Plotly.plot(gd, data);
+            expect(gd.data[0].reversescale).toBe(true);
+            expect(gd.data[0].reversescl).toBe(undefined);
+        });
+
         it('should rename \'YIGnBu\' colorscales YlGnBu (2dMap case)', function() {
             var data = [{
                 type: 'heatmap',

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -2265,7 +2265,7 @@ describe('Test plot api', function() {
             expect(gd.data[0].scl).toBe(undefined);
         });
 
-        it('should not rename \'scl\' to \'colorscale\' when colorscale is defined ', function() {
+        it('should not delete rename \'scl\' to \'colorscale\' when colorscale is defined ', function() {
             var data = [{
                 type: 'heatmap',
                 colorscale: 'Greens',
@@ -2274,7 +2274,7 @@ describe('Test plot api', function() {
 
             Plotly.plot(gd, data);
             expect(gd.data[0].colorscale).toBe('Greens');
-            expect(gd.data[0].scl).toBe(undefined);
+            expect(gd.data[0].scl).not.toBe(undefined);
         });
 
         it('should rename \'reversescl\' to \'reversescale\' when colorscale is not defined', function() {
@@ -2288,7 +2288,7 @@ describe('Test plot api', function() {
             expect(gd.data[0].reversescl).toBe(undefined);
         });
 
-        it('should not rename \'scl\' to \'colorscale\' when colorscale is defined ', function() {
+        it('should not delete & rename \'reversescl\' to \'reversescale\' when colorscale is defined', function() {
             var data = [{
                 type: 'heatmap',
                 reversescale: true,
@@ -2297,7 +2297,7 @@ describe('Test plot api', function() {
 
             Plotly.plot(gd, data);
             expect(gd.data[0].reversescale).toBe(true);
-            expect(gd.data[0].reversescl).toBe(undefined);
+            expect(gd.data[0].reversescl).not.toBe(undefined);
         });
 
         it('should rename \'YIGnBu\' colorscales YlGnBu (2dMap case)', function() {


### PR DESCRIPTION
Fix #3419 
@plotly/plotly_js 