### PR TITLE
Add waterfall trace to finance bundle

### DIFF
--- a/lib/index-finance.js
+++ b/lib/index-finance.js
@@ -15,7 +15,8 @@ Plotly.register([
     require('./histogram'),
     require('./pie'),
     require('./ohlc'),
-    require('./candlestick')
+    require('./candlestick'),
+    require('./waterfall')
 ]);
 
 module.exports = Plotly;


### PR DESCRIPTION
Quick follow-up of https://github.com/plotly/plotly.js/pull/3531

`waterfall` is a finance trace and we should make it part of the finance bundle and npm package.

cc @plotly/plotly_js 