### PR TITLE
Fix emitting event "plotly_relayouting" with wrong data

### DIFF
--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -410,7 +410,6 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
         updateZoombox(zb, corners, box, path0, dimmed, lum);
         computeZoomUpdates();
-        gd.emit('plotly_relayouting', updates);
         dimmed = true;
     }
 


### PR DESCRIPTION
Currently "plotly_relayouting" events are emitted when creating a zoombox. These events use the updates to the layout which would be applied when zooming. Since no relayouting takes place until the zoombox is applied I removed the event.