### PR TITLE
Call styleTextSelection only on hasText traces

### DIFF
--- a/src/traces/scattergl/index.js
+++ b/src/traces/scattergl/index.js
@@ -634,7 +634,8 @@ function plot(gd, subplot, cdata) {
 
         if(scene.glText) {
             cdata.forEach(function(cdscatter) {
-                if(cdscatter && cdscatter[0] && cdscatter[0].trace) {
+                var trace = ((cdscatter || [])[0] || {}).trace || {};
+                if(subTypes.hasText(trace)) {
                     styleTextSelection(cdscatter);
                 }
             });

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -932,8 +932,9 @@ describe('Test gl2d plots', function() {
             var trace = {
                 x: [2],
                 y: [1],
+                text: ['a'],
                 type: 'scattergl',
-                mode: 'markers',
+                mode: 'markers+text',
                 marker: {color: 'red'}
             };
 
@@ -947,6 +948,8 @@ describe('Test gl2d plots', function() {
             expect(scene.unselectBatch).toEqual([[]]);
             expect(scene.markerOptions.length).toBe(2);
             expect(scene.markerOptions[1].color).toEqual(new Uint8Array([255, 0, 0, 255]));
+            expect(scene.textOptions.length).toBe(2);
+            expect(scene.textOptions[1].color).toEqual('#444');
             expect(scene.scatter2d.draw).toHaveBeenCalled();
 
             return Plotly.restyle(gd, 'selectedpoints', null);


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3559

cc @plotly/plotly_js you can compare old vs updated in codepens:

- old: https://codepen.io/anon/pen/JxVZeR?editors=1111
- updated: https://codepen.io/etpinard/pen/YBbova?editors=1111

