### PR TITLE
Plotly.update replot fixes

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2362,20 +2362,12 @@ function update(gd, traceUpdate, layoutUpdate, _traces) {
     // fill in redraw sequence
     var seq = [];
 
-    if(restyleFlags.fullReplot && relayoutFlags.layoutReplot) {
-        var data = gd.data;
-        var layout = gd.layout;
-
-        // clear existing data/layout on gd
-        // so that Plotly.plot doesn't try to extend them
-        gd.data = undefined;
-        gd.layout = undefined;
-
-        seq.push(function() { return exports.plot(gd, data, layout); });
+    if(relayoutFlags.layoutReplot) {
+        // N.B. works fine when both
+        // relayoutFlags.layoutReplot and restyleFlags.fullReplot are true
+        seq.push(subroutines.layoutReplot);
     } else if(restyleFlags.fullReplot) {
         seq.push(exports.plot);
-    } else if(relayoutFlags.layoutReplot) {
-        seq.push(subroutines.layoutReplot);
     } else {
         seq.push(Plots.previousPromises);
         axRangeSupplyDefaultsByPass(gd, relayoutFlags, relayoutSpecs) || Plots.supplyDefaults(gd);

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -2650,16 +2650,29 @@ describe('Test plot api', function() {
         it('should only have one modebar-container', function(done) {
             var data = [{y: [1, 2]}];
 
-            Plotly.plot(gd, data).then(function() {
-                var modebars = document.getElementsByClassName('modebar-container');
-                expect(modebars.length).toBe(1);
+            function _assert(msg) {
+                return function() {
+                    var modebars = document.getElementsByClassName('modebar-container');
+                    expect(modebars.length).toBe(1, msg + ' # of modebar container');
+                    var groups = document.getElementsByClassName('modebar-group');
+                    expect(groups.length).toBe(5, msg + ' # of modebar button groups');
+                };
+            }
 
-                return Plotly.newPlot(gd, data);
-            })
+            Plotly.plot(gd, data)
+            .then(_assert('base'))
+            .then(function() { return Plotly.newPlot(gd, data); })
+            .then(_assert('after newPlot()'))
             .then(function() {
-                var modebars = document.getElementsByClassName('modebar-container');
-                expect(modebars.length).toBe(1);
+                // funky combinations of update flags found in
+                // https://github.com/plotly/plotly.js/issues/3824
+                return Plotly.update(gd, {
+                    visible: false
+                }, {
+                    annotations: [{text: 'a'}]
+                });
             })
+            .then(_assert('after update()'))
             .catch(failTest)
             .then(done);
         });


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3824 

-----------

`Plotly.update` calls like

```js
Plotly.update(gd, {visible: false}, {annotations: [{text: 'a'}]});
```

that lead to restyle flag `fullReplot:true` and relayout flag `layoutReplot:true` erroneously resulted in a [`makePlotFramework`](https://github.com/plotly/plotly.js/blob/adf9bee14a8badcb5b2f49065fd594623421c82e/src/plot_api/plot_api.js#L3679-L3813) call, which (among other things) cleared the modebar container (added in https://github.com/plotly/plotly.js/pull/3589).

In brief, `makePlotFramework` on "empty" graph divs, I suspect other `Plotly.update` bugs went undetected because of this.

--------------

cc @plotly/plotly_js I'll ask @antoinerg to review this thing. Thanks!
