### PR TITLE
Pin down mapbox-gl version

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "glslify": "^7.0.0",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
-    "mapbox-gl": "^1.1.1",
+    "mapbox-gl": "1.1.1",
     "matrix-camera-controller": "^2.1.3",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",


### PR DESCRIPTION
so that `npm i plotly.js` always results in installing the correct `mapbox-gl` version

cc @plotly/plotly_js 