### PR TITLE
Check for typed array in minExtend

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -660,7 +660,7 @@ lib.minExtend = function(obj1, obj2) {
         v = obj1[k];
         if(k.charAt(0) === '_' || typeof v === 'function') continue;
         else if(k === 'module') objOut[k] = v;
-        else if(Array.isArray(v)) {
+        else if(lib.isArrayOrTypedArray(v)) {
             if(k === 'colorscale') {
                 objOut[k] = v.slice();
             } else {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -660,12 +660,14 @@ lib.minExtend = function(obj1, obj2) {
         v = obj1[k];
         if(k.charAt(0) === '_' || typeof v === 'function') continue;
         else if(k === 'module') objOut[k] = v;
-        else if(lib.isArrayOrTypedArray(v)) {
+        else if(Array.isArray(v)) {
             if(k === 'colorscale') {
                 objOut[k] = v.slice();
             } else {
                 objOut[k] = v.slice(0, arrayLen);
             }
+        } else if(lib.isTypedArray(v)) {
+            objOut[k] = v.subarray(0, arrayLen);
         } else if(v && (typeof v === 'object')) objOut[k] = lib.minExtend(obj1[k], obj2[k]);
         else objOut[k] = v;
     }

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -1121,7 +1121,7 @@ describe('end-to-end scatter tests', function() {
 
             var legendPts = d3.select('.legend').selectAll('.scatterpts');
             expect(legendPts.size()).toBe(1, '# legend items');
-            expect(getColor(legendPts.node())).toBe('rgb(0, 0, 0)', 'legend pt color');
+            expect(getColor(legendPts.node())).toBe('rgb(0, 255, 0)', 'legend pt color');
             expect(getMarkerSize(legendPts.node())).toBe(16, 'legend pt size');
         })
         .catch(failTest)


### PR DESCRIPTION
Modified minExtend to check for both arrays and TypedArrays.

Currently, if a trace contains a typedArray, minExtend will treat it it as if it's not an array and will re-create the entire array as opposed to simply taking a slice of the array. To fix this, this change checks if the current value is an array in addition to checking if it is a TypedArray. 