### PR TITLE
Fix `npm run test-image -- *` for mock lists w/o gl2d_* mocks

### DIFF
--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -91,8 +91,7 @@ sortGl2dMockList(allMockList);
 // main
 if(isInQueue) {
     runInQueue(allMockList);
-}
-else {
+} else {
     runInBatch(allMockList);
 }
 
@@ -137,6 +136,7 @@ function sortGl2dMockList(mockList) {
 
     mockNames.forEach(function(m) {
         var ind = mockList.indexOf(m);
+        if(ind === -1) return;
         var tmp = mockList[pos];
         mockList[pos] = m;
         mockList[ind] = tmp;


### PR DESCRIPTION
A follow-up of https://github.com/plotly/plotly.js/pull/3634/

Currently on `master`:

```
npm run test-image -- 10
```

gives us:

![image](https://user-images.githubusercontent.com/6675409/55337676-2460c180-546d-11e9-9733-f49a0ffe17aa.png)

as we're trying to sort `['gl2d_pointcloud-basic', 'gl2d_heatmapgl']` to the front even though they're not in the list of mocks we're trying to test.

cc @plotly/plotly_js 