### PR TITLE
Fix mapbox.style values in attribution declaration

### DIFF
--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -47,7 +47,7 @@ var attrs = module.exports = overrideAll({
     },
     style: {
         valType: 'any',
-        values: constants.styleValuesMapbox.concat(Object.keys(constants.styleValuesNonMapbox)),
+        values: constants.styleValuesMapbox.concat(constants.styleValuesNonMapbox),
         dflt: constants.styleValueDflt,
         role: 'style',
         description: [


### PR DESCRIPTION
```js
Plotly.PlotSchema.get().layout.layoutAttributes.mapbox.style.values
```

now correctly outputs:

```js
["basic", "streets", "outdoors", "light", "dark", "satellite", "satellite-streets", "open-street-map", "white-bg", "carto-positron", "carto-darkmatter", "stamen-terrain", "stamen-toner", "stamen-watercolor"]
```

@plotly/plotly_js 