### PR TITLE
Disable mapbox scroll zoom on init, when required

### DIFF
--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -258,12 +258,6 @@ proto.updateMap = function(calcData, fullLayout, resolve, reject) {
         self.updateLayout(fullLayout);
         self.resolveOnRender(resolve);
     }
-
-    if(this.gd._context._scrollZoom.mapbox) {
-        map.scrollZoom.enable();
-    } else {
-        map.scrollZoom.disable();
-    }
 };
 
 proto.updateData = function(calcData) {
@@ -314,6 +308,12 @@ proto.updateLayout = function(fullLayout) {
     this.updateFramework(fullLayout);
     this.updateFx(fullLayout);
     this.map.resize();
+
+    if(this.gd._context._scrollZoom.mapbox) {
+        map.scrollZoom.enable();
+    } else {
+        map.scrollZoom.disable();
+    }
 };
 
 proto.resolveOnRender = function(resolve) {

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -977,6 +977,9 @@ describe('@noCI, mapbox plots', function() {
     }, LONG_TIMEOUT_INTERVAL);
 
     it('should respect scrollZoom config option', function(done) {
+        var mockCopy2 = Lib.extendDeep({}, mock);
+        mockCopy2.config = {scrollZoom: false};
+
         var relayoutCnt = 0;
         gd.on('plotly_relayout', function() { relayoutCnt++; });
 
@@ -991,6 +994,7 @@ describe('@noCI, mapbox plots', function() {
 
         var zoom = getMapInfo(gd).zoom;
         expect(zoom).toBeCloseTo(1.234);
+        var zoom0 = zoom;
 
         _scroll().then(function() {
             expect(relayoutCnt).toBe(1, 'scroll relayout cnt');
@@ -1015,7 +1019,13 @@ describe('@noCI, mapbox plots', function() {
 
             var zoomNew = getMapInfo(gd).zoom;
             expect(zoomNew).toBeGreaterThan(zoom);
-            zoom = zoomNew;
+        })
+        .then(function() { return Plotly.newPlot(gd, mockCopy2); })
+        .then(_scroll)
+        .then(function() {
+            // see https://github.com/plotly/plotly.js/issues/3738
+            var zoomNew = getMapInfo(gd).zoom;
+            expect(zoomNew).toBe(zoom0);
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3738

before: https://codepen.io/alexcjohnson/pen/mgERKb?editors=0010
after: https://codepen.io/etpinard/pen/eoBvoP?editors=1010

cc @plotly/plotly_js