### PR TITLE
Guard against mirrored+autorange anchor:'free' axes

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1942,7 +1942,7 @@ axes.drawOne = function(gd, ax, opts) {
                     ax.title.font.size;
             }
 
-            if(ax.mirror) {
+            if(ax.mirror && ax.anchor !== 'free') {
                 mirrorPush = {x: 0, y: 0, r: 0, l: 0, t: 0, b: 0};
 
                 mirrorPush[sMirror] = ax.linewidth;

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -927,7 +927,7 @@ plots.linkSubplots = function(newFullData, newFullLayout, oldFullData, oldFullLa
         // this loop can be costly, so only compute it when required
         if(ax._counterAxes.length && (
             (ax.spikemode && ax.spikemode.indexOf('across') !== -1) ||
-            (ax.automargin && ax.mirror) ||
+            (ax.automargin && ax.mirror && ax.anchor !== 'free') ||
             Registry.getComponentMethod('rangeslider', 'isVisible')(ax)
         )) {
             var min = 1;

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -3468,6 +3468,33 @@ describe('Test axes', function() {
             .catch(failTest)
             .then(done);
         });
+
+        it('should handle cases with free+mirror axes', function(done) {
+            Plotly.plot(gd, [{
+                y: [1, 2, 1]
+            }], {
+                xaxis: {
+                    ticks: 'outside',
+                    mirror: 'ticks',
+                    anchor: 'free',
+                    automargin: true
+                },
+                yaxis: {
+                    showline: true,
+                    linewidth: 2,
+                    mirror: 'all',
+                    anchor: 'free',
+                    automargin: true
+                }
+            })
+            .then(function() {
+                // N.B. no '.automargin.mirror'
+                expect(Object.keys(gd._fullLayout._pushmargin))
+                    .toEqual(['x.automargin', 'y.automargin', 'base']);
+            })
+            .catch(failTest)
+            .then(done);
+        });
     });
 
     describe('zeroline visibility logic', function() {

--- a/test/jasmine/tests/transition_test.js
+++ b/test/jasmine/tests/transition_test.js
@@ -1189,7 +1189,7 @@ describe('Plotly.react transitions:', function() {
         .then(done);
     });
 
-    it('should update ranges of date and category axes', function(done) {
+    it('@flaky should update ranges of date and category axes', function(done) {
         Plotly.plot(gd, [
             {x: ['2018-01-01', '2019-01-01', '2020-01-01'], y: [1, 2, 3]},
             {x: ['a', 'b', 'c'], y: [1, 2, 3], xaxis: 'x2', yaxis: 'y2'}


### PR DESCRIPTION
... `anchor:'free'` axes don't draw mirror ticks, so they never need to contribute to the automargin push and most importantly they don't get `ax._anchorAxis` filled in (which lead to this bug).

before (1.50.0): https://codepen.io/etpinard/pen/mddVJxQ?editors=1010
before before (1.49.5): https://codepen.io/etpinard/pen/QWWybrw?editors=1010
after: https://codepen.io/etpinard/pen/OJJMyMP?editors=1010 (noticed also legend fixup from https://github.com/plotly/plotly.js/pull/4160)

To go in `v1.50.1` - cc @archmoj 
