### PR TITLE
Disable dark highlights from Mesh3d

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4854,9 +4854,8 @@
       }
     },
     "gl-mesh3d": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.0.5.tgz",
-      "integrity": "sha512-RBTQ3xzzQV7VXPQsW7JYKgo31FbYYY5Jw2spwShxABbwKXc9/EnEIk5mUvdvO8Nu8FbOI0JGtSEYFOxHhpszBQ==",
+      "version": "git://github.com/gl-vis/gl-mesh3d.git#939428fcf4bc2b000d333f413ece3ab030330ee6",
+      "from": "git://github.com/gl-vis/gl-mesh3d.git#939428fcf4bc2b000d333f413ece3ab030330ee6",
       "requires": {
         "barycentric": "^1.0.1",
         "colormap": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4854,8 +4854,9 @@
       }
     },
     "gl-mesh3d": {
-      "version": "git://github.com/gl-vis/gl-mesh3d.git#939428fcf4bc2b000d333f413ece3ab030330ee6",
-      "from": "git://github.com/gl-vis/gl-mesh3d.git#939428fcf4bc2b000d333f413ece3ab030330ee6",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.0.6.tgz",
+      "integrity": "sha512-uuxXeeJiwQMf6qlYUMMm75653G5+7dJ/oWHD5VGuKemgATzPraFunkw0lbMWmJUMLHIlIEoAUcLOa1ccES/deg==",
       "requires": {
         "barycentric": "^1.0.1",
         "colormap": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gl-heatmap2d": "^1.0.5",
     "gl-line3d": "^1.1.8",
     "gl-mat4": "^1.2.0",
-    "gl-mesh3d": "git://github.com/gl-vis/gl-mesh3d.git#939428fcf4bc2b000d333f413ece3ab030330ee6",
+    "gl-mesh3d": "^2.0.6",
     "gl-plot2d": "^1.4.1",
     "gl-plot3d": "^1.6.2",
     "gl-pointcloud2d": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gl-heatmap2d": "^1.0.5",
     "gl-line3d": "^1.1.8",
     "gl-mat4": "^1.2.0",
-    "gl-mesh3d": "^2.0.5",
+    "gl-mesh3d": "git://github.com/gl-vis/gl-mesh3d.git#939428fcf4bc2b000d333f413ece3ab030330ee6",
     "gl-plot2d": "^1.4.1",
     "gl-plot3d": "^1.6.2",
     "gl-pointcloud2d": "^1.0.2",


### PR DESCRIPTION
Fixes #3462 using newly published `gl-mesh3d` module by not allowing negative highlights.
Example below illustrate a desirable result after using `gl-mesh3d` v.2.0.6
@etpinard cc: @plotly/plotly_js 
![newplot 1 1](https://user-images.githubusercontent.com/33888540/51578993-64b02c00-1e8d-11e9-8c7a-0640e02394cb.png)
