### PR TITLE
Add hoverongaps to heatmap and contour for suppressing hovers on missing data

### DIFF
--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -38,7 +38,7 @@ module.exports = extendFlat({
     ytype: heatmapAttrs.ytype,
     zhoverformat: heatmapAttrs.zhoverformat,
     hovertemplate: heatmapAttrs.hovertemplate,
-    hovergaps: heatmapAttrs.hovergaps,
+    hoverongaps: heatmapAttrs.hoverongaps,
     connectgaps: extendFlat({}, heatmapAttrs.connectgaps, {
         description: [
             'Determines whether or not gaps',

--- a/src/traces/contour/attributes.js
+++ b/src/traces/contour/attributes.js
@@ -38,7 +38,7 @@ module.exports = extendFlat({
     ytype: heatmapAttrs.ytype,
     zhoverformat: heatmapAttrs.zhoverformat,
     hovertemplate: heatmapAttrs.hovertemplate,
-
+    hovergaps: heatmapAttrs.hovergaps,
     connectgaps: extendFlat({}, heatmapAttrs.connectgaps, {
         description: [
             'Determines whether or not gaps',

--- a/src/traces/contour/defaults.js
+++ b/src/traces/contour/defaults.js
@@ -35,7 +35,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     coerce('text');
     coerce('hovertext');
     coerce('hovertemplate');
-    coerce('hovergaps');
+    coerce('hoverongaps');
 
     var isConstraint = (coerce('contours.type') === 'constraint');
     coerce('connectgaps', Lib.isArray1D(traceOut.z));

--- a/src/traces/contour/defaults.js
+++ b/src/traces/contour/defaults.js
@@ -35,6 +35,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     coerce('text');
     coerce('hovertext');
     coerce('hovertemplate');
+    coerce('hovergaps');
 
     var isConstraint = (coerce('contours.type') === 'constraint');
     coerce('connectgaps', Lib.isArray1D(traceOut.z));

--- a/src/traces/heatmap/attributes.js
+++ b/src/traces/heatmap/attributes.js
@@ -79,7 +79,7 @@ module.exports = extendFlat({
             'Picks a smoothing algorithm use to smooth `z` data.'
         ].join(' ')
     },
-    hovergaps: {
+    hoverongaps: {
         valType: 'boolean',
         dflt: true,
         role: 'style',

--- a/src/traces/heatmap/attributes.js
+++ b/src/traces/heatmap/attributes.js
@@ -79,6 +79,17 @@ module.exports = extendFlat({
             'Picks a smoothing algorithm use to smooth `z` data.'
         ].join(' ')
     },
+    hovergaps: {
+        valType: 'boolean',
+        dflt: true,
+        role: 'style',
+        editType: 'none',
+        description: [
+            'Determines whether or not gaps',
+            '(i.e. {nan} or missing values)',
+            'in the `z` data are hovered on.'
+        ].join(' ')
+    },
     connectgaps: {
         valType: 'boolean',
         role: 'info',

--- a/src/traces/heatmap/attributes.js
+++ b/src/traces/heatmap/attributes.js
@@ -87,7 +87,7 @@ module.exports = extendFlat({
         description: [
             'Determines whether or not gaps',
             '(i.e. {nan} or missing values)',
-            'in the `z` data are hovered on.'
+            'in the `z` data have hover labels associated with them.'
         ].join(' ')
     },
     connectgaps: {

--- a/src/traces/heatmap/defaults.js
+++ b/src/traces/heatmap/defaults.js
@@ -34,7 +34,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
 
     handleStyleDefaults(traceIn, traceOut, coerce, layout);
 
-    coerce('hovergaps');
+    coerce('hoverongaps');
     coerce('connectgaps', Lib.isArray1D(traceOut.z) && (traceOut.zsmooth !== false));
 
     colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: '', cLetter: 'z'});

--- a/src/traces/heatmap/defaults.js
+++ b/src/traces/heatmap/defaults.js
@@ -34,6 +34,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
 
     handleStyleDefaults(traceIn, traceOut, coerce, layout);
 
+    coerce('hovergaps');
     coerce('connectgaps', Lib.isArray1D(traceOut.z) && (traceOut.zsmooth !== false));
 
     colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: '', cLetter: 'z'});

--- a/src/traces/heatmap/hover.js
+++ b/src/traces/heatmap/hover.js
@@ -112,7 +112,7 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
     var zVal = z[ny][nx];
     if(zmask && !zmask[ny][nx]) zVal = undefined;
 
-    if(zVal !== undefined || trace.hovergaps) {
+    if(zVal !== undefined || trace.hoverongaps) {
         // dummy axis for formatting the z value
         var cOpts = extractOpts(trace);
         var dummyAx = {

--- a/src/traces/heatmap/hover.js
+++ b/src/traces/heatmap/hover.js
@@ -88,9 +88,6 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
         }
     }
 
-    var zVal = z[ny][nx];
-    if(zmask && !zmask[ny][nx]) zVal = undefined;
-
     var text;
     if(Array.isArray(cd0.hovertext) && Array.isArray(cd0.hovertext[ny])) {
         text = cd0.hovertext[ny][nx];
@@ -98,18 +95,7 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
         text = cd0.text[ny][nx];
     }
 
-    // dummy axis for formatting the z value
-    var cOpts = extractOpts(trace);
-    var dummyAx = {
-        type: 'linear',
-        range: [cOpts.min, cOpts.max],
-        hoverformat: zhoverformat,
-        _separators: xa._separators,
-        _numFormat: xa._numFormat
-    };
-    var zLabel = Axes.tickText(dummyAx, zVal, 'hover').text;
-
-    return [Lib.extendFlat(pointData, {
+    var obj = {
         index: [ny, nx],
         // never let a 2D override 1D type as closest point
         distance: pointData.maxHoverDistance,
@@ -120,8 +106,26 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
         y1: y1,
         xLabelVal: xl,
         yLabelVal: yl,
-        zLabelVal: zVal,
-        zLabel: zLabel,
         text: text
-    })];
+    };
+
+    var zVal = z[ny][nx];
+    if(zmask && !zmask[ny][nx]) zVal = undefined;
+
+    if(zVal !== undefined || trace.hovergaps) {
+        // dummy axis for formatting the z value
+        var cOpts = extractOpts(trace);
+        var dummyAx = {
+            type: 'linear',
+            range: [cOpts.min, cOpts.max],
+            hoverformat: zhoverformat,
+            _separators: xa._separators,
+            _numFormat: xa._numFormat
+        };
+
+        obj.zLabelVal = zVal;
+        obj.zLabel = Axes.tickText(dummyAx, zVal, 'hover').text;
+    }
+
+    return [Lib.extendFlat(pointData, obj)];
 };

--- a/src/traces/heatmap/hover.js
+++ b/src/traces/heatmap/hover.js
@@ -88,6 +88,11 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
         }
     }
 
+    var zVal = z[ny][nx];
+    if(zmask && !zmask[ny][nx]) zVal = undefined;
+
+    if(zVal === undefined && !trace.hoverongaps) return;
+
     var text;
     if(Array.isArray(cd0.hovertext) && Array.isArray(cd0.hovertext[ny])) {
         text = cd0.hovertext[ny][nx];
@@ -95,7 +100,18 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
         text = cd0.text[ny][nx];
     }
 
-    var obj = {
+    // dummy axis for formatting the z value
+    var cOpts = extractOpts(trace);
+    var dummyAx = {
+        type: 'linear',
+        range: [cOpts.min, cOpts.max],
+        hoverformat: zhoverformat,
+        _separators: xa._separators,
+        _numFormat: xa._numFormat
+    };
+    var zLabel = Axes.tickText(dummyAx, zVal, 'hover').text;
+
+    return [Lib.extendFlat(pointData, {
         index: [ny, nx],
         // never let a 2D override 1D type as closest point
         distance: pointData.maxHoverDistance,
@@ -106,26 +122,8 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
         y1: y1,
         xLabelVal: xl,
         yLabelVal: yl,
+        zLabelVal: zVal,
+        zLabel: zLabel,
         text: text
-    };
-
-    var zVal = z[ny][nx];
-    if(zmask && !zmask[ny][nx]) zVal = undefined;
-
-    if(zVal !== undefined || trace.hoverongaps) {
-        // dummy axis for formatting the z value
-        var cOpts = extractOpts(trace);
-        var dummyAx = {
-            type: 'linear',
-            range: [cOpts.min, cOpts.max],
-            hoverformat: zhoverformat,
-            _separators: xa._separators,
-            _numFormat: xa._numFormat
-        };
-
-        obj.zLabelVal = zVal;
-        obj.zLabel = Axes.tickText(dummyAx, zVal, 'hover').text;
-    }
-
-    return [Lib.extendFlat(pointData, obj)];
+    })];
 };

--- a/test/jasmine/tests/contour_test.js
+++ b/test/jasmine/tests/contour_test.js
@@ -66,7 +66,7 @@ describe('contour defaults', function() {
 
     it('should default connectgaps to false if `z` is not a one dimensional array', function() {
         traceIn = {
-            type: 'heatmap',
+            type: 'contour',
             z: [[0, null], [1, 2]]
         };
 
@@ -76,7 +76,7 @@ describe('contour defaults', function() {
 
     it('should default connectgaps to true if `z` is a one dimensional array', function() {
         traceIn = {
-            type: 'heatmap',
+            type: 'contour',
             x: [0, 1, 0, 1],
             y: [0, 0, 1, 1],
             z: [0, null, 1, 2]
@@ -589,5 +589,65 @@ describe('contour plotting and editing', function() {
         })
         .catch(failTest)
         .then(done);
+    });
+});
+
+describe('contour hover', function() {
+    'use strict';
+
+    var gd;
+
+    function _hover(gd, xval, yval) {
+        var fullLayout = gd._fullLayout;
+        var calcData = gd.calcdata;
+        var hoverData = [];
+
+        for(var i = 0; i < calcData.length; i++) {
+            var pointData = {
+                index: false,
+                distance: 20,
+                cd: calcData[i],
+                trace: calcData[i][0].trace,
+                xa: fullLayout.xaxis,
+                ya: fullLayout.yaxis
+            };
+
+            var hoverPoint = Contour.hoverPoints(pointData, xval, yval);
+            if(hoverPoint) hoverData.push(hoverPoint[0]);
+        }
+
+        return hoverData;
+    }
+
+    function assertLabels(hoverPoint, xLabel, yLabel, zLabel, text) {
+        expect(hoverPoint.xLabelVal).toBe(xLabel, 'have correct x label');
+        expect(hoverPoint.yLabelVal).toBe(yLabel, 'have correct y label');
+        expect(hoverPoint.zLabelVal).toBe(zLabel, 'have correct z label');
+        expect(hoverPoint.text).toBe(text, 'have correct text label');
+    }
+
+    describe('missing data', function() {
+        beforeAll(function(done) {
+            gd = createGraphDiv();
+
+            Plotly.plot(gd, {
+                data: [{
+                    type: 'contour',
+                    x: [10, 11, 10, 11],
+                    y: [100, 100, 101, 101],
+                    z: [null, 1, 2, 3],
+                    connectgaps: false,
+                    hovergaps: false
+                }]
+            }).then(done);
+        });
+        afterAll(destroyGraphDiv);
+
+        it('should not create zLabels when hovering on missing data and hovergaps is disabled', function() {
+            var pt = _hover(gd, 10, 100)[0];
+
+            expect(pt.index).toEqual([0, 0], 'have correct index');
+            assertLabels(pt, 10, 100, undefined);
+        });
     });
 });

--- a/test/jasmine/tests/contour_test.js
+++ b/test/jasmine/tests/contour_test.js
@@ -619,13 +619,6 @@ describe('contour hover', function() {
         return hoverData;
     }
 
-    function assertLabels(hoverPoint, xLabel, yLabel, zLabel, text) {
-        expect(hoverPoint.xLabelVal).toBe(xLabel, 'have correct x label');
-        expect(hoverPoint.yLabelVal).toBe(yLabel, 'have correct y label');
-        expect(hoverPoint.zLabelVal).toBe(zLabel, 'have correct z label');
-        expect(hoverPoint.text).toBe(text, 'have correct text label');
-    }
-
     describe('missing data', function() {
         beforeAll(function(done) {
             gd = createGraphDiv();
@@ -643,11 +636,16 @@ describe('contour hover', function() {
         });
         afterAll(destroyGraphDiv);
 
-        it('should not create zLabels when hovering on missing data and hoverongaps is disabled', function() {
+        it('should not display hover on missing data and hoverongaps is disabled', function() {
             var pt = _hover(gd, 10, 100)[0];
 
-            expect(pt.index).toEqual([0, 0], 'have correct index');
-            assertLabels(pt, 10, 100, undefined);
+            var hoverData;
+            gd.on('plotly_hover', function(data) {
+                hoverData = data;
+            });
+
+            expect(hoverData).toEqual(undefined);
+            expect(pt).toEqual(undefined);
         });
     });
 });

--- a/test/jasmine/tests/contour_test.js
+++ b/test/jasmine/tests/contour_test.js
@@ -637,13 +637,13 @@ describe('contour hover', function() {
                     y: [100, 100, 101, 101],
                     z: [null, 1, 2, 3],
                     connectgaps: false,
-                    hovergaps: false
+                    hoverongaps: false
                 }]
             }).then(done);
         });
         afterAll(destroyGraphDiv);
 
-        it('should not create zLabels when hovering on missing data and hovergaps is disabled', function() {
+        it('should not create zLabels when hovering on missing data and hoverongaps is disabled', function() {
             var pt = _hover(gd, 10, 100)[0];
 
             expect(pt.index).toEqual([0, 0], 'have correct index');

--- a/test/jasmine/tests/heatmap_test.js
+++ b/test/jasmine/tests/heatmap_test.js
@@ -988,13 +988,13 @@ describe('heatmap hover', function() {
                     y: [100, 100, 101, 101],
                     z: [null, 1, 2, 3],
                     connectgaps: false,
-                    hovergaps: false
+                    hoverongaps: false
                 }]
             }).then(done);
         });
         afterAll(destroyGraphDiv);
 
-        it('should not create zLabels when hovering on missing data and hovergaps is disabled', function() {
+        it('should not create zLabels when hovering on missing data and hoverongaps is disabled', function() {
             var pt = _hover(gd, 10, 100)[0];
 
             expect(pt.index).toEqual([0, 0], 'have correct index');

--- a/test/jasmine/tests/heatmap_test.js
+++ b/test/jasmine/tests/heatmap_test.js
@@ -994,11 +994,16 @@ describe('heatmap hover', function() {
         });
         afterAll(destroyGraphDiv);
 
-        it('should not create zLabels when hovering on missing data and hoverongaps is disabled', function() {
+        it('should not display hover on missing data and hoverongaps is disabled', function() {
             var pt = _hover(gd, 10, 100)[0];
 
-            expect(pt.index).toEqual([0, 0], 'have correct index');
-            assertLabels(pt, 10, 100, undefined);
+            var hoverData;
+            gd.on('plotly_hover', function(data) {
+                hoverData = data;
+            });
+
+            expect(hoverData).toEqual(undefined);
+            expect(pt).toEqual(undefined);
         });
     });
 });

--- a/test/jasmine/tests/heatmap_test.js
+++ b/test/jasmine/tests/heatmap_test.js
@@ -976,4 +976,29 @@ describe('heatmap hover', function() {
             .then(done);
         });
     });
+
+    describe('missing data', function() {
+        beforeAll(function(done) {
+            gd = createGraphDiv();
+
+            Plotly.plot(gd, {
+                data: [{
+                    type: 'heatmap',
+                    x: [10, 11, 10, 11],
+                    y: [100, 100, 101, 101],
+                    z: [null, 1, 2, 3],
+                    connectgaps: false,
+                    hovergaps: false
+                }]
+            }).then(done);
+        });
+        afterAll(destroyGraphDiv);
+
+        it('should not create zLabels when hovering on missing data and hovergaps is disabled', function() {
+            var pt = _hover(gd, 10, 100)[0];
+
+            expect(pt.index).toEqual([0, 0], 'have correct index');
+            assertLabels(pt, 10, 100, undefined);
+        });
+    });
 });


### PR DESCRIPTION
Resolves https://github.com/plotly/plotly.js/issues/4226.

A new attribute titled `hovergaps` is added to `contour` and `heatmap` for disabling hover when the `z` is missing.

@plotly/plotly_js 