### PR TITLE
Display hoverlabels above modebar

### DIFF
--- a/build/plotcss.js
+++ b/build/plotcss.js
@@ -31,7 +31,7 @@ var rules = {
     "X .cursor-n-resize": "cursor:n-resize;",
     "X .cursor-ne-resize": "cursor:ne-resize;",
     "X .cursor-grab": "cursor:-webkit-grab;cursor:grab;",
-    "X .modebar": "position:absolute;top:2px;right:2px;z-index:1001;",
+    "X .modebar": "position:absolute;top:2px;right:2px;",
     "X .ease-bg": "-webkit-transition:background-color 0.3s ease 0s;-moz-transition:background-color 0.3s ease 0s;-ms-transition:background-color 0.3s ease 0s;-o-transition:background-color 0.3s ease 0s;transition:background-color 0.3s ease 0s;",
     "X .modebar--hover>:not(.watermark)": "opacity:0;-webkit-transition:opacity 0.3s ease 0s;-moz-transition:opacity 0.3s ease 0s;-ms-transition:opacity 0.3s ease 0s;-o-transition:opacity 0.3s ease 0s;transition:opacity 0.3s ease 0s;",
     "X:hover .modebar--hover .modebar-group": "opacity:1;",

--- a/src/css/_modebar.scss
+++ b/src/css/_modebar.scss
@@ -2,7 +2,6 @@
     position: absolute;
     top: 2px;
     right: 2px;
-    z-index: 1001;
 }
 
 .ease-bg {

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -3805,6 +3805,11 @@ function makePlotFramework(gd) {
     fullLayout._toppaper = fullLayout._paperdiv.append('svg')
         .classed('main-svg', true);
 
+    fullLayout._modebardiv = fullLayout._paperdiv.append('div');
+
+    fullLayout._hoverpaper = fullLayout._paperdiv.append('svg')
+        .classed('main-svg', true);
+
     if(!fullLayout._uid) {
         var otherUids = {};
         d3.selectAll('defs').each(function() {
@@ -3881,11 +3886,10 @@ function makePlotFramework(gd) {
     fullLayout._infolayer = fullLayout._toppaper.append('g').classed('infolayer', true);
     fullLayout._menulayer = fullLayout._toppaper.append('g').classed('menulayer', true);
     fullLayout._zoomlayer = fullLayout._toppaper.append('g').classed('zoomlayer', true);
-    fullLayout._hoverlayer = fullLayout._toppaper.append('g').classed('hoverlayer', true);
+    fullLayout._hoverlayer = fullLayout._hoverpaper.append('g').classed('hoverlayer', true);
 
     // Make the modebar container
-    fullLayout._modebardiv = fullLayout._paperdiv.selectAll('.modebar-container').data([0]);
-    fullLayout._modebardiv.enter().append('div')
+    fullLayout._modebardiv
         .classed('modebar-container', true)
         .style('position', 'absolute')
         .style('top', '0px')

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -329,7 +329,7 @@ describe('Test Plots', function() {
 
             it('should resize the main svgs', function() {
                 var mainSvgs = document.getElementsByClassName('main-svg');
-                expect(mainSvgs.length).toBe(2);
+                expect(mainSvgs.length).toBe(3);
 
                 for(var i = 0; i < mainSvgs.length; i++) {
                     var svg = mainSvgs[i];
@@ -343,7 +343,7 @@ describe('Test Plots', function() {
 
             it('should update the axis scales', function() {
                 var mainSvgs = document.getElementsByClassName('main-svg');
-                expect(mainSvgs.length).toBe(2);
+                expect(mainSvgs.length).toBe(3);
 
                 var fullLayout = gd._fullLayout;
                 var plotinfo = fullLayout._plots.xy;
@@ -357,7 +357,7 @@ describe('Test Plots', function() {
 
             it('should allow resizing by plot ID', function(done) {
                 var mainSvgs = document.getElementsByClassName('main-svg');
-                expect(mainSvgs.length).toBe(2);
+                expect(mainSvgs.length).toBe(3);
 
                 expect(typeof gd.id).toBe('string');
                 expect(gd.id).toBeTruthy();


### PR DESCRIPTION
Fixes #3471 

We now insert hoverlabels in a third `svg` element right after the modebar. This ensures that hoverlabels are always visible:
![screenshot_2019-02-28_17-44-55](https://user-images.githubusercontent.com/301546/53603881-e415d700-3b80-11e9-894f-70fd6d9a93bd.png)

We also :hocho: `z-index` for the modebar: it is now sandwiched based on its position in the DOM. This should fix the following issue seen in a Dash app where the `z-index:1001` really was problematic:
![53552498-b65a6f00-3b3b-11e9-805c-e37bba0753b2](https://user-images.githubusercontent.com/301546/53603973-2808dc00-3b81-11e9-88d8-e64d955362dc.png)



