### PR TITLE
Fix typo in colorscale attr description

### DIFF
--- a/src/components/colorscale/attributes.js
+++ b/src/components/colorscale/attributes.js
@@ -194,7 +194,7 @@ module.exports = function colorScaleAttrs(context, opts) {
             ' rgb, rgba, hex, hsl, hsv, or named color string.',
             ' At minimum, a mapping for the lowest (0) and highest (1)',
             ' values are required. For example,',
-            ' `[[0, \'rgb(0,0,255)\', [1, \'rgb(255,0,0)\']]`.',
+            ' `[[0, \'rgb(0,0,255)\'], [1, \'rgb(255,0,0)\']]`.',
             ' To control the bounds of the colorscale in color space,',
             ' use', minmaxFull, '.',
             ' Alternatively, `colorscale` may be a palette name string',


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/4054 

cc @plotly/plotly_js 