### PR TITLE
Preserve marker size in scattergl traces with different glPixelRatio values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8892,17 +8892,23 @@
       "dev": true
     },
     "pxls": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.1.tgz",
-      "integrity": "sha512-942Z8pHA2TLje4NM34Y0Zb6SqvkXq8s+IOM50J1wsYvHdPZfnUNu6U2Qld95dy50HtC9aKi8ZpHcc/iQjsQmeQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
+      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
       "requires": {
         "arr-flatten": "^1.1.0",
         "compute-dims": "^1.1.0",
         "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
         "is-buffer": "^2.0.3",
         "to-uint8": "^1.4.1"
       },
       "dependencies": {
+        "is-browser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
+          "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
+        },
         "is-buffer": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
@@ -9342,9 +9348,8 @@
       }
     },
     "regl-scatter2d": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.1.3.tgz",
-      "integrity": "sha512-71DpYoJKAopjCP8kRgdReoBLIUre9vsoUgoWDEEeSHRsDEqIwPguhuEerxXpqY5zZ8P3COEqjYZ/sGpoeI8WCA==",
+      "version": "git://github.com/gl-vis/regl-scatter2d.git#0fcb2a5b014ee1d4a743ed72bbcfb8ba05ace39b",
+      "from": "git://github.com/gl-vis/regl-scatter2d.git#0fcb2a5b014ee1d4a743ed72bbcfb8ba05ace39b",
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9348,8 +9348,8 @@
       }
     },
     "regl-scatter2d": {
-      "version": "git://github.com/gl-vis/regl-scatter2d.git#0fcb2a5b014ee1d4a743ed72bbcfb8ba05ace39b",
-      "from": "git://github.com/gl-vis/regl-scatter2d.git#0fcb2a5b014ee1d4a743ed72bbcfb8ba05ace39b",
+      "version": "git://github.com/gl-vis/regl-scatter2d.git#6a8f3576467f41bc2f8d6a4e78c646e933532439",
+      "from": "git://github.com/gl-vis/regl-scatter2d.git#6a8f3576467f41bc2f8d6a4e78c646e933532439",
       "requires": {
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "regl": "^1.3.11",
     "regl-error2d": "^2.0.6",
     "regl-line2d": "3.0.13",
-    "regl-scatter2d": "^3.1.3",
+    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#0fcb2a5b014ee1d4a743ed72bbcfb8ba05ace39b",
     "regl-splom": "^1.0.6",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "regl": "^1.3.11",
     "regl-error2d": "^2.0.6",
     "regl-line2d": "3.0.13",
-    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#0fcb2a5b014ee1d4a743ed72bbcfb8ba05ace39b",
+    "regl-scatter2d": "git://github.com/gl-vis/regl-scatter2d.git#6a8f3576467f41bc2f8d6a4e78c646e933532439",
     "regl-splom": "^1.0.6",
     "right-now": "^1.0.0",
     "robust-orientation": "^1.1.3",


### PR DESCRIPTION
Fix #3246 for `scattergl` trace.
[Before codepen](https://codepen.io/anon/pen/aQwzEM).
[After codepen](https://codepen.io/MojtabaSamimi/pen/rRJgRK).