### PR TITLE
gl-text patch to use to-px at 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5181,9 +5181,9 @@
       }
     },
     "gl-text": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.7.tgz",
-      "integrity": "sha512-dEvuxqjgfWI3OeA4GwJ7ERFZEJbo6M/Bqn438L4T+xCuCbIFO0s12WUu3DVy+UyKHXLTVPWLcZKLpzVp8nNZoA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.8.tgz",
+      "integrity": "sha512-whnq9DEFYbW92C4ONwk2eT0YkzmVPHoADnEtuzMOmit87XhgAhBrNs3lK9EgGjU/MoWYvlF6RkI8Kl7Yuo1hUw==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -5200,7 +5200,7 @@
         "parse-unit": "^1.0.1",
         "pick-by-alias": "^1.2.0",
         "regl": "^1.3.11",
-        "to-px": "^1.1.0",
+        "to-px": "^1.0.1",
         "typedarray-pool": "^1.1.0"
       },
       "dependencies": {
@@ -5213,14 +5213,6 @@
             "es5-ext": "^0.10.46",
             "es6-iterator": "^2.0.3",
             "es6-symbol": "^3.1.1"
-          }
-        },
-        "to-px": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
-          "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
-          "requires": {
-            "parse-unit": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.2.1",
     "gl-surface3d": "^1.4.6",
-    "gl-text": "^1.1.7",
+    "gl-text": "^1.1.8",
     "glslify": "^7.0.0",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",


### PR DESCRIPTION
Fixes noCI test: https://github.com/plotly/plotly.js/pull/3904#issuecomment-507852140 as a result of upgrading `to-px` from 1.0.1 to 1.1.0

@etpinard

