### PR TITLE
Adapt `Colorscale.crossTraceDefaults` to array ` _module.colorbar` definitions

### DIFF
--- a/src/components/colorscale/cross_trace_defaults.js
+++ b/src/components/colorscale/cross_trace_defaults.js
@@ -43,10 +43,16 @@ module.exports = function crossTraceDefaults(fullData) {
 
     for(var i = 0; i < fullData.length; i++) {
         var trace = fullData[i];
-        var _module = trace._module;
+        var colorbar = trace._module.colorbar;
 
-        if(_module.colorbar) {
-            relinkColorAtts(trace, _module.colorbar);
+        if(colorbar) {
+            if(Array.isArray(colorbar)) {
+                for(var j = 0; j < colorbar.length; j++) {
+                    relinkColorAtts(trace, colorbar[j]);
+                }
+            } else {
+                relinkColorAtts(trace, colorbar);
+            }
         }
 
         // TODO could generalize _module.colorscale and use it here?

--- a/test/jasmine/tests/colorscale_test.js
+++ b/test/jasmine/tests/colorscale_test.js
@@ -586,7 +586,10 @@ describe('Test colorscale restyle calls:', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(destroyGraphDiv);
+    afterEach(function() {
+        Plotly.purge(gd);
+        destroyGraphDiv();
+    });
 
     function getFill(q) {
         return d3.select(q).node().style.fill;
@@ -898,6 +901,30 @@ describe('Test colorscale restyle calls:', function() {
             _assert('after relayouting in template', {
                 mcc: ['rgb(68, 1, 84)', 'rgb(33, 145, 140)', 'rgb(253, 231, 37)']
             });
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('@gl should work with scatter3d', function(done) {
+        Plotly.plot(gd, [{
+            type: 'scatter3d',
+            x: [1, 2, 3],
+            y: [1, 2, 3],
+            z: [1, 2, 1],
+            marker: {color: [1, 2, 1], showscale: true}
+        }])
+        .then(function() {
+            expect(gd._fullData[0].marker.cmin).toBe(1);
+            expect(gd._fullData[0].marker.cmax).toBe(2);
+        })
+        .then(function() {
+            // some non-calc edit
+            return Plotly.relayout(gd, 'scene.dragmode', 'pab');
+        })
+        .then(function() {
+            expect(gd._fullData[0].marker.cmin).toBe(1);
+            expect(gd._fullData[0].marker.cmax).toBe(2);
         })
         .catch(failTest)
         .then(done);

--- a/test/jasmine/tests/colorscale_test.js
+++ b/test/jasmine/tests/colorscale_test.js
@@ -920,7 +920,7 @@ describe('Test colorscale restyle calls:', function() {
         })
         .then(function() {
             // some non-calc edit
-            return Plotly.relayout(gd, 'scene.dragmode', 'pab');
+            return Plotly.relayout(gd, 'scene.dragmode', 'pan');
         })
         .then(function() {
             expect(gd._fullData[0].marker.cmin).toBe(1);


### PR DESCRIPTION
fixes #3552 - introduced in https://github.com/plotly/plotly.js/pull/3384

@archmoj could you review this one?