### PR TITLE
Use URL.createObjectURL during Plotly.downloadImage

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -733,6 +733,11 @@ lib.isIE = function() {
     return typeof window.navigator.msSaveBlob !== 'undefined';
 };
 
+var IS_SAFARI_REGEX = /Version\/[\d\.]+.*Safari/;
+lib.isSafari = function() {
+    return IS_SAFARI_REGEX.test(window.navigator.userAgent);
+};
+
 /**
  * Duck typing to recognize a d3 selection, mostly for IE9's benefit
  * because it doesn't handle instanceof like modern browsers

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -733,6 +733,11 @@ lib.isIE = function() {
     return typeof window.navigator.msSaveBlob !== 'undefined';
 };
 
+var IS_IE9_OR_BELOW_REGEX = /MSIE [1-9]\./;
+lib.isIE9orBelow = function() {
+    return lib.isIE() && IS_IE9_OR_BELOW_REGEX.test(window.navigator.userAgent);
+};
+
 var IS_SAFARI_REGEX = /Version\/[\d\.]+.*Safari/;
 lib.isSafari = function() {
     return IS_SAFARI_REGEX.test(window.navigator.userAgent);

--- a/src/plot_api/to_image.js
+++ b/src/plot_api/to_image.js
@@ -74,8 +74,6 @@ var attrs = {
     }
 };
 
-var IMAGE_URL_PREFIX = /^data:image\/\w+;base64,/;
-
 /** Plotly.toImage
  *
  * @param {object | string | HTML div} gd
@@ -179,7 +177,7 @@ function toImage(gd, opts) {
                 if(imageDataOnly) {
                     return resolve(svg);
                 } else {
-                    return resolve('data:image/svg+xml,' + encodeURIComponent(svg));
+                    return resolve(helpers.encodeSVG(svg));
                 }
             }
 
@@ -206,7 +204,7 @@ function toImage(gd, opts) {
 
     function urlToImageData(url) {
         if(imageDataOnly) {
-            return url.replace(IMAGE_URL_PREFIX, '');
+            return url.replace(helpers.IMAGE_URL_PREFIX, '');
         } else {
             return url;
         }

--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -8,9 +8,12 @@
 
 'use strict';
 
-var toImage = require('../plot_api/to_image');
 var Lib = require('../lib');
+
+var toImage = require('../plot_api/to_image');
+
 var fileSaver = require('./filesaver');
+var helpers = require('./helpers');
 
 /** Plotly.downloadImage
  *
@@ -41,7 +44,7 @@ function downloadImage(gd, opts) {
         //   does not allow toDataURL
         //   svg format will work though
         if(Lib.isIE() && opts.format !== 'svg') {
-            reject(new Error('Sorry IE does not support downloading from canvas. Try {format:\'svg\'} instead.'));
+            reject(new Error(helpers.MSG_IE_BAD_FORMAT));
         }
 
         if(_gd) _gd._snapshotInProgress = true;

--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -15,23 +15,23 @@ var toImage = require('../plot_api/to_image');
 var fileSaver = require('./filesaver');
 var helpers = require('./helpers');
 
-/** Plotly.downloadImage
+/**
+ * Plotly.downloadImage
  *
  * @param {object | string | HTML div} gd
  *   can either be a data/layout/config object
  *   or an existing graph <div>
  *   or an id to an existing graph <div>
- * @param {object} opts (see ../plot_api/to_image)
+ * @param {object} opts (see Plotly.toImage in ../plot_api/to_image)
  * @return {promise}
  */
 function downloadImage(gd, opts) {
     var _gd;
     if(!Lib.isPlainObject(gd)) _gd = Lib.getGraphDiv(gd);
 
-    // check for undefined opts
     opts = opts || {};
-    // default to png
     opts.format = opts.format || 'png';
+    opts.imageDataOnly = true;
 
     return new Promise(function(resolve, reject) {
         if(_gd && _gd._snapshotInProgress) {
@@ -55,7 +55,7 @@ function downloadImage(gd, opts) {
 
         promise.then(function(result) {
             if(_gd) _gd._snapshotInProgress = false;
-            return fileSaver(result, filename);
+            return fileSaver(result, filename, opts.format);
         }).then(function(name) {
             resolve(name);
         }).catch(function(err) {

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -24,7 +24,6 @@
 var fileSaver = function(url, name) {
     var saveLink = document.createElement('a');
     var canUseSaveLink = 'download' in saveLink;
-    var isSafari = /Version\/[\d\.]+.*Safari/.test(navigator.userAgent);
     var promise = new Promise(function(resolve, reject) {
         // IE <10 is explicitly unsupported
         if(typeof navigator !== 'undefined' && /MSIE [1-9]\./.test(navigator.userAgent)) {
@@ -32,10 +31,10 @@ var fileSaver = function(url, name) {
         }
 
         // First try a.download, then web filesystem, then object URLs
-        if(isSafari) {
             // Safari doesn't allow downloading of blob urls
             document.location.href = 'data:application/octet-stream' + url.slice(url.search(/[,;]/));
             resolve(name);
+        if(Lib.isSafari()) {
         }
 
         if(!name) {

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -31,7 +31,7 @@ function fileSaver(url, name, format) {
         var blob;
         var objectUrl;
 
-        if(isIE9orBelow()) {
+        if(Lib.isIE9orBelow()) {
             reject(new Error('IE < 10 unsupported'));
         }
 
@@ -74,12 +74,5 @@ function fileSaver(url, name, format) {
     return promise;
 }
 
-function isIE9orBelow() {
-    return (
-        Lib.isIE() &&
-        typeof window.navigator !== 'undefined' &&
-        /MSIE [1-9]\./.test(window.navigator.userAgent)
-    );
-}
 
 module.exports = fileSaver;

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -38,8 +38,8 @@ function fileSaver(url, name, format) {
         // Safari doesn't allow downloading of blob urls
         if(Lib.isSafari()) {
             var prefix = format === 'svg' ? ',' : ';base64,';
-            document.location.href = 'data:application/octet-stream' + prefix + encodeURIComponent(url);
-            return resolve();
+            helpers.octetStream(prefix + encodeURIComponent(url));
+            return resolve(name);
         }
 
         // IE 10+ (native saveAs)

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -6,6 +6,10 @@
 * LICENSE file in the root directory of this source tree.
 */
 
+'use strict';
+
+var Lib = require('../lib');
+
 /*
 * substantial portions of this code from FileSaver.js
 * https://github.com/eligrey/FileSaver.js
@@ -18,52 +22,83 @@
 * License: MIT
 *   See https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md
 */
-
-'use strict';
-
-var fileSaver = function(url, name) {
+function fileSaver(url, name, format) {
     var saveLink = document.createElement('a');
     var canUseSaveLink = 'download' in saveLink;
+
     var promise = new Promise(function(resolve, reject) {
-        // IE <10 is explicitly unsupported
-        if(typeof navigator !== 'undefined' && /MSIE [1-9]\./.test(navigator.userAgent)) {
+        var blob;
+        var objectUrl;
+
+        if(isIE9orBelow()) {
             reject(new Error('IE < 10 unsupported'));
         }
 
-        // First try a.download, then web filesystem, then object URLs
-            // Safari doesn't allow downloading of blob urls
-            document.location.href = 'data:application/octet-stream' + url.slice(url.search(/[,;]/));
-            resolve(name);
+        // Safari doesn't allow downloading of blob urls
         if(Lib.isSafari()) {
-        }
-
-        if(!name) {
-            name = 'download';
-        }
-
-        if(canUseSaveLink) {
-            saveLink.href = url;
-            saveLink.download = name;
-            document.body.appendChild(saveLink);
-            saveLink.click();
-            document.body.removeChild(saveLink);
-            resolve(name);
+            var prefix = format === 'svg' ? ',' : ';base64,';
+            document.location.href = 'data:application/octet-stream' + prefix + encodeURIComponent(url);
+            return resolve();
         }
 
         // IE 10+ (native saveAs)
-        if(typeof navigator !== 'undefined' && navigator.msSaveBlob) {
-            // At this point we are only dealing with a SVG encoded as
+        if(Lib.isIE()) {
+            // At this point we are only dealing with a decoded SVG as
             // a data URL (since IE only supports SVG)
-            var encoded = url.split(/^data:image\/svg\+xml,/)[1];
-            var svg = decodeURIComponent(encoded);
-            navigator.msSaveBlob(new Blob([svg]), name);
-            resolve(name);
+            blob = createBlob(url, format);
+            window.navigator.msSaveBlob(blob, name);
+            blob = null;
+            return resolve(name);
+        }
+
+        if(canUseSaveLink) {
+            blob = createBlob(url, format);
+            objectUrl = window.URL.createObjectURL(blob);
+
+            saveLink.href = objectUrl;
+            saveLink.download = name;
+            document.body.appendChild(saveLink);
+            saveLink.click();
+
+            document.body.removeChild(saveLink);
+            window.URL.revokeObjectURL(objectUrl);
+            blob = null;
+
+            return resolve(name);
         }
 
         reject(new Error('download error'));
     });
 
     return promise;
-};
+}
+
+function isIE9orBelow() {
+    return (
+        Lib.isIE() &&
+        typeof window.navigator !== 'undefined' &&
+        /MSIE [1-9]\./.test(window.navigator.userAgent)
+    );
+}
+
+// Taken from https://bl.ocks.org/nolanlawson/0eac306e4dac2114c752
+function fixBinary(b) {
+    var len = b.length;
+    var buf = new ArrayBuffer(len);
+    var arr = new Uint8Array(buf);
+    for(var i = 0; i < len; i++) {
+        arr[i] = b.charCodeAt(i);
+    }
+    return buf;
+}
+
+function createBlob(url, format) {
+    if(format === 'svg') {
+        return new window.Blob([url]);
+    } else {
+        var binary = fixBinary(window.atob(url));
+        return new window.Blob([binary], {type: 'image/' + format});
+    }
+}
 
 module.exports = fileSaver;

--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var Lib = require('../lib');
+var helpers = require('./helpers');
 
 /*
 * substantial portions of this code from FileSaver.js
@@ -45,15 +46,15 @@ function fileSaver(url, name, format) {
         if(Lib.isIE()) {
             // At this point we are only dealing with a decoded SVG as
             // a data URL (since IE only supports SVG)
-            blob = createBlob(url, format);
+            blob = helpers.createBlob(url, 'svg');
             window.navigator.msSaveBlob(blob, name);
             blob = null;
             return resolve(name);
         }
 
         if(canUseSaveLink) {
-            blob = createBlob(url, format);
-            objectUrl = window.URL.createObjectURL(blob);
+            blob = helpers.createBlob(url, format);
+            objectUrl = helpers.createObjectURL(blob);
 
             saveLink.href = objectUrl;
             saveLink.download = name;
@@ -61,7 +62,7 @@ function fileSaver(url, name, format) {
             saveLink.click();
 
             document.body.removeChild(saveLink);
-            window.URL.revokeObjectURL(objectUrl);
+            helpers.revokeObjectURL(objectUrl);
             blob = null;
 
             return resolve(name);
@@ -79,26 +80,6 @@ function isIE9orBelow() {
         typeof window.navigator !== 'undefined' &&
         /MSIE [1-9]\./.test(window.navigator.userAgent)
     );
-}
-
-// Taken from https://bl.ocks.org/nolanlawson/0eac306e4dac2114c752
-function fixBinary(b) {
-    var len = b.length;
-    var buf = new ArrayBuffer(len);
-    var arr = new Uint8Array(buf);
-    for(var i = 0; i < len; i++) {
-        arr[i] = b.charCodeAt(i);
-    }
-    return buf;
-}
-
-function createBlob(url, format) {
-    if(format === 'svg') {
-        return new window.Blob([url]);
-    } else {
-        var binary = fixBinary(window.atob(url));
-        return new window.Blob([binary], {type: 'image/' + format});
-    }
 }
 
 module.exports = fileSaver;

--- a/src/snapshot/helpers.js
+++ b/src/snapshot/helpers.js
@@ -36,6 +36,36 @@ exports.encodeSVG = function(svg) {
     return 'data:image/svg+xml,' + encodeURIComponent(svg);
 };
 
+var DOM_URL = window.URL || window.webkitURL;
+
+exports.createObjectURL = function(blob) {
+    return DOM_URL.createObjectURL(blob);
+};
+
+exports.revokeObjectURL = function(url) {
+    return DOM_URL.revokeObjectURL(url);
+};
+
+exports.createBlob = function(url, format) {
+    if(format === 'svg') {
+        return new window.Blob([url], {type: 'image/svg+xml;charset=utf-8'});
+    } else {
+        var binary = fixBinary(window.atob(url));
+        return new window.Blob([binary], {type: 'image/' + format});
+    }
+};
+
+// Taken from https://bl.ocks.org/nolanlawson/0eac306e4dac2114c752
+function fixBinary(b) {
+    var len = b.length;
+    var buf = new ArrayBuffer(len);
+    var arr = new Uint8Array(buf);
+    for(var i = 0; i < len; i++) {
+        arr[i] = b.charCodeAt(i);
+    }
+    return buf;
+}
+
 exports.IMAGE_URL_PREFIX = /^data:image\/\w+;base64,/;
 
 exports.MSG_IE_BAD_FORMAT = 'Sorry IE does not support downloading from canvas. Try {format:\'svg\'} instead.';

--- a/src/snapshot/helpers.js
+++ b/src/snapshot/helpers.js
@@ -31,3 +31,11 @@ exports.getRedrawFunc = function(gd) {
         }
     };
 };
+
+exports.encodeSVG = function(svg) {
+    return 'data:image/svg+xml,' + encodeURIComponent(svg);
+};
+
+exports.IMAGE_URL_PREFIX = /^data:image\/\w+;base64,/;
+
+exports.MSG_IE_BAD_FORMAT = 'Sorry IE does not support downloading from canvas. Try {format:\'svg\'} instead.';

--- a/src/snapshot/helpers.js
+++ b/src/snapshot/helpers.js
@@ -55,6 +55,10 @@ exports.createBlob = function(url, format) {
     }
 };
 
+exports.octetStream = function(s) {
+    document.location.href = 'data:application/octet-stream' + s;
+};
+
 // Taken from https://bl.ocks.org/nolanlawson/0eac306e4dac2114c752
 function fixBinary(b) {
     var len = b.length;

--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -11,6 +11,8 @@
 var Lib = require('../lib');
 var EventEmitter = require('events').EventEmitter;
 
+var helpers = require('./helpers');
+
 function svgToImg(opts) {
     var ev = opts.emitter || new EventEmitter();
 
@@ -21,7 +23,7 @@ function svgToImg(opts) {
 
         // IE only support svg
         if(Lib.isIE() && format !== 'svg') {
-            var ieSvgError = new Error('Sorry IE does not support downloading from canvas. Try {format:\'svg\'} instead.');
+            var ieSvgError = new Error(helpers.MSG_IE_BAD_FORMAT);
             reject(ieSvgError);
             // eventually remove the ev
             //  in favor of promises
@@ -45,7 +47,7 @@ function svgToImg(opts) {
         // for Safari support, eliminate createObjectURL
         //  this decision could cause problems if content
         //  is not restricted to svg
-        var url = 'data:image/svg+xml,' + encodeURIComponent(svg);
+        var url = helpers.encodeSVG(svg);
 
         canvas.width = w1;
         canvas.height = h1;

--- a/src/snapshot/svgtoimg.js
+++ b/src/snapshot/svgtoimg.js
@@ -43,17 +43,23 @@ function svgToImg(opts) {
 
         var ctx = canvas.getContext('2d');
         var img = new Image();
+        var svgBlob, url;
 
-        // for Safari support, eliminate createObjectURL
-        //  this decision could cause problems if content
-        //  is not restricted to svg
-        var url = helpers.encodeSVG(svg);
+        if(format === 'svg' || Lib.isIE9orBelow() || Lib.isSafari()) {
+            url = helpers.encodeSVG(svg);
+        } else {
+            svgBlob = helpers.createBlob(svg, 'svg');
+            url = helpers.createObjectURL(svgBlob);
+        }
 
         canvas.width = w1;
         canvas.height = h1;
 
         img.onload = function() {
             var imgData;
+
+            svgBlob = null;
+            helpers.revokeObjectURL(url);
 
             // don't need to draw to canvas if svg
             //  save some time and also avoid failure on IE
@@ -92,6 +98,9 @@ function svgToImg(opts) {
         };
 
         img.onerror = function(err) {
+            svgBlob = null;
+            helpers.revokeObjectURL(url);
+
             reject(err);
             // eventually remove the ev
             //  in favor of promises

--- a/test/jasmine/tests/download_test.js
+++ b/test/jasmine/tests/download_test.js
@@ -180,12 +180,8 @@ function downloadTest(gd, format) {
         var linkadded = domchanges[domchanges.length - 2].addedNodes[0];
         var linkdeleted = domchanges[domchanges.length - 1].removedNodes[0];
 
-        // check for a <a element and proper file type
-        expect(linkadded.getAttribute('href').split(format)[0]).toEqual('data:image/');
-        // check that filename option handled properly
-        expect(filename).toEqual('plotly_download.' + format);
-
-        // check that link removed
+        expect(linkadded.getAttribute('href').split(':')[0]).toBe('blob');
+        expect(filename).toBe('plotly_download.' + format);
         expect(linkadded).toBe(linkdeleted);
     });
 }


### PR DESCRIPTION
... to not hit the 2MB URL-length limit in Chrome - which resolves https://github.com/plotly/plotly.js/issues/3771 - and improve `downloadImage` performance.

before: https://codepen.io/anon/pen/WWZBOB
after: https://codepen.io/etpinard/pen/MMGGVW (click to "Download plot as a png" modebar button)

All-format playground: https://codepen.io/etpinard/pen/QXraeW 

@plotly/plotly_js 