### PR TITLE
ensure that tester property of drawing object exists

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -942,6 +942,9 @@ drawing.bBox = function(node, inTester, hash) {
     if(inTester) {
         testNode = node;
     } else {
+        if(!drawing.tester) {
+            drawing.makeTester();
+        }
         tester = drawing.tester.node();
 
         // copy the node to test into the tester


### PR DESCRIPTION
When I tried to customize modeBarButtons by using imported objects (import PlotlyButtons from 'plotly.js/src/components/modebar/buttons') I got following error:

`TypeError: Cannot read property 'node' of undefined at Object.push../node_modules/plotly.js/src/components/drawing/index.js.drawing.bBox (index.js:926)`

I've noticed this issue was once explained here https://github.com/plotly/plotly.js/issues/3106, but no actions have been taken. I can confirm, that this issue exists, but I have reproduced it differently. 
