### PR TITLE
texttemplate: accept empty text string

### DIFF
--- a/src/traces/pie/helpers.js
+++ b/src/traces/pie/helpers.js
@@ -30,7 +30,7 @@ exports.getFirstFilled = function getFirstFilled(array, indices) {
     if(!Array.isArray(array)) return;
     for(var i = 0; i < indices.length; i++) {
         var v = array[indices[i]];
-        if(v || v === 0) return v;
+        if(v || v === 0 || v === '') return v;
     }
 };
 

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -991,8 +991,8 @@ function formatSliceLabel(gd, pt, cd0) {
             pt.text = '';
         } else {
             var obj = makeTemplateVariables(pt);
-            var ptTx = helpers.getFirstFilled(trace.text, pt.pts);
-            if(isValidTextValue(ptTx)) obj.text = ptTx;
+            var ptTx = Lib.castOption(trace, pt.i, 'text');
+            if(isValidTextValue(ptTx) || ptTx === '') obj.text = ptTx;
             pt.text = Lib.texttemplateString(txt, obj, gd._fullLayout._d3locale, obj, trace._meta || {});
         }
     }

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -991,7 +991,7 @@ function formatSliceLabel(gd, pt, cd0) {
             pt.text = '';
         } else {
             var obj = makeTemplateVariables(pt);
-            var ptTx = Lib.castOption(trace, pt.i, 'text');
+            var ptTx = helpers.getFirstFilled(trace.text, pt.pts);
             if(isValidTextValue(ptTx) || ptTx === '') obj.text = ptTx;
             pt.text = Lib.texttemplateString(txt, obj, gd._fullLayout._d3locale, obj, trace._meta || {});
         }

--- a/src/traces/sunburst/plot.js
+++ b/src/traces/sunburst/plot.js
@@ -718,7 +718,7 @@ function formatSliceLabel(pt, trace, fullLayout) {
         obj.color = cdi.color;
     }
     var ptTx = Lib.castOption(trace, cdi.i, 'text');
-    if(Lib.isValidTextValue(ptTx)) obj.text = ptTx;
+    if(Lib.isValidTextValue(ptTx) || ptTx === '') obj.text = ptTx;
     obj.customdata = Lib.castOption(trace, cdi.i, 'customdata');
     return Lib.texttemplateString(txt, obj, fullLayout._d3locale, obj, trace._meta || {});
 }

--- a/test/jasmine/assets/check_texttemplate.js
+++ b/test/jasmine/assets/check_texttemplate.js
@@ -65,11 +65,21 @@ module.exports = function checkTextTemplate(mock, selector, tests) {
     }
     tests.push(['%{meta.colname}', metaSolution]);
 
+    // Make sure that empty text shows up as an empty string
+    var emptyTextMock = Lib.extendDeep([], mock);
+    var emptyTextSolution = [];
+    emptyTextMock[0].text = [];
+    for(i = 0; i < N; i++) {
+        emptyTextMock[0].text[i] = '';
+        emptyTextSolution[i] = 'text:';
+    }
+    tests.push(['text:%{text}', emptyTextSolution, emptyTextMock]);
+
     if(isGL) {
         tests.forEach(function(test) {
             it('@gl should support texttemplate', function(done) {
                 var gd = createGraphDiv();
-                var mockCopy = Lib.extendDeep([], mock);
+                var mockCopy = Lib.extendDeep([], test[2] || mock);
                 mockCopy[0].texttemplate = test[0];
                 Plotly.newPlot(gd, mockCopy)
                     .then(function() {
@@ -101,7 +111,7 @@ module.exports = function checkTextTemplate(mock, selector, tests) {
         tests.forEach(function(test) {
             it('should support texttemplate', function(done) {
                 var gd = createGraphDiv();
-                var mockCopy = Lib.extendDeep([], mock);
+                var mockCopy = Lib.extendDeep([], test[2] || mock);
                 mockCopy[0].texttemplate = test[0];
                 Plotly.newPlot(gd, mockCopy)
                     .then(function() {

--- a/test/jasmine/assets/check_texttemplate.js
+++ b/test/jasmine/assets/check_texttemplate.js
@@ -9,7 +9,7 @@ var supplyAllDefaults = require('../assets/supply_defaults');
 
 'use strict';
 
-module.exports = function checkTextTemplate(mock, selector, tests) {
+module.exports = function checkTextTemplate(mock, selector, tests, skipExtra) {
     var isGL = Registry.traceIs(mock[0].type, 'gl');
     var isPolar = Registry.traceIs(mock[0].type, 'polar');
     var isScatterLike = Registry.traceIs(mock[0].type, 'scatter-like');
@@ -46,35 +46,37 @@ module.exports = function checkTextTemplate(mock, selector, tests) {
         });
     }
 
-    var N = tests[0][1].length;
-    var i;
+    // Extra tests
+    if(!skipExtra) {
+        var N = tests[0][1].length;
+        var i;
 
-    // Generate customdata
-    var customdata = [];
-    for(i = 0; i < N; i++) {
-        customdata.push(Lib.randstr({}));
+        // Generate customdata
+        var customdata = [];
+        for(i = 0; i < N; i++) {
+            customdata.push(Lib.randstr({}));
+        }
+        mock[0].customdata = customdata;
+        tests.push(['%{customdata}', customdata]);
+
+        // Generate meta
+        mock[0].meta = {'colname': 'A'};
+        var metaSolution = [];
+        for(i = 0; i < N; i++) {
+            metaSolution.push(mock[0].meta.colname);
+        }
+        tests.push(['%{meta.colname}', metaSolution]);
+
+        // Make sure that empty text shows up as an empty string
+        var emptyTextMock = Lib.extendDeep([], mock);
+        var emptyTextSolution = [];
+        emptyTextMock[0].text = [];
+        for(i = 0; i < N; i++) {
+            emptyTextMock[0].text[i] = '';
+            emptyTextSolution[i] = 'text:';
+        }
+        tests.push(['text:%{text}', emptyTextSolution, emptyTextMock]);
     }
-    mock[0].customdata = customdata;
-    tests.push(['%{customdata}', customdata]);
-
-    // Generate meta
-    mock[0].meta = {'colname': 'A'};
-    var metaSolution = [];
-    for(i = 0; i < N; i++) {
-        metaSolution.push(mock[0].meta.colname);
-    }
-    tests.push(['%{meta.colname}', metaSolution]);
-
-    // Make sure that empty text shows up as an empty string
-    var emptyTextMock = Lib.extendDeep([], mock);
-    var emptyTextSolution = [];
-    emptyTextMock[0].text = [];
-    for(i = 0; i < N; i++) {
-        emptyTextMock[0].text[i] = '';
-        emptyTextSolution[i] = 'text:';
-    }
-    tests.push(['text:%{text}', emptyTextSolution, emptyTextMock]);
-
     if(isGL) {
         tests.forEach(function(test) {
             it('@gl should support texttemplate', function(done) {

--- a/test/jasmine/tests/pie_test.js
+++ b/test/jasmine/tests/pie_test.js
@@ -876,6 +876,17 @@ describe('Pie traces', function() {
         [['%{label} - %{value}', '%{text}', '%{value}', '%{percent}'], ['A - 1', 'textB', '3', '18.2%']],
         ['%{text}-%{color}', ['textA-#d62728', 'textB-#1f77b4', 'textC-#ff7f0e', 'textD-#2ca02c']]
     ]);
+
+    // Check texttemplate with aggregated values
+    checkTextTemplate([{
+        type: 'pie',
+        values: [1, 1, 1],
+        labels: ['A', 'A', 'B'],
+        text: ['textA1', 'textA2', 'textB'],
+        textposition: 'inside'
+    }], 'g.slicetext', [
+        ['%{text}', ['textA1', 'textB']]
+    ], true);
 });
 
 describe('pie hovering', function() {


### PR DESCRIPTION
This closes #4173 which affected the following traces:
- [x] pie
- [x] funnelarea
- [x] sunburst

Commit https://github.com/plotly/plotly.js/commit/9b4a38d6d5052343543fb3445c4ba6f002c669ee introduces a test to :lock: and find all the traces with the bug.

Commit https://github.com/plotly/plotly.js/commit/2e966e03ceec3e2a23f07b654d3f06ed328eb114 contains the fix

[Codepen before](https://codepen.io/MojtabaSamimi/pen/KKPQELB)
[Codepen after](https://codepen.io/antoinerg/pen/BaBrLVP)
