### PR TITLE
Enable second try to create gl3d scenes for Chrome 77 webgl bug

### DIFF
--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -230,13 +230,20 @@ function tryCreatePlot(scene, cameraObject, pixelRatio, canvas, gl) {
         glplotOptions.canvas = STATIC_CANVAS;
     }
 
+    var failed = 0;
+
     try {
         scene.glplot = createPlot(glplotOptions);
     } catch(e) {
-        return false;
+        failed++;
+        try { // try second time to fix issue with Chrome 77 https://github.com/plotly/plotly.js/issues/4233
+            scene.glplot = createPlot(glplotOptions);
+        } catch(e) {
+            failed++;
+        }
     }
 
-    return true;
+    return failed < 2;
 }
 
 function initializeGLPlot(scene, pixelRatio, canvas, gl) {


### PR DESCRIPTION
Addresses https://github.com/plotly/plotly.js/issues/4233.
The very first try to create a 3-D scene in Chrome 77 is not successful.
This patch enables the second attempt to create `gl3d` scene in case the first try was not successful.
@etpinard 