### PR TITLE
Process data uri images synchronously

### DIFF
--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -84,7 +84,7 @@ module.exports = function draw(gd) {
             var img = new Image();
             this.img = img;
 
-            if (d.source && d.source.slice(0, 5) === 'data:') {
+            if(d.source && d.source.slice(0, 5) === '') {
                 img.src = d.source;
                 thisImage.attr('xlink:href', d.source);
                 resolve();

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -89,31 +89,31 @@ module.exports = function draw(gd) {
                 thisImage.attr('xlink:href', d.source);
                 resolve();
             } else {
-            // If not set, a `tainted canvas` error is thrown
-            img.setAttribute('crossOrigin', 'anonymous');
-            img.onerror = errorHandler;
-            img.onload = function() {
-                var canvas = document.createElement('canvas');
-                canvas.width = this.width;
-                canvas.height = this.height;
+                // If not set, a `tainted canvas` error is thrown
+                img.setAttribute('crossOrigin', 'anonymous');
+                img.onerror = errorHandler;
+                img.onload = function() {
+                    var canvas = document.createElement('canvas');
+                    canvas.width = this.width;
+                    canvas.height = this.height;
 
-                var ctx = canvas.getContext('2d');
-                ctx.drawImage(this, 0, 0);
+                    var ctx = canvas.getContext('2d');
+                    ctx.drawImage(this, 0, 0);
 
-                var dataURL = canvas.toDataURL('image/png');
+                    var dataURL = canvas.toDataURL('image/png');
 
-                thisImage.attr('xlink:href', dataURL);
+                    thisImage.attr('xlink:href', dataURL);
 
-                // resolve promise in onload handler instead of on 'load' to support IE11
-                // see https://github.com/plotly/plotly.js/issues/1685
-                // for more details
-                resolve();
-            };
+                    // resolve promise in onload handler instead of on 'load' to support IE11
+                    // see https://github.com/plotly/plotly.js/issues/1685
+                    // for more details
+                    resolve();
+                };
 
 
-            thisImage.on('error', errorHandler);
+                thisImage.on('error', errorHandler);
 
-            img.src = d.source;
+                img.src = d.source;
             }
 
             function errorHandler() {

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -84,7 +84,7 @@ module.exports = function draw(gd) {
             var img = new Image();
             this.img = img;
 
-            if(d.source && d.source.slice(0, 5) === '') {
+            if(d.source && d.source.slice(0, 5) === 'data:') {
                 img.src = d.source;
                 thisImage.attr('xlink:href', d.source);
                 resolve();

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -84,6 +84,11 @@ module.exports = function draw(gd) {
             var img = new Image();
             this.img = img;
 
+            if (d.source && d.source.slice(0, 5) === 'data:') {
+                img.src = d.source;
+                thisImage.attr('xlink:href', d.source);
+                resolve();
+            } else {
             // If not set, a `tainted canvas` error is thrown
             img.setAttribute('crossOrigin', 'anonymous');
             img.onerror = errorHandler;
@@ -109,6 +114,7 @@ module.exports = function draw(gd) {
             thisImage.on('error', errorHandler);
 
             img.src = d.source;
+            }
 
             function errorHandler() {
                 thisImage.remove();

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -74,21 +74,20 @@ module.exports = function draw(gd) {
     function setImage(d) {
         var thisImage = d3.select(this);
 
-        if(this.img && this.img.src === d.source) {
+        if(this._imgSrc === d.source) {
             return;
         }
 
         thisImage.attr('xmlns', xmlnsNamespaces.svg);
 
-        var imagePromise = new Promise(function(resolve) {
-            var img = new Image();
-            this.img = img;
+        if(d.source && d.source.slice(0, 5) === 'data:') {
+            thisImage.attr('xlink:href', d.source);
+            this._imgSrc = d.source;
+        } else {
+            var imagePromise = new Promise(function(resolve) {
+                var img = new Image();
+                this.img = img;
 
-            if(d.source && d.source.slice(0, 5) === 'data:') {
-                img.src = d.source;
-                thisImage.attr('xlink:href', d.source);
-                resolve();
-            } else {
                 // If not set, a `tainted canvas` error is thrown
                 img.setAttribute('crossOrigin', 'anonymous');
                 img.onerror = errorHandler;
@@ -110,19 +109,19 @@ module.exports = function draw(gd) {
                     resolve();
                 };
 
-
                 thisImage.on('error', errorHandler);
 
                 img.src = d.source;
-            }
+                this._imgSrc = d.source;
 
-            function errorHandler() {
-                thisImage.remove();
-                resolve();
-            }
-        }.bind(this));
+                function errorHandler() {
+                    thisImage.remove();
+                    resolve();
+                }
+            }.bind(this));
 
-        gd._promises.push(imagePromise);
+            gd._promises.push(imagePromise);
+        }
     }
 
     function applyAttributes(d) {

--- a/test/jasmine/tests/layout_images_test.js
+++ b/test/jasmine/tests/layout_images_test.js
@@ -306,17 +306,17 @@ describe('Layout images', function() {
                 return element;
             });
 
-            Plotly.relayout(gd, 'images[0].source', dataUriImage).then(function() {
-                setTimeout(function() {
-                    expect(newCanvasElement).toBeUndefined();
-                    Plotly.relayout(gd, 'images[0].source', pythonLogo).then(function() {
-                        expect(newCanvasElement).eventually.toBeDefined();
-                        expect(newCanvasElement.toDataURL).toHaveBeenCalledTimes(1);
-                    });
-
-                    done();
-                }, 500);
-            });
+            Plotly.relayout(gd, 'images[0].source', dataUriImage)
+            .then(function() {
+                expect(newCanvasElement).toBeUndefined();
+            })
+            .then(function() { return Plotly.relayout(gd, 'images[0].source', jsLogo); })
+            .then(function() {
+                expect(newCanvasElement).toBeDefined();
+                expect(newCanvasElement.toDataURL).toHaveBeenCalledTimes(1);
+            })
+            .catch(failTest)
+            .then(done);
         });
 
         it('should update the image if changed', function(done) {

--- a/test/jasmine/tests/layout_images_test.js
+++ b/test/jasmine/tests/layout_images_test.js
@@ -12,6 +12,10 @@ var mouseEvent = require('../assets/mouse_event');
 var jsLogo = 'https://images.plot.ly/language-icons/api-home/js-logo.png';
 var pythonLogo = 'https://images.plot.ly/language-icons/api-home/python-logo.png';
 
+// Single red pixel png generated with http://png-pixel.com/
+var dataUriImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfF' +
+    'cSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+
 describe('Layout images', function() {
     describe('supplyLayoutDefaults', function() {
         var layoutIn,
@@ -289,6 +293,31 @@ describe('Layout images', function() {
         });
 
         afterEach(destroyGraphDiv);
+
+        it('should only create canvas if url image', function(done) {
+            var originalCreateElement = document.createElement;
+            var newCanvasElement;
+            spyOn(document, 'createElement').and.callFake(function(elementType) {
+                var element = originalCreateElement.call(document, elementType);
+                if(elementType === 'canvas') {
+                    newCanvasElement = element;
+                    spyOn(newCanvasElement, 'toDataURL');
+                }
+                return element;
+            });
+
+            Plotly.relayout(gd, 'images[0].source', dataUriImage).then(function() {
+                setTimeout(function() {
+                    expect(newCanvasElement).toBeUndefined();
+                    Plotly.relayout(gd, 'images[0].source', pythonLogo).then(function() {
+                        expect(newCanvasElement).eventually.toBeDefined();
+                        expect(newCanvasElement.toDataURL).toHaveBeenCalledTimes(1);
+                    });
+
+                    done();
+                }, 500);
+            });
+        });
 
         it('should update the image if changed', function(done) {
             var img = Plotly.d3.select('image');


### PR DESCRIPTION
This PR is the result of some time spent debugging an odd behavior I was seeing when using plotly.js layout images to display interactive results generated by [Datashader](http://datashader.org/).

The basic idea is that every time the viewport of a plot changes (pan or zoom), a new image is generated by datashader to be displayed for that viewport.  By encoding these images a data uris, I've been able to display them pretty successfully using `layout.image` objects.

But one problem has been that sometimes the images appear to jump right before they are updated.  Here's what that looks like.

![datashader_jump](https://user-images.githubusercontent.com/15064365/62414978-bf6ed100-b5f0-11e9-8cd9-a95f281b69a3.gif)

After playing with this for a while, I realized that what's happening is that the image position (with the old image) is getting updated a moment before the new image is displayed.  Here's a pure JavaScript example that shows the problem a little more clearly. (gist: https://gist.github.com/jonmmease/d2793251fdb1f370e483d54ca6561690).  In this snippet, each time the viewport changes, `Plotly.react` is used to update the image with a new `source` and a new position, where the position is always the bottom right corner of the viewport.

![datauri_before](https://user-images.githubusercontent.com/15064365/62414879-6e121200-b5ef-11e9-8fb0-44908d3203c3.gif)

Notice how the old image is moved to the bottom right corner before the new image is displayed.

After digging into plotly.js a bit, I realized that the reason this is happening is that the displayed image is updated in an `img.onload` callback that is executed after the image has loaded.   This callback then builds and saves the data uri form of the image using a canvas element.

This PR makes a small adjustment to bypass the `onload` callback for images that are specified as data uri's already.  In this case we can use the `layout.image.source` string directly.  With this change, images specified as data uris will update at the same time that their position is updated. This change is in commit 536c90e. Commit 0a397c4 contains the indentation that I omitted from 536c90e in order to make a cleaner diff of the logic changes.

Here is what the example above looks like in this PR:
![datauri_after](https://user-images.githubusercontent.com/15064365/62414881-723e2f80-b5ef-11e9-916a-8cd5376cc00c.gif)

Let me know if there are any specific tests you'd like to see for this change.  I did notice that there is already a data uri image being tested by the `layout_image` mock.