### PR TITLE
[dragelement] Make touchmove event listener non passive

### DIFF
--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -163,7 +163,7 @@ dragElement.init = function init(options) {
         if(options.dragmode !== false) {
             e.preventDefault();
             document.addEventListener('mousemove', onMove);
-            document.addEventListener('touchmove', onMove);
+            document.addEventListener('touchmove', onMove, {passive: false});
         }
 
         return;


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/3371.

Touch event listeners are passive by default in some browsers and calling preventDefault inside passive event listeners is not allowed.

This is the only case I've come across but there might be more cases in the code base.