### PR TITLE
Disable transforms for `image` traces

### DIFF
--- a/src/traces/image/attributes.js
+++ b/src/traces/image/attributes.js
@@ -114,5 +114,7 @@ module.exports = extendFlat({
     }),
     hovertemplate: hovertemplateAttrs({}, {
         keys: ['z', 'color', 'colormodel']
-    })
+    }),
+
+    transforms: undefined
 });

--- a/src/traces/image/defaults.js
+++ b/src/traces/image/defaults.js
@@ -35,4 +35,6 @@ module.exports = function supplyDefaults(traceIn, traceOut) {
     coerce('text');
     coerce('hovertext');
     coerce('hovertemplate');
+
+    traceOut._length = null;
 };


### PR DESCRIPTION
fixes this

https://github.com/plotly/plotly.js/blob/fbfadbeaa304110ba3173e84d3e6573c07b0f41f/test/jasmine/tests/plot_api_react_test.js#L844-L846

 `@noCI` test for our brand-new `image trace type.

cc @archmoj 