### PR TITLE
using Attrs as the short form of Attributes everywhere

### DIFF
--- a/src/components/annotations3d/attributes.js
+++ b/src/components/annotations3d/attributes.js
@@ -9,12 +9,12 @@
 
 'use strict';
 
-var annAtts = require('../annotations/attributes');
+var annAttrs = require('../annotations/attributes');
 var overrideAll = require('../../plot_api/edit_types').overrideAll;
 var templatedArray = require('../../plot_api/plot_template').templatedArray;
 
 module.exports = overrideAll(templatedArray('annotation', {
-    visible: annAtts.visible,
+    visible: annAttrs.visible,
     x: {
         valType: 'any',
         role: 'info',
@@ -51,41 +51,41 @@ module.exports = overrideAll(templatedArray('annotation', {
         ].join(' ')
     },
 
-    xanchor: annAtts.xanchor,
-    xshift: annAtts.xshift,
-    yanchor: annAtts.yanchor,
-    yshift: annAtts.yshift,
+    xanchor: annAttrs.xanchor,
+    xshift: annAttrs.xshift,
+    yanchor: annAttrs.yanchor,
+    yshift: annAttrs.yshift,
 
-    text: annAtts.text,
-    textangle: annAtts.textangle,
-    font: annAtts.font,
-    width: annAtts.width,
-    height: annAtts.height,
-    opacity: annAtts.opacity,
-    align: annAtts.align,
-    valign: annAtts.valign,
-    bgcolor: annAtts.bgcolor,
-    bordercolor: annAtts.bordercolor,
-    borderpad: annAtts.borderpad,
-    borderwidth: annAtts.borderwidth,
-    showarrow: annAtts.showarrow,
-    arrowcolor: annAtts.arrowcolor,
-    arrowhead: annAtts.arrowhead,
-    startarrowhead: annAtts.startarrowhead,
-    arrowside: annAtts.arrowside,
-    arrowsize: annAtts.arrowsize,
-    startarrowsize: annAtts.startarrowsize,
-    arrowwidth: annAtts.arrowwidth,
-    standoff: annAtts.standoff,
-    startstandoff: annAtts.startstandoff,
-    hovertext: annAtts.hovertext,
-    hoverlabel: annAtts.hoverlabel,
-    captureevents: annAtts.captureevents,
+    text: annAttrs.text,
+    textangle: annAttrs.textangle,
+    font: annAttrs.font,
+    width: annAttrs.width,
+    height: annAttrs.height,
+    opacity: annAttrs.opacity,
+    align: annAttrs.align,
+    valign: annAttrs.valign,
+    bgcolor: annAttrs.bgcolor,
+    bordercolor: annAttrs.bordercolor,
+    borderpad: annAttrs.borderpad,
+    borderwidth: annAttrs.borderwidth,
+    showarrow: annAttrs.showarrow,
+    arrowcolor: annAttrs.arrowcolor,
+    arrowhead: annAttrs.arrowhead,
+    startarrowhead: annAttrs.startarrowhead,
+    arrowside: annAttrs.arrowside,
+    arrowsize: annAttrs.arrowsize,
+    startarrowsize: annAttrs.startarrowsize,
+    arrowwidth: annAttrs.arrowwidth,
+    standoff: annAttrs.standoff,
+    startstandoff: annAttrs.startstandoff,
+    hovertext: annAttrs.hovertext,
+    hoverlabel: annAttrs.hoverlabel,
+    captureevents: annAttrs.captureevents,
 
     // maybes later?
-    // clicktoshow: annAtts.clicktoshow,
-    // xclick: annAtts.xclick,
-    // yclick: annAtts.yclick,
+    // clicktoshow: annAttrs.clicktoshow,
+    // xclick: annAttrs.xclick,
+    // yclick: annAttrs.yclick,
 
     // not needed!
     // axref: 'pixel'

--- a/src/components/colorscale/cross_trace_defaults.js
+++ b/src/components/colorscale/cross_trace_defaults.js
@@ -20,7 +20,7 @@ module.exports = function crossTraceDefaults(fullData, fullLayout) {
         }
     }
 
-    function relinkColorAtts(outerCont, cbOpt) {
+    function relinkColorAttrs(outerCont, cbOpt) {
         var cont = cbOpt.container ?
             Lib.nestedProperty(outerCont, cbOpt.container).get() :
             outerCont;
@@ -53,15 +53,15 @@ module.exports = function crossTraceDefaults(fullData, fullLayout) {
         if(cbOpts) {
             if(Array.isArray(cbOpts)) {
                 for(var j = 0; j < cbOpts.length; j++) {
-                    relinkColorAtts(trace, cbOpts[j]);
+                    relinkColorAttrs(trace, cbOpts[j]);
                 }
             } else {
-                relinkColorAtts(trace, cbOpts);
+                relinkColorAttrs(trace, cbOpts);
             }
         }
 
         if(hasColorscale(trace, 'marker.line')) {
-            relinkColorAtts(trace, {
+            relinkColorAttrs(trace, {
                 container: 'marker.line',
                 min: 'cmin',
                 max: 'cmax'
@@ -70,6 +70,6 @@ module.exports = function crossTraceDefaults(fullData, fullLayout) {
     }
 
     for(var k in fullLayout._colorAxes) {
-        relinkColorAtts(fullLayout[k], {min: 'cmin', max: 'cmax'});
+        relinkColorAttrs(fullLayout[k], {min: 'cmin', max: 'cmax'});
     }
 };

--- a/src/traces/mesh3d/attributes.js
+++ b/src/traces/mesh3d/attributes.js
@@ -10,7 +10,7 @@
 
 var colorScaleAttrs = require('../../components/colorscale/attributes');
 var hovertemplateAttrs = require('../../components/fx/hovertemplate_attributes');
-var surfaceAtts = require('../surface/attributes');
+var surfaceAttrs = require('../surface/attributes');
 var baseAttrs = require('../../plots/attributes');
 
 var extendFlat = require('../../lib/extend').extendFlat;
@@ -185,7 +185,7 @@ colorScaleAttrs('', {
     showScaleDflt: true,
     editTypeOverride: 'calc'
 }), {
-    opacity: surfaceAtts.opacity,
+    opacity: surfaceAttrs.opacity,
 
     // Flat shaded mode
     flatshading: {
@@ -200,20 +200,20 @@ colorScaleAttrs('', {
     },
 
     contour: {
-        show: extendFlat({}, surfaceAtts.contours.x.show, {
+        show: extendFlat({}, surfaceAttrs.contours.x.show, {
             description: [
                 'Sets whether or not dynamic contours are shown on hover'
             ].join(' ')
         }),
-        color: surfaceAtts.contours.x.color,
-        width: surfaceAtts.contours.x.width,
+        color: surfaceAttrs.contours.x.color,
+        width: surfaceAttrs.contours.x.width,
         editType: 'calc'
     },
 
     lightposition: {
-        x: extendFlat({}, surfaceAtts.lightposition.x, {dflt: 1e5}),
-        y: extendFlat({}, surfaceAtts.lightposition.y, {dflt: 1e5}),
-        z: extendFlat({}, surfaceAtts.lightposition.z, {dflt: 0}),
+        x: extendFlat({}, surfaceAttrs.lightposition.x, {dflt: 1e5}),
+        y: extendFlat({}, surfaceAttrs.lightposition.y, {dflt: 1e5}),
+        z: extendFlat({}, surfaceAttrs.lightposition.z, {dflt: 0}),
         editType: 'calc'
     },
     lighting: extendFlat({
@@ -236,7 +236,7 @@ colorScaleAttrs('', {
             description: 'Epsilon for face normals calculation avoids math issues arising from degenerate geometry.'
         },
         editType: 'calc'
-    }, surfaceAtts.lighting),
+    }, surfaceAttrs.lighting),
 
     hoverinfo: extendFlat({}, baseAttrs.hoverinfo, {editType: 'calc'})
 });

--- a/src/traces/sunburst/attributes.js
+++ b/src/traces/sunburst/attributes.js
@@ -11,7 +11,7 @@
 var plotAttrs = require('../../plots/attributes');
 var hovertemplateAttrs = require('../../components/fx/hovertemplate_attributes');
 var domainAttrs = require('../../plots/domain').attributes;
-var pieAtts = require('../pie/attributes');
+var pieAttrs = require('../pie/attributes');
 
 var extendFlat = require('../../lib/extend').extendFlat;
 
@@ -98,14 +98,14 @@ module.exports = {
         // },
 
         line: {
-            color: extendFlat({}, pieAtts.marker.line.color, {
+            color: extendFlat({}, pieAttrs.marker.line.color, {
                 dflt: null,
                 description: [
                     'Sets the color of the line enclosing each sector.',
                     'Defaults to the `paper_bgcolor` value.'
                 ].join(' ')
             }),
-            width: extendFlat({}, pieAtts.marker.line.width, {dflt: 1}),
+            width: extendFlat({}, pieAttrs.marker.line.width, {dflt: 1}),
             editType: 'calc'
         },
         editType: 'calc'
@@ -124,21 +124,21 @@ module.exports = {
         editType: 'plot'
     },
 
-    text: pieAtts.text,
-    textinfo: extendFlat({}, pieAtts.textinfo, {
+    text: pieAttrs.text,
+    textinfo: extendFlat({}, pieAttrs.textinfo, {
         editType: 'plot',
         flags: ['label', 'text', 'value']
     }),
-    textfont: pieAtts.textfont,
+    textfont: pieAttrs.textfont,
 
-    hovertext: pieAtts.hovertext,
+    hovertext: pieAttrs.hovertext,
     hoverinfo: extendFlat({}, plotAttrs.hoverinfo, {
         flags: ['label', 'text', 'value', 'name']
     }),
     hovertemplate: hovertemplateAttrs(),
 
-    insidetextfont: pieAtts.insidetextfont,
-    outsidetextfont: pieAtts.outsidetextfont,
+    insidetextfont: pieAttrs.insidetextfont,
+    outsidetextfont: pieAttrs.outsidetextfont,
 
     domain: domainAttrs({name: 'sunburst', trace: true, editType: 'calc'})
 };


### PR DESCRIPTION
There were few cases in the code where `Atts` is used next to `Attrs`. 
While both refer to `Attributes` the `Atts` forms are simply replaced in this PR.

@plotly/plotly_js 