### PR TITLE
No more allowing specular greater than one on mesh3d

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4854,9 +4854,9 @@
       }
     },
     "gl-mesh3d": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.0.6.tgz",
-      "integrity": "sha512-uuxXeeJiwQMf6qlYUMMm75653G5+7dJ/oWHD5VGuKemgATzPraFunkw0lbMWmJUMLHIlIEoAUcLOa1ccES/deg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.0.7.tgz",
+      "integrity": "sha512-sP4qv1c3nBRfCJmW499DldibUjm7DNVOJMiyTS33Q39dcBGPdI9u1yzpzIRi6eQ216DZasaKZrLPF6W7nEABkQ==",
       "requires": {
         "barycentric": "^1.0.1",
         "colormap": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gl-heatmap2d": "^1.0.5",
     "gl-line3d": "^1.1.8",
     "gl-mat4": "^1.2.0",
-    "gl-mesh3d": "^2.0.6",
+    "gl-mesh3d": "^2.0.7",
     "gl-plot2d": "^1.4.2",
     "gl-plot3d": "^1.6.3",
     "gl-pointcloud2d": "^1.0.2",


### PR DESCRIPTION
Fixes #3482 by setting the limit of one and bumping `gl-mesh3d` module to 2.0.7
Image below illustrates the correct behaviour when compared to the one presented on #3482.
@etpinard 
![after](https://user-images.githubusercontent.com/33888540/51721907-9fe36400-2021-11e9-8831-66996482b52f.png)
