### PR TITLE
1d -> 2d -> 1d zoombox regression fix + drag test maintenance

### DIFF
--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -85,7 +85,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     // graph-wide optimization flags
     var hasScatterGl, hasSplom, hasSVG;
     // collected changes to be made to the plot by relayout at the end
-    var updates = {};
+    var updates;
 
     function recomputeAxisLists() {
         xa0 = plotinfo.xaxis;
@@ -415,6 +415,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     }
 
     function computeZoomUpdates() {
+        updates = {};
+
         // TODO: edit linked axes in zoomAxRanges and in dragTail
         if(zoomMode === 'xy' || zoomMode === 'x') {
             zoomAxRanges(xaxes, box.l / pw, box.r / pw, updates, links.xaxes);
@@ -427,8 +429,6 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     }
 
     function zoomDone() {
-        updates = {};
-
         // more strict than dragged, which allows you to come back to where you started
         // and still count as dragged
         if(Math.min(box.h, box.w) < MINDRAG * 2) {
@@ -654,12 +654,12 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             var ax2 = constrainedAxes[0] || xaHash[axId2] || yaHash[axId2];
 
             if(ax2) {
-                var rng = ax2.range;
                 if(out) {
-                    out[ax._name + '.range[0]'] = rng[0];
-                    out[ax._name + '.range[1]'] = rng[1];
+                    // zoombox case - don't mutate 'range', just add keys in 'updates'
+                    out[ax._name + '.range[0]'] = out[ax2._name + '.range[0]'];
+                    out[ax._name + '.range[1]'] = out[ax2._name + '.range[1]'];
                 } else {
-                    ax.range = rng;
+                    ax.range = ax2.range.slice();
                 }
             }
         }
@@ -995,19 +995,14 @@ function zoomAxRanges(axList, r0Fraction, r1Fraction, updates, linkedAxes) {
 
         var axRangeLinear0 = axi._rl[0];
         var axRangeLinearSpan = axi._rl[1] - axRangeLinear0;
-        axi.range = [
-            axi.l2r(axRangeLinear0 + axRangeLinearSpan * r0Fraction),
-            axi.l2r(axRangeLinear0 + axRangeLinearSpan * r1Fraction)
-        ];
-
-        updates[axi._name + '.range[0]'] = axi.range[0];
-        updates[axi._name + '.range[1]'] = axi.range[1];
+        updates[axi._name + '.range[0]'] = axi.l2r(axRangeLinear0 + axRangeLinearSpan * r0Fraction);
+        updates[axi._name + '.range[1]'] = axi.l2r(axRangeLinear0 + axRangeLinearSpan * r1Fraction);
     }
 
     // zoom linked axes about their centers
     if(linkedAxes && linkedAxes.length) {
         var linkedR0Fraction = (r0Fraction + (1 - r1Fraction)) / 2;
-        zoomAxRanges(linkedAxes, linkedR0Fraction, 1 - linkedR0Fraction, updates, [], []);
+        zoomAxRanges(linkedAxes, linkedR0Fraction, 1 - linkedR0Fraction, updates, []);
     }
 }
 

--- a/test/jasmine/assets/drag.js
+++ b/test/jasmine/assets/drag.js
@@ -1,42 +1,146 @@
 var isNumeric = require('fast-isnumeric');
+
 var mouseEvent = require('./mouse_event');
+var touchEvent = require('./touch_event');
 var getNodeCoords = require('./get_node_coords');
 var delay = require('./delay');
 
-function makeFns(node, dx, dy, opts) {
+/**
+ * Inside `opts`:
+ *
+ * @param {array of 2 numbers} pos0 :
+ *  px position of start of drag motion, default computed using `node` and `edge`
+ * @param {DOM element} node :
+ *  element to drag on, default found using `pos0`
+ * @param {string} edge :
+ *  combinations of 'n', 's', 'e', 'w' used to find `pos0` of `node`
+ *
+ * Set one of:
+ * @param {array of arrays of numbers} path :
+ *  px position drag path
+ * @param {array of 2 numbers} dpos :
+ *  px position delta
+ * @param {array of 2 numbers} posN :
+ *  px position of end of drag motion
+ *
+ * If using `dpos` or `posN`
+ * @param {number} nsteps :
+ *  set number of steps to take between `pos0` and `pos0` + `dpos` or `posN`, default is 1
+ *
+ * @param {boolean} touch :
+ *  pass `true` to simulate touch events
+ * @param {boolean} shiftKey, altKey, ctrlKey ....
+ * pass `true to simulate <shift>, alt, ctrl drag (see ./mouse_event.js for more info)
+ *
+ * @param {function} clearThrottle :
+ *  pass Lib.clearThrottle to clear throttle for all mouse/touch event
+ * @param {boolean} noCover :
+ *  do not wait for "drag cover" element to start "move" events
+ *
+ * @return {object}
+ *  - {function} start
+ *  - {function} end
+ */
+function makeFns(opts) {
     opts = opts || {};
 
-    var nsteps = opts.nsteps || 1;
-    var edge = opts.edge || '';
-    var noCover = Boolean(opts.noCover);
+    var path;
 
-    var coords = getNodeCoords(node, edge);
-    var fromX = isNumeric(opts.x0) ? opts.x0 : coords.x;
-    var fromY = isNumeric(opts.y0) ? opts.y0 : coords.y;
+    if(Array.isArray(opts.path) && opts.path.length >= 2 &&
+        Array.isArray(opts.path[0]) && Array.isArray(opts.path[1])) {
+        path = opts.path;
+    } else {
+        var nsteps = opts.nsteps || 1;
+        var p0, dp;
+        var msg = [];
+
+        if(opts.pos0 && isNumeric(opts.pos0[0]) && isNumeric(opts.pos0[1])) {
+            p0 = opts.pos0;
+        } else if(opts.node) {
+            var coords = getNodeCoords(opts.node, opts.edge || '');
+            p0 = [coords.x, coords.y];
+        } else {
+            msg.push('Cannot determine drag path start position from the given options');
+        }
+
+        if(opts.dpos && isNumeric(opts.dpos[0]) && isNumeric(opts.dpos[1])) {
+            dp = opts.dpos;
+        } else if(opts.posN && isNumeric(opts.posN[0]) && isNumeric(opts.posN[1])) {
+            dp = [opts.posN[0] - opts.pos0[0], opts.posN[1] - opts.pos0[1]];
+        } else {
+            msg.push('Cannot determine drag path step from the given options');
+        }
+
+        if(msg.length) {
+            throw new Error(msg.join('\n'));
+        }
+
+        path = [p0];
+
+        for(var i = 1; i <= nsteps; i++) {
+            path[i] = [
+                p0[0] + i * dp[0] / nsteps,
+                p0[1] + i * dp[1] / nsteps
+            ];
+        }
+    }
+
+    function extendOpts(patch) {
+        var out = {};
+        var k;
+        for(k in opts) out[k] = opts[k];
+        for(k in patch) out[k] = patch[k];
+        return out;
+    }
 
     var dragCoverNode;
-    var toX;
-    var toY;
 
     function start() {
-        mouseEvent('mousemove', fromX, fromY, {element: node});
-        mouseEvent('mousedown', fromX, fromY, {element: node});
+        if(opts.clearThrottle) opts.clearThrottle();
 
-        return (noCover ? Promise.resolve(node) : waitForDragCover())
+        var x0 = path[0][0];
+        var y0 = path[0][1];
+
+        var _opts = extendOpts({element: opts.node});
+
+        if(opts.touch) {
+            touchEvent('touchstart', x0, y0, _opts);
+        } else {
+            mouseEvent('mousemove', x0, y0, _opts);
+            mouseEvent('mousedown', x0, y0, _opts);
+        }
+
+        return (opts.noCover ? Promise.resolve(opts.node) : waitForDragCover())
         .then(function(_dragCoverNode) {
             dragCoverNode = _dragCoverNode;
 
-            for(var i = 1; i <= nsteps; i++) {
-                toX = fromX + i * dx / nsteps;
-                toY = fromY + i * dy / nsteps;
-                mouseEvent('mousemove', toX, toY, {element: dragCoverNode});
-            }
+            var _opts = extendOpts({element: dragCoverNode});
+
+            path.slice(1).forEach(function(p) {
+                if(opts.clearThrottle) opts.clearThrottle();
+                if(opts.touch) {
+                    touchEvent('touchmove', p[0], p[1], _opts);
+                } else {
+                    mouseEvent('mousemove', p[0], p[1], _opts);
+                }
+            });
         });
     }
 
     function end() {
-        mouseEvent('mouseup', toX, toY, {element: dragCoverNode});
-        return noCover || waitForDragCoverRemoval();
+        var iN = path.length - 1;
+        var xN = path[iN][0];
+        var yN = path[iN][1];
+
+        var _opts = extendOpts({element: dragCoverNode});
+
+        if(opts.touch) {
+            touchEvent('touchend', xN, yN, _opts);
+        } else {
+            mouseEvent('mouseup', xN, yN, _opts);
+        }
+
+        return opts.noCover || waitForDragCoverRemoval();
     }
 
     return {
@@ -45,21 +149,17 @@ function makeFns(node, dx, dy, opts) {
     };
 }
 
-/*
- * drag: grab a node and drag it (dx, dy) pixels
- * optionally specify an edge ('n', 'se', 'w' etc)
- * to grab it by an edge or corner (otherwise the middle is used)
+/**
+ * Inside `opts`:
+ *
+ * Same as in makeDragFns plus:
+ *
+ * @param {number} timeDelay :
+ *  time delay between drag start promise resolve and drag end call
  */
-function drag(node, dx, dy, edge, x0, y0, nsteps, noCover, timeDelay) {
-    if(!timeDelay) timeDelay = 0;
-    var fns = makeFns(node, dx, dy, {
-        edge: edge,
-        x0: x0,
-        y0: y0,
-        nsteps: nsteps,
-        noCover: noCover
-    });
-
+function drag(opts) {
+    var fns = makeFns(opts);
+    var timeDelay = opts.timeDelay || 0;
     return fns.start().then(delay(timeDelay)).then(fns.end);
 }
 

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -1050,7 +1050,7 @@ describe('annotation effects', function() {
     afterEach(destroyGraphDiv);
 
     function dragAndReplot(node, dx, dy, edge) {
-        return drag(node, dx, dy, edge).then(function() {
+        return drag({node: node, dpos: [dx, dy], edge: edge}).then(function() {
             return Plots.previousPromises(gd);
         });
     }

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -812,7 +812,7 @@ describe('axis zoom/pan and main plot zoom', function() {
 
             tickLabels2.each(function(_, i) {
                 var y = d3.select(this).attr('y');
-                expect(Number(y)).toBeWithin(exp.y[i], 5, msg + ' - node ' + i);
+                expect(Number(y)).toBeWithin(exp.y[i], 5.5, msg + ' - node ' + i);
             });
         }
 

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -329,7 +329,7 @@ describe('axis zoom/pan and main plot zoom', function() {
     function doDrag(subplot, directions, dx, dy, nsteps) {
         return function() {
             var dragger = getDragger(subplot, directions);
-            return drag(dragger, dx, dy, undefined, undefined, undefined, nsteps);
+            return drag({node: dragger, dpos: [dx, dy], nsteps: nsteps});
         };
     }
 
@@ -359,7 +359,7 @@ describe('axis zoom/pan and main plot zoom', function() {
 
     function makeDragFns(subplot, directions, dx, dy, x0, y0) {
         var dragger = getDragger(subplot, directions);
-        return drag.makeFns(dragger, dx, dy, {x0: x0, y0: y0});
+        return drag.makeFns({node: dragger, dpos: [dx, dy], pos0: [x0, y0]});
     }
 
     describe('subplots with shared axes', function() {

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -8,6 +8,7 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var failTest = require('../assets/fail_test');
 var mouseEvent = require('../assets/mouse_event');
+var drag = require('../assets/drag');
 var getRectCenter = require('../assets/get_rect_center');
 
 // cartesian click events events use the hover data
@@ -26,20 +27,6 @@ function move(fromX, fromY, toX, toY, delay) {
         }, delay || DBLCLICKDELAY / 4);
     });
 }
-
-function drag(fromX, fromY, toX, toY, delay) {
-    return new Promise(function(resolve) {
-        mouseEvent('mousemove', fromX, fromY);
-        mouseEvent('mousedown', fromX, fromY);
-        mouseEvent('mousemove', toX, toY);
-
-        setTimeout(function() {
-            mouseEvent('mouseup', toX, toY);
-            resolve();
-        }, delay || DBLCLICKDELAY / 4);
-    });
-}
-
 
 describe('Test click interactions:', function() {
     var mock = require('@mocks/14.json');
@@ -427,17 +414,20 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 10, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [10, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.08579746, 2.156130559]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.99100863, 1.86546098]);
-
-                return drag(pos[0], pos[1], pos[0] - 10, pos[1] - 50);
-            }).then(function() {
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-10, -50]});
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.99100863, 1.10938115]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on ne dragbox should update the axis ranges', function(done) {
@@ -449,17 +439,20 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 50, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [50, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.01196749, 1.72466470]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.99100863, 1.86546098]);
-
-                return drag(pos[0], pos[1], pos[0] - 50, pos[1] - 50);
-            }).then(function() {
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-50, -50]});
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.01196749, 2.08350047]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.99100863, 1.10938115]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on sw dragbox should update the axis ranges', function(done) {
@@ -471,17 +464,19 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 10, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [10, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.08579746, 2.15613055]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.36094210, 1.38938271]);
-
-                return drag(pos[0], pos[1], pos[0] - 10, pos[1] - 50);
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-10, -50]});
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.00958227, 2.15613055]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.71100706, 1.38938271]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on se dragbox should update the axis ranges', function(done) {
@@ -493,17 +488,20 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 50, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [50, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.01196749, 1.72466470]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.36094210, 1.38938271]);
-
-                return drag(pos[0], pos[1], pos[0] - 50, pos[1] - 50);
-            }).then(function() {
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-50, -50]});
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.01196749, 2.08350047]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.71100706, 1.38938271]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on ew dragbox should update the xaxis range', function(done) {
@@ -515,17 +513,19 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 50, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [50, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.375918058, 1.792179992]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
-
-                return drag(pos[0], pos[1], pos[0] - 50, pos[1] - 50);
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-50, -50]});
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.01196749, 2.15613055]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on w dragbox should update the xaxis range', function(done) {
@@ -537,17 +537,19 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 50, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [50, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.40349007, 2.15613055]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
-
-                return drag(pos[0], pos[1], pos[0] - 50, pos[1] - 50);
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-50, -50]});
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-2.93933740, 2.15613055]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on e dragbox should update the xaxis range', function(done) {
@@ -559,17 +561,18 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 50, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [50, 50]}).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.01196749, 1.7246647]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
-
-                return drag(pos[0], pos[1], pos[0] - 50, pos[1] - 50);
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-50, 50]});
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-3.01196749, 2.0835004]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on ns dragbox should update the yaxis range', function(done) {
@@ -581,17 +584,20 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 10, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [10, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.59427673, 1.78611460]);
-
-                return drag(pos[0], pos[1], pos[0] - 10, pos[1] - 50);
-            }).then(function() {
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-10, -50]});
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on s dragbox should update the yaxis range', function(done) {
@@ -603,17 +609,20 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 10, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [10, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.3609421011, 1.3893827]);
-
-                return drag(pos[0], pos[1], pos[0] - 10, pos[1] - 50);
-            }).then(function() {
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-10, -50]});
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.7110070646, 1.3893827]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('on n dragbox should update the yaxis range', function(done) {
@@ -625,17 +634,20 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(pos[0], pos[1], pos[0] + 10, pos[1] + 50).then(function() {
+            drag({pos0: pos, dpos: [10, 50]})
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.991008630, 1.86546098]);
-
-                return drag(pos[0], pos[1], pos[0] - 10, pos[1] - 50);
-            }).then(function() {
+            })
+            .then(function() {
+                return drag({pos0: pos, dpos: [-10, -50]});
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.991008630, 1.10938115]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
     });
 
@@ -719,9 +731,9 @@ describe('Test click interactions:', function() {
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('when set to \'reset+autorange\' (the default) should autosize on 1st double click and zoom when immediately dragged', function(done) {
@@ -732,17 +744,19 @@ describe('Test click interactions:', function() {
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
                 return doubleClick(blankPos[0], blankPos[1]);
-            }).then(function() {
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-                return drag(100, 100, 200, 200, DBLCLICKDELAY / 2);
-            }).then(function() {
+                return drag({pos0: [100, 100], posN: [200, 200], timeDelay: DBLCLICKDELAY / 2});
+            })
+            .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-2.6480169249531356, -1.920115790911955]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([0.4372261777201992, 1.2306899598686027]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('when set to \'reset+autorange\' (the default) should follow updated auto ranges', function(done) {
@@ -956,7 +970,7 @@ describe('Test click interactions:', function() {
                     y2Rng: [-1, 1]
                 });
             })
-            .then(function() { return drag(200, 200, 250, 250); })
+            .then(function() { return drag({pos0: [200, 200], posN: [250, 250]}); })
             .then(function() {
                 _assert('after zoom', {
                     xRng: [1.509, 2.138],
@@ -995,17 +1009,17 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(93, 93, 393, 293).then(function() {
+            drag({pos0: [93, 93], posN: [393, 293]}).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-2.69897000, -0.515266602]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([-0.30069513, 1.2862324246]);
 
-                return drag(93, 93, 393, 293);
+                return drag({pos0: [93, 93], posN: [393, 293]});
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-2.56671754, -1.644025966]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([0.159513853, 1.2174655634]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
     });
 
@@ -1047,32 +1061,33 @@ describe('Test click interactions:', function() {
             expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
             expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
-            drag(93, 93, 393, 293).then(function() {
+            drag({pos0: [93, 93], posN: [393, 293]}).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-5.19567089, -0.02757284]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([0.595918934, 2.976310280]);
 
-                return drag(93, 93, 393, 293);
+                return drag({pos0: [93, 93], posN: [393, 293]});
             }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray([-7.37937429, -2.21127624]);
                 expect(gd.layout.yaxis.range).toBeCloseToArray([2.182846498, 4.563237844]);
-
-                done();
-            });
+            })
+            .catch(failTest)
+            .then(done);
         });
 
 
-        it('should move the plot when panning', function() {
+        it('should move the plot when panning', function(done) {
             var start = 100;
             var end = 300;
             var plot = gd._fullLayout._plots.xy.plot;
 
-            mouseEvent('mousemove', start, start);
-            mouseEvent('mousedown', start, start);
-            mouseEvent('mousemove', end, end);
+            var fns = drag.makeFns({pos0: [start, start], posN: [end, end]});
 
-            expect(plot.attr('transform')).toBe('translate(250, 280) scale(1, 1)');
-
-            mouseEvent('mouseup', end, end);
+            fns.start().then(function() {
+                expect(plot.attr('transform')).toBe('translate(250, 280) scale(1, 1)');
+            })
+            .then(fns.end)
+            .catch(failTest)
+            .then(done);
         });
     });
 });
@@ -1093,6 +1108,7 @@ describe('dragbox', function() {
         Plotly.plot(createGraphDiv(), mock).then(function() {
             var node = d3.select('rect.nedrag').node();
             var pos = getRectCenter(node);
+            var fns = drag.makeFns({pos0: pos, dpos: [50, 0]});
 
             assertScale(d3.select('.plot').node(), 1, 1);
 
@@ -1100,11 +1116,7 @@ describe('dragbox', function() {
                 assertScale(this, 1, 1);
             });
 
-            mouseEvent('mousemove', pos[0], pos[1]);
-            mouseEvent('mousedown', pos[0], pos[1]);
-            mouseEvent('mousemove', pos[0] + 50, pos[1]);
-
-            setTimeout(function() {
+            fns.start().then(function() {
                 assertScale(d3.select('.plot').node(), 1.14, 1);
 
                 d3.select('.scatterlayer').selectAll('.point').each(function() {
@@ -1113,10 +1125,10 @@ describe('dragbox', function() {
                 d3.select('.barlayer').selectAll('.point').each(function() {
                     assertScale(this, 1, 1);
                 });
-
-                mouseEvent('mouseup', pos[0] + 50, pos[1]);
-                done();
-            }, DBLCLICKDELAY / 4);
+            })
+            .then(fns.end)
+            .catch(failTest)
+            .then(done);
         });
     });
 });

--- a/test/jasmine/tests/colorbar_test.js
+++ b/test/jasmine/tests/colorbar_test.js
@@ -406,7 +406,7 @@ describe('Test colorbar:', function() {
                 expect(gd.data[0].colorbar).toBeUndefined();
                 expect(gd._fullData[0].colorbar.x).toBe(1.02);
                 expect(gd._fullData[0].colorbar.y).toBe(0.5);
-                return drag(getCBNode(), -100, 100);
+                return drag({node: getCBNode(), dpos: [-100, 100]});
             })
             .then(function() {
                 expect(gd.data[0].colorbar.x).toBeWithin(0.591, 0.01);
@@ -426,7 +426,7 @@ describe('Test colorbar:', function() {
                 expect(gd.data[0].marker.colorbar).toBeUndefined();
                 expect(gd._fullData[0].marker.colorbar.x).toBe(1.02);
                 expect(gd._fullData[0].marker.colorbar.y).toBe(0.5);
-                return drag(getCBNode(), -100, 100);
+                return drag({node: getCBNode(), dpos: [-100, 100]});
             })
             .then(function() {
                 expect(gd.data[0].marker.colorbar.x).toBeWithin(0.591, 0.01);
@@ -446,7 +446,7 @@ describe('Test colorbar:', function() {
                 expect(gd.layout.coloraxis.colorbar).toBeUndefined();
                 expect(gd._fullLayout.coloraxis.colorbar.x).toBe(1.02);
                 expect(gd._fullLayout.coloraxis.colorbar.y).toBe(0.5);
-                return drag(getCBNode(), -100, 100);
+                return drag({node: getCBNode(), dpos: [-100, 100]});
             })
             .then(function() {
                 expect(gd.layout.coloraxis.colorbar.x).toBeWithin(0.591, 0.01);

--- a/test/jasmine/tests/drawing_test.js
+++ b/test/jasmine/tests/drawing_test.js
@@ -357,7 +357,7 @@ describe('Drawing', function() {
                 'width', 'left', 'right'
             ].forEach(function(dim) {
                 // give larger dimensions some extra tolerance
-                var tol = Math.max(expected[dim] / 10, 3.5);
+                var tol = Math.max(expected[dim] / 10, 5.5);
                 expect(actual[dim]).toBeWithin(expected[dim], tol, dim);
             });
         }

--- a/test/jasmine/tests/geo_test.js
+++ b/test/jasmine/tests/geo_test.js
@@ -14,6 +14,7 @@ var failTest = require('../assets/fail_test');
 var getClientPosition = require('../assets/get_client_position');
 var mouseEvent = require('../assets/mouse_event');
 var click = require('../assets/click');
+var drag = require('../assets/drag');
 
 var DBLCLICKDELAY = require('@src/constants/interactions').DBLCLICKDELAY;
 var HOVERMINTIME = require('@src/components/fx').constants.HOVERMINTIME;
@@ -1717,20 +1718,6 @@ describe('Test geo zoom/pan/drag interactions:', function() {
         dblClickCnt = 0;
     }
 
-
-    function drag(path) {
-        var len = path.length;
-
-        mouseEvent('mousemove', path[0][0], path[0][1]);
-        mouseEvent('mousedown', path[0][0], path[0][1]);
-
-        path.slice(1, len).forEach(function(pt) {
-            mouseEvent('mousemove', pt[0], pt[1]);
-        });
-
-        mouseEvent('mouseup', path[len - 1][0], path[len - 1][1]);
-    }
-
     function scroll(pos, delta) {
         return new Promise(function(resolve) {
             mouseEvent('mousemove', pos[0], pos[1]);
@@ -1789,7 +1776,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
             ], [
                 [90, 0], [350, 260], [0, 0], 101.9
             ], undefined);
-            return drag([[350, 250], [400, 250]]);
+            return drag({path: [[350, 250], [400, 250]], noCover: true});
         })
         .then(function() {
             _assert('after east-west drag', [
@@ -1799,7 +1786,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
             ], [
                 'geo.projection.rotation.lon', 'geo.center.lon'
             ]);
-            return drag([[400, 250], [400, 300]]);
+            return drag({path: [[400, 250], [400, 300]], noCover: true});
         })
         .then(function() {
             _assert('after north-south drag', [
@@ -1880,7 +1867,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
             ], [
                 [75, -45], 160
             ], undefined);
-            return drag([[250, 250], [300, 250]]);
+            return drag({path: [[250, 250], [300, 250]], noCover: true});
         })
         .then(function() {
             _assert('after east-west drag', [
@@ -1890,7 +1877,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
             ], [
                 'geo.projection.rotation.lon', 'geo.projection.rotation.lat'
             ]);
-            return drag([[250, 250], [300, 300]]);
+            return drag({path: [[250, 250], [300, 300]], noCover: true});
         })
         .then(function() {
             _assert('after NW-SE drag', [
@@ -1973,7 +1960,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
             ], [
                 [247, 260], [0, 57.5], 292.2
             ], undefined);
-            return drag([[250, 250], [200, 200]]);
+            return drag({path: [[250, 250], [200, 200]], noCover: true});
         })
         .then(function() {
             _assert('after SW-NE drag', [
@@ -2054,7 +2041,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
             ], [
                 [416, 309], 738.5
             ], undefined);
-            return drag([[250, 250], [200, 200]]);
+            return drag({path: [[250, 250], [200, 200]], noCover: true});
         })
         .then(function() {
             _assert('after NW-SE drag', [
@@ -2192,7 +2179,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
                         gd.on('plotly_relayouting', function(e) {
                             events.push(e);
                         });
-                        return drag(path);
+                        return drag({path: path, noCover: true});
                     })
                     .then(function() {
                         expect(events.length).toEqual(path.length - 1);

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -403,7 +403,7 @@ describe('Test gl2d plot interactions:', function() {
         var node = d3.select('.nsewdrag[data-subplot="xy"]').node();
         var dx = p1[0] - p0[0];
         var dy = p1[1] - p0[1];
-        return drag(node, dx, dy, null, p0[0], p0[1]);
+        return drag({node: node, dpos: [dx, dy], pos0: p0});
     }
 
     it('@gl should respond to drag interactions', function(done) {

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -9,7 +9,7 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var failTest = require('../assets/fail_test');
 var mouseEvent = require('../assets/mouse_event');
-var touchEvent = require('../assets/touch_event');
+var drag = require('../assets/drag');
 var selectButton = require('../assets/modebar_button');
 var delay = require('../assets/delay');
 
@@ -650,24 +650,6 @@ describe('Test gl3d drag and wheel interactions', function() {
         });
     }
 
-    function drag(target, start, end) {
-        return new Promise(function(resolve) {
-            mouseEvent('mousedown', start[0], start[1], {element: target});
-            mouseEvent('mousemove', end[0], end[1], {element: target});
-            mouseEvent('mouseup', end[0], end[1], {element: target});
-            setTimeout(resolve, 0);
-        });
-    }
-
-    function touchDrag(target, start, end) {
-        return new Promise(function(resolve) {
-            touchEvent('touchstart', start[0], start[1], {element: target});
-            touchEvent('touchmove', end[0], end[1], {element: target});
-            touchEvent('touchend', end[0], end[1], {element: target});
-            setTimeout(resolve, 0);
-        });
-    }
-
     beforeEach(function() {
         gd = createGraphDiv();
         jasmine.DEFAULT_TIMEOUT_INTERVAL = 3000;
@@ -707,10 +689,10 @@ describe('Test gl3d drag and wheel interactions', function() {
         .then(function() {
             sceneTarget = gd.querySelector('.svg-container .gl-container #scene');
 
-            return touchDrag(sceneTarget, [100, 100], [0, 0]);
+            return drag({touch: true, node: sceneTarget, pos0: [100, 100], posN: [0, 0], noCover: true});
         })
         .then(function() {
-            return drag(sceneTarget, [100, 100], [0, 0]);
+            return drag({node: sceneTarget, pos0: [100, 100], posN: [0, 0], noCover: true});
         })
         .then(function() {
             return scroll(sceneTarget);
@@ -768,11 +750,11 @@ describe('Test gl3d drag and wheel interactions', function() {
         })
         .then(function() {
             _assertAndReset(1);
-            return drag(sceneTarget2, [0, 0], [100, 100]);
+            return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(1);
-            return drag(sceneTarget, [0, 0], [100, 100]);
+            return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(1);
@@ -780,10 +762,10 @@ describe('Test gl3d drag and wheel interactions', function() {
         })
         .then(function() {
             _assertAndReset(1);
-            return drag(sceneTarget, [0, 0], [100, 100]);
+            return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
-            return drag(sceneTarget2, [0, 0], [100, 100]);
+            return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(0);
@@ -794,10 +776,10 @@ describe('Test gl3d drag and wheel interactions', function() {
             expect(relayoutCallback).toHaveBeenCalledTimes(1);
             relayoutCallback.calls.reset();
 
-            return drag(sceneTarget, [0, 0], [100, 100]);
+            return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
-            return drag(sceneTarget2, [0, 0], [100, 100]);
+            return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(2);
@@ -872,11 +854,11 @@ describe('Test gl3d drag and wheel interactions', function() {
         })
         .then(function() {
             _assertAndReset(1);
-            return drag(sceneTarget2, [0, 0], [100, 100]);
+            return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(1);
-            return drag(sceneTarget, [0, 0], [100, 100]);
+            return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(1);
@@ -884,10 +866,10 @@ describe('Test gl3d drag and wheel interactions', function() {
         })
         .then(function() {
             _assertAndReset(1);
-            return drag(sceneTarget, [0, 0], [100, 100]);
+            return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
-            return drag(sceneTarget2, [0, 0], [100, 100]);
+            return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(0);
@@ -898,10 +880,10 @@ describe('Test gl3d drag and wheel interactions', function() {
             expect(relayoutCallback).toHaveBeenCalledTimes(1);
             relayoutCallback.calls.reset();
 
-            return drag(sceneTarget, [0, 0], [100, 100]);
+            return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
-            return drag(sceneTarget2, [0, 0], [100, 100]);
+            return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
             _assertAndReset(2);
@@ -932,6 +914,8 @@ describe('Test gl3d drag and wheel interactions', function() {
 
     it('@gl should fire plotly_relayouting events', function(done) {
         var sceneTarget, relayoutEvent;
+
+        var nsteps = 10;
         var relayoutCnt = 0;
         var events = [];
 
@@ -945,20 +929,6 @@ describe('Test gl3d drag and wheel interactions', function() {
             }
         };
 
-        var nsteps = 10;
-        function _drag(target, start, end, n) {
-            return new Promise(function(resolve) {
-                mouseEvent('mousedown', start[0], start[1], {element: target, buttons: 1});
-                var dx = (end[0] - start[0]) / n;
-                var dy = (end[1] - start[1]) / n;
-                for(var i = 1; i <= n; i++) {
-                    mouseEvent('mousemove', start[0] + dx * n, start[1] + dy * n, {element: target, buttons: 1});
-                }
-                mouseEvent('mouseup', end[0], end[1], {element: target, buttons: 1});
-                setTimeout(resolve, 0);
-            });
-        }
-
         Plotly.plot(gd, mock)
         .then(function() {
             gd.on('plotly_relayout', function(e) {
@@ -971,7 +941,14 @@ describe('Test gl3d drag and wheel interactions', function() {
 
             sceneTarget = gd.querySelector('.svg-container .gl-container #scene canvas');
 
-            return _drag(sceneTarget, [200, 200], [100, 100], nsteps);
+            return drag({
+                node: sceneTarget,
+                pos0: [200, 200],
+                posN: [100, 100],
+                nsteps: nsteps,
+                buttons: 1,
+                noCover: true
+            });
         })
         .then(function() {
             expect(events.length).toEqual(nsteps);
@@ -1436,10 +1413,7 @@ describe('Test gl3d annotations', function() {
                     resolve();
                 });
 
-                mouseEvent('mousemove', px, py);
-                mouseEvent('mousedown', px, py);
-                mouseEvent('mousemove', px + dx, py + dy);
-                mouseEvent('mouseup', px + dx, py + dy);
+                drag({pos0: [px, py], dpos: [dx, dy], noCover: true});
             });
         }
 
@@ -1648,30 +1622,23 @@ describe('Test gl3d drag events', function() {
     }
 
     function verifyInteractionEffects(tuple) {
-        // One 'drag': simulating fairly thoroughly as the mouseup event is also needed here
-        mouseEvent('mousemove', 400, 200);
-        mouseEvent('mousedown', 400, 200);
-        mouseEvent('mousemove', 320, 320, {buttons: 1});
-        mouseEvent('mouseup', 320, 320);
+        return drag({pos0: [400, 200], posN: [320, 320], buttons: 1, noCover: true}).then(function() {
+            // Check event emission count
+            expect(tuple.relayoutCallback).toHaveBeenCalledTimes(1);
 
-        // Check event emission count
-        expect(tuple.relayoutCallback).toHaveBeenCalledTimes(1);
+            // Check structure of event callback value contents
+            expect(tuple.relayoutCallback).toHaveBeenCalledWith(jasmine.objectContaining({'scene.camera': cameraStructure}));
 
-        // Check structure of event callback value contents
-        expect(tuple.relayoutCallback).toHaveBeenCalledWith(jasmine.objectContaining({'scene.camera': cameraStructure}));
-
-        // Check camera contents on the DIV layout
-        var divCamera = tuple.graphDiv.layout.scene.camera;
-
-        expect(divCamera).toEqual(cameraStructure);
-
-        return tuple.graphDiv;
+            // Check camera contents on the DIV layout
+            var divCamera = tuple.graphDiv.layout.scene.camera;
+            expect(divCamera).toEqual(cameraStructure);
+        });
     }
 
     function testEvents(plot) {
         return plot.then(function(graphDiv) {
             var tuple = addEventCallback(graphDiv);
-            verifyInteractionEffects(tuple);
+            return verifyInteractionEffects(tuple);
         });
     }
 

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -1260,7 +1260,7 @@ describe('legend interaction', function() {
                         item.dispatchEvent(new MouseEvent('mousedown'));
                         item.dispatchEvent(new MouseEvent('mouseup'));
                     }
-                    setTimeout(resolve, DBLCLICKDELAY + 20);
+                    setTimeout(resolve, DBLCLICKDELAY + 100);
                 });
             };
         }
@@ -1682,6 +1682,7 @@ describe('legend interaction', function() {
                             'legend.itemdoubleclick': false
                         });
                     })
+                    .then(delay(100))
                     .then(click(0, 1)).then(_assert([true, true, true]))
                     .then(click(0, 2)).then(_assert([true, true, true]))
                     .then(function() {
@@ -1690,6 +1691,7 @@ describe('legend interaction', function() {
                             'legend.itemdoubleclick': 'toggle'
                         });
                     })
+                    .then(delay(100))
                     .then(click(0, 1)).then(_assert([true, 'legendonly', 'legendonly']))
                     .then(click(0, 1)).then(_assert([true, true, true]))
                     .then(click(0, 2)).then(_assert(['legendonly', true, true]))
@@ -1707,7 +1709,7 @@ describe('legend interaction', function() {
                 .then(run)
                 .catch(failTest)
                 .then(done);
-            });
+            }, 2 * jasmine.DEFAULT_TIMEOUT_INTERVAL);
 
             it('- pie case', function(done) {
                 _assert = function(_exp) {
@@ -1728,7 +1730,7 @@ describe('legend interaction', function() {
                 .then(run)
                 .catch(failTest)
                 .then(done);
-            });
+            }, 2 * jasmine.DEFAULT_TIMEOUT_INTERVAL);
         });
     });
 });

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -1504,8 +1504,7 @@ describe('Plotly.react and uirevision attributes', function() {
         function editSelection() {
             // drag across the upper right quadrant, so we'll select
             // curve 0 point 1 and curve 1 point 2
-            return drag(document.querySelector('.nsewdrag'),
-                148, 100, '', 150, 102);
+            return drag({node: document.querySelector('.nsewdrag'), dpos: [148, 100], pos0: [150, 102]});
         }
 
         var checkNoSelection = checkState([
@@ -1547,8 +1546,7 @@ describe('Plotly.react and uirevision attributes', function() {
         function editSelection() {
             // drag across the upper right quadrant, so we'll select
             // curve 0 point 1 and curve 1 point 2
-            return drag(document.querySelector('.nsewdrag'),
-                148, 148, '', 150, 102);
+            return drag({node: document.querySelector('.nsewdrag'), dpos: [148, 148], pos0: [150, 102]});
         }
 
         var checkNoSelection = checkState([{selectedpoints: undefined}]);
@@ -1800,19 +1798,18 @@ describe('Plotly.react and uirevision attributes', function() {
         }
 
         function editTrace() {
-            var _;
             return Registry.call('_guiRestyle', gd,
                 {'line.colorbar.title.text': 'color', name: 'name'},
                 [0]
             )
             .then(function() {
-                return drag(axisDragNode(0), 0, 50, _, _, _, _, true);
+                return drag({node: axisDragNode(0), dpos: [0, 50], noCover: true});
             })
             .then(function() {
-                return drag(axisDragNode(0), 0, -50, _, _, _, _, true);
+                return drag({node: axisDragNode(0), dpos: [0, -50], noCover: true});
             })
             .then(function() {
-                return drag(axisDragNode(1), 0, -50, _, _, _, _, true);
+                return drag({node: axisDragNode(1), dpos: [0, -50], noCover: true});
             });
         }
 

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -1994,13 +1994,6 @@ describe('Test Plotly.react + interactions under uirevision:', function() {
             });
         }
 
-        function _drag(x0, y0, dx, dy) {
-            mouseEvent('mousemove', x0, y0);
-            mouseEvent('mousedown', x0, y0);
-            mouseEvent('mousemove', x0 + dx, y0 + dy);
-            mouseEvent('mouseup', x0 + dx, y0 + dy);
-        }
-
         // should be same before & after 2nd react()
         function _assertGUI(msg) {
             var TOL = 2;
@@ -2033,7 +2026,7 @@ describe('Test Plotly.react + interactions under uirevision:', function() {
 
             expect(gd._fullLayout._preGUI).toEqual({});
         })
-        .then(function() { return _drag(200, 200, 50, 50); })
+        .then(function() { return drag({pos0: [200, 200], dpos: [50, 50], noCover: true}); })
         .then(function() { _assertGUI('before'); })
         .then(_react)
         .then(function() { _assertGUI('after'); })

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -874,7 +874,7 @@ describe('Test polar interactions:', function() {
 
         function _drag(p0, dp) {
             var node = d3.select('.polar > .draglayer > .maindrag').node();
-            return drag(node, dp[0], dp[1], null, p0[0], p0[1]);
+            return drag({node: node, dpos: dp, pos0: p0});
         }
 
         function _assertRange(rng, msg) {
@@ -984,7 +984,7 @@ describe('Test polar interactions:', function() {
         // to activate the radial drag mode
         function _drag(p0, dp) {
             var node = d3.select('.polar > .draglayer > .radialdrag').node();
-            return drag(node, dp[0], dp[1], null, p0[0], p0[1], 2);
+            return drag({node: node, dpos: dp, pos0: p0, nsteps: 2});
         }
 
         function _assert(rng, angle, evtRng1, evtAngle, msg) {
@@ -1066,7 +1066,7 @@ describe('Test polar interactions:', function() {
         // to activate the radial drag mode
         function _drag(p0, dp) {
             var node = d3.select('.polar > .draglayer > .radialdrag-inner').node();
-            return drag(node, dp[0], dp[1], null, p0[0], p0[1], 2);
+            return drag({node: node, dpos: dp, pos0: p0, nsteps: 2});
         }
 
         function _assert(rng, msg) {
@@ -1105,7 +1105,7 @@ describe('Test polar interactions:', function() {
 
         function _drag(p0, dp) {
             var node = d3.select('.polar > .draglayer > .angulardrag').node();
-            return drag(node, dp[0], dp[1], null, p0[0], p0[1]);
+            return drag({node: node, dpos: dp, pos0: p0});
         }
 
         function _assert(rot, msg, noEvent) {
@@ -1161,14 +1161,14 @@ describe('Test polar interactions:', function() {
             var node = d3.select('.polar > .draglayer > .radialdrag').node();
             var p0 = [375, 200];
             var dp = [-50, 0];
-            return drag(node, dp[0], dp[1], null, p0[0], p0[1], 2);
+            return drag({node: node, dpos: dp, pos0: p0, nsteps: 2});
         }
 
         function _dragAngular() {
             var node = d3.select('.polar > .draglayer > .angulardrag').node();
             var p0 = [350, 150];
             var dp = [-20, 20];
-            return drag(node, dp[0], dp[1], null, p0[0], p0[1]);
+            return drag({node: node, dpos: dp, pos0: p0});
         }
 
         // once on drag, once on mouseup relayout
@@ -1266,7 +1266,7 @@ describe('Test polar interactions:', function() {
 
             function _drag(p0, dp, nsteps) {
                 var node = d3.select('.polar > .draglayer > .radialdrag').node();
-                return drag(node, dp[0], dp[1], null, p0[0], p0[1], nsteps);
+                return drag({node: node, dpos: dp, pos0: p0, nsteps: nsteps});
             }
 
             var gd = createGraphDiv();
@@ -1300,7 +1300,7 @@ describe('Test polar interactions:', function() {
 
             function _drag(p0, dp, nsteps) {
                 var node = d3.select('.polar > .draglayer > .maindrag').node();
-                return drag(node, dp[0], dp[1], null, p0[0], p0[1], nsteps);
+                return drag({node: node, dpos: dp, pos0: p0, nsteps: nsteps});
             }
 
             var gd = createGraphDiv();
@@ -1332,7 +1332,7 @@ describe('Test polar interactions:', function() {
 
             function _drag(p0, dp, nsteps) {
                 var node = d3.select('.polar > .draglayer > .angulardrag').node();
-                return drag(node, dp[0], dp[1], null, p0[0], p0[1], nsteps);
+                return drag({node: node, dpos: dp, pos0: p0, nsteps: nsteps});
             }
 
             var dragPos0 = [360, 180];
@@ -1381,7 +1381,7 @@ describe('Test polar *gridshape linear* interactions', function() {
         // to activate the radial drag mode
         function _drag(p0, dp) {
             var node = d3.select('.polar > .draglayer > .radialdrag').node();
-            return drag(node, dp[0], dp[1], null, p0[0], p0[1], 2);
+            return drag({node: node, dpos: dp, pos0: p0, nsteps: 2});
         }
 
         function _assert(msg, angle) {
@@ -1441,7 +1441,7 @@ describe('Test polar *gridshape linear* interactions', function() {
 
         function _run(msg, p0, dp, exp) {
             var node = d3.select('.polar > .draglayer > .angulardrag').node();
-            var dragFns = drag.makeFns(node, dp[0], dp[1], {x0: p0[0], y0: p0[1]});
+            var dragFns = drag.makeFns({node: node, dpos: dp, pos0: p0});
 
             return dragFns.start().then(function() {
                 layersRotateFromZero.forEach(function(q) {
@@ -1517,7 +1517,7 @@ describe('Test polar *gridshape linear* interactions', function() {
 
         function _run(msg, p0, dp, exp) {
             var node = d3.select('.polar > .draglayer > .maindrag').node();
-            var dragFns = drag.makeFns(node, dp[0], dp[1], {x0: p0[0], y0: p0[1]});
+            var dragFns = drag.makeFns({node: node, dpos: dp, pos0: p0});
 
             return dragFns.start().then(function() {
                 var zl = d3.select(gd).select('g.zoomlayer');

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -1274,7 +1274,9 @@ describe('sankey tests', function() {
                             nodes = document.getElementsByClassName('sankey-node');
                             node = nodes.item(nodes.length - 1); // Dragged node is now the last one
                             var newPosition = getNodeCoords(node);
-                            if(arrangement === 'freeform') expect(newPosition.x).toBeCloseTo(position.x + move[0], 2, 'final x position is off');
+                            if(arrangement === 'freeform') {
+                                expect(newPosition.x).toBeCloseTo(position.x + move[0], 0, 'final x position is off');
+                            }
                             expect(newPosition.y).toBeCloseTo(position.y + move[1], 2, 'final y position is off');
                             return Promise.resolve(true);
                         });
@@ -1308,7 +1310,7 @@ describe('sankey tests', function() {
                     var node;
                     var x, x1;
                     var y, y1;
-                    var precision = 3;
+                    var precision = 2;
 
                     Plotly.newPlot(gd, mockCopy)
                       .then(function() {

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -1268,7 +1268,7 @@ describe('sankey tests', function() {
                             node = nodes.item(nodeId);
                             position = getNodeCoords(node);
                             var timeDelay = (arrangement === 'snap') ? 2000 : 0; // Wait for force simulation to finish
-                            return drag(node, move[0], move[1], false, false, false, 10, false, timeDelay);
+                            return drag({node: node, dpos: move, nsteps: 10, timeDelay: timeDelay});
                         })
                         .then(function() {
                             nodes = document.getElementsByClassName('sankey-node');
@@ -1319,7 +1319,7 @@ describe('sankey tests', function() {
 
                           nodes = document.getElementsByClassName('sankey-node');
                           node = nodes.item(nodeId);
-                          return drag(node, move[0], move[1]);
+                          return drag({node: node, dpos: move});
                       })
                       .then(function() {
                           x = gd._fullData[0].node.x.slice();
@@ -1329,7 +1329,7 @@ describe('sankey tests', function() {
 
                           nodes = document.getElementsByClassName('sankey-node');
                           node = nodes.item(nodes.length - 1); // Dragged node is now the last one
-                          return drag(node, move[0], move[1]);
+                          return drag({node: node, dpos: move});
                       })
                       .then(function() {
                           x1 = gd._fullData[0].node.x.slice();
@@ -1384,7 +1384,7 @@ describe('sankey tests', function() {
                           positionBeforeDrag = getNodeCoords(node);
                           positionBeforeDrag = [positionBeforeDrag.x, positionBeforeDrag.y];
                           positionAfterDrag = [positionBeforeDrag[0] + move[0], positionBeforeDrag[1] + move[1]];
-                          return drag(node, move[0], move[1], false, false, false, 10, false, 1000);
+                          return drag({node: node, dpos: move, nsteps: 10, timeDelay: 1000});
                       })
                       .then(function() {
                           // Check that the node was really moved

--- a/test/jasmine/tests/shapes_test.js
+++ b/test/jasmine/tests/shapes_test.js
@@ -834,7 +834,7 @@ describe('A fixed size path shape', function() {
     it('is draggable', function(done) {
         Plotly.plot(gd, data, layout, {editable: true})
           .then(function() {
-              drag(getFirstShapeNode(), 50, 50).then(function() {
+              drag({node: getFirstShapeNode(), dpos: [50, 50]}).then(function() {
                   assertShapeSize(getFirstShapeNode(), 30, 20);
                   done();
               });
@@ -852,7 +852,7 @@ describe('A fixed size path shape', function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var widthBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().width;
 
-                drag(shapeNodeBeforeDrag, 300, 50).then(function() {
+                drag({node: shapeNodeBeforeDrag, dpos: [300, 50]}).then(function() {
                     var shapeNodeAfterDrag = getFirstShapeNode();
                     var bbox = shapeNodeAfterDrag.getBoundingClientRect();
                     expect(bbox.height).toBe(20);
@@ -874,7 +874,7 @@ describe('A fixed size path shape', function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var heightBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().height;
 
-                drag(shapeNodeBeforeDrag, 50, 300).then(function() {
+                drag({node: shapeNodeBeforeDrag, dpos: [50, 300]}).then(function() {
                     var shapeNodeAfterDrag = getFirstShapeNode();
                     var bbox = shapeNodeAfterDrag.getBoundingClientRect();
                     expect(bbox.width).toBe(30);
@@ -1006,7 +1006,7 @@ describe('A fixed size shape', function() {
     it('is draggable', function(done) {
         Plotly.plot(gd, data, layout, {editable: true})
           .then(function() {
-              drag(getFirstShapeNode(), 50, 50).then(function() {
+              drag({node: getFirstShapeNode(), dpos: [50, 50]}).then(function() {
                   assertShapeSize(getFirstShapeNode(), 25, 25);
                   done();
               });
@@ -1025,7 +1025,7 @@ describe('A fixed size shape', function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var widthBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().width;
 
-                drag(shapeNodeBeforeDrag, 300, 50).then(function() {
+                drag({node: shapeNodeBeforeDrag, dpos: [300, 50]}).then(function() {
                     var shapeNodeAfterDrag = getFirstShapeNode();
                     var bbox = shapeNodeAfterDrag.getBoundingClientRect();
                     expect(bbox.height).toBe(25);
@@ -1048,7 +1048,7 @@ describe('A fixed size shape', function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var heightBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().height;
 
-                drag(shapeNodeBeforeDrag, 50, 300).then(function() {
+                drag({node: shapeNodeBeforeDrag, dpos: [50, 300]}).then(function() {
                     var shapeNodeAfterDrag = getFirstShapeNode();
                     var bbox = shapeNodeAfterDrag.getBoundingClientRect();
                     expect(bbox.width).toBe(25);
@@ -1088,7 +1088,7 @@ describe('A fixed size shape', function() {
                           var dx = shallShrink ? dxToShrinkWidth[direction] : dxToEnlargeWidth[direction];
                           var dy = shallShrink ? dyToShrinkHeight[direction] : dyToEnlargeHeight[direction];
 
-                          drag(shapeNodeBeforeDrag, dx, dy, direction)
+                          drag({node: shapeNodeBeforeDrag, dpos: [dx, dy], edge: direction})
                             .then(function() {
                                 var shapeNodeAfterDrag = getFirstShapeNode();
                                 var bBoxAfterDrag = shapeNodeAfterDrag.getBoundingClientRect();
@@ -1117,7 +1117,7 @@ describe('A fixed size shape', function() {
                   var bBoxBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect();
 
                   var dragSensitiveElement = getMoveLineDragElement(0);
-                  drag(dragSensitiveElement, 10, -10)
+                  drag({node: dragSensitiveElement, dpos: [10, -10]})
                     .then(function() {
                         var shapeNodeAfterDrag = getFirstShapeNode();
                         var bBoxAfterDrag = shapeNodeAfterDrag.getBoundingClientRect();
@@ -1138,7 +1138,7 @@ describe('A fixed size shape', function() {
                   var bBoxBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect();
 
                   var dragSensitiveElement = getResizeLineOverStartPointElement();
-                  drag(dragSensitiveElement, 50, -10)
+                  drag({node: dragSensitiveElement, dpos: [50, -10]})
                     .then(function() {
                         var shapeNodeAfterDrag = getFirstShapeNode();
                         var bBoxAfterDrag = shapeNodeAfterDrag.getBoundingClientRect();
@@ -1161,7 +1161,7 @@ describe('A fixed size shape', function() {
                   var bBoxBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect();
 
                   var dragSensitiveElement = getResizeLineOverEndPointElement();
-                  drag(dragSensitiveElement, 50, -10)
+                  drag({node: dragSensitiveElement, dpos: [50, -10]})
                     .then(function() {
                         var shapeNodeAfterDrag = getFirstShapeNode();
                         var bBoxAfterDrag = shapeNodeAfterDrag.getBoundingClientRect();
@@ -1464,7 +1464,7 @@ describe('Test shapes', function() {
 
         var initialCoordinates = getShapeCoordinates(layoutShape, x2p, y2p);
 
-        return drag(node, dx, dy).then(function() {
+        return drag({node: node, dpos: [dx, dy]}).then(function() {
             var finalCoordinates = getShapeCoordinates(layoutShape, x2p, y2p);
 
             expect(finalCoordinates.x0 - initialCoordinates.x0).toBeCloseTo(dx);
@@ -1494,7 +1494,7 @@ describe('Test shapes', function() {
 
         expect(initialCoordinates.length).toBe(6);
 
-        return drag(node, dx, dy).then(function() {
+        return drag({node: node, dpos: [dx, dy]}).then(function() {
             var finalPath = layoutShape.path;
             var finalCoordinates = getPathCoordinates(finalPath, x2p, y2p);
 
@@ -1523,7 +1523,7 @@ describe('Test shapes', function() {
 
         var initialCoordinates = getShapeCoordinates(layoutShape, x2p, y2p);
 
-        return drag(node, dx, dy, direction).then(function() {
+        return drag({node: node, dpos: [dx, dy], edge: direction}).then(function() {
             var finalCoordinates = getShapeCoordinates(layoutShape, x2p, y2p);
 
             var keyN, keyS, keyW, keyE;
@@ -1572,7 +1572,7 @@ describe('Test shapes', function() {
               getResizeLineOverEndPointElement();
 
             var initialCoordinates = getShapeCoordinates(layoutShape, x2p, y2p);
-            return drag(dragHandle, 10, 10).then(function() {
+            return drag({node: dragHandle, dpos: [10, 10]}).then(function() {
                 var finalCoordinates = getShapeCoordinates(layoutShape, x2p, y2p);
 
                 if(pointToMove === 'start') {

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -1501,7 +1501,7 @@ describe('Test splom drag:', function() {
         var node = d3.select('.nsewdrag[data-subplot="xy"]').node();
         var dx = p1[0] - p0[0];
         var dy = p1[1] - p0[1];
-        return drag(node, dx, dy, null, p0[0], p0[1]);
+        return drag({node: node, dpos: [dx, dy], pos0: p0});
     }
 
     it('@gl should update scattermatrix ranges on pan', function(done) {

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -1597,17 +1597,9 @@ describe('Test splom select:', function() {
                 resolve();
             });
 
-            Lib.clearThrottle();
-            mouseEvent('mousemove', path[0][0], path[0][1], opts);
-            mouseEvent('mousedown', path[0][0], path[0][1], opts);
-
-            var len = path.length;
-            path.slice(1, len).forEach(function(pt) {
-                Lib.clearThrottle();
-                mouseEvent('mousemove', pt[0], pt[1], opts);
-            });
-
-            mouseEvent('mouseup', path[len - 1][0], path[len - 1][1], opts);
+            opts.path = path;
+            opts.clearThrottle = Lib.clearThrottle;
+            drag(opts);
         });
     }
 

--- a/test/jasmine/tests/template_test.js
+++ b/test/jasmine/tests/template_test.js
@@ -9,7 +9,6 @@ var drag = require('../assets/drag');
 var scatterFillMock = require('@mocks/scatter_fill_self_next.json');
 var templateMock = require('@mocks/template.json');
 
-
 describe('makeTemplate', function() {
     it('does not template arrays', function() {
         var template = Plotly.makeTemplate(Lib.extendDeep({}, scatterFillMock));
@@ -243,13 +242,13 @@ describe('template interactions', function() {
 
         var schoolDragger = checkAnnotations(5, 4, 5);
 
-        drag(schoolDragger, 0, -80)
+        drag({node: schoolDragger, dpos: [0, -80]})
         .then(function() {
             // added an item to layout.annotations and put that before the
             // remaining default item in the DOM
             schoolDragger = checkAnnotations(6, 5, 4, 0.25);
 
-            return drag(schoolDragger, 0, -80);
+            return drag({node: schoolDragger, dpos: [0, -80]});
         })
         .then(function() {
             // item count and order are unchanged now, item just moves.
@@ -281,12 +280,12 @@ describe('template interactions', function() {
 
         var rectDragger = checkShapes(1);
 
-        drag(rectDragger, 0, -80, 's')
+        drag({node: rectDragger, dpos: [0, -80], edge: 's'})
         .then(function() {
             // added an item to layout.shapes
             rectDragger = checkShapes(2, 0.15);
 
-            return drag(rectDragger, 0, -80, 's');
+            return drag({node: rectDragger, dpos: [0, -80], edge: 's'});
         })
         .then(function() {
             // item count and order are unchanged now, item just resizes.


### PR DESCRIPTION
commit https://github.com/plotly/plotly.js/commit/8d0ccb109aa3fc0ab53225a3e9beff8f430fe79c fixes https://github.com/plotly/plotly.js/issues/3943 a regression that slipped in 1.48.0 via the `plotly_relayouting` PR https://github.com/plotly/plotly.js/pull/3888

before https://codepen.io/etpinard/pen/jjEWyR?editors=1010

![Peek 2019-06-11 15-50](https://user-images.githubusercontent.com/6675409/59301881-a4bb5400-8c60-11e9-912b-435bad45d958.gif)

after https://codepen.io/etpinard/pen/GbgoWx?editors=1010

![Peek 2019-06-11 15-53](https://user-images.githubusercontent.com/6675409/59302071-1abfbb00-8c61-11e9-8b4f-9a04fc9e0d6f.gif)


----

commit https://github.com/plotly/plotly.js/commit/8806fb710f7276714506e3d021b25601b5c3263c generalizes our `test/jasmine/assets/drag.js` helpers, so that we can use them almost everywhere with https://github.com/plotly/plotly.js/commit/ee74b289165e0dabdb67b9a3e011e8083b00b37f and https://github.com/plotly/plotly.js/commit/c48b5bffaf43f2b89515511fb447b452769b4983. This should make some of our tests less flaky.

----

The other commits bumped a few tolerance values to make the tests :white_check_mark: on my laptop running Chrome 70

------

@plotly/plotly_js looking for a quick review to release 1.48.2 asap. Thanks!