### PR TITLE
Add constraint info to parcats click/hover events

### DIFF
--- a/src/traces/parcats/calc.js
+++ b/src/traces/parcats/calc.js
@@ -86,14 +86,15 @@ module.exports = function calc(gd, trace) {
 
     // Build color generation function
     function getMarkerColorInfo(index) {
-        var value;
+        var value, rawColor;
         if(Lib.isArrayOrTypedArray(line.color)) {
             value = line.color[index % line.color.length];
+            rawColor = value;
         } else {
             value = line.color;
         }
 
-        return {color: markerColorscale(value), rawColor: value};
+        return {color: markerColorscale(value), rawColor: rawColor};
     }
 
     // Number of values and counts

--- a/test/jasmine/tests/parcats_test.js
+++ b/test/jasmine/tests/parcats_test.js
@@ -1190,6 +1190,10 @@ describe('Click events', function() {
                     {curveNumber: 0, pointNumber: 4},
                     {curveNumber: 0, pointNumber: 5},
                     {curveNumber: 0, pointNumber: 8}]);
+
+                // Check constraints
+                var constraints = clickData.constraints;
+                expect(constraints).toEqual({1: 'C'});
             })
             .catch(failTest)
             .then(done);
@@ -1261,6 +1265,10 @@ describe('Click events', function() {
                 expect(pts).toEqual([
                     {curveNumber: 0, pointNumber: 5},
                     {curveNumber: 0, pointNumber: 8}]);
+
+                // Check constraints
+                var constraints = clickData.constraints;
+                expect(constraints).toEqual({0: 1, 1: 'C', 2: 11});
             })
             .catch(failTest)
             .then(done);
@@ -1347,6 +1355,10 @@ describe('Click events with hoveron color', function() {
                 // Check points
                 expect(pts).toEqual([
                     {curveNumber: 0, pointNumber: 5}]);
+
+                // Check constraints
+                var constraints = clickData.constraints;
+                expect(constraints).toEqual({1: 'C', color: 1});
             })
             .catch(failTest)
             .then(done);
@@ -1387,6 +1399,10 @@ describe('Click events with hoveron color', function() {
                 // Check points
                 expect(pts).toEqual([
                     {curveNumber: 0, pointNumber: 5}]);
+
+                // Check constraints
+                var constraints = clickData.constraints;
+                expect(constraints).toEqual({0: 1, 1: 'C', 2: 11, color: 1});
             })
             .catch(failTest)
             .then(done);


### PR DESCRIPTION
This PR adds a new `constraints` key to the event data emitted by parcats click/hover events.  The keys are dimension indices or `color`, and the values are category values.

When clicking on a path, there will be a key for each dimension. When clicking on a category rectangle, there will be a key for the dimension the category belongs to. The `color` key is only added if:
 1. A color array was provided
 2. The click was on a path or on a category with `hoveron: 'color'`

