### PR TITLE
Update connectgaps description in respect to heatmap and contour default logics

### DIFF
--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -39,7 +39,16 @@ module.exports = extendFlat({
     zhoverformat: heatmapAttrs.zhoverformat,
     hovertemplate: heatmapAttrs.hovertemplate,
 
-    connectgaps: heatmapAttrs.connectgaps,
+    connectgaps: extendFlat({}, heatmapAttrs.connectgaps, {
+        description: [
+            'Determines whether or not gaps',
+            '(i.e. {nan} or missing values)',
+            'in the `z` data are filled in.',
+            'It is defaulted to true if `z` is a',
+            'one dimensional array',
+            'otherwise it is defaulted to false.'
+        ].join(' ')
+    }),
 
     fillcolor: {
         valType: 'color',

--- a/src/traces/heatmap/attributes.js
+++ b/src/traces/heatmap/attributes.js
@@ -81,13 +81,15 @@ module.exports = extendFlat({
     },
     connectgaps: {
         valType: 'boolean',
-        dflt: false,
         role: 'info',
         editType: 'calc',
         description: [
             'Determines whether or not gaps',
             '(i.e. {nan} or missing values)',
-            'in the `z` data are filled in.'
+            'in the `z` data are filled in.',
+            'It is defaulted to true if `z` is a',
+            'one dimensional array and `zsmooth` is not false;',
+            'otherwise it is defaulted to false.'
         ].join(' ')
     },
     xgap: {

--- a/test/jasmine/tests/contour_test.js
+++ b/test/jasmine/tests/contour_test.js
@@ -64,6 +64,28 @@ describe('contour defaults', function() {
         expect(traceOut.autocontour).toBe(true);
     });
 
+    it('should default connectgaps to false if `z` is not a one dimensional array', function() {
+        traceIn = {
+            type: 'heatmap',
+            z: [[0, null], [1, 2]]
+        };
+
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.connectgaps).toBe(false);
+    });
+
+    it('should default connectgaps to true if `z` is a one dimensional array', function() {
+        traceIn = {
+            type: 'heatmap',
+            x: [0, 1, 0, 1],
+            y: [0, 0, 1, 1],
+            z: [0, null, 1, 2]
+        };
+
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.connectgaps).toBe(true);
+    });
+
     it('should inherit layout.calendar', function() {
         traceIn = {
             x: [1, 2],

--- a/test/jasmine/tests/heatmap_test.js
+++ b/test/jasmine/tests/heatmap_test.js
@@ -128,6 +128,42 @@ describe('heatmap supplyDefaults', function() {
         expect(traceOut.ygap).toBe(undefined);
     });
 
+    it('should default connectgaps to false if `z` is not a one dimensional array', function() {
+        traceIn = {
+            type: 'heatmap',
+            z: [[0, null], [1, 2]]
+        };
+
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.connectgaps).toBe(false);
+    });
+
+    it('should default connectgaps to true if `z` is a one dimensional array and `zsmooth` is not false', function() {
+        traceIn = {
+            zsmooth: 'fast',
+            type: 'heatmap',
+            x: [1, 1, 2, 2, 2],
+            y: [1, 2, 1, 2, 3],
+            z: [1, null, 4, 5, 6]
+        };
+
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.connectgaps).toBe(true);
+    });
+
+    it('should default connectgaps to false if `zsmooth` is false', function() {
+        traceIn = {
+            zsmooth: false,
+            type: 'heatmap',
+            x: [1, 1, 2, 2, 2],
+            y: [1, 2, 1, 2, 3],
+            z: [1, null, 4, 5, 6]
+        };
+
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.connectgaps).toBe(false);
+    });
+
     it('should inherit layout.calendar', function() {
         traceIn = {
             x: [1, 2],


### PR DESCRIPTION
The `connectgaps` attributes of `heatmap` and `contour` traces has some default logics which could result in enabling by default.
So they are not `dflt: false`.

This PR updates the description and add tests for different scenarios.

@etpinard 