### PR TITLE
Fix `line.width` attr declaration in *contour traces

### DIFF
--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -239,9 +239,17 @@ module.exports = extendFlat({
                 'Has no effect if `contours.coloring` is set to *lines*.'
             ].join(' ')
         }),
-        width: extendFlat({}, scatterLineAttrs.width, {
-            editType: 'style+colorbars'
-        }),
+        width: {
+            valType: 'number',
+            min: 0,
+            role: 'style',
+            editType: 'style+colorbars',
+            description: [
+                'Sets the contour line width in (in px)',
+                'Defaults to *0.5* when `contours.type` is *levels*.',
+                'Defaults to *2* when `contour.type` is *constraint*.'
+            ].join(' ')
+        },
         dash: dash,
         smoothing: extendFlat({}, scatterLineAttrs.smoothing, {
             description: [

--- a/src/traces/contourcarpet/attributes.js
+++ b/src/traces/contourcarpet/attributes.js
@@ -10,13 +10,11 @@
 
 var heatmapAttrs = require('../heatmap/attributes');
 var contourAttrs = require('../contour/attributes');
-var contourContourAttrs = contourAttrs.contours;
-var scatterAttrs = require('../scatter/attributes');
 var colorScaleAttrs = require('../../components/colorscale/attributes');
 
 var extendFlat = require('../../lib/extend').extendFlat;
 
-var scatterLineAttrs = scatterAttrs.line;
+var contourContourAttrs = contourAttrs.contours;
 
 module.exports = extendFlat({
     carpet: {
@@ -75,22 +73,13 @@ module.exports = extendFlat({
     },
 
     line: {
-        color: extendFlat({}, scatterLineAttrs.color, {
-            description: [
-                'Sets the color of the contour level.',
-                'Has no if `contours.coloring` is set to *lines*.'
-            ].join(' ')
-        }),
-        width: scatterLineAttrs.width,
-        dash: scatterLineAttrs.dash,
-        smoothing: extendFlat({}, scatterLineAttrs.smoothing, {
-            description: [
-                'Sets the amount of smoothing for the contour lines,',
-                'where *0* corresponds to no smoothing.'
-            ].join(' ')
-        }),
+        color: contourAttrs.line.color,
+        width: contourAttrs.line.width,
+        dash: contourAttrs.line.dash,
+        smoothing: contourAttrs.line.smoothing,
         editType: 'plot'
     },
+
     transforms: undefined
 },
 

--- a/src/traces/histogram2dcontour/attributes.js
+++ b/src/traces/histogram2dcontour/attributes.js
@@ -36,7 +36,16 @@ module.exports = extendFlat({
     autocontour: contourAttrs.autocontour,
     ncontours: contourAttrs.ncontours,
     contours: contourAttrs.contours,
-    line: contourAttrs.line,
+    line: {
+        color: contourAttrs.line.color,
+        width: extendFlat({}, contourAttrs.line.width, {
+            dflt: 0.5,
+            description: 'Sets the contour line width in (in px)'
+        }),
+        dash: contourAttrs.line.dash,
+        smoothing: contourAttrs.line.smoothing,
+        editType: 'plot'
+    },
     zhoverformat: histogram2dAttrs.zhoverformat,
     hovertemplate: histogram2dAttrs.hovertemplate
 },


### PR DESCRIPTION
fixes #4203 

- unset dflt in contour `line.width`, explain default logic in description
- reuse contour `line` declaration in contourcarpet
- set hard dflt in histogram2dcontour `line.width` declaration,
  as histogram2dcontour trace only support level-style contours
  at the moment.

cc @archmoj 