### PR TITLE
Fix tiny zoombox behavior

### DIFF
--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -429,14 +429,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     }
 
     function zoomDone() {
-        // more strict than dragged, which allows you to come back to where you started
-        // and still count as dragged
-        if(Math.min(box.h, box.w) < MINDRAG * 2) {
-            return removeZoombox(gd);
-        }
-
         computeZoomUpdates();
-
         removeZoombox(gd);
         dragTail();
         showDoubleClickNotifier(gd);

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -65,7 +65,6 @@ describe('zoom box element', function() {
     });
 });
 
-
 describe('main plot pan', function() {
     var gd, modeBar, relayoutCallback;
 
@@ -893,7 +892,7 @@ describe('axis zoom/pan and main plot zoom', function() {
                         cnt++;
                         // called twice as many times on drag:
                         // - once per axis during mousemouve
-                        // - once per raxis on mouseup
+                        // - once per axis on mouseup
                         if(opts.dragged) cnt++;
                     }
                 });
@@ -1726,7 +1725,7 @@ describe('axis zoom/pan and main plot zoom', function() {
 
             Plotly.plot(gd, [{ type: 'heatmap', z: z() }], {dragmode: 'pan'})
             .then(function() {
-                // inspired by https://github.com/plotly/plotly.js/issues/2687<Paste>
+                // inspired by https://github.com/plotly/plotly.js/issues/2687
                 gd.on('plotly_relayout', function(d) {
                     relayoutTracker.unshift(d);
                     setTimeout(function() {

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -439,15 +439,21 @@ describe('Click-to-select', function() {
           })
           .then(function() {
               assertSelectedPoints(35);
-              drag(LASSO_PATH);
-          })
-          .then(function() {
-              assertSelectedPoints(35);
               _clickPt(mock14Pts[35], { shiftKey: true });
               return deselectPromise;
           })
           .then(function() {
               assertSelectionCleared();
+              return _clickPt(mock14Pts[7], { shiftKey: true });
+          })
+          .then(function() {
+              assertSelectedPoints(7);
+              drag([[110, 100], [300, 300]]);
+          })
+          .then(delay(100))
+          .then(function() {
+              // persist after zoombox
+              assertSelectedPoints(7);
           })
           .catch(failTest)
           .then(done);


### PR DESCRIPTION
fixes https://github.com/plotly/plotly.js/issues/4156

where zoomboxes smaller than `2*MINDRAG=16px` now lead to an axis range relayout

Before:

![Peek 2019-09-13 12-04](https://user-images.githubusercontent.com/6675409/64877156-cdb40200-d61e-11e9-806e-698d4c90d342.gif)

After:

![Peek 2019-09-13 12-10](https://user-images.githubusercontent.com/6675409/64877474-87ab6e00-d61f-11e9-8e78-12a5ee0b538c.gif)

cc @plotly/plotly_js 


