### PR TITLE
Add way for `toImage` to export images with current graph width/height

### DIFF
--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -6,7 +6,6 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
 var Registry = require('../../registry');
@@ -44,7 +43,6 @@ var modeBarButtons = module.exports = {};
  * @param {boolean} [toggle]
  *      is the button a toggle button?
  */
-
 modeBarButtons.toImage = {
     name: 'toImage',
     title: function(gd) {

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -65,7 +65,7 @@ modeBarButtons.toImage = {
         }
 
         ['filename', 'width', 'height', 'scale'].forEach(function(key) {
-            if(toImageButtonOptions[key]) {
+            if(key in toImageButtonOptions) {
                 opts[key] = toImageButtonOptions[key];
             }
         });

--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -6,11 +6,10 @@
 * LICENSE file in the root directory of this source tree.
 */
 
-
 'use strict';
 
 var toImage = require('../plot_api/to_image');
-var Lib = require('../lib'); // for isIE
+var Lib = require('../lib');
 var fileSaver = require('./filesaver');
 
 /** Plotly.downloadImage

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -11,7 +11,6 @@ var destroyGraphDiv = require('../assets/destroy_graph_div');
 var selectButton = require('../assets/modebar_button');
 var failTest = require('../assets/fail_test');
 
-
 describe('ModeBar', function() {
     'use strict';
 
@@ -960,10 +959,11 @@ describe('ModeBar', function() {
                 Plotly.plot(gd, {data: [], layout: {}})
                 .then(function() {
                     selectButton(gd._fullLayout._modeBar, 'toImage').click();
-                    expect(Registry.call).toHaveBeenCalledWith('downloadImage', gd,
-                        {format: 'png'});
-                    done();
-                });
+                    expect(Registry.call)
+                        .toHaveBeenCalledWith('downloadImage', gd, {format: 'png'});
+                })
+                .catch(failTest)
+                .then(done);
             });
 
             it('should accept overriding defaults', function(done) {
@@ -973,13 +973,14 @@ describe('ModeBar', function() {
                         filename: 'x',
                         unsupported: 'should not pass'
                     }
-                } })
+                }})
                 .then(function() {
                     selectButton(gd._fullLayout._modeBar, 'toImage').click();
-                    expect(Registry.call).toHaveBeenCalledWith('downloadImage', gd,
-                        {format: 'svg', filename: 'x'});
-                    done();
-                });
+                    expect(Registry.call)
+                        .toHaveBeenCalledWith('downloadImage', gd, {format: 'svg', filename: 'x'});
+                })
+                .catch(failTest)
+                .then(done);
             });
         });
 

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -982,6 +982,19 @@ describe('ModeBar', function() {
                 .catch(failTest)
                 .then(done);
             });
+
+            it('should accept overriding defaults with null values', function(done) {
+                Plotly.plot(gd, {data: [], layout: {}, config: {
+                    toImageButtonOptions: {width: null, height: null}
+                }})
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'toImage').click();
+                    expect(Registry.call)
+                        .toHaveBeenCalledWith('downloadImage', gd, {format: 'png', width: null, height: null});
+                })
+                .catch(failTest)
+                .then(done);
+            });
         });
 
         describe('cartesian handlers', function() {

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -115,6 +115,24 @@ describe('Plotly.toImage', function() {
         .then(done);
     });
 
+    it('should use width/height of graph div when width/height are set to *null*', function(done) {
+        var fig = Lib.extendDeep({}, subplotMock);
+
+        gd.style.width = '832px';
+        gd.style.height = '502px';
+
+        Plotly.plot(gd, fig.data, fig.layout).then(function() {
+            expect(gd.layout.width).toBe(undefined, 'user layout width');
+            expect(gd.layout.height).toBe(undefined, 'user layout height');
+            expect(gd._fullLayout.width).toBe(832, 'full layout width');
+            expect(gd._fullLayout.height).toBe(502, 'full layout height');
+        })
+        .then(function() { return Plotly.toImage(gd, {width: null, height: null}); })
+        .then(function(url) { return assertSize(url, 832, 502); })
+        .catch(failTest)
+        .then(done);
+    });
+
     it('should create proper file type', function(done) {
         var fig = Lib.extendDeep({}, subplotMock);
 


### PR DESCRIPTION
resolves https://github.com/plotly/plotly.js/issues/3743 ... in a slightly more general way than proposed in that issue. 

This PR adds special logic to `Plotly.toImage` (which is called by `Plotly.downloadImage`, which is itself called when clicking on the `toImage` modebar button) for options `width:null` and `height:null`.

In brief, `Plotly.toImage(gd, {width:null, height:null})` will use the width/height values found in `gd._fullLayout` to generate its output image. Equivalently, 

```js
Plotly.react(gd, data, layout, {
  toImageButtonOptions: {width: null, height: null}
})
```

and clicking on the `toImage` modebar button will generate an image using the current `gd._fullLayout.width` and `gd._fullLayout.height` values - which (should at least) always store the current graph width/height values.

@plotly/plotly_js @nicolaskruchten - let me know what you think!