### PR TITLE
Fetch topojson when 1+ trace(s) has `locationmode`

### DIFF
--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -80,6 +80,12 @@ proto.plot = function(geoCalcData, fullLayout, promises) {
             break;
         }
     }
+    for(var i = 0; i < geoCalcData.length; i++) {
+        if(geoCalcData[0][0].trace.locationmode) {
+            needsTopojson = true;
+            break;
+        }
+    }
     if(!needsTopojson) {
         return _this.update(geoCalcData, fullLayout);
     }


### PR DESCRIPTION
... so that `_module.plot` can find the relevant polygon and/or  centroids, even though no base layer is drawn - fixes https://github.com/plotly/plotly.js/issues/3992 introduced in https://github.com/plotly/plotly.js/pull/3856/commits/b04102b745df2a4c79e86c27b8bd1e7d108fab67

before: https://codepen.io/michaelbabyn/pen/agVGQQ
after: https://codepen.io/etpinard/pen/YoYYyO

@plotly/plotly_js 