### PR TITLE
Distribute minified files in own packages

### DIFF
--- a/tasks/stats.js
+++ b/tasks/stats.js
@@ -142,7 +142,10 @@ function getMainBundleInfo() {
         '',
         constants.partialBundlePaths.map(makeBundleHeaderInfo).join('\n'),
         '',
-        'Starting in `v1.39.0`, each plotly.js partial bundle has a corresponding npm package with no dependencies.'
+        'Starting in `v1.39.0`, each plotly.js partial bundle has a corresponding npm package with no dependencies.',
+        '',
+        'Starting in `v1.50.0`, the minified version of each partial bundle is also published to npm in a separate "dist min" package.',
+        ''
     ];
 }
 
@@ -208,6 +211,13 @@ function makeBundleInfo(pathObj) {
         '```js',
         'var Plotly = require(\'' + pkgName + '\');',
         '```',
+        '',
+        '#### dist min npm package (starting in `v1.50.0`)',
+        '',
+        'Install [`' + pkgName + '-min`](https://www.npmjs.com/package/' + pkgName + '-min) with',
+        '```',
+        'npm install ' + pkgName + '-min',
+        '```',        
         '',
         '#### Other plotly.js entry points',
         '',

--- a/tasks/stats.js
+++ b/tasks/stats.js
@@ -217,7 +217,7 @@ function makeBundleInfo(pathObj) {
         'Install [`' + pkgName + '-min`](https://www.npmjs.com/package/' + pkgName + '-min) with',
         '```',
         'npm install ' + pkgName + '-min',
-        '```',        
+        '```',
         '',
         '#### Other plotly.js entry points',
         '',

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -41,6 +41,26 @@ constants.partialBundlePaths
     }])
     .forEach(syncPartialBundlePkg);
 
+// sync "minified partial bundle" packages
+constants.partialBundlePaths
+    .map(function(d) {
+        return {
+            name: 'plotly.js-' + d.name + '-dist-min',
+            index: d.index,
+            main: 'plotly-' + d.name + '.min.js',
+            dist: d.distMin,
+            desc: 'Ready-to-use minified plotly.js ' + d.name + ' distributed bundle.',
+        };
+    })
+    .concat([{
+        name: 'plotly.js-dist-min',
+        index: path.join(constants.pathToLib, 'index.js'),
+        main: 'plotly.min.js',
+        dist: constants.pathToPlotlyDistMin,
+        desc: 'Ready-to-use minified plotly.js distributed bundle.',
+    }])
+    .forEach(syncPartialBundlePkg);
+
 // sync "locales" package
 syncLocalesPkg({
     name: 'plotly.js-locales',


### PR DESCRIPTION
The "dist" bundle packages (e.g. https://www.npmjs.com/package/plotly.js-dist) currently only include un-minified JavaScript. This PR is to create a separate package (e.g. `plotly.js-dist-min`) for each of the minified versions of the "dist" files.