### PR TITLE
refactor drag element and hover indices - add module.exports blocks

### DIFF
--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -15,14 +15,12 @@ var supportsPassive = require('has-passive-events');
 var removeElement = require('../../lib').removeElement;
 var constants = require('../../plots/cartesian/constants');
 
-var dragElement = module.exports = {};
+var unhoverAll = require('./unhover');
+var unhover = unhoverAll.wrapped;
+var unhoverRaw = unhoverAll.raw;
 
-dragElement.align = require('./align');
-dragElement.getCursor = require('./cursor');
-
-var unhover = require('./unhover');
-dragElement.unhover = unhover.wrapped;
-dragElement.unhoverRaw = unhover.raw;
+var align = require('./align');
+var getCursor = require('./cursor');
 
 /**
  * Abstracts click & drag interactions
@@ -78,7 +76,7 @@ dragElement.unhoverRaw = unhover.raw;
  *          By default, clamping is done using `minDrag` to x and y displacements
  *          independently.
  */
-dragElement.init = function init(options) {
+function init(options) {
     var gd = options.gd;
     var numClicks = 1;
     var doubleClickDelay = gd._context.doubleClickDelay;
@@ -180,7 +178,7 @@ dragElement.init = function init(options) {
 
         if(dx || dy) {
             gd._dragged = true;
-            dragElement.unhover(gd);
+            unhover(gd);
         }
 
         if(gd._dragged && options.moveFn && !rightClick) {
@@ -260,7 +258,7 @@ dragElement.init = function init(options) {
         gd._dragged = false;
         return;
     }
-};
+}
 
 function coverSlip() {
     var cover = document.createElement('div');
@@ -280,11 +278,18 @@ function coverSlip() {
     return cover;
 }
 
-dragElement.coverSlip = coverSlip;
-
 function pointerOffset(e) {
     return mouseOffset(
         e.changedTouches ? e.changedTouches[0] : e,
         document.body
     );
 }
+
+module.exports = {
+    init: init,
+    align: align,
+    getCursor: getCursor,
+    coverSlip: coverSlip,
+    unhover: unhover,
+    unhoverRaw: unhoverRaw
+};

--- a/src/components/dragelement/unhover.js
+++ b/src/components/dragelement/unhover.js
@@ -14,9 +14,12 @@ var getGraphDiv = require('../../lib/dom').getGraphDiv;
 
 var hoverConstants = require('../fx/constants');
 
-var unhover = module.exports = {};
+module.exports = {
+    wrapped: wrapped,
+    raw: raw
+};
 
-unhover.wrapped = function(gd, evt, subplot) {
+function wrapped(gd, evt, subplot) {
     gd = getGraphDiv(gd);
 
     // Important, clear any queued hovers
@@ -24,12 +27,12 @@ unhover.wrapped = function(gd, evt, subplot) {
         throttle.clear(gd._fullLayout._uid + hoverConstants.HOVERID);
     }
 
-    unhover.raw(gd, evt, subplot);
-};
+    raw(gd, evt, subplot);
+}
 
 
 // remove hover effects on mouse out, and emit unhover event
-unhover.raw = function raw(gd, evt) {
+function raw(gd, evt) {
     var fullLayout = gd._fullLayout;
     var oldhoverdata = gd._hoverdata;
 
@@ -50,4 +53,4 @@ unhover.raw = function raw(gd, evt) {
             points: oldhoverdata
         });
     }
-};
+}


### PR DESCRIPTION
Similar to https://github.com/plotly/plotly.js/pull/4108 `dragelement` is the last `component` object where a module.exports block is added i.e. to avoid mutating the exports object.

Thanks @plotly/plotly_js for your time reviewing this one too.
