### PR TITLE
Bump gl-surface3d 1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5124,9 +5124,9 @@
       }
     },
     "gl-surface3d": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.4.2.tgz",
-      "integrity": "sha512-y+yYrkKk6stUApUuKyPyZydcXrjGT3O18WuULLSJsTeBD0+quCMyVAIS+YiyBvEwao1NKDk45CgxMxCY3DHZaA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.4.3.tgz",
+      "integrity": "sha512-ueOZIdvRFhOpyYrruAKF3rZWLhRzBpSDoa5hko97CSkBBTjqySS5Tmwv0JHZGZ7OYNPfUKHHeM51B9HOzWUB8g==",
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "bit-twiddle": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "gl-select-box": "^1.0.3",
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.2.0",
-    "gl-surface3d": "^1.4.2",
+    "gl-surface3d": "^1.4.3",
     "gl-text": "^1.1.6",
     "glslify": "^7.0.0",
     "has-hover": "^1.0.1",


### PR DESCRIPTION
In PR #3573 multiple modules were updated for more consistency pass down WebGL pixel ratio.
However; there was one remaining `gl.lineWidth` call in `gl-scatter3d` that needed similar consideration: https://github.com/gl-vis/gl-surface3d/commit/703a196f6d040fbf4c51fa1b3d6bb21870bcac5d which is noticed & fixed in a patch release.
This PR is to bump `gl-surface3d` to this latest version.
@antoinerg 

cc: @etpinard  
