### PR TITLE
Rearrange jasmine test retries

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -6,13 +6,13 @@ set +o pipefail
 
 ROOT=$(dirname $0)/..
 EXIT_STATE=0
-MAX_AUTO_RETRY=5
 
 log () {
     echo -e "\n$1"
 }
 
 # inspired by https://unix.stackexchange.com/a/82602
+MAX_AUTO_RETRY=1
 retry () {
     local n=1
 
@@ -54,9 +54,9 @@ case $1 in
         set_tz
 
         SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --tag=gl))
-
+        MAX_AUTO_RETRY=2
         for s in ${SHARDS[@]}; do
-            retry npm run test-jasmine -- "$s" --tags=gl --skip-tags=noCI
+            retry npm run test-jasmine -- "${s}" --tags=gl --skip-tags=noCI
         done
 
         exit $EXIT_STATE
@@ -66,9 +66,9 @@ case $1 in
         set_tz
 
         SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --tag=flaky))
-
+        MAX_AUTO_RETRY=5
         for s in ${SHARDS[@]}; do
-            retry npm run test-jasmine -- "$s" --tags=flaky --skip-tags=noCI
+            retry npm run test-jasmine -- "${s}" --tags=flaky --skip-tags=noCI
         done
 
         exit $EXIT_STATE

--- a/tasks/shard_jasmine_tests.js
+++ b/tasks/shard_jasmine_tests.js
@@ -15,7 +15,7 @@ var argv = minimist(process.argv.slice(2), {
         limit: ['l'],
     },
     default: {
-        limit: 20
+        limit: 1
     }
 });
 

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -561,7 +561,7 @@ describe('Test hover and click interactions', function() {
     });
 });
 
-describe('@noCI Test gl2d lasso/select:', function() {
+describe('Test gl2d lasso/select:', function() {
     var mockFancy = require('@mocks/gl2d_14.json');
     delete mockFancy.layout.xaxis.autorange;
     delete mockFancy.layout.yaxis.autorange;
@@ -613,7 +613,7 @@ describe('@noCI Test gl2d lasso/select:', function() {
     function select(path) {
         return new Promise(function(resolve, reject) {
             gd.once('plotly_selected', resolve);
-            setTimeout(function() { reject('did not trigger *plotly_selected*');}, 200);
+            setTimeout(function() { reject('did not trigger *plotly_selected*');}, 300);
             drag(path);
         });
     }

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -215,7 +215,7 @@ describe('Test gl plot side effects', function() {
         .then(done);
     });
 
-    it('@noCI @gl should fire *plotly_webglcontextlost* when on webgl context lost', function(done) {
+    it('@gl should fire *plotly_webglcontextlost* when on webgl context lost', function(done) {
         var _mock = Lib.extendDeep({}, require('@mocks/gl2d_12.json'));
 
         function _trigger(name) {
@@ -551,7 +551,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@noCI @gl should display selection of big number of regular points', function(done) {
+    it('@gl should display selection of big number of regular points', function(done) {
         // generate large number of points
         var x = [];
         var y = [];
@@ -582,7 +582,7 @@ describe('Test gl2d plots', function() {
         .then(done);
     });
 
-    it('@noCI @gl should display selection of big number of miscellaneous points', function(done) {
+    it('@gl should display selection of big number of miscellaneous points', function(done) {
         var colorList = [
             '#006385', '#F06E75', '#90ed7d', '#f7a35c', '#8085e9',
             '#f15c80', '#e4d354', '#2b908f', '#f45b5b', '#91e8e1',

--- a/test/jasmine/tests/gl2d_pointcloud_test.js
+++ b/test/jasmine/tests/gl2d_pointcloud_test.js
@@ -196,7 +196,7 @@ describe('pointcloud traces', function() {
     it('@gl should not change other traces colors', function(done) {
         var _mock = Lib.extendDeep({}, multipleScatter2dMock);
         Plotly.plot(gd, _mock)
-        .then(delay(40))
+        .then(delay(20))
         .then(function() {
             var canvas = d3.select('.gl-canvas-context').node();
 
@@ -226,13 +226,13 @@ describe('pointcloud traces', function() {
         }
 
         Plotly.plot(gd, Lib.extendDeep({}, plotData))
-        .then(delay(40))
+        .then(delay(20))
         .then(function() {
             _assertRange('base', [-0.548, 9.548], [-1.415, 10.415]);
         })
-        .then(delay(40))
+        .then(delay(20))
         .then(function() { _drag([200, 200], [350, 350]); })
-        .then(delay(40))
+        .then(delay(20))
         .then(function() {
             _assertRange('after zoombox drag', [0.768, 1.591], [5.462, 7.584]);
         })
@@ -248,9 +248,9 @@ describe('pointcloud traces', function() {
         .then(function() {
             return Plotly.relayout(gd, 'dragmode', 'pan');
         })
-        .then(delay(40))
+        .then(delay(20))
         .then(function() { _drag([200, 200], [350, 350]); })
-        .then(delay(40))
+        .then(delay(20))
         .then(function() {
             _assertRange('after pan drag', [0.2743, 10.3719], [-3.537, 8.292]);
         })

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -509,7 +509,7 @@ describe('parcoords edge cases', function() {
         .then(done);
     });
 
-    it('@noCI @gl Works with 60 dimensions', function(done) {
+    it('@gl Works with 60 dimensions', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         var newDimension, i, j;
@@ -539,7 +539,7 @@ describe('parcoords edge cases', function() {
         .then(done);
     });
 
-    it('@noCI @gl Truncates 60+ dimensions to 60', function(done) {
+    it('@gl Truncates 60+ dimensions to 60', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         var newDimension, i, j;
@@ -567,7 +567,7 @@ describe('parcoords edge cases', function() {
         .then(done);
     });
 
-    it('@noCI @gl Truncates dimension values to the shortest array, retaining only 3 lines', function(done) {
+    it('@gl Truncates dimension values to the shortest array, retaining only 3 lines', function(done) {
 
         var mockCopy = Lib.extendDeep({}, mock1);
         var newDimension, i, j;
@@ -1218,7 +1218,7 @@ describe('parcoords basic use', function() {
     });
 });
 
-describe('@noCI parcoords constraint interactions', function() {
+describe('parcoords constraint interactions', function() {
     var gd, initialDashArray0, initialDashArray1;
 
     function initialFigure() {
@@ -1302,7 +1302,7 @@ describe('@noCI parcoords constraint interactions', function() {
         expect(dashArray.length).toBe(segmentCount, dashArray);
     }
 
-    it('@gl snaps ordinal constraints', function(done) {
+    it('@noCI @gl snaps ordinal constraints', function(done) {
         // first: drag almost to 2 but not quite - constraint will snap back to [2.75, 4]
         mostOfDrag(105, 165, 105, 190);
         var newDashArray = getDashArray(0);
@@ -1380,7 +1380,7 @@ describe('@noCI parcoords constraint interactions', function() {
         .then(done);
     });
 
-    it('@gl updates continuous constraints with no snap', function(done) {
+    it('@noCI @gl updates continuous constraints with no snap', function(done) {
         // first: extend 7 to 5
         mostOfDrag(295, 160, 295, 200);
         var newDashArray = getDashArray(1);

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -700,7 +700,7 @@ describe('@noCIdep Plotly.react', function() {
         .then(done);
     });
 
-    it('can change parcoords aggregations', function(done) {
+    it('@gl can change parcoords aggregations', function(done) {
         Plotly.newPlot(gd, aggregatedParcoords(0))
         .then(checkValues(aggParcoords0Vals))
 
@@ -717,7 +717,7 @@ describe('@noCIdep Plotly.react', function() {
         .then(done);
     });
 
-    it('can change type with aggregations', function(done) {
+    it('@gl can change type with aggregations', function(done) {
         Plotly.newPlot(gd, aggregatedScatter(1))
         .then(checkCalcData(aggScatter1CD))
 
@@ -1766,7 +1766,7 @@ describe('Plotly.react and uirevision attributes', function() {
         _run(fig, editEditable, checkAttrs(true), checkAttrs).then(done);
     });
 
-    it('preserves editable: true name, colorbar title and parcoords constraint range via trace.uirevision', function(done) {
+    it('@gl preserves editable: true name, colorbar title and parcoords constraint range via trace.uirevision', function(done) {
         function fig(mainRev, traceRev) {
             return {
                 data: [{

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -899,16 +899,12 @@ describe('Test polar interactions:', function() {
         }
 
         function _reset() {
-            return delay(100)()
-                .then(function() { return _doubleClick(mid); })
-                .then(function() {
-                    relayoutNumber++;
-                    resetNumber++;
+            relayoutNumber++;
+            resetNumber++;
 
-                    var extra = '(reset ' + resetNumber + ')';
-                    _assertBase(extra);
-                    expect(eventCnts.plotly_doubleclick).toBe(resetNumber, 'doubleclick event #' + extra);
-                });
+            var extra = '(reset ' + resetNumber + ')';
+            _assertBase(extra);
+            expect(eventCnts.plotly_doubleclick).toBe(resetNumber, 'doubleclick event #' + extra);
         }
 
         _plot(fig)
@@ -917,21 +913,33 @@ describe('Test polar interactions:', function() {
         .then(function() {
             _assertDrag([0, 5.24], 'from center move toward bottom-right');
         })
+        .then(delay(20))
+        .then(function() { return _doubleClick(mid); })
+        .then(delay(20))
         .then(_reset)
         .then(function() { return _drag(mid, [-50, -50]); })
         .then(function() {
             _assertDrag([0, 5.24], 'from center move toward top-left');
         })
+        .then(delay(20))
+        .then(function() { return _doubleClick(mid); })
+        .then(delay(20))
         .then(_reset)
         .then(function() { return _drag([mid[0] + 30, mid[0] - 30], [50, -50]); })
         .then(function() {
             _assertDrag([3.1, 8.4], 'from quadrant #1 move top-right');
         })
+        .then(delay(20))
+        .then(function() { return _doubleClick(mid); })
+        .then(delay(20))
         .then(_reset)
         .then(function() { return _drag([345, 200], [-50, 0]); })
         .then(function() {
             _assertDrag([7.0, 11.1], 'from right edge move left');
         })
+        .then(delay(20))
+        .then(function() { return _doubleClick(mid); })
+        .then(delay(20))
         .then(_reset)
         .then(function() { return _drag(mid, [10, 10]);})
         .then(function() { _assertBase('from center to not far enough'); })
@@ -943,6 +951,9 @@ describe('Test polar interactions:', function() {
             expect(eventCnts.plotly_relayout)
                 .toBe(relayoutNumber, 'no new relayout events after *not far enough* cases');
         })
+        .then(delay(20))
+        .then(function() { return _doubleClick(mid); })
+        .then(delay(20))
         .then(_reset)
         .then(function() { return Plotly.relayout(gd, 'polar.hole', 0.2); })
         .then(function() { relayoutNumber++; })

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -658,7 +658,7 @@ describe('Click-to-select', function() {
               { mapboxAccessToken: require('@build/credentials.json').MAPBOX_ACCESS_TOKEN })
         ]
           .forEach(function(testCase) {
-              it('@noCI @gl trace type ' + testCase.label, function(done) {
+              it('@gl trace type ' + testCase.label, function(done) {
                   _run(testCase, done);
               });
           });

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -943,7 +943,7 @@ describe('Test splom interactions:', function() {
         .then(done);
     });
 
-    it('@noCI @gl should clear graph and replot when canvas and WebGL context dimensions do not match', function(done) {
+    it('@gl should clear graph and replot when canvas and WebGL context dimensions do not match', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_iris.json'));
 
         function assertDims(msg, w, h) {
@@ -1737,7 +1737,7 @@ describe('Test splom select:', function() {
         .then(done);
     });
 
-    it('@noCI @gl should behave correctly during select->dblclick->pan scenarios', function(done) {
+    it('@gl should behave correctly during select->dblclick->pan scenarios', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_0.json'));
         fig.layout = {
             width: 400,


### PR DESCRIPTION
A follow up of #3661 and #3599 in order to have more robust image tests with less retries
- [x] applied different retry numbers for gl and flaky containers
- [x] reduced number of retries for jasmine-2 test
- [x] reduced number of retries for jasmine-3 test
- [x] set shards limit to 1 i.e. helped fix various side effects between different tests
- [x] removed `noCI` tags from a number of tests
- [x] adjusted timeouts of some tests to run on CI
@plotly/plotly_js 