### PR TITLE
More stable jasmine2 test runs

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -53,7 +53,7 @@ case $1 in
     jasmine2)
         set_tz
 
-        SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --tag=gl | circleci tests split))
+        SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --limit=5 --tag=gl | circleci tests split))
         for s in ${SHARDS[@]}; do
             retry npm run test-jasmine -- "$s" --tags=gl --skip-tags=noCI --showSkipped
         done


### PR DESCRIPTION
https://github.com/plotly/plotly.js/pull/3667 solved the failing issues of `jasmine3` container. 
However, rerunning `jasmine2` still is take some time & attention.
This PR can help improve this situation by simply reducing the shards limits from default 20 to 5. 
@plotly/plotly_js 

<b>Before:</b>
![Jasmine2_limit20](https://user-images.githubusercontent.com/33888540/55897309-473a5680-5b8e-11e9-9575-e233bcc8f8b7.png)

<b>After:</b>
![Jasmine2_Limit5](https://user-images.githubusercontent.com/33888540/55897315-4a354700-5b8e-11e9-84f7-3a682b350b05.png)
 