### PR TITLE
refactoring drawing index

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -27,14 +27,18 @@ var DESELECTDIM = require('../../constants/interactions').DESELECTDIM;
 var subTypes = require('../../traces/scatter/subtypes');
 var makeBubbleSizeFn = require('../../traces/scatter/make_bubble_size_func');
 
+var symbolList = [];
+var symbolNames = [];
+var symbolFuncs = [];
+
 module.exports = {
     // data:
     tester: undefined,
     testref: undefined,
 
-    symbolList: [],
-    symbolNames: [],
-    symbolFuncs: [],
+    symbolList: symbolList,
+    symbolNames: symbolNames,
+    symbolFuncs: symbolFuncs,
     symbolNoDot: {},
     symbolNoFill: {},
     symbolNeedLines: {},
@@ -263,23 +267,23 @@ var SYMBOLDEFS = require('./symbol_defs');
 
 Object.keys(SYMBOLDEFS).forEach(function(k) {
     var symDef = SYMBOLDEFS[k];
-    module.exports.symbolList.push(symDef.n, k, symDef.n + 100, k + '-open');
-    module.exports.symbolNames[symDef.n] = k;
-    module.exports.symbolFuncs[symDef.n] = symDef.f;
+    symbolList.push(symDef.n, k, symDef.n + 100, k + '-open');
+    symbolNames[symDef.n] = k;
+    symbolFuncs[symDef.n] = symDef.f;
     if(symDef.needLine) {
         module.exports.symbolNeedLines[symDef.n] = true;
     }
     if(symDef.noDot) {
         module.exports.symbolNoDot[symDef.n] = true;
     } else {
-        module.exports.symbolList.push(symDef.n + 200, k + '-dot', symDef.n + 300, k + '-open-dot');
+        symbolList.push(symDef.n + 200, k + '-dot', symDef.n + 300, k + '-open-dot');
     }
     if(symDef.noFill) {
         module.exports.symbolNoFill[symDef.n] = true;
     }
 });
 
-var MAXSYMBOL = module.exports.symbolNames.length;
+var MAXSYMBOL = symbolNames.length;
 // add a dot in the middle of the symbol
 var DOTPATH = 'M0,0.5L0.5,0L0,-0.5L-0.5,0Z';
 
@@ -294,7 +298,7 @@ function symbolNumber(v) {
             vbase += 200;
             v = v.replace('-dot', '');
         }
-        v = module.exports.symbolNames.indexOf(v);
+        v = symbolNames.indexOf(v);
         if(v >= 0) { v += vbase; }
     }
     if((v % 100 >= MAXSYMBOL) || v >= 400) { return 0; }
@@ -303,7 +307,7 @@ function symbolNumber(v) {
 
 function makePointPath(symbolNumber, r) {
     var base = symbolNumber % 100;
-    return module.exports.symbolFuncs[base](r) + (symbolNumber >= 200 ? DOTPATH : '');
+    return symbolFuncs[base](r) + (symbolNumber >= 200 ? DOTPATH : '');
 }
 
 var HORZGRADIENT = {x1: 1, x2: 0, y1: 0, y2: 0};

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -30,6 +30,9 @@ var makeBubbleSizeFn = require('../../traces/scatter/make_bubble_size_func');
 var symbolList = [];
 var symbolNames = [];
 var symbolFuncs = [];
+var symbolNoDot = {};
+var symbolNoFill = {};
+var symbolNeedLines = {};
 
 module.exports = {
     // data:
@@ -39,9 +42,9 @@ module.exports = {
     symbolList: symbolList,
     symbolNames: symbolNames,
     symbolFuncs: symbolFuncs,
-    symbolNoDot: {},
-    symbolNoFill: {},
-    symbolNeedLines: {},
+    symbolNoDot: symbolNoDot,
+    symbolNoFill: symbolNoFill,
+    symbolNeedLines: symbolNeedLines,
     savedBBoxes: {},
 
     // methods:
@@ -271,15 +274,15 @@ Object.keys(SYMBOLDEFS).forEach(function(k) {
     symbolNames[symDef.n] = k;
     symbolFuncs[symDef.n] = symDef.f;
     if(symDef.needLine) {
-        module.exports.symbolNeedLines[symDef.n] = true;
+        symbolNeedLines[symDef.n] = true;
     }
     if(symDef.noDot) {
-        module.exports.symbolNoDot[symDef.n] = true;
+        symbolNoDot[symDef.n] = true;
     } else {
         symbolList.push(symDef.n + 200, k + '-dot', symDef.n + 300, k + '-open-dot');
     }
     if(symDef.noFill) {
-        module.exports.symbolNoFill[symDef.n] = true;
+        symbolNoFill[symDef.n] = true;
     }
 });
 

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -27,6 +27,8 @@ var DESELECTDIM = require('../../constants/interactions').DESELECTDIM;
 var subTypes = require('../../traces/scatter/subtypes');
 var makeBubbleSizeFn = require('../../traces/scatter/make_bubble_size_func');
 
+var SYMBOLDEFS = require('./symbol_defs');
+
 var symbolList = [];
 var symbolNames = [];
 var symbolFuncs = [];
@@ -263,8 +265,6 @@ function fillGroupStyle(s) {
         }
     });
 }
-
-var SYMBOLDEFS = require('./symbol_defs');
 
 Object.keys(SYMBOLDEFS).forEach(function(k) {
     var symDef = SYMBOLDEFS[k];

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -29,8 +29,8 @@ var makeBubbleSizeFn = require('../../traces/scatter/make_bubble_size_func');
 
 module.exports = {
     // data:
-    tester: this.tester,
-    testref: this.testref,
+    tester: undefined,
+    testref: undefined,
 
     symbolList: [],
     symbolNames: [],

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -263,8 +263,7 @@ var SYMBOLDEFS = require('./symbol_defs');
 
 Object.keys(SYMBOLDEFS).forEach(function(k) {
     var symDef = SYMBOLDEFS[k];
-    module.exports.symbolList = module.exports.symbolList.concat(
-        [symDef.n, k, symDef.n + 100, k + '-open']);
+    module.exports.symbolList.push(symDef.n, k, symDef.n + 100, k + '-open');
     module.exports.symbolNames[symDef.n] = k;
     module.exports.symbolFuncs[symDef.n] = symDef.f;
     if(symDef.needLine) {
@@ -273,8 +272,7 @@ Object.keys(SYMBOLDEFS).forEach(function(k) {
     if(symDef.noDot) {
         module.exports.symbolNoDot[symDef.n] = true;
     } else {
-        module.exports.symbolList = module.exports.symbolList.concat(
-            [symDef.n + 200, k + '-dot', symDef.n + 300, k + '-open-dot']);
+        module.exports.symbolList.push(symDef.n + 200, k + '-dot', symDef.n + 300, k + '-open-dot');
     }
     if(symDef.noFill) {
         module.exports.symbolNoFill[symDef.n] = true;


### PR DESCRIPTION
This PR refactores `drawing` index file so that it would have a clear module interface.

@plotly/plotly_js 

Also to note: 
- Commit e14338e0ac97f24f9c312cf9006f178e9041e23b avoids keeping extra arrays in memory.
- Commit ef6206c2225a727929a101625ea631b2ea5b933f fixes a bug where falsely hashes in some scenarios could have increased the counter and result in removing all the saved bounding boxes.
https://github.com/plotly/plotly.js/blob/ffa6e3468b592e45db2a00bb65805a92fd59c4fb/src/components/drawing/index.js#L982-L983