### PR TITLE
fix svgTextUtils for FF: use child element instead of SVG to getSize()

### DIFF
--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -114,10 +114,11 @@ exports.convertToTspans = function(_context, gd, _callback) {
                 .style({overflow: 'visible', 'pointer-events': 'none'});
 
                 var fill = _context.node().style.fill || 'black';
-                newSvg.select('g').attr({fill: fill, stroke: fill});
+                var g = newSvg.select('g');
+                g.attr({fill: fill, stroke: fill});
 
-                var newSvgW = getSize(newSvg, 'width');
-                var newSvgH = getSize(newSvg, 'height');
+                var newSvgW = getSize(g, 'width');
+                var newSvgH = getSize(g, 'height');
                 var newX = +_context.attr('x') - newSvgW *
                     {start: 0, middle: 0.5, end: 1}[_context.attr('text-anchor') || 'start'];
                 // font baseline is about 1/4 fontSize below centerline

--- a/tasks/test_bundle.js
+++ b/tasks/test_bundle.js
@@ -31,6 +31,23 @@ glob(pathToJasmineBundleTests + '/*.js', function(err, files) {
         };
     });
 
+    var mathjaxTestFirefox = function(cb) {
+        var cmd = [
+            'karma', 'start',
+            path.join(constants.pathToRoot, 'test', 'jasmine', 'karma.conf.js'),
+            '--FF',
+            '--bundleTest=mathjax',
+            '--nowatch'
+        ].join(' ');
+
+        console.log('Running: ' + cmd);
+
+        exec(cmd, function(err) {
+            cb(null, err);
+        }).stdout.pipe(process.stdout);
+    };
+    tasks.push(mathjaxTestFirefox);
+
     runSeries(tasks, function(err, results) {
         if(err) throw err;
 


### PR DESCRIPTION
Closes #2616 

The fix was tested in `Mozilla Firefox 62.0.3` in Linux. I try to fix the following misbehaving routine in FF:
https://github.com/plotly/plotly.js/blob/fe842c4cc7fa38fa8fb77b36a4010d7722cbe7b0/src/lib/svg_text_utils.js#L22-L24
However, after inspecting the DOM in Firefox, it turns out that it sets the size of the embedded `svg.gtitle-math` elements to a very large value. However, it sizes properly its first and only child element. We use this one instead when calling `getSize()`.

Codepen before: https://codepen.io/antoinerg/pen/oOEaPz
Codepen after: https://codepen.io/antoinerg/pen/ZZrqmd

Before:
![newplot(1)](https://user-images.githubusercontent.com/301546/56311799-d4485700-611c-11e9-9411-f5a34548d6e6.png)
After:
![newplot(2)](https://user-images.githubusercontent.com/301546/56311814-d9a5a180-611c-11e9-89ef-59d49984f9e3.png)