### PR TITLE
Clean CI run of gl hovers

### DIFF
--- a/test/jasmine/tests/cone_test.js
+++ b/test/jasmine/tests/cone_test.js
@@ -266,12 +266,12 @@ describe('Test cone interactions', function() {
 
         function _hover() {
             mouseEvent('mouseover', 200, 200);
-            return delay(20)();
         }
 
         Plotly.plot(gd, fig)
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 nums: ['x: 2', 'y: 2', 'z: 2', 'norm: 3.00'].join('\n')
@@ -281,6 +281,7 @@ describe('Test cone interactions', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 nums: ['u: 0', 'v: 3', 'w: 0'].join('\n')
@@ -302,6 +303,7 @@ describe('Test cone interactions', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 name: 'trace 0',
@@ -317,6 +319,7 @@ describe('Test cone interactions', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 name: 'LOOKOUT',
@@ -330,7 +333,6 @@ describe('Test cone interactions', function() {
     it('@gl should display hover labels (multi-trace case)', function(done) {
         function _hover() {
             mouseEvent('mouseover', 282, 240);
-            return delay(20)();
         }
 
         Plotly.plot(gd, [{
@@ -359,6 +361,7 @@ describe('Test cone interactions', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 nums: ['x: 1', 'y: 1', 'z: 1', 'norm: 1.41'].join('\n'),

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -183,7 +183,7 @@ describe('Test hover and click interactions', function() {
     afterEach(function(done) {
         Plotly.purge(gd);
         destroyGraphDiv();
-        setTimeout(done, 1000);
+        setTimeout(done, 1500);
     });
 
     it('@gl should output correct event data for scattergl', function(done) {

--- a/test/jasmine/tests/gl2d_pointcloud_test.js
+++ b/test/jasmine/tests/gl2d_pointcloud_test.js
@@ -230,6 +230,7 @@ describe('pointcloud traces', function() {
         .then(function() {
             _assertRange('base', [-0.548, 9.548], [-1.415, 10.415]);
         })
+        .then(delay(40))
         .then(function() { _drag([200, 200], [350, 350]); })
         .then(delay(40))
         .then(function() {
@@ -247,6 +248,7 @@ describe('pointcloud traces', function() {
         .then(function() {
             return Plotly.relayout(gd, 'dragmode', 'pan');
         })
+        .then(delay(40))
         .then(function() { _drag([200, 200], [350, 350]); })
         .then(delay(40))
         .then(function() {

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -194,7 +194,7 @@ describe('Test gl3d plots', function() {
         gd = createGraphDiv();
         ptData = {};
 
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 4000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 6000;
     });
 
     afterEach(function() {
@@ -207,7 +207,6 @@ describe('Test gl3d plots', function() {
 
         function _hover() {
             mouseEvent('mouseover', 300, 200);
-            return delay(20)();
         }
 
         Plotly.plot(gd, _mock)
@@ -217,7 +216,9 @@ describe('Test gl3d plots', function() {
                 ptData = eventData.points[0];
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent(
                 {
@@ -236,7 +237,6 @@ describe('Test gl3d plots', function() {
         function _hover() {
             mouseEvent('mouseover', 0, 0);
             mouseEvent('mouseover', 655, 221);
-            return delay(20)();
         }
 
         Plotly.plot(gd, _mock)
@@ -246,7 +246,9 @@ describe('Test gl3d plots', function() {
                 ptData = eventData.points[0];
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 100.75', 'y: −102.63', 'z: −102.63');
             assertEventData(100.75, -102.63, -102.63, 0, 0, {
@@ -267,7 +269,9 @@ describe('Test gl3d plots', function() {
                 x: [['2016-01-11', '2016-01-12', '2017-01-01', '2017-02-01']]
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: Jan 11, 2016', 'y: −102.63', 'z: −102.63');
 
@@ -275,7 +279,9 @@ describe('Test gl3d plots', function() {
                 x: [[new Date(2017, 2, 1), new Date(2017, 2, 2), new Date(2017, 2, 3), new Date(2017, 2, 4)]]
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: Mar 1, 2017', 'y: −102.63', 'z: −102.63');
 
@@ -286,25 +292,33 @@ describe('Test gl3d plots', function() {
                 'scene.zaxis.type': 'log'
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: Mar 1, 2017', 'y: a', 'z: 10');
 
             return Plotly.relayout(gd, 'scene.xaxis.calendar', 'chinese');
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 二 4, 2017', 'y: a', 'z: 10');
 
             return Plotly.restyle(gd, 'text', [['A', 'B', 'C', 'D']]);
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 二 4, 2017', 'y: a', 'z: 10', 'A');
 
             return Plotly.restyle(gd, 'hovertext', [['Apple', 'Banana', 'Clementine', 'Dragon fruit']]);
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 二 4, 2017', 'y: a', 'z: 10', 'Apple');
 
@@ -313,7 +327,9 @@ describe('Test gl3d plots', function() {
                 'hoverlabel.font.size': 20
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelStyle(d3.selectAll('g.hovertext'), {
                 bgcolor: 'rgb(255, 0, 0)',
@@ -329,7 +345,9 @@ describe('Test gl3d plots', function() {
                 'hoverlabel.font.family': 'Roboto'
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelStyle(d3.selectAll('g.hovertext'), {
                 bgcolor: 'rgb(255, 0, 0)',
@@ -341,7 +359,9 @@ describe('Test gl3d plots', function() {
 
             return Plotly.restyle(gd, 'hoverinfo', [[null, null, 'y', null]]);
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             var label = d3.selectAll('g.hovertext');
 
@@ -350,27 +370,33 @@ describe('Test gl3d plots', function() {
 
             return Plotly.restyle(gd, 'hoverinfo', [[null, null, 'dont+know', null]]);
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 二 4, 2017', 'y: a', 'z: 10', 'Apple');
 
             return Plotly.restyle(gd, 'hoverinfo', 'text');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'Apple');
 
             return Plotly.restyle(gd, 'hovertext', 'HEY');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'HEY');
 
             return Plotly.restyle(gd, 'hoverinfo', 'z');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, '10');
 
             return Plotly.restyle(gd, 'hovertemplate', 'THIS Y -- %{y}<extra></extra>');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'THIS Y -- a');
         })
@@ -384,7 +410,6 @@ describe('Test gl3d plots', function() {
 
         function _hover() {
             mouseEvent('mouseover', 300, 200);
-            return delay(20)();
         }
 
         Plotly.plot(gd, _mock)
@@ -394,7 +419,9 @@ describe('Test gl3d plots', function() {
                 ptData = eventData.points[0];
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 0.2', 'y: 2', 'z: 1,001.25');
             assertEventData(0.2, 2, 1001.25, 0, [1, 2]);
@@ -414,7 +441,6 @@ describe('Test gl3d plots', function() {
 
         function _hover() {
             mouseEvent('mouseover', 605, 271);
-            return delay(20)();
         }
 
         Plotly.plot(gd, _mock)
@@ -424,7 +450,9 @@ describe('Test gl3d plots', function() {
                 ptData = eventData.points[0];
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 1', 'y: 2', 'z: 43', 'one two');
             assertEventData(1, 2, 43, 0, [1, 2]);
@@ -436,7 +464,7 @@ describe('Test gl3d plots', function() {
                 fontColor: 'rgb(255, 255, 255)'
             }, 'initial');
 
-            Plotly.restyle(gd, {
+            return Plotly.restyle(gd, {
                 'hoverinfo': [[
                     ['all', 'all', 'all'],
                     ['all', 'all', 'y'],
@@ -451,7 +479,9 @@ describe('Test gl3d plots', function() {
                 ]]
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertEventData(1, 2, 43, 0, [1, 2], {
                 'hoverinfo': 'y',
@@ -475,7 +505,9 @@ describe('Test gl3d plots', function() {
                 'colorbar.ticktext': [['single tick!']]
             });
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertEventData(1, 2, 43, 0, [1, 2], {
                 'hoverinfo': 'y',
@@ -486,29 +518,37 @@ describe('Test gl3d plots', function() {
 
             return Plotly.restyle(gd, 'hoverinfo', 'z');
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, '43');
 
             return Plotly.restyle(gd, 'hoverinfo', 'text');
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'one two');
 
             return Plotly.restyle(gd, 'text', 'yo!');
         })
+        .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'yo!');
 
             return Plotly.restyle(gd, 'hovertext', 'ONE TWO');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'ONE TWO');
 
             return Plotly.restyle(gd, 'hovertemplate', '!!! %{z} !!!<extra></extra>');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, '!!! 43 !!!');
         })
@@ -522,7 +562,6 @@ describe('Test gl3d plots', function() {
         // with button 1 pressed
         function _click() {
             mouseEvent('mouseover', 605, 271, {buttons: 1});
-            return delay(20)();
         }
 
         Plotly.plot(gd, _mock)
@@ -532,6 +571,7 @@ describe('Test gl3d plots', function() {
                 ptData = eventData.points[0];
             });
         })
+        .then(delay(20))
         .then(_click)
         .then(delay(20))
         .then(function() {
@@ -554,7 +594,6 @@ describe('Test gl3d plots', function() {
 
         function _hover() {
             mouseEvent('mouseover', 250, 250);
-            return delay(20)();
         }
 
         Plotly.newPlot(gd, [{
@@ -569,24 +608,28 @@ describe('Test gl3d plots', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverText('x: 4', 'y: 5', 'z: 3.5', 'ts: 4\nhz: 5\nftt:3.5');
         })
         .then(function() {
             return Plotly.restyle(gd, 'hoverinfo', 'x+y');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText('(4, 5)');
         })
         .then(function() {
             return Plotly.restyle(gd, 'hoverinfo', 'text');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText('ts: 4\nhz: 5\nftt:3.5');
         })
         .then(function() {
             return Plotly.restyle(gd, 'text', 'yo!');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'yo!');
         })
@@ -595,12 +638,14 @@ describe('Test gl3d plots', function() {
                 text.map(function(tx) { return tx + ' !!'; })
             ]);
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, 'ts: 4\nhz: 5\nftt:3.5 !!');
         })
         .then(function() {
             return Plotly.restyle(gd, 'hovertemplate', '%{x}-%{y}-%{z}<extra></extra>');
         })
+        .then(delay(20))
         .then(function() {
             assertHoverText(null, null, null, '4-5-3.5');
         })

--- a/test/jasmine/tests/isosurface_test.js
+++ b/test/jasmine/tests/isosurface_test.js
@@ -331,27 +331,16 @@ describe('Test isosurface', function() {
 
             function _hover1() {
                 mouseEvent('mouseover', 200, 200);
-                return delay(20)();
             }
 
             function _hover2() {
                 mouseEvent('mouseover', 100, 100);
-                return delay(20)();
-            }
-
-            function _hover3() {
-                mouseEvent('mouseover', 300, 150);
-                return delay(20)();
-            }
-
-            function _hover4() {
-                mouseEvent('mouseover', 150, 300);
-                return delay(20)();
             }
 
             Plotly.plot(gd, fig)
             .then(delay(20))
             .then(_hover1)
+            .then(delay(20))
             .then(function() {
                 assertHoverLabelContent({
                     nums: [
@@ -364,6 +353,7 @@ describe('Test isosurface', function() {
             })
             .then(delay(20))
             .then(_hover2)
+            .then(delay(20))
             .then(function() {
                 assertHoverLabelContent({
                     nums: [
@@ -374,45 +364,21 @@ describe('Test isosurface', function() {
                     ].join('\n')
                 });
             })
-            .then(delay(20))
-            .then(_hover3)
-            .then(function() {
-                assertHoverLabelContent({
-                    nums: [
-                        'x: 0.3',
-                        'y: 100μ',
-                        'z: −8',
-                        'value: −1.19'
-                    ].join('\n')
-                });
-            })
-            .then(delay(20))
-            .then(_hover4)
-            .then(function() {
-                assertHoverLabelContent({
-                    nums: [
-                        'x: 0.4',
-                        'y: 100μ',
-                        'z: −2',
-                        'value: −1.29'
-                    ].join('\n')
-                });
-            })
             .then(function() {
                 return Plotly.restyle(gd, 'hovertext', [
                     fig.data[0].value.map(function(v) { return '!! ' + v + ' !!'; })
                 ]);
             })
             .then(delay(20))
-            .then(_hover4)
+            .then(_hover2)
             .then(function() {
                 assertHoverLabelContent({
                     nums: [
                         'x: 0.4',
-                        'y: 100μ',
-                        'z: −2',
-                        'value: −1.29',
-                        '!! -1.29 !!'
+                        'y: 0.001',
+                        'z: −8',
+                        'value: −1.28',
+                        '!! -1.28 !!'
                     ].join('\n')
                 });
             })
@@ -420,10 +386,11 @@ describe('Test isosurface', function() {
                 return Plotly.restyle(gd, 'hovertemplate', '%{value}<br>(%{x},%{y},%{z})<extra>!!</extra>');
             })
             .then(delay(20))
-            .then(_hover4)
+            .then(_hover2)
+            .then(delay(20))
             .then(function() {
                 assertHoverLabelContent({
-                    nums: '−1.29\n(0.4,100μ,−2)',
+                    nums: '−1.28\n(0.4,0.001,−8)',
                     name: '!!'
                 });
             })

--- a/test/jasmine/tests/streamtube_test.js
+++ b/test/jasmine/tests/streamtube_test.js
@@ -316,12 +316,12 @@ describe('Test streamtube hover', function() {
 
         function _hover() {
             mouseEvent('mouseover', 188, 199);
-            return delay(20)();
         }
 
         Plotly.plot(gd, fig)
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 nums: [
@@ -336,6 +336,7 @@ describe('Test streamtube hover', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 nums: [
@@ -348,6 +349,7 @@ describe('Test streamtube hover', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({nums: 'divergence: 0.465'});
             return Plotly.restyle(gd, {
@@ -357,12 +359,14 @@ describe('Test streamtube hover', function() {
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({nums: '!SCALAR TX!'});
             return Plotly.restyle(gd, 'hovertext', 'SCALAR HOVERTEXT !!');
         })
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({nums: 'SCALAR HOVERTEXT !!'});
         })
@@ -385,12 +389,12 @@ describe('Test streamtube hover', function() {
 
         function _hover() {
             mouseEvent('mouseover', 193, 177);
-            return delay(20)();
         }
 
         Plotly.plot(gd, fig)
         .then(delay(20))
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             assertHoverLabelContent({
                 nums: [
@@ -426,7 +430,6 @@ describe('Test streamtube hover', function() {
 
         function _hover() {
             mouseEvent('mouseover', 188, 199);
-            return delay(20)();
         }
 
         Plotly.plot(gd, fig)
@@ -435,6 +438,7 @@ describe('Test streamtube hover', function() {
             gd.on('plotly_hover', function(d) { ptData = d.points[0]; });
         })
         .then(_hover)
+        .then(delay(20))
         .then(function() {
             if(ptData) {
                 expect(Object.keys(ptData).length).toBe(12, 'key cnt');


### PR DESCRIPTION
A follow up of PR #3585 now to help run the `gl+hover` tests on the CI much more smoothly! Recently we had to re-run `jasmine2` container few times after it failed several times which was not optimal. 
@plotly/plotly_js 