### PR TITLE
Use Axes.prepTicks not Axes.calcTicks for indicator number and delta

### DIFF
--- a/src/traces/indicator/plot.js
+++ b/src/traces/indicator/plot.js
@@ -572,7 +572,7 @@ function drawNumbers(gd, plotGroup, cd, opts) {
     function drawBignumber() {
         var bignumberAx = mockAxis(gd, {tickformat: trace.number.valueformat}, trace._range);
         bignumberAx.setScale();
-        Axes.calcTicks(bignumberAx);
+        Axes.prepTicks(bignumberAx);
 
         var fmt = function(v) { return Axes.tickText(bignumberAx, v).text;};
         var bignumberSuffix = trace.number.suffix;
@@ -617,7 +617,7 @@ function drawNumbers(gd, plotGroup, cd, opts) {
     function drawDelta() {
         var deltaAx = mockAxis(gd, {tickformat: trace.delta.valueformat}, trace._range);
         deltaAx.setScale();
-        Axes.calcTicks(deltaAx);
+        Axes.prepTicks(deltaAx);
 
         var deltaFmt = function(v) { return Axes.tickText(deltaAx, v).text;};
         var deltaValue = function(d) {


### PR DESCRIPTION
cc @plotly/plotly_js - I totally forgot about [`Axes.prepTicks`](https://github.com/plotly/plotly.js/blob/dab7d8365e87f43f829124803261c4ae1c566c28/src/plots/cartesian/axes.js#L500-L546) which does all the things required to then call `Axes.tickText` w/o having to compute tick-value arrays like in `Axes.calcTicks`. 

`Axes.prepTicks` is currently used in the contour and carpet code (that I've been staring at for ~1 week) and should lead to an enjoyable performance boost. 