### PR TITLE
bump regl-error2d 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9268,8 +9268,9 @@
       "integrity": "sha512-tmt6CRhRqbcsYDWNwv+iG7GGOXdgoOBC7lKzoPMgnzpt3WKBQ3c8i7AxgbvTRZzty29hrW92fAJeZkPFQehfWA=="
     },
     "regl-error2d": {
-      "version": "2.0.6",
-      "resolved": "git://github.com/gl-vis/regl-error2d.git#0d27313d932fdb8ffaed17931b7258958bce0b88",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.7.tgz",
+      "integrity": "sha512-YCXlu3BIDpR1hsU8HqMn+SiRldevdP2gIFNpaOdBSV2PEJsMmDHo532elzU2K3sB7heDqZzXuY66CfYRL89oDg==",
       "requires": {
         "array-bounds": "^1.0.1",
         "bubleify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "point-cluster": "^3.1.4",
     "polybooljs": "^1.2.0",
     "regl": "^1.3.11",
-    "regl-error2d": "^2.0.6",
+    "regl-error2d": "^2.0.7",
     "regl-line2d": "3.0.13",
     "regl-scatter2d": "^3.1.4",
     "regl-splom": "^1.0.6",


### PR DESCRIPTION
Bump regl-error2d to point to 2.0.7 with `highp` fragment shader flag.
@etpinard 