### PR TITLE
Add correct number formater

### DIFF
--- a/lib/locales/it.js
+++ b/lib/locales/it.js
@@ -85,7 +85,7 @@ module.exports = {
             'Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu',
             'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'
         ],
-        date: '%d/%m/%Y',        
+        date: '%d/%m/%Y',
         decimal: ',',
         thousands: '.'
     }

--- a/lib/locales/it.js
+++ b/lib/locales/it.js
@@ -85,6 +85,8 @@ module.exports = {
             'Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu',
             'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'
         ],
-        date: '%d/%m/%Y'
+        date: '%d/%m/%Y',        
+        decimal: ',',
+        thousands: '.'
     }
 };


### PR DESCRIPTION
This adds the missing decimal and thousands separator for the italian language as also mentioned [here](https://docs.oracle.com/cd/E19455-01/806-0169/overview-9/index.html).
@ghtmtt, @alexcjohnson, @archmoj, @etpinard

Thanks for your interest in plotly.js!