### PR TITLE
Replot on drag

### DIFF
--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -6,15 +6,13 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
 var mouseOffset = require('mouse-event-offset');
 var hasHover = require('has-hover');
 var supportsPassive = require('has-passive-events');
 
-var Lib = require('../../lib');
-
+var removeElement = require('../../lib').removeElement;
 var constants = require('../../plots/cartesian/constants');
 var interactConstants = require('../../constants/interactions');
 
@@ -26,7 +24,6 @@ dragElement.getCursor = require('./cursor');
 var unhover = require('./unhover');
 dragElement.unhover = unhover.wrapped;
 dragElement.unhoverRaw = unhover.raw;
-
 
 /**
  * Abstracts click & drag interactions
@@ -105,8 +102,7 @@ dragElement.init = function init(options) {
 
     if(!supportsPassive) {
         element.ontouchstart = onStart;
-    }
-    else {
+    } else {
         if(element._ontouchstart) {
             element.removeEventListener('touchstart', element._ontouchstart);
         }
@@ -144,8 +140,7 @@ dragElement.init = function init(options) {
         if(newMouseDownTime - gd._mouseDownTime < DBLCLICKDELAY) {
             // in a click train
             numClicks += 1;
-        }
-        else {
+        } else {
             // new click train
             numClicks = 1;
             gd._mouseDownTime = newMouseDownTime;
@@ -156,8 +151,7 @@ dragElement.init = function init(options) {
         if(hasHover && !rightClick) {
             dragCover = coverSlip();
             dragCover.style.cursor = window.getComputedStyle(element).cursor;
-        }
-        else if(!hasHover) {
+        } else if(!hasHover) {
             // document acts as a dragcover for mobile, bc we can't create dragcover dynamically
             dragCover = document;
             cursor = window.getComputedStyle(document.documentElement).cursor;
@@ -215,9 +209,8 @@ dragElement.init = function init(options) {
         document.removeEventListener('touchend', onDone);
 
         if(hasHover) {
-            Lib.removeElement(dragCover);
-        }
-        else if(cursor) {
+            removeElement(dragCover);
+        } else if(cursor) {
             dragCover.documentElement.style.cursor = cursor;
             cursor = null;
         }
@@ -236,8 +229,7 @@ dragElement.init = function init(options) {
 
         if(gd._dragged) {
             if(options.doneFn) options.doneFn();
-        }
-        else {
+        } else {
             if(options.clickFn) options.clickFn(numClicks, initialEvent);
 
             // If we haven't dragged, this should be a click. But because of the

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -13,7 +13,6 @@ var mouseOffset = require('mouse-event-offset');
 var hasHover = require('has-hover');
 var supportsPassive = require('has-passive-events');
 
-var Registry = require('../../registry');
 var Lib = require('../../lib');
 
 var constants = require('../../plots/cartesian/constants');
@@ -191,12 +190,21 @@ dragElement.init = function init(options) {
             dragElement.unhover(gd);
         }
 
-        if(gd._dragged && options.moveFn && !rightClick) options.moveFn(dx, dy);
+        if(gd._dragged && options.moveFn && !rightClick) {
+            gd._dragdata = {
+                element: element,
+                dx: dx,
+                dy: dy
+            };
+            options.moveFn(dx, dy);
+        }
 
         return;
     }
 
     function onDone(e) {
+        delete gd._dragdata;
+
         if(options.dragmode !== false) {
             e.preventDefault();
             document.removeEventListener('mousemove', onMove);
@@ -258,10 +266,8 @@ dragElement.init = function init(options) {
             }
         }
 
-        finishDrag(gd);
-
+        gd._dragging = false;
         gd._dragged = false;
-
         return;
     }
 };
@@ -285,11 +291,6 @@ function coverSlip() {
 }
 
 dragElement.coverSlip = coverSlip;
-
-function finishDrag(gd) {
-    gd._dragging = false;
-    if(gd._replotPending) Registry.call('plot', gd);
-}
 
 function pointerOffset(e) {
     return mouseOffset(

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1994,13 +1994,8 @@ function addAxRangeSequence(seq, rangesAltered) {
             return Axes.draw(gd, 'redraw');
         };
 
-    var _clearSelect = function(gd) {
-        var zoomlayer = gd._fullLayout._zoomlayer;
-        if(zoomlayer) clearSelect(zoomlayer);
-    };
-
     seq.push(
-        _clearSelect,
+        clearSelect,
         subroutines.doAutoRangeAndConstraints,
         drawAxes,
         subroutines.drawData,

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -135,7 +135,9 @@ exports.plot = function(gd, data, layout, config) {
         gd.empty = false;
     }
 
-    if(!gd.layout || graphWasEmpty) gd.layout = helpers.cleanLayout(layout);
+    if(!gd.layout || graphWasEmpty) {
+        gd.layout = helpers.cleanLayout(layout);
+    }
 
     // if the user is trying to drag the axes, allow new data and layout
     // to come in but don't allow a replot.
@@ -195,7 +197,7 @@ exports.plot = function(gd, data, layout, config) {
     if(gd._context.responsive) {
         if(!gd._responsiveChartHandler) {
             // Keep a reference to the resize handler to purge it down the road
-            gd._responsiveChartHandler = function() {Plots.resize(gd);};
+            gd._responsiveChartHandler = function() { Plots.resize(gd); };
 
             // Listen to window resize
             window.addEventListener('resize', gd._responsiveChartHandler);
@@ -242,10 +244,10 @@ exports.plot = function(gd, data, layout, config) {
                     return 'gl-canvas gl-canvas-' + d.key.replace('Layer', '');
                 })
                 .style({
-                    'position': 'absolute',
-                    'top': 0,
-                    'left': 0,
-                    'overflow': 'visible',
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    overflow: 'visible',
                     'pointer-events': 'none'
                 });
         }

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -228,6 +228,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 }
 
                 // TODO should we try to "re-select" under select/lasso modes?
+                // probably best to wait for https://github.com/plotly/plotly.js/issues/1851
             }
         };
     };

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -222,7 +222,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         // clear selection polygon cache (if any)
         dragOptions.plotinfo.selection = false;
         // clear selection outlines
-        clearSelect(zoomlayer);
+        clearSelect(gd);
     }
 
     function clickFn(numClicks, evt) {

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -601,8 +601,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         else if(yActive === 's') dy = dz(yaxes, 0, -dy);
         else if(!yActive) dy = 0;
 
-        var x0 = (xActive === 'w') ? dx : 0;
-        var y0 = (yActive === 'n') ? dy : 0;
+        var xStart = (xActive === 'w') ? dx : 0;
+        var yStart = (yActive === 'n') ? dy : 0;
 
         if(links.isSubplotConstrained) {
             var i;
@@ -614,7 +614,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                     scaleZoom(xaxes[i], 1 - dy / ph);
                 }
                 dx = dy * pw / ph;
-                x0 = dx / 2;
+                xStart = dx / 2;
             }
             if(!yActive && xActive.length === 1) {
                 for(i = 0; i < yaxes.length; i++) {
@@ -622,13 +622,13 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                     scaleZoom(yaxes[i], 1 - dx / pw);
                 }
                 dy = dx * ph / pw;
-                y0 = dy / 2;
+                yStart = dy / 2;
             }
         }
 
         updateMatchedAxRange('x');
         updateMatchedAxRange('y');
-        updateSubplots([x0, y0, pw - dx, ph - dy]);
+        updateSubplots([xStart, yStart, pw - dx, ph - dy]);
         ticksAndAnnotations();
     }
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -226,6 +226,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                     updateSubplots([0, 0, pw, ph]);
                     dragOptions.moveFn(dragDataNow.dx, dragDataNow.dy);
                 }
+
+                // TODO should we try to "re-select" under select/lasso modes?
             }
         };
     };

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -6,7 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
 var d3 = require('d3');
@@ -37,7 +36,6 @@ var scaleZoom = require('./scale_zoom');
 var constants = require('./constants');
 var MINDRAG = constants.MINDRAG;
 var MINZOOM = constants.MINZOOM;
-
 
 // flag for showing "doubleclick to zoom out" only at the beginning
 var SHOWZOOMOUTTIP = true;
@@ -216,6 +214,20 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 }
             }
         }
+
+        gd._fullLayout._redrag = function() {
+            var dragDataNow = gd._dragdata;
+
+            if(dragDataNow && dragDataNow.element === dragger) {
+                var dragModeNow = gd._fullLayout.dragmode;
+
+                if(!isSelectOrLasso(dragModeNow)) {
+                    recomputeAxisLists();
+                    updateSubplots([0, 0, pw, ph]);
+                    dragOptions.moveFn(dragDataNow.dx, dragDataNow.dy);
+                }
+            }
+        };
     };
 
     function clearAndResetSelect() {

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -465,14 +465,14 @@ function multiTester(list) {
 
 function coerceSelectionsCache(evt, gd, dragOptions) {
     var fullLayout = gd._fullLayout;
-    var zoomLayer = fullLayout._zoomlayer;
     var plotinfo = dragOptions.plotinfo;
 
     var selectingOnSameSubplot = (
-      fullLayout._lastSelectedSubplot &&
-      fullLayout._lastSelectedSubplot === plotinfo.id
+        fullLayout._lastSelectedSubplot &&
+        fullLayout._lastSelectedSubplot === plotinfo.id
     );
     var hasModifierKey = evt.shiftKey || evt.altKey;
+
     if(selectingOnSameSubplot && hasModifierKey &&
       (plotinfo.selection && plotinfo.selection.selectionDefs) && !dragOptions.selectionDefs) {
         // take over selection definitions from prev mode, if any
@@ -484,7 +484,7 @@ function coerceSelectionsCache(evt, gd, dragOptions) {
 
     // clear selection outline when selecting a different subplot
     if(!selectingOnSameSubplot) {
-        clearSelect(zoomLayer);
+        clearSelect(gd);
         fullLayout._lastSelectedSubplot = plotinfo.id;
     }
 }
@@ -774,11 +774,15 @@ function fillSelectionItem(selection, searchInfo) {
     return selection;
 }
 
-function clearSelect(zoomlayer) {
-    // until we get around to persistent selections, remove the outline
-    // here. The selection itself will be removed when the plot redraws
-    // at the end.
-    zoomlayer.selectAll('.select-outline').remove();
+// until we get around to persistent selections, remove the outline
+// here. The selection itself will be removed when the plot redraws
+// at the end.
+function clearSelect(gd) {
+    var fullLayout = gd._fullLayout || {};
+    var zoomlayer = fullLayout._zoomlayer;
+    if(zoomlayer) {
+        zoomlayer.selectAll('.select-outline').remove();
+    }
 }
 
 module.exports = {

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -20,6 +20,7 @@ var throttle = require('../../lib/throttle');
 var makeEventData = require('../../components/fx/helpers').makeEventData;
 var getFromId = require('./axis_ids').getFromId;
 var clearGlCanvases = require('../../lib/clear_gl_canvases');
+
 var redrawReglTraces = require('../../plot_api/subroutines').redrawReglTraces;
 
 var constants = require('./constants');
@@ -669,7 +670,7 @@ function updateSelectedState(gd, searchTraces, eventData) {
     // before anything else, update preGUI if necessary
     for(i = 0; i < searchTraces.length; i++) {
         var fullInputTrace = searchTraces[i].cd[0].trace._fullInput;
-        var tracePreGUI = gd._fullLayout._tracePreGUI[fullInputTrace.uid];
+        var tracePreGUI = gd._fullLayout._tracePreGUI[fullInputTrace.uid] || {};
         if(tracePreGUI.selectedpoints === undefined) {
             tracePreGUI.selectedpoints = fullInputTrace._input.selectedpoints || null;
         }

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -19,7 +19,7 @@ var Lib = require('../lib');
 var Color = require('../components/color');
 var BADNUM = require('../constants/numerical').BADNUM;
 
-var axisIDs = require('../plots/cartesian/axis_ids');
+var axisIDs = require('./cartesian/axis_ids');
 
 var animationAttrs = require('./animation_attributes');
 var frameAttrs = require('./frame_attributes');
@@ -476,6 +476,15 @@ plots.supplyDefaults = function(gd, opts) {
     // clean subplots and other artifacts from previous plot calls
     plots.cleanPlot(newFullData, newFullLayout, oldFullData, oldFullLayout);
 
+    // clear selection outline until we implement persistent selection,
+    // don't clear them though when drag handlers (e.g. listening to
+    // `plotly_selecting`) update the graph.
+    // we should try to come up with a better solution when implementing
+    // https://github.com/plotly/plotly.js/issues/1851
+    if(oldFullLayout._zoomlayer && !gd._dragging) {
+        oldFullLayout._zoomlayer.selectAll('.select-outline').remove();
+    }
+
     // relink functions and _ attributes to promote consistency between plots
     relinkPrivateKeys(newFullLayout, oldFullLayout);
 
@@ -778,10 +787,6 @@ plots.cleanPlot = function(newFullData, newFullLayout, oldFullData, oldFullLayou
         if(hasInfoLayer) {
             oldFullLayout._infolayer.select('.cb' + oldUid).remove();
         }
-    }
-
-    if(oldFullLayout._zoomlayer) {
-        oldFullLayout._zoomlayer.selectAll('.select-outline').remove();
     }
 };
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1679,10 +1679,10 @@ plots.purge = function(gd) {
     // themselves, but may not if there was an error
     delete gd._dragging;
     delete gd._dragged;
+    delete gd._dragdata;
     delete gd._hoverdata;
     delete gd._snapshotInProgress;
     delete gd._editing;
-    delete gd._replotPending;
     delete gd._mouseDownTime;
     delete gd._legendMouseDownTime;
 
@@ -2904,6 +2904,12 @@ function doCrossTraceCalc(gd) {
 plots.rehover = function(gd) {
     if(gd._fullLayout._rehover) {
         gd._fullLayout._rehover();
+    }
+};
+
+plots.redrag = function(gd) {
+    if(gd._fullLayout._redrag) {
+        gd._fullLayout._redrag();
     }
 };
 

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -795,7 +795,7 @@ proto.updateMainDrag = function(fullLayout) {
         zb = dragBox.makeZoombox(zoomlayer, lum, cx, cy, path0);
         zb.attr('fill-rule', 'evenodd');
         corners = dragBox.makeCorners(zoomlayer, cx, cy);
-        clearSelect(zoomlayer);
+        clearSelect(gd);
     }
 
     // N.B. this sets scoped 'r0' and 'r1'
@@ -1115,7 +1115,7 @@ proto.updateRadialDrag = function(fullLayout, polarLayout, rngIndex) {
         dragOpts.moveFn = moveFn;
         dragOpts.doneFn = doneFn;
 
-        clearSelect(fullLayout._zoomlayer);
+        clearSelect(gd);
     };
 
     dragOpts.clampFn = function(dx, dy) {
@@ -1263,7 +1263,7 @@ proto.updateAngularDrag = function(fullLayout) {
         dragOpts.moveFn = moveFn;
         dragOpts.doneFn = doneFn;
 
-        clearSelect(fullLayout._zoomlayer);
+        clearSelect(gd);
     };
 
     // I don't what we should do in this case, skip we now

--- a/src/plots/ternary/ternary.js
+++ b/src/plots/ternary/ternary.js
@@ -493,7 +493,7 @@ proto.initInteractions = function() {
     var _this = this;
     var dragger = _this.layers.plotbg.select('path').node();
     var gd = _this.graphDiv;
-    var zoomContainer = gd._fullLayout._zoomlayer;
+    var zoomLayer = gd._fullLayout._zoomlayer;
 
     // use plotbg for the main interactions
     var dragOptions = {
@@ -578,7 +578,7 @@ proto.initInteractions = function() {
         path0 = 'M0,' + _this.h + 'L' + (_this.w / 2) + ', 0L' + _this.w + ',' + _this.h + 'Z';
         dimmed = false;
 
-        zb = zoomContainer.append('path')
+        zb = zoomLayer.append('path')
             .attr('class', 'zoombox')
             .attr('transform', 'translate(' + _this.x0 + ', ' + _this.y0 + ')')
             .style({
@@ -587,7 +587,7 @@ proto.initInteractions = function() {
             })
             .attr('d', path0);
 
-        corners = zoomContainer.append('path')
+        corners = zoomLayer.append('path')
             .attr('class', 'zoombox-corners')
             .attr('transform', 'translate(' + _this.x0 + ', ' + _this.y0 + ')')
             .style({

--- a/src/plots/ternary/ternary.js
+++ b/src/plots/ternary/ternary.js
@@ -526,7 +526,7 @@ proto.initInteractions = function() {
                 dragOptions.clickFn = clickZoomPan;
                 dragOptions.doneFn = dragDone;
                 panPrep();
-                clearSelect(zoomContainer);
+                clearSelect(gd);
             }
             else if(dragModeNow === 'select' || dragModeNow === 'lasso') {
                 prepSelect(e, startX, startY, dragOptions, dragModeNow);
@@ -598,7 +598,7 @@ proto.initInteractions = function() {
             })
             .attr('d', 'M0,0Z');
 
-        clearSelect(zoomContainer);
+        clearSelect(gd);
     }
 
     function getAFrac(x, y) { return 1 - (y / _this.h); }

--- a/test/jasmine/tests/plot_promise_test.js
+++ b/test/jasmine/tests/plot_promise_test.js
@@ -62,32 +62,6 @@ describe('Plotly.___ methods', function() {
         });
     });
 
-    describe('Plotly.plot promise', function() {
-        var gd;
-        var promise;
-        var promiseRejected = false;
-
-        beforeEach(function(done) {
-            var data = [{ x: [1, 2, 3], y: [4, 5, 6] }];
-
-            gd = createGraphDiv();
-
-            gd._dragging = true;
-
-            promise = Plotly.plot(gd, data, {});
-
-            promise.then(null, function() {
-                promiseRejected = true;
-                done();
-            });
-        });
-
-
-        it('should reject the promise when graph is being dragged', function() {
-            expect(promiseRejected).toBe(true);
-        });
-    });
-
     describe('Plotly.redraw promise', function() {
         var promise;
         var promiseGd;

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -405,10 +405,10 @@ describe('Test Plots', function() {
             // because _dragging and _dragged were not cleared by purge.
             gd._dragging = true;
             gd._dragged = true;
+            gd._dragdata = true;
             gd._hoverdata = true;
             gd._snapshotInProgress = true;
             gd._editing = true;
-            gd._replotPending = true;
             gd._mouseDownTime = true;
             gd._legendMouseDownTime = true;
         });
@@ -427,8 +427,8 @@ describe('Test Plots', function() {
                 'empty', 'fid', 'undoqueue', 'undonum', 'autoplay', 'changed',
                 '_promises', '_redrawTimer', 'firstscatter',
                 '_transitionData', '_transitioning', '_hmpixcount', '_hmlumcount',
-                '_dragging', '_dragged', '_hoverdata', '_snapshotInProgress', '_editing',
-                '_replotPending', '_mouseDownTime', '_legendMouseDownTime'
+                '_dragging', '_dragged', '_dragdata', '_hoverdata', '_snapshotInProgress', '_editing',
+                '_mouseDownTime', '_legendMouseDownTime'
             ];
 
             Plots.purge(gd);


### PR DESCRIPTION
an attempt at fixing https://github.com/plotly/plotly.js/issues/3305

In brief, this PR completely :hocho: 

https://github.com/plotly/plotly.js/blob/7bb5daaaa118537ca01464d12cdbcef6f9cc764a/src/plot_api/plot_api.js#L139-L149

and its `replotPending` logic and replaces it with a `Plots.redrag` handler called at the end `Plotly.plot` similar to `Plots.rehover`. Bye bye uncaught promises and console errors :wave: 

The current solution most likely **will break** in some scenarios, but it is enough to fix (I think) all the problematic examples listed in https://github.com/plotly/plotly.js/issues/3305#issuecomment-478748135, see:

- https://codepen.io/etpinard/pen/VNLoNB
- https://codepen.io/etpinard/pen/jRbNOW?editors=1010
- https://codepen.io/etpinard/pen/rbOBNw?editors=1111
- https://codepen.io/etpinard/pen/rbOBwp
- https://codepen.io/etpinard/pen/qwOWOK
- https://codepen.io/etpinard/pen/MRwNoY?editors=1010

For example, dragging under `dragmode:'zoom'` in an `extendTraces` interval looks like:

![Peek 2019-04-02 16-51](https://user-images.githubusercontent.com/6675409/55435326-99b0bd00-5567-11e9-9ba7-9076affb7807.gif)

Notice: we're not trying to resize the zoombox, but instead we update its corresponding data-space range as new (auto-ranged) data pts come in.

---------

cc @plotly/plotly_js 