### PR TITLE
add missing translation keys

### DIFF
--- a/lib/locales/cs.js
+++ b/lib/locales/cs.js
@@ -26,6 +26,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': 'Dvojklikem na legendu izolujete jedinou datovou sadu',  // components/legend/handle_click.js:90
         'Double-click to zoom back out': 'Dvojklikem vrátíte zvětšení',                                  // plots/cartesian/dragbox.js:299
         'Download plot as a png': 'Uložit jsko PNG',                                                       // components/modebar/buttons.js:52
+        'Download plot': 'Uložit',                                                                         // components/modebar/buttons.js:53
         'Edit in Chart Studio': 'Editovat v Chart Studio',                                               // components/modebar/buttons.js:76
         'IE only supports svg.  Changing format to svg.': 'IE podporuje pouze SVG formát. Změněno na SVG.', // components/modebar/buttons.js:60
         'Lasso Select': 'Vyběr lasem',                                                                     // components/modebar/buttons.js:112

--- a/lib/locales/de.js
+++ b/lib/locales/de.js
@@ -24,8 +24,8 @@ module.exports = {
         'Compare data on hover': 'Über die Daten fahren, um sie zu vergleichen',                            // components/modebar/buttons.js:167
         'Double-click on legend to isolate one trace': 'Daten isolieren durch Doppelklick in der Legende',  // components/legend/handle_click.js:90
         'Double-click to zoom back out': 'Herauszoomen durch Doppelklick',                                  // plots/cartesian/dragbox.js:299
-        'Download plot as a png': 'Download als PNG',                                                       // components/modebar/buttons.js:52
-        'Download plot': 'Download',                                                                        // components/modebar/buttons.js:53
+        'Download plot as a png': 'Graphen als PNG herunterladen',                                                       // components/modebar/buttons.js:52
+        'Download plot': 'Graphen herunterladen',                                                                        // components/modebar/buttons.js:53
         'Edit in Chart Studio': 'Im Chart Studio bearbeiten',                                               // components/modebar/buttons.js:76
         'IE only supports svg.  Changing format to svg.': 'IE unterstützt nur SVG-Dateien.  Format wird zu SVG gewechselt.', // components/modebar/buttons.js:60
         'Lasso Select': 'Lassoauswahl',                                                                     // components/modebar/buttons.js:112

--- a/lib/locales/de.js
+++ b/lib/locales/de.js
@@ -25,6 +25,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': 'Daten isolieren durch Doppelklick in der Legende',  // components/legend/handle_click.js:90
         'Double-click to zoom back out': 'Herauszoomen durch Doppelklick',                                  // plots/cartesian/dragbox.js:299
         'Download plot as a png': 'Download als PNG',                                                       // components/modebar/buttons.js:52
+        'Download plot': 'Download',                                                                        // components/modebar/buttons.js:53
         'Edit in Chart Studio': 'Im Chart Studio bearbeiten',                                               // components/modebar/buttons.js:76
         'IE only supports svg.  Changing format to svg.': 'IE unterstützt nur SVG-Dateien.  Format wird zu SVG gewechselt.', // components/modebar/buttons.js:60
         'Lasso Select': 'Lassoauswahl',                                                                     // components/modebar/buttons.js:112

--- a/lib/locales/es.js
+++ b/lib/locales/es.js
@@ -26,6 +26,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': 'Haga doble-clic en la leyenda para aislar una traza', // components/legend/handle_click.js:90
         'Double-click to zoom back out': 'Haga doble-clic para restaurar la escala', // plots/cartesian/dragbox.js:335
         'Download plot as a png': 'Descargar gráfica como png',       // components/modebar/buttons.js:52
+        'Download plot': 'Descargar gráfica',                         // components/modebar/buttons.js:53
         'Edit in Chart Studio': 'Editar en Chart Studio',             // components/modebar/buttons.js:76
         'IE only supports svg.  Changing format to svg.': 'IE solo soporta svg. Cambiando formato a svg.', // components/modebar/buttons.js:60
         'Lasso Select': 'Seleccionar con lazo',                       // components/modebar/buttons.js:112

--- a/lib/locales/fr.js
+++ b/lib/locales/fr.js
@@ -26,6 +26,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': 'Double-cliquer sur la légende pour isoler une série',
         'Double-click to zoom back out': 'Double-cliquer pour dézoomer',
         'Download plot as a png': 'Télécharger le graphique en fichier PNG',
+        'Download plot': 'Télécharger le graphique',
         'Edit in Chart Studio': 'Éditer le graphique sur plot.ly',
         'IE only supports svg.  Changing format to svg.': 'IE ne permet que les conversions en SVG. Conversion en SVG en cours.',
         'Lasso Select': 'Sélection lasso',

--- a/lib/locales/it.js
+++ b/lib/locales/it.js
@@ -26,6 +26,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': 'Doppio click per isolare i dati di una traccia',  // components/legend/handle_click.js:90
         'Double-click to zoom back out': 'Doppio click per tornare allo zoom iniziale',                                  // plots/cartesian/dragbox.js:299
         'Download plot as a png': 'Scarica il grafico come immagine png',                                                       // components/modebar/buttons.js:52
+        'Download plot': 'Scarica il grafico',                                                                                  // components/modebar/buttons.js:53
         'Edit in Chart Studio': 'Modifica in Chart Studio',                                               // components/modebar/buttons.js:76
         'IE only supports svg.  Changing format to svg.': 'IE supporta solo svg.  Modifica formato in svg.', // components/modebar/buttons.js:60
         'Lasso Select': 'Selezione lazo',                                                                     // components/modebar/buttons.js:112

--- a/lib/locales/ja.js
+++ b/lib/locales/ja.js
@@ -25,6 +25,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': '凡例をダブルクリックして1つのトレースを無効化します', // components/legend/handle_click.js:90
         'Double-click to zoom back out': 'ダブルクリックでズームを戻します',                               // plots/cartesian/dragbox.js:299
         'Download plot as a png': 'PNGファイルでダウンロード',                                             // components/modebar/buttons.js:52
+        'Download plot': 'ダウンロード',                                                                  // components/modebar/buttons.js:53
         'Edit in Chart Studio': 'Chart Studioで編集',                                                      // components/modebar/buttons.js:76
         'IE only supports svg.  Changing format to svg.': 'IEはSVGのみサポートしています。SVGに変換します。', // components/modebar/buttons.js:60
         'Lasso Select': '投げ縄選択',                                                                      // components/modebar/buttons.js:112

--- a/lib/locales/pt-br.js
+++ b/lib/locales/pt-br.js
@@ -26,6 +26,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': 'Duplo clique na legenda para isolar uma série',
         'Double-click to zoom back out': 'Duplo clique para reverter zoom',
         'Download plot as a png': 'Fazer download do gráfico como imagem (png)',
+        'Download plot': 'Fazer download do gráfico',
         'Edit in Chart Studio': 'Editar no Chart Studio',
         'IE only supports svg.  Changing format to svg.': 'IE suporta apenas svg. Alterando formato para svg',
         'Lasso Select': 'Seleção de laço',

--- a/lib/locales/sw.js
+++ b/lib/locales/sw.js
@@ -26,6 +26,7 @@ module.exports = {
         'Double-click on legend to isolate one trace': 'Bonyeza mara mbili juu ya hadithi ili kutenganisha moja kwa moja',
         'Double-click to zoom back out': 'Bonyeza mara mbili ili kuvuta nje',
         'Download plot as a png': 'Pakua mpango kama png',
+        'Download plot': 'Pakua mpango',
         'Edit in Chart Studio': 'Hariri katika Chart studio',
         'IE only supports svg.  Changing format to svg.': 'IE inatumia tu svg. Tunabadilisha muundo kuwa svg.',
         'Lasso Select': 'Kuteua lasso',


### PR DESCRIPTION
See https://github.com/plotly/plotly.js/issues/4142

This PR adds the missing "Download plot" localization key for the following languages:
- cs
- de
- es
- fr
- it
- ja
- pt-br
- sw

The others languages either have already the missing key or do not translate modebar buttons.
I am by no mean a translator (Deepl/Translate for the win). Native speakers feedbacks are welcome even if it seemed "simple".