### PR TITLE
Don't init gl3d scenes with premultipliedAlpha true on Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4646,9 +4646,8 @@
       }
     },
     "gl-plot3d": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.2.2.tgz",
-      "integrity": "sha512-is8RoDVUEbUM7kJ2qjhKJlfGLECH3ML9pTCW1V7ylUdmUACmcZ4lzJrQr/NIRkHC5WcUNOp3QJKPjBND3ngZ2A==",
+      "version": "git://github.com/gl-vis/gl-plot3d.git#bb597b7dc8b7d70a8b0d4b4e042e2171ba091dbc",
+      "from": "git://github.com/gl-vis/gl-plot3d.git#bb597b7dc8b7d70a8b0d4b4e042e2171ba091dbc",
       "requires": {
         "3d-view": "^2.0.0",
         "a-big-triangle": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.1.1",
     "gl-plot2d": "^1.4.2",
-    "gl-plot3d": "^2.2.2",
+    "gl-plot3d": "git://github.com/gl-vis/gl-plot3d.git#bb597b7dc8b7d70a8b0d4b4e042e2171ba091dbc",
     "gl-pointcloud2d": "^1.0.2",
     "gl-scatter3d": "^1.2.2",
     "gl-select-box": "^1.0.3",


### PR DESCRIPTION
Fix #4236.
Avoid creation of artifacts when rendering of transparent 3d surfaces on Firefox.

[Before vs After codepen](https://codepen.io/MojtabaSamimi/pen/eYYzxqN?editors=0010)

@etpinard 