### PR TITLE
Show box/violin position when hovering over pts

### DIFF
--- a/src/traces/box/hover.js
+++ b/src/traces/box/hover.js
@@ -240,15 +240,25 @@ function hoverOnPoints(pointData, xval, yval) {
         name: trace.name,
         x0: xc - rad,
         x1: xc + rad,
-        xLabelVal: pt.x,
         y0: yc - rad,
         y1: yc + rad,
-        yLabelVal: pt.y,
         spikeDistance: pointData.distance
     });
-    var pLetter = trace.orientation === 'h' ? 'y' : 'x';
-    var pa = trace.orientation === 'h' ? ya : xa;
+
+    var pa;
+    if(trace.orientation === 'h') {
+        pa = ya;
+        closePtData.xLabelVal = pt.x;
+        closePtData.yLabelVal = di.pos;
+    } else {
+        pa = xa;
+        closePtData.xLabelVal = di.pos;
+        closePtData.yLabelVal = pt.y;
+    }
+
+    var pLetter = pa._id.charAt(0);
     closePtData[pLetter + 'Spike'] = pa.c2p(di.pos, true);
+
     fillHoverText(pt, trace, closePtData);
 
     return closePtData;

--- a/test/jasmine/tests/box_test.js
+++ b/test/jasmine/tests/box_test.js
@@ -335,6 +335,21 @@ describe('Test box hover:', function() {
             '(q1: 0.5, day 2)', '(q3: 0.9, day 2)', '(median: 0.7, day 2)'],
         name: ['', '', '', '', '', 'carrots'],
         hOrder: [0, 4, 5, 1, 3, 2]
+    }, {
+        desc: 'on boxpoints with numeric positions | hovermode:closest',
+        mock: {
+            data: [{
+                type: 'box',
+                boxpoints: 'all',
+                jitter: 0,
+                x: [2, 2, 2, 2, 2],
+                y: [13.1, 14.2, 14, 13, 13.3]
+            }],
+            layout: {hovermode: 'closest'}
+        },
+        pos: [202, 335],
+        nums: '(2, 13.1)',
+        name: ''
     }].forEach(function(specs) {
         it('should generate correct hover labels ' + specs.desc, function(done) {
             run(specs).catch(failTest).then(done);

--- a/test/jasmine/tests/violin_test.js
+++ b/test/jasmine/tests/violin_test.js
@@ -523,6 +523,22 @@ describe('Test violin hover:', function() {
         ],
         name: ['', '', '', '', 'kale'],
         hOrder: [0, 3, 4, 2, 1]
+    }, {
+        desc: 'on points with numeric positions | orientation:h | hovermode:closest',
+        mock: {
+            data: [{
+                type: 'violin',
+                points: 'all',
+                jitter: 0,
+                orientation: 'h',
+                y: [2, 2, 2, 2, 2],
+                x: [13.1, 14.2, 14, 13, 13.3]
+            }],
+            layout: {hovermode: 'closest'}
+        },
+        pos: [417, 309],
+        nums: '(14, 2)',
+        name: ''
     }]
     .forEach(function(specs) {
         it('should generate correct hover labels ' + specs.desc, function(done) {


### PR DESCRIPTION
... instead of showing the point's position - fixes https://github.com/plotly/plotly.js/issues/3440

https://codepen.io/etpinard/pen/NeVaYR?editors=1010

now looks like:

![peek 2019-01-17 10-27](https://user-images.githubusercontent.com/6675409/51328977-826f3280-1a42-11e9-8315-75f93a0c5456.gif)

Note that this was only a problem for box/violin traces with numeric positions (e.g. with set `x` and `y` arrays) under `hovermode:'closest'`, as deeper down `Fx.hover` 

https://github.com/plotly/plotly.js/blob/cc4597257b411688b2bbc6dbe90f8a6e78cc96c8/src/components/fx/hover.js#L1341-L1348

calls [`Axes.hoverLabelText`](https://github.com/plotly/plotly.js/blob/cc4597257b411688b2bbc6dbe90f8a6e78cc96c8/src/plots/cartesian/axes.js#L1008-L1025) which then formats the positions back to categories with: 

https://github.com/plotly/plotly.js/blob/cc4597257b411688b2bbc6dbe90f8a6e78cc96c8/src/plots/cartesian/axes.js#L1164-L1168