### PR TITLE
Fix parcoords dimensions values & line coloring error with integer TypedArray

### DIFF
--- a/src/traces/parcoords/calc.js
+++ b/src/traces/parcoords/calc.js
@@ -46,10 +46,6 @@ function constHalf(len) {
     return out;
 }
 
-function isTypedArray(a) {
-    return !Array.isArray(a) && Lib.isArrayOrTypedArray(a);
-}
-
 function convertTypedArray(a) {
-    return (isTypedArray(a)) ? Array.prototype.slice.call(a) : a;
+    return (Lib.isTypedArray(a)) ? Array.prototype.slice.call(a) : a;
 }

--- a/src/traces/parcoords/calc.js
+++ b/src/traces/parcoords/calc.js
@@ -14,7 +14,13 @@ var Lib = require('../../lib');
 var wrap = require('../../lib/gup').wrap;
 
 module.exports = function calc(gd, trace) {
-    var cs = !!trace.line.colorscale && Lib.isArrayOrTypedArray(trace.line.color);
+
+    for(var i = 0; i < trace.dimensions.length; i++) {
+        trace.dimensions[i].values = convertTypedArray(trace.dimensions[i].values);
+    }
+    trace.line.color = convertTypedArray(trace.line.color);
+
+    var cs = !!trace.line.colorscale && Array.isArray(trace.line.color);
     var color = cs ? trace.line.color : constHalf(trace._length);
     var cscale = cs ? trace.line.colorscale : [[0, trace.line.color], [1, trace.line.color]];
 
@@ -38,4 +44,12 @@ function constHalf(len) {
         out[i] = 0.5;
     }
     return out;
+}
+
+function isTypedArray(a) {
+    return !Array.isArray(a) && Lib.isArrayOrTypedArray(a);
+}
+
+function convertTypedArray(a) {
+    return (isTypedArray(a)) ? Array.prototype.slice.call(a) : a;
 }

--- a/src/traces/parcoords/defaults.js
+++ b/src/traces/parcoords/defaults.js
@@ -20,12 +20,7 @@ var maxDimensionCount = require('./constants').maxDimensionCount;
 var mergeLength = require('./merge_length');
 
 function handleLineDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
-
     var lineColor = coerce('line.color', defaultColor);
-    if(!Array.isArray(lineColor) && Lib.isArrayOrTypedArray(lineColor)) {
-        // should convert typed arrays e.g. integers to real numbers
-        lineColor = traceOut.line.color = Array.prototype.slice.call(lineColor);
-    }
 
     if(hasColorscale(traceIn, 'line') && Lib.isArrayOrTypedArray(lineColor)) {
         if(lineColor.length) {
@@ -49,11 +44,6 @@ function dimensionDefaults(dimensionIn, dimensionOut) {
     }
 
     var values = coerce('values');
-    if(!Array.isArray(values) && Lib.isArrayOrTypedArray(values)) {
-        // should convert typed arrays e.g. integers to real numbers
-        values = dimensionOut.values = Array.prototype.slice.call(values);
-    }
-
     var visible = coerce('visible');
     if(!(values && values.length)) {
         visible = dimensionOut.visible = false;

--- a/src/traces/parcoords/defaults.js
+++ b/src/traces/parcoords/defaults.js
@@ -20,8 +20,8 @@ var maxDimensionCount = require('./constants').maxDimensionCount;
 var mergeLength = require('./merge_length');
 
 function handleLineDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
-    var lineColor = coerce('line.color', defaultColor);
 
+    var lineColor = coerce('line.color', defaultColor);
     if(!Array.isArray(lineColor) && Lib.isArrayOrTypedArray(lineColor)) {
         // should convert typed arrays e.g. integers to real numbers
         lineColor = traceOut.line.color = Array.prototype.slice.call(lineColor);
@@ -49,6 +49,11 @@ function dimensionDefaults(dimensionIn, dimensionOut) {
     }
 
     var values = coerce('values');
+    if(!Array.isArray(values) && Lib.isArrayOrTypedArray(values)) {
+        // should convert typed arrays e.g. integers to real numbers
+        values = dimensionOut.values = Array.prototype.slice.call(values);
+    }
+
     var visible = coerce('visible');
     if(!(values && values.length)) {
         visible = dimensionOut.visible = false;

--- a/src/traces/parcoords/defaults.js
+++ b/src/traces/parcoords/defaults.js
@@ -22,6 +22,11 @@ var mergeLength = require('./merge_length');
 function handleLineDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
     var lineColor = coerce('line.color', defaultColor);
 
+    if(!Array.isArray(lineColor) && Lib.isArrayOrTypedArray(lineColor)) {
+        // should convert typed arrays e.g. integers to real numbers
+        lineColor = traceOut.line.color = Array.prototype.slice.call(lineColor);
+    }
+
     if(hasColorscale(traceIn, 'line') && Lib.isArrayOrTypedArray(lineColor)) {
         if(lineColor.length) {
             coerce('line.colorscale');

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -145,6 +145,28 @@ describe('parcoords initialization tests', function() {
             });
         });
 
+        it('\'line.color\' should convert typed arrays to normal arrays', function() {
+            var fullTrace = _supply({
+                dimensions: [{
+                    range: [1, 5],
+                    label: 'A',
+                    values: [1, 4, 3]
+                }, {
+                    range: [1, 5],
+                    label: 'B',
+                    values: [3, 1.5, 2],
+                }, {
+                    range: [1, 5],
+                    label: 'C',
+                    values: [2, 4, 1],
+                }],
+                line: {
+                    color: new Int32Array([0, 1, 2])
+                }
+            });
+            expect(Array.isArray(fullTrace.line.color) === true).toEqual(true);
+        });
+
         it('\'domain\' specification should have a default', function() {
             var fullTrace = _supply({});
             expect(fullTrace.domain).toEqual({x: [0, 1], y: [0, 1]});

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -145,7 +145,7 @@ describe('parcoords initialization tests', function() {
             });
         });
 
-        it('\'line.color\' should convert typed arrays to normal arrays', function() {
+        it('\'dimensions.values\' and \'line.color\' should convert typed arrays to normal arrays', function() {
             var fullTrace = _supply({
                 dimensions: [{
                     range: [1, 5],
@@ -154,17 +154,19 @@ describe('parcoords initialization tests', function() {
                 }, {
                     range: [1, 5],
                     label: 'B',
-                    values: [3, 1.5, 2],
+                    values: new Float64Array([3, 1.5, 2]),
                 }, {
                     range: [1, 5],
                     label: 'C',
-                    values: [2, 4, 1],
+                    values: new Int32Array([2, 4, 1]),
                 }],
                 line: {
                     color: new Int32Array([0, 1, 2])
                 }
             });
             expect(Array.isArray(fullTrace.line.color) === true).toEqual(true);
+            expect(Array.isArray(fullTrace.dimensions[1].values) === true).toEqual(true);
+            expect(Array.isArray(fullTrace.dimensions[2].values) === true).toEqual(true);
         });
 
         it('\'domain\' specification should have a default', function() {

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -145,30 +145,6 @@ describe('parcoords initialization tests', function() {
             });
         });
 
-        it('\'dimensions.values\' and \'line.color\' should convert typed arrays to normal arrays', function() {
-            var fullTrace = _supply({
-                dimensions: [{
-                    range: [1, 5],
-                    label: 'A',
-                    values: [1, 4, 3]
-                }, {
-                    range: [1, 5],
-                    label: 'B',
-                    values: new Float64Array([3, 1.5, 2]),
-                }, {
-                    range: [1, 5],
-                    label: 'C',
-                    values: new Int32Array([2, 4, 1]),
-                }],
-                line: {
-                    color: new Int32Array([0, 1, 2])
-                }
-            });
-            expect(Array.isArray(fullTrace.line.color) === true).toEqual(true);
-            expect(Array.isArray(fullTrace.dimensions[1].values) === true).toEqual(true);
-            expect(Array.isArray(fullTrace.dimensions[2].values) === true).toEqual(true);
-        });
-
         it('\'domain\' specification should have a default', function() {
             var fullTrace = _supply({});
             expect(fullTrace.domain).toEqual({x: [0, 1], y: [0, 1]});
@@ -349,6 +325,30 @@ describe('parcoords initialization tests', function() {
             expect(fullTrace.line).toEqual({
                 color: '#444'
             });
+        });
+
+        it('\'dimensions.values\' and \'line.color\' should convert typed arrays to normal arrays', function() {
+            var fullTrace = _calc(Lib.extendDeep({}, base, {
+                dimensions: [{
+                    range: [1, 5],
+                    label: 'A',
+                    values: [1, 4, 3]
+                }, {
+                    range: [1, 5],
+                    label: 'B',
+                    values: new Float64Array([3, 1.5, 2]),
+                }, {
+                    range: [1, 5],
+                    label: 'C',
+                    values: new Int32Array([2, 4, 1]),
+                }],
+                line: {
+                    color: new Int32Array([0, 1, 2])
+                }
+            }));
+            expect(Array.isArray(fullTrace.line.color) === true).toEqual(true);
+            expect(Array.isArray(fullTrace.dimensions[1].values) === true).toEqual(true);
+            expect(Array.isArray(fullTrace.dimensions[2].values) === true).toEqual(true);
         });
     });
 });


### PR DESCRIPTION
Fixes two issues reported & discovered in #3595 resulted from `integer` rounding errors. 
- [x] case of `color.line` typed arrays e.g. int32
- [x] case of `dimensions.values` typed arrays e.g. int32

@plotly_js
[Codepen Before](https://codepen.io/jonmmease/pen/QoNgMe?editors=1010).
[Codepen After](https://codepen.io/MojtabaSamimi/pen/GeZzjj?editors=1010).
