### PR TITLE
append coverSlip to fullscreen element instead of body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4295,6 +4295,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fscreen": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.0.2.tgz",
+      "integrity": "sha1-xMUdltgZ11oZ1yjg30Rfm+m7mE8="
+    },
     "fsevents": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "delaunay-triangulate": "^1.1.6",
     "es6-promise": "^3.0.2",
     "fast-isnumeric": "^1.1.3",
+    "fscreen": "^1.0.2",
     "gl-cone3d": "^1.5.1",
     "gl-contour2d": "^1.1.6",
     "gl-error3d": "^1.0.15",

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -11,6 +11,7 @@
 var mouseOffset = require('mouse-event-offset');
 var hasHover = require('has-hover');
 var supportsPassive = require('has-passive-events');
+var fscreen = require('fscreen').default;
 
 var removeElement = require('../../lib').removeElement;
 var constants = require('../../plots/cartesian/constants');
@@ -264,7 +265,7 @@ dragElement.init = function init(options) {
 
 function coverSlip() {
     var cover = document.createElement('div');
-    var fullscreenElement = document.fullscreenElement;
+    var fullscreenElement = fscreen.fullscreenElement;
 
     cover.className = 'dragcover';
     var cStyle = cover.style;

--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -264,6 +264,7 @@ dragElement.init = function init(options) {
 
 function coverSlip() {
     var cover = document.createElement('div');
+    var fullscreenElement = document.fullscreenElement;
 
     cover.className = 'dragcover';
     var cStyle = cover.style;
@@ -274,6 +275,12 @@ function coverSlip() {
     cStyle.bottom = 0;
     cStyle.zIndex = 999999999;
     cStyle.background = 'none';
+
+    if(fullscreenElement) {
+        fullscreenElement.appendChild(cover);
+
+        return cover;
+    }
 
     document.body.appendChild(cover);
 


### PR DESCRIPTION
Resolves #4259 

This PR checks if there is a fullscreen element and appends dragelements coverSlip to this element instead of documents body.