### PR TITLE
fixup hoverinfo & hovertemplate initial, delta and final flags for waterfalls

### DIFF
--- a/src/traces/waterfall/attributes.js
+++ b/src/traces/waterfall/attributes.js
@@ -10,6 +10,9 @@
 
 var barAttrs = require('../bar/attributes');
 var lineAttrs = require('../scatter/attributes').line;
+var plotAttrs = require('../../plots/attributes');
+var hovertemplateAttrs = require('../../components/fx/hovertemplate_attributes');
+var constants = require('./constants');
 var extendFlat = require('../../lib/extend').extendFlat;
 var Color = require('../../components/color');
 
@@ -74,7 +77,13 @@ module.exports = {
     dy: barAttrs.dy,
 
     hovertext: barAttrs.hovertext,
-    hovertemplate: barAttrs.hovertemplate,
+    hovertemplate: hovertemplateAttrs({}, {
+        keys: constants.eventDataKeys
+    }),
+
+    hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {
+        flags: ['name', 'x', 'y', 'text', 'initial', 'delta', 'final']
+    }),
 
     textinfo: {
         valType: 'flaglist',

--- a/src/traces/waterfall/constants.js
+++ b/src/traces/waterfall/constants.js
@@ -1,0 +1,17 @@
+/**
+* Copyright 2012-2019, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+module.exports = {
+    eventDataKeys: [
+        'initial',
+        'delta',
+        'final'
+    ]
+};

--- a/src/traces/waterfall/event_data.js
+++ b/src/traces/waterfall/event_data.js
@@ -1,0 +1,25 @@
+/**
+* Copyright 2012-2019, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+module.exports = function eventData(out, pt /* , trace, cd, pointNumber */) {
+    // standard cartesian event data
+    out.x = 'xVal' in pt ? pt.xVal : pt.x;
+    out.y = 'yVal' in pt ? pt.yVal : pt.y;
+
+    // for funnel
+    if('initial' in pt) out.initial = pt.initial;
+    if('delta' in pt) out.delta = pt.delta;
+    if('final' in pt) out.final = pt.final;
+
+    if(pt.xa) out.xaxis = pt.xa;
+    if(pt.ya) out.yaxis = pt.ya;
+
+    return out;
+};

--- a/src/traces/waterfall/hover.js
+++ b/src/traces/waterfall/hover.js
@@ -28,7 +28,7 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
     var vAxis = isHorizontal ? pointData.xa : pointData.ya;
 
     function formatNumber(a) {
-        return (a === undefined) ? '' : hoverLabelText(vAxis, a);
+        return hoverLabelText(vAxis, a);
     }
 
     // the closest data point
@@ -37,20 +37,16 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
 
     var size = (di.isSum) ? di.b + di.s : di.rawS;
 
-    if(di.isSum) {
-        point.final = undefined;
-        point.initial = undefined;
-        point.delta = size - di.b;
-    } else {
+    if(!di.isSum) {
         point.initial = di.b + di.s - size;
         point.delta = size;
         point.final = point.initial + point.delta;
-    }
 
-    var v = formatNumber(Math.abs(point.delta));
-    point.deltaLabel = size < 0 ? '(' + v + ')' : v;
-    point.finalLabel = formatNumber(point.final);
-    point.initialLabel = formatNumber(point.initial);
+        var v = formatNumber(Math.abs(point.delta));
+        point.deltaLabel = size < 0 ? '(' + v + ')' : v;
+        point.finalLabel = formatNumber(point.final);
+        point.initialLabel = formatNumber(point.initial);
+    }
 
     var hoverinfo = di.hi || trace.hoverinfo;
     var text = [];
@@ -60,18 +56,20 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
 
         var hasFlag = function(flag) { return isAll || parts.indexOf(flag) !== -1; };
 
-        if(hasFlag('final') && point.finalLabel !== '') {
-            text.push(point.finalLabel);
-        }
-        if(hasFlag('delta') && point.deltaLabel !== '') {
-            if(size < 0) {
-                text.push(point.deltaLabel + ' ' + DIRSYMBOL.decreasing);
-            } else {
-                text.push(point.deltaLabel + ' ' + DIRSYMBOL.increasing);
+        if(!di.isSum) {
+            if(hasFlag('final')) {
+                text.push(point.finalLabel);
             }
-        }
-        if(hasFlag('initial') && point.initialLabel !== '') {
-            text.push('Initial: ' + point.initialLabel);
+            if(hasFlag('delta')) {
+                if(size < 0) {
+                    text.push(point.deltaLabel + ' ' + DIRSYMBOL.decreasing);
+                } else {
+                    text.push(point.deltaLabel + ' ' + DIRSYMBOL.increasing);
+                }
+            }
+            if(hasFlag('initial')) {
+                text.push('Initial: ' + point.initialLabel);
+            }
         }
     }
 

--- a/src/traces/waterfall/hover.js
+++ b/src/traces/waterfall/hover.js
@@ -38,17 +38,43 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
     var size = (di.isSum) ? di.b + di.s : di.rawS;
 
     if(!di.isSum) {
-        // format delta numbers:
-        if(size > 0) {
-            point.extraText = formatNumber(size) + ' ' + DIRSYMBOL.increasing;
-        } else if(size < 0) {
-            point.extraText = '(' + (formatNumber(-size)) + ') ' + DIRSYMBOL.decreasing;
-        } else {
-            return;
-        }
-        // display initial value
-        point.extraText += '<br>Initial: ' + formatNumber(di.b + di.s - size);
+        point.initial = di.b + di.s - size;
+        point.delta = size;
+        point.final = point.initial + point.delta;
+    } else {
+        point.final = size;
+        point.initial = di.b;
+        point.delta = point.final - point.initial;
     }
+
+    point.finalLabel = formatNumber(point.final);
+    point.deltaLabel = formatNumber(Math.abs(point.delta));
+    point.initialLabel = formatNumber(point.initial, 1);
+
+    var hoverinfo = di.hi || trace.hoverinfo;
+    var text = [];
+    if(hoverinfo && hoverinfo !== 'none' && hoverinfo !== 'skip') {
+        var isAll = (hoverinfo === 'all');
+        var parts = hoverinfo.split('+');
+
+        var hasFlag = function(flag) { return isAll || parts.indexOf(flag) !== -1; };
+
+        if(hasFlag('final') && point.finalLabel !== '') {
+            text.push('Final: ' + point.finalLabel);
+        }
+        if(hasFlag('delta') && point.deltaLabel !== '') {
+            if(size < 0) {
+                text.push('(' + point.deltaLabel + ') ' + DIRSYMBOL.decreasing);
+            } else {
+                text.push(point.deltaLabel + ' ' + DIRSYMBOL.increasing);
+            }
+        }
+        if(hasFlag('initial') && point.initialLabel !== '') {
+            text.push('Initial: ' + point.initialLabel);
+        }
+    }
+
+    if(text.length) point.extraText = text.join('<br>');
 
     point.color = getTraceColor(trace, di);
 

--- a/src/traces/waterfall/hover.js
+++ b/src/traces/waterfall/hover.js
@@ -28,7 +28,7 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
     var vAxis = isHorizontal ? pointData.xa : pointData.ya;
 
     function formatNumber(a) {
-        return hoverLabelText(vAxis, a);
+        return (a === undefined) ? '' : hoverLabelText(vAxis, a);
     }
 
     // the closest data point
@@ -37,19 +37,20 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
 
     var size = (di.isSum) ? di.b + di.s : di.rawS;
 
-    if(!di.isSum) {
+    if(di.isSum) {
+        point.final = undefined;
+        point.initial = undefined;
+        point.delta = size - di.b;
+    } else {
         point.initial = di.b + di.s - size;
         point.delta = size;
         point.final = point.initial + point.delta;
-    } else {
-        point.final = size;
-        point.initial = di.b;
-        point.delta = point.final - point.initial;
     }
 
+    var v = formatNumber(Math.abs(point.delta));
+    point.deltaLabel = size < 0 ? '(' + v + ')' : v;
     point.finalLabel = formatNumber(point.final);
-    point.deltaLabel = formatNumber(Math.abs(point.delta));
-    point.initialLabel = formatNumber(point.initial, 1);
+    point.initialLabel = formatNumber(point.initial);
 
     var hoverinfo = di.hi || trace.hoverinfo;
     var text = [];
@@ -60,11 +61,11 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
         var hasFlag = function(flag) { return isAll || parts.indexOf(flag) !== -1; };
 
         if(hasFlag('final') && point.finalLabel !== '') {
-            text.push('Final: ' + point.finalLabel);
+            text.push(point.finalLabel);
         }
         if(hasFlag('delta') && point.deltaLabel !== '') {
             if(size < 0) {
-                text.push('(' + point.deltaLabel + ') ' + DIRSYMBOL.decreasing);
+                text.push(point.deltaLabel + ' ' + DIRSYMBOL.decreasing);
             } else {
                 text.push(point.deltaLabel + ' ' + DIRSYMBOL.increasing);
             }

--- a/src/traces/waterfall/hover.js
+++ b/src/traces/waterfall/hover.js
@@ -57,7 +57,9 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode) {
         var hasFlag = function(flag) { return isAll || parts.indexOf(flag) !== -1; };
 
         if(!di.isSum) {
-            if(hasFlag('final')) {
+            if(hasFlag('final') &&
+                (isHorizontal ? !hasFlag('x') : !hasFlag('y')) // don't display redundant info.
+            ) {
                 text.push(point.finalLabel);
             }
             if(hasFlag('delta')) {

--- a/src/traces/waterfall/index.js
+++ b/src/traces/waterfall/index.js
@@ -19,6 +19,8 @@ module.exports = {
     plot: require('./plot'),
     style: require('./style').style,
     hoverPoints: require('./hover'),
+    eventData: require('./event_data'),
+
     selectPoints: require('../bar/select'),
 
     moduleType: 'trace',

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -1379,7 +1379,7 @@ describe('waterfall hover', function() {
             .then(done);
         });
 
-        it('should turn off percentages with hoveinfo none or skip', function(done) {
+        it('should turn off hoverinfo flags with hoveinfo none or skip', function(done) {
             gd = createGraphDiv();
 
             var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
@@ -1406,7 +1406,7 @@ describe('waterfall hover', function() {
             .then(done);
         });
 
-        it('should turn on percentages with hoveinfo all', function(done) {
+        it('should turn on hoverinfo flags with hoveinfo all', function(done) {
             gd = createGraphDiv();
 
             var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
@@ -1426,9 +1426,9 @@ describe('waterfall hover', function() {
             .then(function() {
                 assertHoverLabelContent({
                     nums: [
-                        '1001\nHover text A\nFinal: 1001\n1 ▲\nInitial: 1000',
-                        '1002\nHover text G\nFinal: 1002\n2 ▲\nInitial: 1000',
-                        '1,001.5\na (hover)\nFinal: 1,001.5\n1.5 ▲\nInitial: 1000'
+                        '1001\nHover text A\n1001\n1 ▲\nInitial: 1000',
+                        '1002\nHover text G\n1002\n2 ▲\nInitial: 1000',
+                        '1,001.5\na (hover)\n1,001.5\n1.5 ▲\nInitial: 1000'
                     ],
                     name: ['Lines, Marke...', 'Lines and Text', 'missing text'],
                     axis: '0'
@@ -1486,7 +1486,7 @@ describe('waterfall hover', function() {
             })
             .then(function() {
                 assertHoverLabelContent({
-                    nums: '2.2\nFinal: 2.2\n4.4 ▲\nInitial: −2.2',
+                    nums: '2.2\n2.2\n4.4 ▲\nInitial: −2.2',
                     name: '',
                     axis: 'E'
                 });
@@ -1522,31 +1522,31 @@ describe('waterfall hover', function() {
             .then(function() {
                 var out = _hover(gd, 0, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1002.201);
-                expect(out.extraText).toEqual('Final: $1,002.201m<br>$2.2m ▲<br>Initial: $1,000.001m');
+                expect(out.extraText).toEqual('$2.2m ▲');
                 expect(out.style).toEqual([0, '#4499FF', 0, 1002.201]);
             })
             .then(function() {
                 var out = _hover(gd, 1, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1001.101);
-                expect(out.extraText).toEqual('Final: $1,001.101m<br>($1.1m) ▼<br>Initial: $1,002.201m');
+                expect(out.extraText).toEqual('$1,001.101m<br>($1.1m) ▼<br>Initial: $1,002.201m');
                 expect(out.style).toEqual([1, '#FF4136', 1, 1001.101]);
             })
             .then(function() {
                 var out = _hover(gd, 2, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1001.101);
-                expect(out.extraText).toEqual('Final: $1,001.101m<br>$1.1m ▲<br>Initial: $1,000.001m');
+                expect(out.extraText).toEqual('$1.1m ▲');
                 expect(out.style).toEqual([2, '#4499FF', 2, 1001.101]);
             })
             .then(function() {
                 var out = _hover(gd, 3, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1004.401);
-                expect(out.extraText).toEqual('Final: $1,004.401m<br>$3.3m ▲<br>Initial: $1,001.101m');
+                expect(out.extraText).toEqual('$1,004.401m<br>$3.3m ▲<br>Initial: $1,001.101m');
                 expect(out.style).toEqual([3, '#3D9970', 3, 1004.401]);
             })
             .then(function() {
                 var out = _hover(gd, 4, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1004.401);
-                expect(out.extraText).toEqual('Final: $1,004.401m<br>$4.4m ▲<br>Initial: $1,000.001m');
+                expect(out.extraText).toEqual('$4.4m ▲');
                 expect(out.style).toEqual([4, '#4499FF', 4, 1004.401]);
             })
             .catch(failTest)

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -1444,7 +1444,7 @@ describe('waterfall hover', function() {
             var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
             mock.data.forEach(function(t) {
                 t.type = 'waterfall';
-                t.hovertemplate = t.hovertemplate = 'Value: %{y}<br>SUM: %{final}<br>START: %{initial}<br>DIFF: %{delta}<extra></extra>';
+                t.hovertemplate = 'Value: %{y}<br>SUM: %{final}<br>START: %{initial}<br>DIFF: %{delta}<extra></extra>';
             });
 
             function _hover() {

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -1379,13 +1379,41 @@ describe('waterfall hover', function() {
             .then(done);
         });
 
-        it('should use hovertemplate if specified', function(done) {
+        it('should turn off percentages with hoveinfo none or skip', function(done) {
+            gd = createGraphDiv();
+
+            var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
+            mock.data.forEach(function(t, i) {
+                t.type = 'waterfall';
+                if(i === 0) {
+                    t.hoverinfo = 'none';
+                } else {
+                    t.hoverinfo = 'skip';
+                }
+            });
+
+            function _hover() {
+                var evt = { xpx: 125, ypx: 150 };
+                Fx.hover('graph', evt, 'xy');
+            }
+
+            Plotly.plot(gd, mock)
+            .then(_hover)
+            .then(function() {
+                expect(d3.selectAll('g.hovertext').size()).toBe(0);
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
+        it('should turn on percentages with hoveinfo all', function(done) {
             gd = createGraphDiv();
 
             var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
             mock.data.forEach(function(t) {
                 t.type = 'waterfall';
-                t.hovertemplate = '%{y}<extra></extra>';
+                t.base = 1000;
+                t.hoverinfo = 'all';
             });
 
             function _hover() {
@@ -1397,11 +1425,45 @@ describe('waterfall hover', function() {
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({
-                    nums: ['1', '2', '1.5'],
+                    nums: [
+                        '1001\nHover text A\nFinal: 1001\n1 ▲\nInitial: 1000',
+                        '1002\nHover text G\nFinal: 1002\n2 ▲\nInitial: 1000',
+                        '1,001.5\na (hover)\nFinal: 1,001.5\n1.5 ▲\nInitial: 1000'
+                    ],
+                    name: ['Lines, Marke...', 'Lines and Text', 'missing text'],
+                    axis: '0'
+                });
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
+        it('should use hovertemplate if specified', function(done) {
+            gd = createGraphDiv();
+
+            var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
+            mock.data.forEach(function(t) {
+                t.type = 'waterfall';
+                t.hovertemplate = t.hovertemplate = 'Value: %{y}<br>SUM: %{final}<br>START: %{initial}<br>DIFF: %{delta}<extra></extra>';
+            });
+
+            function _hover() {
+                var evt = { xpx: 125, ypx: 150 };
+                Fx.hover('graph', evt, 'xy');
+            }
+
+            Plotly.plot(gd, mock)
+            .then(_hover)
+            .then(function() {
+                assertHoverLabelContent({
+                    nums: [
+                        'Value: 1\nSUM: 1\nSTART: 0\nDIFF: 1',
+                        'Value: 2\nSUM: 2\nSTART: 0\nDIFF: 2',
+                        'Value: 1.5\nSUM: 1.5\nSTART: 0\nDIFF: 1.5'
+                    ],
                     name: ['', '', ''],
                     axis: '0'
                 });
-                // return Plotly.restyle(gd, 'text', ['APPLE', 'BANANA', 'ORANGE']);
             })
             .catch(failTest)
             .then(done);
@@ -1424,7 +1486,7 @@ describe('waterfall hover', function() {
             })
             .then(function() {
                 assertHoverLabelContent({
-                    nums: '2.2\n4.4 ▲\nInitial: −2.2',
+                    nums: '2.2\nFinal: 2.2\n4.4 ▲\nInitial: −2.2',
                     name: '',
                     axis: 'E'
                 });
@@ -1460,31 +1522,31 @@ describe('waterfall hover', function() {
             .then(function() {
                 var out = _hover(gd, 0, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1002.201);
-                expect(out.extraText).toEqual(undefined);
+                expect(out.extraText).toEqual('Final: $1,002.201m<br>$2.2m ▲<br>Initial: $1,000.001m');
                 expect(out.style).toEqual([0, '#4499FF', 0, 1002.201]);
             })
             .then(function() {
                 var out = _hover(gd, 1, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1001.101);
-                expect(out.extraText).toEqual('($1.1m) ▼<br>Initial: $1,002.201m');
+                expect(out.extraText).toEqual('Final: $1,001.101m<br>($1.1m) ▼<br>Initial: $1,002.201m');
                 expect(out.style).toEqual([1, '#FF4136', 1, 1001.101]);
             })
             .then(function() {
                 var out = _hover(gd, 2, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1001.101);
-                expect(out.extraText).toEqual(undefined);
+                expect(out.extraText).toEqual('Final: $1,001.101m<br>$1.1m ▲<br>Initial: $1,000.001m');
                 expect(out.style).toEqual([2, '#4499FF', 2, 1001.101]);
             })
             .then(function() {
                 var out = _hover(gd, 3, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1004.401);
-                expect(out.extraText).toEqual('$3.3m ▲<br>Initial: $1,001.101m');
+                expect(out.extraText).toEqual('Final: $1,004.401m<br>$3.3m ▲<br>Initial: $1,001.101m');
                 expect(out.style).toEqual([3, '#3D9970', 3, 1004.401]);
             })
             .then(function() {
                 var out = _hover(gd, 4, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1004.401);
-                expect(out.extraText).toEqual(undefined);
+                expect(out.extraText).toEqual('Final: $1,004.401m<br>$4.4m ▲<br>Initial: $1,000.001m');
                 expect(out.style).toEqual([4, '#4499FF', 4, 1004.401]);
             })
             .catch(failTest)

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -1522,7 +1522,7 @@ describe('waterfall hover', function() {
             .then(function() {
                 var out = _hover(gd, 0, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1002.201);
-                expect(out.extraText).toEqual('$2.2m ▲');
+                expect(out.extraText).toEqual(undefined);
                 expect(out.style).toEqual([0, '#4499FF', 0, 1002.201]);
             })
             .then(function() {
@@ -1534,7 +1534,7 @@ describe('waterfall hover', function() {
             .then(function() {
                 var out = _hover(gd, 2, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1001.101);
-                expect(out.extraText).toEqual('$1.1m ▲');
+                expect(out.extraText).toEqual(undefined);
                 expect(out.style).toEqual([2, '#4499FF', 2, 1001.101]);
             })
             .then(function() {
@@ -1546,7 +1546,7 @@ describe('waterfall hover', function() {
             .then(function() {
                 var out = _hover(gd, 4, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1004.401);
-                expect(out.extraText).toEqual('$4.4m ▲');
+                expect(out.extraText).toEqual(undefined);
                 expect(out.style).toEqual([4, '#4499FF', 4, 1004.401]);
             })
             .catch(failTest)

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -1426,9 +1426,9 @@ describe('waterfall hover', function() {
             .then(function() {
                 assertHoverLabelContent({
                     nums: [
-                        '1001\nHover text A\n1001\n1 ▲\nInitial: 1000',
-                        '1002\nHover text G\n1002\n2 ▲\nInitial: 1000',
-                        '1,001.5\na (hover)\n1,001.5\n1.5 ▲\nInitial: 1000'
+                        '1001\nHover text A\n1 ▲\nInitial: 1000',
+                        '1002\nHover text G\n2 ▲\nInitial: 1000',
+                        '1,001.5\na (hover)\n1.5 ▲\nInitial: 1000'
                     ],
                     name: ['Lines, Marke...', 'Lines and Text', 'missing text'],
                     axis: '0'
@@ -1486,7 +1486,7 @@ describe('waterfall hover', function() {
             })
             .then(function() {
                 assertHoverLabelContent({
-                    nums: '2.2\n2.2\n4.4 ▲\nInitial: −2.2',
+                    nums: '2.2\n4.4 ▲\nInitial: −2.2',
                     name: '',
                     axis: 'E'
                 });
@@ -1528,7 +1528,7 @@ describe('waterfall hover', function() {
             .then(function() {
                 var out = _hover(gd, 1, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1001.101);
-                expect(out.extraText).toEqual('$1,001.101m<br>($1.1m) ▼<br>Initial: $1,002.201m');
+                expect(out.extraText).toEqual('($1.1m) ▼<br>Initial: $1,002.201m');
                 expect(out.style).toEqual([1, '#FF4136', 1, 1001.101]);
             })
             .then(function() {
@@ -1540,7 +1540,7 @@ describe('waterfall hover', function() {
             .then(function() {
                 var out = _hover(gd, 3, 1000.5, 'closest');
                 expect(out.yLabelVal).toEqual(1004.401);
-                expect(out.extraText).toEqual('$1,004.401m<br>$3.3m ▲<br>Initial: $1,001.101m');
+                expect(out.extraText).toEqual('$3.3m ▲<br>Initial: $1,001.101m');
                 expect(out.style).toEqual([3, '#3D9970', 3, 1004.401]);
             })
             .then(function() {


### PR DESCRIPTION
A follow up of #3954, #3958 and to address #3960.
The `initial`, `delta` and `final` displayed in the `waterfall` hover now could be controlled and turned off using `hovertemplate` and `hoverinfo`.

Also to note for consistency the initial values and delta from `base` is also displayed over the total bars.  

[Codepen before](https://codepen.io/MojtabaSamimi/pen/OeMLEr?editors=0010)
[Codepen after](https://codepen.io/MojtabaSamimi/pen/BgjLxw?editors=1000)

@plotly/plotly_js 
cc: @nicolaskruchten  