### PR TITLE
Keep orthographic zoom scales in fullLayout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4646,9 +4646,8 @@
       }
     },
     "gl-plot3d": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.2.2.tgz",
-      "integrity": "sha512-is8RoDVUEbUM7kJ2qjhKJlfGLECH3ML9pTCW1V7ylUdmUACmcZ4lzJrQr/NIRkHC5WcUNOp3QJKPjBND3ngZ2A==",
+      "version": "git://github.com/gl-vis/gl-plot3d.git#4d41ca21b3c0a25db8776ce92261995323bb62e8",
+      "from": "git://github.com/gl-vis/gl-plot3d.git#4d41ca21b3c0a25db8776ce92261995323bb62e8",
       "requires": {
         "3d-view": "^2.0.0",
         "a-big-triangle": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4646,8 +4646,9 @@
       }
     },
     "gl-plot3d": {
-      "version": "git://github.com/gl-vis/gl-plot3d.git#83e9c9406976e5ee92bf1f1851e4366e516c06f7",
-      "from": "git://github.com/gl-vis/gl-plot3d.git#83e9c9406976e5ee92bf1f1851e4366e516c06f7",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.3.0.tgz",
+      "integrity": "sha512-qg269QiLpaw16d2D5Gz9fa8vsLcA8kbX/cv1u9S7BsH6jD9qGYxsY8iWJ8ea9/68WhPS5En2kUavkXINkmHsOQ==",
       "requires": {
         "3d-view": "^2.0.0",
         "a-big-triangle": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4646,8 +4646,8 @@
       }
     },
     "gl-plot3d": {
-      "version": "git://github.com/gl-vis/gl-plot3d.git#4d41ca21b3c0a25db8776ce92261995323bb62e8",
-      "from": "git://github.com/gl-vis/gl-plot3d.git#4d41ca21b3c0a25db8776ce92261995323bb62e8",
+      "version": "git://github.com/gl-vis/gl-plot3d.git#83e9c9406976e5ee92bf1f1851e4366e516c06f7",
+      "from": "git://github.com/gl-vis/gl-plot3d.git#83e9c9406976e5ee92bf1f1851e4366e516c06f7",
       "requires": {
         "3d-view": "^2.0.0",
         "a-big-triangle": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.1.1",
     "gl-plot2d": "^1.4.2",
-    "gl-plot3d": "git://github.com/gl-vis/gl-plot3d.git#4d41ca21b3c0a25db8776ce92261995323bb62e8",
+    "gl-plot3d": "git://github.com/gl-vis/gl-plot3d.git#83e9c9406976e5ee92bf1f1851e4366e516c06f7",
     "gl-pointcloud2d": "^1.0.2",
     "gl-scatter3d": "^1.2.2",
     "gl-select-box": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.1.1",
     "gl-plot2d": "^1.4.2",
-    "gl-plot3d": "^2.2.2",
+    "gl-plot3d": "git://github.com/gl-vis/gl-plot3d.git#4d41ca21b3c0a25db8776ce92261995323bb62e8",
     "gl-pointcloud2d": "^1.0.2",
     "gl-scatter3d": "^1.2.2",
     "gl-select-box": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.1.1",
     "gl-plot2d": "^1.4.2",
-    "gl-plot3d": "git://github.com/gl-vis/gl-plot3d.git#83e9c9406976e5ee92bf1f1851e4366e516c06f7",
+    "gl-plot3d": "^2.3.0",
     "gl-pointcloud2d": "^1.0.2",
     "gl-scatter3d": "^1.2.2",
     "gl-select-box": "^1.0.3",

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -344,17 +344,27 @@ function handleCamera3d(gd, ev) {
 
     for(var i = 0; i < sceneIds.length; i++) {
         var sceneId = sceneIds[i];
-        var key = sceneId + '.camera';
+        var camera = sceneId + '.camera';
+        var aspectratio = sceneId + '.aspectratio';
         var scene = fullLayout[sceneId]._scene;
+        var didUpdate;
 
         if(attr === 'resetLastSave') {
-            aobj[key + '.up'] = scene.viewInitial.up;
-            aobj[key + '.eye'] = scene.viewInitial.eye;
-            aobj[key + '.center'] = scene.viewInitial.center;
+            aobj[camera + '.up'] = scene.viewInitial.up;
+            aobj[camera + '.eye'] = scene.viewInitial.eye;
+            aobj[camera + '.center'] = scene.viewInitial.center;
+            didUpdate = true;
         } else if(attr === 'resetDefault') {
-            aobj[key + '.up'] = null;
-            aobj[key + '.eye'] = null;
-            aobj[key + '.center'] = null;
+            aobj[camera + '.up'] = null;
+            aobj[camera + '.eye'] = null;
+            aobj[camera + '.center'] = null;
+            didUpdate = true;
+        }
+
+        if(didUpdate) {
+            aobj[aspectratio + '.x'] = scene.viewInitial.aspectratio.x;
+            aobj[aspectratio + '.y'] = scene.viewInitial.aspectratio.y;
+            aobj[aspectratio + '.z'] = scene.viewInitial.aspectratio.z;
         }
     }
 

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -578,8 +578,7 @@ exports.doCamera = function(gd) {
         var sceneLayout = fullLayout[sceneIds[i]];
         var scene = sceneLayout._scene;
 
-        var cameraData = sceneLayout.camera;
-        scene.setCamera(cameraData);
+        scene.setViewport(sceneLayout);
     }
 };
 

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -417,7 +417,6 @@ proto.recoverContext = function() {
     var scene = this;
     var gl = this.glplot.gl;
     var canvas = this.glplot.canvas;
-    var camera = this.glplot.camera;
     var pixelRatio = this.glplot.pixelRatio;
     this.glplot.dispose();
 
@@ -426,7 +425,7 @@ proto.recoverContext = function() {
             requestAnimationFrame(tryRecover);
             return;
         }
-        if(!initializeGLPlot(scene, camera, pixelRatio, canvas, gl)) {
+        if(!initializeGLPlot(scene, pixelRatio, canvas, gl)) {
             Lib.error('Catastrophic and unrecoverable WebGL error. Context lost.');
             return;
         }

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -11,6 +11,7 @@
 
 var createCamera = require('gl-plot3d').createCamera;
 var createPlot = require('gl-plot3d').createScene;
+var mouseWheel = require('mouse-wheel');
 var getContext = require('webgl-context');
 var passiveSupported = require('has-passive-events');
 
@@ -243,7 +244,26 @@ function tryCreatePlot(scene, cameraObject, pixelRatio, canvas, gl) {
         }
     }
 
-    return failed < 2;
+    if(failed < 2) {
+        scene.wheelListener = mouseWheel(scene.glplot.canvas, function(dx, dy) {
+            // TODO remove now that we can disable scroll via scrollZoom?
+            if(scene.glplot.camera.keyBindingMode === false) return;
+            if(!scene.glplot.camera.enableWheel) return;
+
+            if(scene.glplot.camera._ortho) {
+                var s = (dx > dy) ? 1.1 : 1.0 / 1.1;
+
+                scene.fullSceneLayout.aspectratio.x = scene.glplot.aspect[0] *= s;
+                scene.fullSceneLayout.aspectratio.y = scene.glplot.aspect[1] *= s;
+                scene.fullSceneLayout.aspectratio.z = scene.glplot.aspect[2] *= s;
+
+                scene.glplot.redraw();
+            }
+        }, true);
+
+        return true;
+    }
+    return false;
 }
 
 function initializeGLPlot(scene, pixelRatio, canvas, gl) {

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -248,10 +248,10 @@ function tryCreatePlot(scene, cameraObject, pixelRatio, canvas, gl) {
     return failed < 2;
 }
 
-function initializeGLPlot(scene, pixelRatio, canvas, gl) {
+function initializeGLPlot(scene, canvas, gl) {
     scene.initializeGLCamera();
 
-    var success = tryCreatePlot(scene, scene.camera, pixelRatio, canvas, gl);
+    var success = tryCreatePlot(scene, scene.camera, scene.pixelRatio, canvas, gl);
     /*
     * createPlot will throw when webgl is not enabled in the client.
     * Lets return an instance of the module with all functions noop'd.
@@ -393,7 +393,7 @@ function Scene(options, fullLayout) {
     this.convertAnnotations = Registry.getComponentMethod('annotations3d', 'convert');
     this.drawAnnotations = Registry.getComponentMethod('annotations3d', 'draw');
 
-    initializeGLPlot(this, this.pixelRatio);
+    initializeGLPlot(this);
 }
 
 var proto = Scene.prototype;
@@ -417,7 +417,7 @@ proto.recoverContext = function() {
     var scene = this;
     var gl = this.glplot.gl;
     var canvas = this.glplot.canvas;
-    var pixelRatio = this.glplot.pixelRatio;
+
     this.glplot.dispose();
 
     function tryRecover() {
@@ -425,7 +425,7 @@ proto.recoverContext = function() {
             requestAnimationFrame(tryRecover);
             return;
         }
-        if(!initializeGLPlot(scene, pixelRatio, canvas, gl)) {
+        if(!initializeGLPlot(scene, canvas, gl)) {
             Lib.error('Catastrophic and unrecoverable WebGL error. Context lost.');
             return;
         }
@@ -825,8 +825,6 @@ proto.setViewport = function(sceneLayout) {
     if(newOrtho !== oldOrtho) {
         this.glplot.redraw();
 
-        var pixelRatio = this.glplot.pixelRatio;
-
         var RGBA = this.glplot.clearColor;
         this.glplot.gl.clearColor(
             RGBA[0], RGBA[1], RGBA[2], RGBA[3]
@@ -838,7 +836,7 @@ proto.setViewport = function(sceneLayout) {
 
         this.glplot.dispose();
 
-        initializeGLPlot(this, pixelRatio);
+        initializeGLPlot(this);
         this.glplot.camera._ortho = newOrtho;
     }
 };

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -412,7 +412,7 @@ describe('Test gl3d plots', function() {
     });
 });
 
-describe('Test gl3d modebar handlers', function() {
+describe('Test gl3d modebar handlers - perspective case', function() {
     var gd, modeBar;
 
     function assertScenes(cont, attr, val) {
@@ -444,8 +444,17 @@ describe('Test gl3d modebar handlers', function() {
                 { type: 'surface', scene: 'scene2' }
             ],
             layout: {
-                scene: { camera: { eye: { x: 0.1, y: 0.1, z: 1 }}},
-                scene2: { camera: { eye: { x: 2.5, y: 2.5, z: 2.5 }}}
+                scene: {
+                    camera: {
+                        eye: { x: 0.1, y: 0.1, z: 1 }
+                    }
+                },
+                scene2: {
+                    camera: {
+                        eye: { x: 2.5, y: 2.5, z: 2.5 }
+                    },
+                    aspectratio: { x: 3, y: 2, z: 1 }
+                }
             }
         };
 
@@ -559,6 +568,242 @@ describe('Test gl3d modebar handlers', function() {
 
             expect(gd._fullLayout.scene._scene.getCamera().eye.z).toBeCloseTo(1.25);
             expect(gd._fullLayout.scene2._scene.getCamera().eye.z).toBeCloseTo(1.25);
+
+            done();
+        });
+
+        buttonDefault.click();
+    });
+
+    it('@gl button resetCameraDefault3d should reset to initial aspectratios', function(done) {
+        var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
+
+        expect(gd._fullLayout.scene._scene.viewInitial.aspectratio).toEqual({ x: 1, y: 1, z: 1 });
+        expect(gd._fullLayout.scene2._scene.viewInitial.aspectratio).toEqual({ x: 3, y: 2, z: 1 });
+
+        gd.once('plotly_relayout', function() {
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().x).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().y).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().z).toBeCloseTo(1);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().x).toBeCloseTo(3);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().y).toBeCloseTo(2);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().z).toBeCloseTo(1);
+
+            done();
+        });
+
+        buttonDefault.click();
+    });
+
+    it('@gl button resetCameraLastSave3d should reset to initial aspectratios', function(done) {
+        var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
+
+        expect(gd._fullLayout.scene._scene.viewInitial.aspectratio).toEqual({ x: 1, y: 1, z: 1 });
+        expect(gd._fullLayout.scene2._scene.viewInitial.aspectratio).toEqual({ x: 3, y: 2, z: 1 });
+
+        gd.once('plotly_relayout', function() {
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().x).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().y).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().z).toBeCloseTo(1);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().x).toBeCloseTo(3);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().y).toBeCloseTo(2);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().z).toBeCloseTo(1);
+
+            done();
+        });
+
+        buttonDefault.click();
+    });
+
+    it('@gl button resetCameraLastSave3d should reset camera to default', function(done) {
+        var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
+        var buttonLastSave = selectButton(modeBar, 'resetCameraLastSave3d');
+
+        Plotly.relayout(gd, {
+            'scene.camera.eye.z': 4,
+            'scene2.camera.eye.z': 5
+        })
+        .then(function() {
+            assertCameraEye(gd._fullLayout.scene, 0.1, 0.1, 4);
+            assertCameraEye(gd._fullLayout.scene2, 2.5, 2.5, 5);
+
+            return new Promise(function(resolve) {
+                gd.once('plotly_relayout', resolve);
+                buttonLastSave.click();
+            });
+        })
+        .then(function() {
+            assertCameraEye(gd._fullLayout.scene, 0.1, 0.1, 1);
+            assertCameraEye(gd._fullLayout.scene2, 2.5, 2.5, 2.5);
+
+            return new Promise(function(resolve) {
+                gd.once('plotly_relayout', resolve);
+                buttonDefault.click();
+            });
+        })
+        .then(function() {
+            assertCameraEye(gd._fullLayout.scene, 1.25, 1.25, 1.25);
+            assertCameraEye(gd._fullLayout.scene2, 1.25, 1.25, 1.25);
+
+            return new Promise(function(resolve) {
+                gd.once('plotly_relayout', resolve);
+                buttonLastSave.click();
+            });
+        })
+        .then(function() {
+            assertCameraEye(gd._fullLayout.scene, 0.1, 0.1, 1);
+            assertCameraEye(gd._fullLayout.scene2, 2.5, 2.5, 2.5);
+
+            delete gd._fullLayout.scene._scene.viewInitial;
+            delete gd._fullLayout.scene2._scene.viewInitial;
+
+            Plotly.relayout(gd, {
+                'scene.bgcolor': '#d3d3d3',
+                'scene.camera.eye.z': 4,
+                'scene2.camera.eye.z': 5
+            });
+        })
+        .then(function() {
+            assertCameraEye(gd._fullLayout.scene, 0.1, 0.1, 4);
+            assertCameraEye(gd._fullLayout.scene2, 2.5, 2.5, 5);
+
+            return new Promise(function(resolve) {
+                gd.once('plotly_relayout', resolve);
+                buttonDefault.click();
+            });
+        })
+        .then(function() {
+            assertCameraEye(gd._fullLayout.scene, 1.25, 1.25, 1.25);
+            assertCameraEye(gd._fullLayout.scene2, 1.25, 1.25, 1.25);
+
+            return new Promise(function(resolve) {
+                gd.once('plotly_relayout', resolve);
+                buttonLastSave.click();
+            });
+        })
+        .then(function() {
+            assertCameraEye(gd._fullLayout.scene, 0.1, 0.1, 4);
+            assertCameraEye(gd._fullLayout.scene2, 2.5, 2.5, 5);
+        })
+        .then(done);
+    });
+});
+
+
+describe('Test gl3d modebar handlers - orthographic case', function() {
+    var gd, modeBar;
+
+    function assertScenes(cont, attr, val) {
+        var sceneIds = cont._subplots.gl3d;
+
+        sceneIds.forEach(function(sceneId) {
+            var thisVal = Lib.nestedProperty(cont[sceneId], attr).get();
+            expect(thisVal).toEqual(val);
+        });
+    }
+
+    function assertCameraEye(sceneLayout, eyeX, eyeY, eyeZ) {
+        expect(sceneLayout.camera.eye.x).toEqual(eyeX);
+        expect(sceneLayout.camera.eye.y).toEqual(eyeY);
+        expect(sceneLayout.camera.eye.z).toEqual(eyeZ);
+
+        var camera = sceneLayout._scene.getCamera();
+        expect(camera.eye.x).toBeCloseTo(eyeX);
+        expect(camera.eye.y).toBeCloseTo(eyeY);
+        expect(camera.eye.z).toBeCloseTo(eyeZ);
+    }
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+
+        var mock = {
+            data: [
+                { type: 'scatter3d' },
+                { type: 'surface', scene: 'scene2' }
+            ],
+            layout: {
+                scene: {
+                    camera: {
+                        eye: { x: 0.1, y: 0.1, z: 1 },
+                        projection: {type: 'orthographic'}
+                    }
+                },
+                scene2: {
+                    camera: {
+                        eye: { x: 2.5, y: 2.5, z: 2.5 },
+                        projection: {type: 'orthographic'}
+                    },
+                    aspectratio: { x: 3, y: 2, z: 1 }
+                }
+            }
+        };
+
+        Plotly.plot(gd, mock)
+        .then(delay(20))
+        .then(function() {
+            modeBar = gd._fullLayout._modeBar;
+        })
+        .then(done);
+    });
+
+    afterEach(function() {
+        Plotly.purge(gd);
+        destroyGraphDiv();
+    });
+
+    it('@gl button resetCameraDefault3d should reset camera to default', function(done) {
+        var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
+
+        expect(gd._fullLayout.scene._scene.viewInitial.eye).toEqual({ x: 0.1, y: 0.1, z: 1 });
+        expect(gd._fullLayout.scene2._scene.viewInitial.eye).toEqual({ x: 2.5, y: 2.5, z: 2.5 });
+
+        gd.once('plotly_relayout', function() {
+            assertScenes(gd._fullLayout, 'camera.eye.x', 1.25);
+            assertScenes(gd._fullLayout, 'camera.eye.y', 1.25);
+            assertScenes(gd._fullLayout, 'camera.eye.z', 1.25);
+
+            expect(gd._fullLayout.scene._scene.getCamera().eye.z).toBeCloseTo(1.25);
+            expect(gd._fullLayout.scene2._scene.getCamera().eye.z).toBeCloseTo(1.25);
+
+            done();
+        });
+
+        buttonDefault.click();
+    });
+
+    it('@gl button resetCameraDefault3d should reset to initial aspectratios', function(done) {
+        var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
+
+        expect(gd._fullLayout.scene._scene.viewInitial.aspectratio).toEqual({ x: 1, y: 1, z: 1 });
+        expect(gd._fullLayout.scene2._scene.viewInitial.aspectratio).toEqual({ x: 3, y: 2, z: 1 });
+
+        gd.once('plotly_relayout', function() {
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().x).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().y).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().z).toBeCloseTo(1);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().x).toBeCloseTo(3);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().y).toBeCloseTo(2);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().z).toBeCloseTo(1);
+
+            done();
+        });
+
+        buttonDefault.click();
+    });
+
+    it('@gl button resetCameraLastSave3d should reset to initial aspectratios', function(done) {
+        var buttonDefault = selectButton(modeBar, 'resetCameraDefault3d');
+
+        expect(gd._fullLayout.scene._scene.viewInitial.aspectratio).toEqual({ x: 1, y: 1, z: 1 });
+        expect(gd._fullLayout.scene2._scene.viewInitial.aspectratio).toEqual({ x: 3, y: 2, z: 1 });
+
+        gd.once('plotly_relayout', function() {
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().x).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().y).toBeCloseTo(1);
+            expect(gd._fullLayout.scene._scene.glplot.getAspectratio().z).toBeCloseTo(1);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().x).toBeCloseTo(3);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().y).toBeCloseTo(2);
+            expect(gd._fullLayout.scene2._scene.glplot.getAspectratio().z).toBeCloseTo(1);
 
             done();
         });
@@ -773,22 +1018,28 @@ describe('Test gl3d drag and wheel interactions', function() {
             return Plotly.relayout(gd, {'scene.dragmode': 'orbit', 'scene2.dragmode': 'turntable'});
         })
         .then(function() {
-            expect(relayoutCallback).toHaveBeenCalledTimes(1);
-            relayoutCallback.calls.reset();
+            _assertAndReset(1);
 
             return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
+            _assertAndReset(1);
+
             return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
-            _assertAndReset(2);
+            _assertAndReset(1);
+
             return Plotly.plot(gd, [], {}, {scrollZoom: false});
         })
         .then(function() {
+            _assertAndReset(0);
+
             return scroll(sceneTarget);
         })
         .then(function() {
+            _assertAndReset(0);
+
             return scroll(sceneTarget2);
         })
         .then(function() {
@@ -796,13 +1047,17 @@ describe('Test gl3d drag and wheel interactions', function() {
             return Plotly.plot(gd, [], {}, {scrollZoom: 'gl3d'});
         })
         .then(function() {
+            _assertAndReset(0);
+
             return scroll(sceneTarget);
         })
         .then(function() {
+            _assertAndReset(1);
+
             return scroll(sceneTarget2);
         })
         .then(function() {
-            _assertAndReset(2);
+            _assertAndReset(1);
         })
         .catch(failTest)
         .then(done);
@@ -877,22 +1132,28 @@ describe('Test gl3d drag and wheel interactions', function() {
             return Plotly.relayout(gd, {'scene.dragmode': 'orbit', 'scene2.dragmode': 'turntable'});
         })
         .then(function() {
-            expect(relayoutCallback).toHaveBeenCalledTimes(1);
-            relayoutCallback.calls.reset();
+            _assertAndReset(1);
 
             return drag({node: sceneTarget, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
+            _assertAndReset(1);
+
             return drag({node: sceneTarget2, pos0: [0, 0], posN: [100, 100], noCover: true});
         })
         .then(function() {
-            _assertAndReset(2);
+            _assertAndReset(1);
+
             return Plotly.plot(gd, [], {}, {scrollZoom: false});
         })
         .then(function() {
+            _assertAndReset(0);
+
             return scroll(sceneTarget);
         })
         .then(function() {
+            _assertAndReset(0);
+
             return scroll(sceneTarget2);
         })
         .then(function() {
@@ -903,16 +1164,117 @@ describe('Test gl3d drag and wheel interactions', function() {
             return scroll(sceneTarget);
         })
         .then(function() {
+            _assertAndReset(1);
+
             return scroll(sceneTarget2);
         })
         .then(function() {
-            _assertAndReset(2);
+            _assertAndReset(1);
         })
         .catch(failTest)
         .then(done);
     });
 
-    it('@gl should fire plotly_relayouting events', function(done) {
+    it('@gl should fire plotly_relayouting events when dragged - perspective case', function(done) {
+        var sceneTarget, relayoutEvent;
+
+        var nsteps = 10;
+        var relayoutCnt = 0;
+        var events = [];
+
+        var mock = {
+            data: [
+                { type: 'scatter3d', x: [1, 2, 3], y: [2, 3, 1], z: [3, 1, 2] }
+            ],
+            layout: {
+                scene: { camera: { projection: {type: 'perspective'}, eye: { x: 0.1, y: 0.1, z: 1 }}},
+                width: 400, height: 400
+            }
+        };
+
+        Plotly.plot(gd, mock)
+        .then(function() {
+            gd.on('plotly_relayout', function(e) {
+                relayoutCnt++;
+                relayoutEvent = e;
+            });
+            gd.on('plotly_relayouting', function(e) {
+                events.push(e);
+            });
+
+            sceneTarget = gd.querySelector('.svg-container .gl-container #scene canvas');
+
+            return drag({
+                node: sceneTarget,
+                pos0: [200, 200],
+                posN: [100, 100],
+                nsteps: nsteps,
+                buttons: 1,
+                noCover: true
+            });
+        })
+        .then(function() {
+            expect(events.length).toEqual(nsteps);
+            expect(relayoutCnt).toEqual(1);
+            Object.keys(relayoutEvent).sort().forEach(function(key) {
+                expect(Object.keys(events[0])).toContain(key);
+            });
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('@gl should fire plotly_relayouting events when dragged - orthographic case', function(done) {
+        var sceneTarget, relayoutEvent;
+
+        var nsteps = 10;
+        var relayoutCnt = 0;
+        var events = [];
+
+        var mock = {
+            data: [
+                { type: 'scatter3d', x: [1, 2, 3], y: [2, 3, 1], z: [3, 1, 2] }
+            ],
+            layout: {
+                scene: { camera: { projection: {type: 'orthographic'}, eye: { x: 0.1, y: 0.1, z: 1 }}},
+                width: 400, height: 400
+            }
+        };
+
+        Plotly.plot(gd, mock)
+        .then(function() {
+            gd.on('plotly_relayout', function(e) {
+                relayoutCnt++;
+                relayoutEvent = e;
+            });
+            gd.on('plotly_relayouting', function(e) {
+                events.push(e);
+            });
+
+            sceneTarget = gd.querySelector('.svg-container .gl-container #scene canvas');
+
+            return drag({
+                node: sceneTarget,
+                pos0: [200, 200],
+                posN: [100, 100],
+                nsteps: nsteps,
+                buttons: 1,
+                noCover: true
+            });
+        })
+        .then(function() {
+            expect(events.length).toEqual(nsteps);
+            expect(relayoutCnt).toEqual(1);
+            Object.keys(relayoutEvent).sort().forEach(function(key) {
+                expect(Object.keys(events[0])).toContain(key);
+            });
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+
+    it('@gl should fire plotly_relayouting events when dragged - orthographic case', function(done) {
         var sceneTarget, relayoutEvent;
 
         var nsteps = 10;

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -1187,7 +1187,10 @@ describe('Test gl3d annotations', function() {
         var camera = scene.getCamera();
 
         camera.eye = {x: x, y: y, z: z};
-        scene.setCamera(camera);
+        scene.setViewport({
+            camera: camera,
+            aspectratio: gd._fullLayout.scene.aspectratio
+        });
         // need a fairly long delay to let the camera update here
         // 300 was not robust for me (AJ), 500 seems to be.
         return delay(500)();

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -906,6 +906,24 @@ describe('Test gl3d drag and wheel interactions', function() {
             return scroll(sceneTarget2);
         })
         .then(function() {
+            expect(
+                gd._fullLayout.scene2.aspectratio.x
+            ).toEqual(
+                gd._fullLayout.scene2._scene.glplot.aspect[0]
+            );
+
+            expect(
+                gd._fullLayout.scene2.aspectratio.y
+            ).toEqual(
+                gd._fullLayout.scene2._scene.glplot.aspect[1]
+            );
+
+            expect(
+                gd._fullLayout.scene2.aspectratio.z
+            ).toEqual(
+                gd._fullLayout.scene2._scene.glplot.aspect[2]
+            );
+
             _assertAndReset(2);
         })
         .catch(failTest)

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -906,24 +906,6 @@ describe('Test gl3d drag and wheel interactions', function() {
             return scroll(sceneTarget2);
         })
         .then(function() {
-            expect(
-                gd._fullLayout.scene2.aspectratio.x
-            ).toEqual(
-                gd._fullLayout.scene2._scene.glplot.aspect[0]
-            );
-
-            expect(
-                gd._fullLayout.scene2.aspectratio.y
-            ).toEqual(
-                gd._fullLayout.scene2._scene.glplot.aspect[1]
-            );
-
-            expect(
-                gd._fullLayout.scene2.aspectratio.z
-            ).toEqual(
-                gd._fullLayout.scene2._scene.glplot.aspect[2]
-            );
-
             _assertAndReset(2);
         })
         .catch(failTest)

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -1968,11 +1968,14 @@ describe('Test Plotly.react + interactions under uirevision:', function() {
         function _mouseup() {
             var sceneLayout = gd._fullLayout.scene;
             var cameraOld = sceneLayout.camera;
-            sceneLayout._scene.setCamera({
-                projection: {type: 'perspective'},
-                eye: {x: 2, y: 2, z: 2},
-                center: cameraOld.center,
-                up: cameraOld.up
+            sceneLayout._scene.setViewport({
+                camera: {
+                    projection: {type: 'perspective'},
+                    eye: {x: 2, y: 2, z: 2},
+                    center: cameraOld.center,
+                    up: cameraOld.up
+                },
+                aspectratio: gd._fullLayout.scene.aspectratio
             });
 
             var target = gd.querySelector('.svg-container .gl-container #scene canvas');


### PR DESCRIPTION
Fix #4274.
Orthographic scroll zoom changes `aspectratio` values. These changes should be reflected in `fullLayout` and also `relayout` should be emitted.

[Before](https://codepen.io/emmanuelle-plotly/pen/QWWyjxg?editors=0011)
[After](https://codepen.io/MojtabaSamimi/pen/dyyNNWO?editors=0011)

In addition, there was a mistake noticed in calling arguments i.e. when try recovering the context which was fixed in https://github.com/plotly/plotly.js/pull/4292/commits/d486dcd56560feca1c8e486bffee31e822f8fda4.

Also to mention commit https://github.com/plotly/plotly.js/pull/4292/commits/496059ca3fe1c9baf4a6d690be7987c5cf5cb39a simplifies calling arguments by applying scene `pixelRatio`.

@plotly/plotly_js 