### PR TITLE
Fix hovermode default logic for stacked scatter traces

### DIFF
--- a/src/components/fx/layout_defaults.js
+++ b/src/components/fx/layout_defaults.js
@@ -28,7 +28,7 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
         } else {
             // flag for 'horizontal' plots:
             // determines the state of the mode bar 'compare' hovermode button
-            layoutOut._isHoriz = isHoriz(fullData);
+            layoutOut._isHoriz = isHoriz(fullData, layoutOut);
             hovermodeDflt = layoutOut._isHoriz ? 'y' : 'x';
         }
     }
@@ -55,17 +55,19 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
     }
 };
 
-function isHoriz(fullData) {
-    var out = true;
+function isHoriz(fullData, fullLayout) {
+    var stackOpts = fullLayout._scatterStackOpts || {};
 
     for(var i = 0; i < fullData.length; i++) {
         var trace = fullData[i];
+        var subplot = trace.xaxis + trace.yaxis;
+        var subplotStackOpts = stackOpts[subplot] || {};
+        var groupOpts = subplotStackOpts[trace.stackgroup] || {};
 
-        if(trace.orientation !== 'h') {
-            out = false;
-            break;
+        if(trace.orientation !== 'h' && groupOpts.orientation !== 'h') {
+            return false;
         }
     }
 
-    return out;
+    return true;
 }

--- a/test/jasmine/tests/fx_test.js
+++ b/test/jasmine/tests/fx_test.js
@@ -58,6 +58,24 @@ describe('Fx defaults', function() {
         expect(layoutOut._isHoriz).toBe(true, 'isHoriz to true');
     });
 
+    it('should default (cartesian horizontal version, stacked scatter)', function() {
+        var layoutOut = _supply([{
+            orientation: 'h',
+            stackgroup: '1',
+            x: [1, 2, 3],
+            y: [1, 2, 1]
+        }, {
+            stackgroup: '1',
+            x: [1, 2, 3],
+            y: [1, 2, 1]
+        }])
+        .layout;
+
+        expect(layoutOut.hovermode).toBe('y', 'hovermode to y');
+        expect(layoutOut.dragmode).toBe('zoom', 'dragmode to zoom');
+        expect(layoutOut._isHoriz).toBe(true, 'isHoriz to true');
+    });
+
     it('should default (gl3d version)', function() {
         var layoutOut = _supply([{
             type: 'scatter3d',


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3619 - so that by default graphs with horizontally stacked scatter traces get the correct `hovermode: 'y'` default (that is, until https://github.com/plotly/plotly.js/issues/778 in v2 :smirk: )

cc @plotly/plotly_js note that `orientation` is only coerced into `fullData` once per stack. Unnecessary keys are removed [here](
https://github.com/plotly/plotly.js/blob/05884832cb59c9ec159141b791a4645d09b2d7c3/src/traces/scatter/stack_defaults.js#L86).