### PR TITLE
Refactoring color index

### DIFF
--- a/src/components/color/index.js
+++ b/src/components/color/index.js
@@ -45,8 +45,8 @@ function cleanOne(val) {
     if(!match) return val;
 
     var parts = match[1].trim().split(/\s*[\s,]\s*/);
-    var rgba = valTrim.charAt(3) === 'a' && parts.length === 4;
-    if(!rgba && parts.length !== 3) return val;
+    var hasAlpha = valTrim.charAt(3) === 'a' && parts.length === 4;
+    if(!hasAlpha && parts.length !== 3) return val;
 
     for(var i = 0; i < parts.length; i++) {
         if(!parts[i].length) return val;
@@ -69,11 +69,13 @@ function cleanOne(val) {
         }
     }
 
-    var rgbStr = Math.round(parts[0] * 255) + ', ' +
+    var rgbStr = (
+        Math.round(parts[0] * 255) + ', ' +
         Math.round(parts[1] * 255) + ', ' +
-        Math.round(parts[2] * 255);
+        Math.round(parts[2] * 255)
+    );
 
-    if(rgba) return 'rgba(' + rgbStr + ', ' + parts[3] + ')';
+    if(hasAlpha) return 'rgba(' + rgbStr + ', ' + parts[3] + ')';
     return 'rgb(' + rgbStr + ')';
 }
 

--- a/src/components/color/index.js
+++ b/src/components/color/index.js
@@ -11,39 +11,54 @@
 
 var tinycolor = require('tinycolor2');
 var isNumeric = require('fast-isnumeric');
-
-var color = module.exports = {};
-
 var colorAttrs = require('./attributes');
-color.defaults = colorAttrs.defaults;
-var defaultLine = color.defaultLine = colorAttrs.defaultLine;
-color.lightLine = colorAttrs.lightLine;
-var background = color.background = colorAttrs.background;
+
+var defaults = colorAttrs.defaults;
+var lightLine = colorAttrs.lightLine;
+var defaultLine = colorAttrs.defaultLine;
+var background = colorAttrs.background;
+
+module.exports = {
+    defaults: defaults,
+    lightLine: lightLine,
+    defaultLine: defaultLine,
+    background: background,
+
+    tinyRGB: tinyRGB,
+    rgb: rgb,
+    opacity: opacity,
+    addOpacity: addOpacity,
+    combine: combine,
+    contrast: contrast,
+    stroke: stroke,
+    fill: fill,
+    clean: clean
+};
 
 /*
  * tinyRGB: turn a tinycolor into an rgb string, but
  * unlike the built-in tinycolor.toRgbString this never includes alpha
  */
-color.tinyRGB = function(tc) {
+function tinyRGB(tc) {
     var c = tc.toRgb();
     return 'rgb(' + Math.round(c.r) + ', ' +
         Math.round(c.g) + ', ' + Math.round(c.b) + ')';
-};
+}
 
-color.rgb = function(cstr) { return color.tinyRGB(tinycolor(cstr)); };
+function rgb(cstr) { return tinyRGB(tinycolor(cstr)); }
 
-color.opacity = function(cstr) { return cstr ? tinycolor(cstr).getAlpha() : 0; };
+function opacity(cstr) { return cstr ? tinycolor(cstr).getAlpha() : 0; }
 
-color.addOpacity = function(cstr, op) {
+function addOpacity(cstr, op) {
     var c = tinycolor(cstr).toRgb();
     return 'rgba(' + Math.round(c.r) + ', ' +
         Math.round(c.g) + ', ' + Math.round(c.b) + ', ' + op + ')';
-};
+}
 
 // combine two colors into one apparent color
 // if back has transparency or is missing,
-// color.background is assumed behind it
-color.combine = function(front, back) {
+// background is assumed behind it
+function combine(front, back) {
     var fc = tinycolor(front).toRgb();
     if(fc.a === 1) return tinycolor(front).toRgbString();
 
@@ -59,7 +74,7 @@ color.combine = function(front, back) {
         b: bcflat.b * (1 - fc.a) + fc.b * fc.a
     };
     return tinycolor(fcflat).toRgbString();
-};
+}
 
 /*
  * Create a color that contrasts with cstr.
@@ -69,34 +84,34 @@ color.combine = function(front, back) {
  * If lightAmount / darkAmount are used, we adjust by these percentages,
  * otherwise we go all the way to white or black.
  */
-color.contrast = function(cstr, lightAmount, darkAmount) {
+function contrast(cstr, lightAmount, darkAmount) {
     var tc = tinycolor(cstr);
 
-    if(tc.getAlpha() !== 1) tc = tinycolor(color.combine(cstr, background));
+    if(tc.getAlpha() !== 1) tc = tinycolor(combine(cstr, background));
 
     var newColor = tc.isDark() ?
         (lightAmount ? tc.lighten(lightAmount) : background) :
         (darkAmount ? tc.darken(darkAmount) : defaultLine);
 
     return newColor.toString();
-};
+}
 
-color.stroke = function(s, c) {
+function stroke(s, c) {
     var tc = tinycolor(c);
-    s.style({'stroke': color.tinyRGB(tc), 'stroke-opacity': tc.getAlpha()});
-};
+    s.style({'stroke': tinyRGB(tc), 'stroke-opacity': tc.getAlpha()});
+}
 
-color.fill = function(s, c) {
+function fill(s, c) {
     var tc = tinycolor(c);
     s.style({
-        'fill': color.tinyRGB(tc),
+        'fill': tinyRGB(tc),
         'fill-opacity': tc.getAlpha()
     });
-};
+}
 
 // search container for colors with the deprecated rgb(fractions) format
 // and convert them to rgb(0-255 values)
-color.clean = function(container) {
+function clean(container) {
     if(!container || typeof container !== 'object') return;
 
     var keys = Object.keys(container);
@@ -123,11 +138,11 @@ color.clean = function(container) {
 
             var el0 = val[0];
             if(!Array.isArray(el0) && el0 && typeof el0 === 'object') {
-                for(j = 0; j < val.length; j++) color.clean(val[j]);
+                for(j = 0; j < val.length; j++) clean(val[j]);
             }
-        } else if(val && typeof val === 'object') color.clean(val);
+        } else if(val && typeof val === 'object') clean(val);
     }
-};
+}
 
 function cleanOne(val) {
     if(isNumeric(val) || typeof val !== 'string') return val;

--- a/src/components/color/index.js
+++ b/src/components/color/index.js
@@ -35,6 +35,48 @@ module.exports = {
     clean: clean
 };
 
+function cleanOne(val) {
+    if(isNumeric(val) || typeof val !== 'string') return val;
+
+    var valTrim = val.trim();
+    if(valTrim.substr(0, 3) !== 'rgb') return val;
+
+    var match = valTrim.match(/^rgba?\s*\(([^()]*)\)$/);
+    if(!match) return val;
+
+    var parts = match[1].trim().split(/\s*[\s,]\s*/);
+    var rgba = valTrim.charAt(3) === 'a' && parts.length === 4;
+    if(!rgba && parts.length !== 3) return val;
+
+    for(var i = 0; i < parts.length; i++) {
+        if(!parts[i].length) return val;
+        parts[i] = Number(parts[i]);
+
+        if(!(parts[i] >= 0)) {
+            // all parts must be non-negative numbers
+
+            return val;
+        }
+
+        if(i === 3) {
+            // alpha>1 gets clipped to 1
+
+            if(parts[i] > 1) parts[i] = 1;
+        } else if(parts[i] >= 1) {
+            // r, g, b must be < 1 (ie 1 itself is not allowed)
+
+            return val;
+        }
+    }
+
+    var rgbStr = Math.round(parts[0] * 255) + ', ' +
+        Math.round(parts[1] * 255) + ', ' +
+        Math.round(parts[2] * 255);
+
+    if(rgba) return 'rgba(' + rgbStr + ', ' + parts[3] + ')';
+    return 'rgb(' + rgbStr + ')';
+}
+
 /*
  * tinyRGB: turn a tinycolor into an rgb string, but
  * unlike the built-in tinycolor.toRgbString this never includes alpha
@@ -142,46 +184,4 @@ function clean(container) {
             }
         } else if(val && typeof val === 'object') clean(val);
     }
-}
-
-function cleanOne(val) {
-    if(isNumeric(val) || typeof val !== 'string') return val;
-
-    var valTrim = val.trim();
-    if(valTrim.substr(0, 3) !== 'rgb') return val;
-
-    var match = valTrim.match(/^rgba?\s*\(([^()]*)\)$/);
-    if(!match) return val;
-
-    var parts = match[1].trim().split(/\s*[\s,]\s*/);
-    var rgba = valTrim.charAt(3) === 'a' && parts.length === 4;
-    if(!rgba && parts.length !== 3) return val;
-
-    for(var i = 0; i < parts.length; i++) {
-        if(!parts[i].length) return val;
-        parts[i] = Number(parts[i]);
-
-        if(!(parts[i] >= 0)) {
-            // all parts must be non-negative numbers
-
-            return val;
-        }
-
-        if(i === 3) {
-            // alpha>1 gets clipped to 1
-
-            if(parts[i] > 1) parts[i] = 1;
-        } else if(parts[i] >= 1) {
-            // r, g, b must be < 1 (ie 1 itself is not allowed)
-
-            return val;
-        }
-    }
-
-    var rgbStr = Math.round(parts[0] * 255) + ', ' +
-        Math.round(parts[1] * 255) + ', ' +
-        Math.round(parts[2] * 255);
-
-    if(rgba) return 'rgba(' + rgbStr + ', ' + parts[3] + ')';
-    return 'rgb(' + rgbStr + ')';
 }


### PR DESCRIPTION
Most of our `component` indices have clear `module.exports` interface block.
This PR adds a similar one for `color` component i.e to increase the readability of the code base.

@plotly/plotly_js 
