### PR TITLE
Bump down karma-jasmine-spec-tags to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6772,9 +6772,9 @@
       "dev": true
     },
     "karma-jasmine-spec-tags": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/karma-jasmine-spec-tags/-/karma-jasmine-spec-tags-1.1.0.tgz",
-      "integrity": "sha512-uhGYcGV1jmUSe2QZ6D/pmVehnggQaB8LCaG17EWetYJnGGu6C7LUcPkVNeMXMiewwa5V6g8RxOG8LP8Jh1ZBsQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/karma-jasmine-spec-tags/-/karma-jasmine-spec-tags-1.0.1.tgz",
+      "integrity": "sha1-Mz7WJZKSMG81Dez3f5uNxcOVQhI=",
       "dev": true
     },
     "karma-spec-reporter": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^1.1.2",
-    "karma-jasmine-spec-tags": "^1.1.0",
+    "karma-jasmine-spec-tags": "^1.0.1",
     "karma-spec-reporter": "0.0.32",
     "karma-verbose-reporter": "0.0.6",
     "karma-viewport": "^1.0.4",

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -2555,7 +2555,7 @@ describe('Test select box and lasso per trace:', function() {
                         2: [1, 4, 5]
                     });
                     assertLassoPoints([
-                        ['day 1', 'day 2', 'day 2', 'day 1', 'day 1'],
+                        [0.0423, 1.0546, 1.0546, 0.0423, 0.0423],
                         [0.71, 0.71, 0.1875, 0.1875, 0.71]
                     ]);
                 },
@@ -2579,7 +2579,7 @@ describe('Test select box and lasso per trace:', function() {
                         1: [11, 8, 6, 10],
                         2: [1, 4, 5]
                     });
-                    assertRanges([['day 1', 'day 2'], [0.1875, 0.71]]);
+                    assertRanges([[0.04235, 1.0546], [0.1875, 0.71]]);
                 },
                 null, BOXEVENTS, 'box select'
             );
@@ -2617,7 +2617,7 @@ describe('Test select box and lasso per trace:', function() {
                         2: [1, 4, 5, 3]
                     });
                     assertLassoPoints([
-                        ['day 1', 'day 2', 'day 2', 'day 1', 'day 1'],
+                        [0.07777, 1.0654, 1.0654, 0.07777, 0.07777],
                         [1.02, 1.02, 0.27, 0.27, 1.02]
                     ]);
                 },
@@ -2642,7 +2642,7 @@ describe('Test select box and lasso per trace:', function() {
                         1: [8, 6, 10, 9, 7],
                         2: [1, 4, 5, 3]
                     });
-                    assertRanges([['day 1', 'day 2'], [0.27, 1.02]]);
+                    assertRanges([[0.07777, 1.0654], [0.27, 1.02]]);
                 },
                 null, BOXEVENTS, 'violin select'
             );


### PR DESCRIPTION
... as v1.1.0 is only compatible with karma-jasmine@2x - making `npm run test-jasmine` work again.

Cherry-picked from https://github.com/plotly/plotly.js/pull/3868