### PR TITLE
Bump tinycolor2 to 1.4.1 - as well as few dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4712,9 +4712,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "fuse.js": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.4.tgz",
-      "integrity": "sha512-pyLQo/1oR5Ywf+a/tY8z4JygnIglmRxVUOiyFAbd11o9keUDpUJSMGRWJngcnkURj30kDHPmhoKY8ChJiz3EpQ==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.5.tgz",
+      "integrity": "sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ==",
       "dev": true
     },
     "gamma": {
@@ -5590,9 +5590,9 @@
       "integrity": "sha1-rSxdVM5bNUN/r/HXCprrPR0mERA="
     },
     "gzip-size": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.0.tgz",
-      "integrity": "sha512-wfSnvypBDRW94v5W3ckvvz/zFUNdJ81VgOP6tE4bPpRUcc0wGqU+y0eZjJEvKxwubJFix6P84sE8M51YWLT7rQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
@@ -5895,9 +5895,9 @@
       }
     },
     "image-size": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
-      "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.4.tgz",
+      "integrity": "sha512-GqPgxs+VkOr12aWwjSkyRzf5atzObWpFtiRuDgxCl2I/SDpZOKZFRD3iIAeAN6/usmn8SeLWRt7a8JRYK0Whbw==",
       "dev": true
     },
     "import-fresh": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "strongly-connected-components": "^1.0.1",
     "superscript-text": "^1.0.0",
     "svg-path-sdf": "^1.1.3",
-    "tinycolor2": "^1.3.0",
+    "tinycolor2": "^1.4.1",
     "topojson-client": "^2.1.0",
     "webgl-context": "^2.2.0",
     "world-calendars": "^1.0.3"
@@ -126,12 +126,12 @@
     "derequire": "^2.0.6",
     "ecstatic": "^3.3.1",
     "eslint": "^5.16.0",
-    "falafel": "^2.0.0",
+    "falafel": "^2.1.0",
     "fs-extra": "^2.0.0",
-    "fuse.js": "^3.4.4",
+    "fuse.js": "^3.4.5",
     "glob": "^7.1.4",
-    "gzip-size": "^5.1.0",
-    "image-size": "^0.6.3",
+    "gzip-size": "^5.1.1",
+    "image-size": "^0.7.4",
     "into-stream": "^4.0.0",
     "jasmine-core": "^2.99.1",
     "jsdom": "^11.12.0",
@@ -160,6 +160,6 @@
     "through2": "^3.0.1",
     "true-case-path": "^1.0.3",
     "watchify": "^3.11.1",
-    "xml2js": "^0.4.16"
+    "xml2js": "^0.4.19"
   }
 }


### PR DESCRIPTION
@plotly/plotly_js 