### PR TITLE
Don't try to access textfont when bar has no text

### DIFF
--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -205,11 +205,6 @@ function appendBarText(gd, bar, calcTrace, i, x0, x1, y0, y1) {
     var text = getText(trace, i);
     textPosition = getTextPosition(trace, i);
 
-    var layoutFont = fullLayout.font;
-    var barColor = style.getBarColor(calcTrace[i], trace);
-    var insideTextFont = style.getInsideTextFont(trace, i, layoutFont, barColor);
-    var outsideTextFont = style.getOutsideTextFont(trace, i, layoutFont);
-
     // compute text position
     var prefix = trace.type === 'waterfall' ? 'waterfall' : 'bar';
     var barmode = fullLayout[prefix + 'mode'];
@@ -218,15 +213,20 @@ function appendBarText(gd, bar, calcTrace, i, x0, x1, y0, y1) {
     var calcBar = calcTrace[i];
     var isOutmostBar = !inStackOrRelativeMode || calcBar._outmost;
 
-    // padding excluded
-    var barWidth = Math.abs(x1 - x0) - 2 * TEXTPAD;
-    var barHeight = Math.abs(y1 - y0) - 2 * TEXTPAD;
-
     if(!text || textPosition === 'none' ||
         (calcBar.isBlank && (textPosition === 'auto' || textPosition === 'inside'))) {
         bar.select('text').remove();
         return;
     }
+
+    var layoutFont = fullLayout.font;
+    var barColor = style.getBarColor(calcTrace[i], trace);
+    var insideTextFont = style.getInsideTextFont(trace, i, layoutFont, barColor);
+    var outsideTextFont = style.getOutsideTextFont(trace, i, layoutFont);
+
+    // padding excluded
+    var barWidth = Math.abs(x1 - x0) - 2 * TEXTPAD;
+    var barHeight = Math.abs(y1 - y0) - 2 * TEXTPAD;
 
     var textSelection;
     var textBB;

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -1886,6 +1886,20 @@ describe('A bar plot', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('should not error out when *textfont* is set in traces w/o *text*', function(done) {
+        Plotly.plot(gd, [{
+            type: 'bar',
+            x: ['A', 'K', 'M', 'O', 'Q', 'S', 'T', 'V', 'X', 'Z', 'D', 'F', 'H'],
+            y: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25],
+            textfont: {color: 'red'}
+        }])
+        .then(function() {
+            expect(getAllBarNodes(gd).length).toBe(13, '# of bars');
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('bar visibility toggling:', function() {


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3714 - a fixup of my https://github.com/plotly/plotly.js/pull/3701