### PR TITLE
Display true boolean text on bars

### DIFF
--- a/src/traces/bar/helpers.js
+++ b/src/traces/bar/helpers.js
@@ -14,7 +14,7 @@ var tinycolor = require('tinycolor2');
 exports.coerceString = function(attributeDefinition, value, defaultValue) {
     if(typeof value === 'string') {
         if(value || !attributeDefinition.noBlank) return value;
-    } else if(typeof value === 'number') {
+    } else if(typeof value === 'number' || value === true) {
         if(!attributeDefinition.strict) return String(value);
     }
 

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -1849,6 +1849,10 @@ describe('A bar plot', function() {
         })
         .then(function() {
             _assertNumberOfBarTextNodes(3);
+            return Plotly.restyle(gd, 'text', [[null, true, '']]);
+        })
+        .then(function() {
+            _assertNumberOfBarTextNodes(1);
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
Fixes #3850.
[Codepen before](https://codepen.io/MojtabaSamimi/pen/ardKdR?editors=0010).
[Codepen after](https://codepen.io/MojtabaSamimi/pen/rgxrLX?editors=0010).

@plotly/plotly_js 
