### PR TITLE
Adapt default axis ranges to rangemode

### DIFF
--- a/src/plots/cartesian/set_convert.js
+++ b/src/plots/cartesian/set_convert.js
@@ -398,6 +398,10 @@ module.exports = function setConvert(ax, fullLayout) {
         // make sure we don't later mutate the defaults
         dflt = dflt.slice();
 
+        if(ax.rangemode === 'tozero' || ax.rangemode === 'nonnegative') {
+            dflt[0] = 0;
+        }
+
         if(!range || range.length !== 2) {
             Lib.nestedProperty(ax, rangeAttr).set(dflt);
             return;

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -870,6 +870,25 @@ describe('Test axes', function() {
             _assertMatchingAxes(['xaxis3', 'yaxis3'], true, [-1, 6]);
             _assertMatchingAxes(['xaxis4', 'yaxis4'], false, [-1, 3]);
         });
+
+        it('should adapt default axis ranges to *rangemode*', function() {
+            layoutIn = {
+                xaxis: {rangemode: 'tozero'},
+                yaxis: {rangemode: 'nonnegative'},
+                xaxis2: {rangemode: 'nonnegative'},
+                yaxis2: {rangemode: 'tozero'}
+            };
+            layoutOut._subplots.cartesian.push('x2y2');
+            layoutOut._subplots.xaxis.push('x2');
+            layoutOut._subplots.yaxis.push('y2');
+
+            supplyLayoutDefaults(layoutIn, layoutOut, fullData);
+
+            expect(layoutOut.xaxis.range).withContext('xaxis range').toEqual([0, 6]);
+            expect(layoutOut.xaxis2.range).withContext('xaxis2 range').toEqual([0, 6]);
+            expect(layoutOut.yaxis.range).withContext('yaxis range').toEqual([0, 4]);
+            expect(layoutOut.yaxis2.range).withContext('yaxis2 range').toEqual([0, 4]);
+        });
     });
 
     describe('constraints relayout', function() {


### PR DESCRIPTION
so that even if no `_extremes` stashes get filled in, `ax.rangemode` still as an effect.

fixes https://github.com/plotly/plotly.js/issues/4137 - cc @plotly/plotly_js 

before: https://codepen.io/DaanyWaay/pen/eYOdNVV
after: https://codepen.io/etpinard/pen/dybJBzo