### PR TITLE
Add info about 2D array `fill.color` input in table attributes

### DIFF
--- a/src/traces/table/attributes.js
+++ b/src/traces/table/attributes.js
@@ -110,7 +110,7 @@ var attrs = module.exports = overrideAll({
                 role: 'style',
                 description: [
                     'Sets the cell fill color. It accepts either a specific color',
-                    ' or an array of colors.'
+                    ' or an array of colors or a 2D array of colors.'
                 ].join('')
             }
         },
@@ -190,7 +190,7 @@ var attrs = module.exports = overrideAll({
                 dflt: 'white',
                 description: [
                     'Sets the cell fill color. It accepts either a specific color',
-                    ' or an array of colors.'
+                    ' or an array of colors or a 2D array of colors.'
                 ].join('')
             }
         },


### PR DESCRIPTION
as recommended in https://github.com/plotly/plotly.js/issues/3472#issuecomment-457249376