### PR TITLE
Use correct index to lookup unique histogram2d y vals

### DIFF
--- a/src/traces/histogram2d/calc.js
+++ b/src/traces/histogram2d/calc.js
@@ -149,8 +149,8 @@ module.exports = function calc(gd, trace) {
                 else if(xVals[n] !== xi) uniqueValsPerX = false;
             }
             if(uniqueValsPerY) {
-                if(yVals[n] === undefined) yVals[n] = yi;
-                else if(yVals[n] !== yi) uniqueValsPerY = false;
+                if(yVals[m] === undefined) yVals[m] = yi;
+                else if(yVals[m] !== yi) uniqueValsPerY = false;
             }
 
             xGapLow = Math.min(xGapLow, xi - xEdges[n]);

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -1225,6 +1225,26 @@ describe('hover info', function() {
             .then(done);
         });
 
+        it('shows the data range when bins have multiple values (case 2)', function(done) {
+            var gd = createGraphDiv();
+
+            Plotly.plot(gd, [{
+                type: 'histogram2d',
+                x: ['a', 'b', 'c', 'a'],
+                y: [7, 2, 3, 7],
+                nbinsy: 3
+            }], {
+                width: 600,
+                height: 600
+            })
+            .then(function() {
+                _hover(gd, 250, 200);
+                assertHoverLabelContent({nums: ['x: b', 'y: 4 - 5', 'z: 0'].join('\n')});
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
         it('shows the exact data when bins have single values', function(done) {
             var gd = createGraphDiv();
 


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/3872 - by patching only 3 characters in `histogram2d/calc.js` :smirk: @plotly/plotly_js 

before: https://codepen.io/antoinerg/pen/EzmmdP?editors=0010 (which has been broken since https://github.com/plotly/plotly.js/pull/2113/ released in `1.32.0` :expressionless: )
after: https://codepen.io/etpinard/pen/xNpMOX


