### PR TITLE
Fix annotations SVG errors on trace-less subplots

### DIFF
--- a/src/components/annotations/draw.js
+++ b/src/components/annotations/draw.js
@@ -67,6 +67,9 @@ function drawOne(gd, index) {
     var xa = Axes.getFromId(gd, options.xref);
     var ya = Axes.getFromId(gd, options.yref);
 
+    if(xa) xa.setScale();
+    if(ya) ya.setScale();
+
     drawRaw(gd, options, index, false, xa, ya);
 }
 

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -399,6 +399,29 @@ function computeTraceBounds(scene, trace, bounds) {
     }
 }
 
+function computeAnnotationBounds(scene, bounds) {
+    var sceneLayout = scene.fullSceneLayout;
+    var annotations = sceneLayout.annotations || [];
+
+    for(var d = 0; d < 3; d++) {
+        var axisName = axisProperties[d];
+        var axLetter = axisName.charAt(0);
+        var ax = sceneLayout[axisName];
+
+        for(var j = 0; j < annotations.length; j++) {
+            var ann = annotations[j];
+
+            if(ann.visible) {
+                var pos = ax.r2l(ann[axLetter]);
+                if(!isNaN(pos) && isFinite(pos)) {
+                    bounds[0][d] = Math.min(bounds[0][d], pos);
+                    bounds[1][d] = Math.max(bounds[1][d], pos);
+                }
+            }
+        }
+    }
+}
+
 proto.plot = function(sceneData, fullLayout, layout) {
     // Save parameters
     this.plotArgs = [sceneData, fullLayout, layout];
@@ -443,18 +466,20 @@ proto.plot = function(sceneData, fullLayout, layout) {
         [Infinity, Infinity, Infinity],
         [-Infinity, -Infinity, -Infinity]
     ];
+
     for(i = 0; i < sceneData.length; ++i) {
         data = sceneData[i];
         if(data.visible !== true) continue;
 
         computeTraceBounds(this, data, dataBounds);
     }
+    computeAnnotationBounds(this, dataBounds);
+
     var dataScale = [1, 1, 1];
     for(j = 0; j < 3; ++j) {
         if(dataBounds[1][j] === dataBounds[0][j]) {
             dataScale[j] = 1.0;
-        }
-        else {
+        } else {
             dataScale[j] = 1.0 / (dataBounds[1][j] - dataBounds[0][j]);
         }
     }

--- a/test/image/strict-d3.js
+++ b/test/image/strict-d3.js
@@ -58,6 +58,10 @@ function checkAttrVal(sel, key, val) {
     if(/--/.test(val) && isNumeric(val.split('--')[1].charAt(0))) {
         throw new Error('d3 selection.attr called with value ' + val + ' which includes a double negative');
     }
+
+    if(/transform/.test(key) && /NaN/.test(val)) {
+        throw new Error('d3 selection.attr called with ' + key + ' ' + val + ' containing a NaN');
+    }
 }
 
 function checkStyleVal(sel, key, val) {

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -814,6 +814,28 @@ describe('annotations autorange', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('should not error out on subplots w/o visible traces', function(done) {
+        Plotly.plot(gd, [{}], {
+            annotations: [{
+                x: 0.1,
+                y: 0.1,
+                text: 't',
+                showarrow: false
+            }, {
+                x: 0.2,
+                y: 0.3,
+                text: 'a'
+            }]
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis.range).toBeCloseToArray([0.099, 0.201], 1, 'x rng');
+            expect(gd._fullLayout.yaxis.range).toBeCloseToArray([0.091, 0.335], 1, 'y rng');
+            assertVisible([0, 1]);
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('annotation clicktoshow', function() {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3526 - which was slightly misreported, this bug has nothing to do with heatmaps. All cartesian autoranged subplots w/o a single `visible:true` trace were affected.

cc @plotly/plotly_js looking a for a quick review. I'll like to include this in tomorrow's `v1.44.4`. Thanks!