### PR TITLE
Fix toggleHover and resetViews modebar buttons for some partial bundle + graph setups 

### DIFF
--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -343,7 +343,7 @@ function handleCamera3d(gd, ev) {
     var button = ev.currentTarget;
     var attr = button.getAttribute('data-attr');
     var fullLayout = gd._fullLayout;
-    var sceneIds = fullLayout._subplots.gl3d;
+    var sceneIds = fullLayout._subplots.gl3d || [];
     var aobj = {};
 
     for(var i = 0; i < sceneIds.length; i++) {
@@ -380,7 +380,7 @@ function getNextHover3d(gd, ev) {
     var button = ev.currentTarget;
     var val = button._previousVal;
     var fullLayout = gd._fullLayout;
-    var sceneIds = fullLayout._subplots.gl3d;
+    var sceneIds = fullLayout._subplots.gl3d || [];
 
     var axes = ['xaxis', 'yaxis', 'zaxis'];
 
@@ -618,7 +618,7 @@ modeBarButtons.resetViewMapbox = {
 
 function resetView(gd, subplotType) {
     var fullLayout = gd._fullLayout;
-    var subplotIds = fullLayout._subplots[subplotType];
+    var subplotIds = fullLayout._subplots[subplotType] || [];
     var aObj = {};
 
     for(var i = 0; i < subplotIds.length; i++) {

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -1342,6 +1342,56 @@ describe('ModeBar', function() {
                 .then(done);
             });
         });
+
+        describe('button toggleHover', function() {
+            it('ternary case', function(done) {
+                var gd = createGraphDiv();
+
+                function _run(msg) {
+                    expect(gd._fullLayout.hovermode).toBe('closest', msg + '| pre');
+                    selectButton(gd._fullLayout._modeBar, 'toggleHover').click();
+                    expect(gd._fullLayout.hovermode).toBe(false, msg + '| after first click');
+                    selectButton(gd._fullLayout._modeBar, 'toggleHover').click();
+                    expect(gd._fullLayout.hovermode).toBe('closest', msg + '| after 2nd click');
+                }
+
+                Plotly.plot(gd, [
+                    {type: 'scatterternary', a: [1], b: [2], c: [3]}
+                ])
+                .then(function() {
+                    _run('base');
+
+                    // mock for *cartesian* bundle
+                    delete gd._fullLayout._subplots.gl3d;
+
+                    _run('cartesian bundle');
+                })
+                .catch(failTest)
+                .then(done);
+            });
+        });
+
+        describe('button resetViews', function() {
+            it('ternary + geo case ', function(done) {
+                var gd = createGraphDiv();
+
+                Plotly.plot(gd, [
+                    {type: 'scatterternary', a: [1], b: [2], c: [3]},
+                    {type: 'scattergeo', lon: [10], lat: [20]}
+                ])
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'resetViews').click();
+
+                    // mock for custom geo + ternary bundle
+                    delete gd._fullLayout._subplots.gl3d;
+                    delete gd._fullLayout._subplots.mapbox;
+
+                    selectButton(gd._fullLayout._modeBar, 'resetViews').click();
+                })
+                .catch(failTest)
+                .then(done);
+            });
+        });
     });
 
     describe('modebar styling', function() {


### PR DESCRIPTION
fix #4164 - by adding fallbacks to `fullLayout._subplots[k]` entries in modebar buttons handlers called on graphs with different subplot arrangements that may or may not be part of one's partial or custom bundle.

The reason why some `fullLayout._subplots[k]` are empty in partial bundles is due to this routine here:

https://github.com/plotly/plotly.js/blob/9b5f0898e13c24f2ad23c9745cac07e48c0e35d9/src/plots/plots.js#L584-L624

which loops over the **registered** base-plot modules - which is a subset of all the available base-plot modules.

cc @plotly/plotly_js - we don't publish partial bundles on CI, so I can't show you a before/after from https://github.com/plotly/plotly.js/issues/4164#issuecomment-530110586 - I hope you'll find the fix trivial enough to not mind. Please let me know if that's not case.