### PR TITLE
Do not coerce contour & colorscale attributes for mesh3d when not needed

### DIFF
--- a/src/traces/mesh3d/defaults.js
+++ b/src/traces/mesh3d/defaults.js
@@ -68,8 +68,6 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
         'contour.show',
         'contour.color',
         'contour.width',
-        'colorscale',
-        'reversescale',
         'flatshading',
         'alphahull',
         'delaunayaxis',

--- a/src/traces/mesh3d/defaults.js
+++ b/src/traces/mesh3d/defaults.js
@@ -65,14 +65,17 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
         'lightposition.x',
         'lightposition.y',
         'lightposition.z',
-        'contour.show',
-        'contour.color',
-        'contour.width',
         'flatshading',
         'alphahull',
         'delaunayaxis',
         'opacity'
     ].forEach(function(x) { coerce(x); });
+
+    var showContour = coerce('contour.show');
+    if(showContour) {
+        coerce('contour.color');
+        coerce('contour.width');
+    }
 
     if('intensity' in traceIn) {
         coerce('intensity');

--- a/test/jasmine/tests/mesh3d_test.js
+++ b/test/jasmine/tests/mesh3d_test.js
@@ -1,10 +1,222 @@
 var Plotly = require('@lib');
+var Lib = require('@src/lib');
+var supplyDefaults = require('@src/traces/mesh3d').supplyDefaults;
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var failTest = require('../assets/fail_test');
 
 describe('Test mesh3d', function() {
     'use strict';
+
+    describe('supplyDefaults', function() {
+        var defaultColor = '#444';
+        var layout = {_dfltTitle: {colorbar: 'cb'}};
+
+        var traceIn, traceOut;
+
+        beforeEach(function() {
+            traceOut = {};
+        });
+
+        it('should set \'visible\' to false if \'x\' isn\'t provided', function() {
+            traceIn = {
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.visible).toBe(false);
+        });
+
+        it('should set \'visible\' to false if \'y\' isn\'t provided', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.visible).toBe(false);
+        });
+
+        it('should set \'visible\' to false if \'z\' isn\'t provided', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.visible).toBe(false);
+        });
+
+        it('should set \'visible\' to false if \'i\' isn\'t provided', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.visible).toBe(false);
+        });
+
+        it('should set \'visible\' to false if \'j\' isn\'t provided', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.visible).toBe(false);
+        });
+
+        it('should set \'visible\' to false if \'k\' isn\'t provided', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.visible).toBe(false);
+        });
+
+        it('should coerce contour style attributes if contour line is enabled', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2],
+                contour: {
+                    show: true
+                }
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.contour.color).toEqual('#444');
+            expect(traceOut.contour.width).toEqual(2);
+        });
+
+        it('should not coerce contour attributes when contour line is disabled', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2],
+                contour: {
+                    show: false
+                }
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.contour.color).toBeUndefined();
+            expect(traceOut.contour.width).toBeUndefined();
+        });
+
+        it('should coerce colorscale and colorbar attributes when intensity is present', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2],
+                intensity: [1, 2, 3, 4, 5, 6, 7, 8]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.cauto).toBe(true);
+            expect(traceOut.cmin).toBeUndefined();
+            expect(traceOut.cmax).toBeUndefined();
+            expect(traceOut.colorscale).toEqual([
+                [0, 'rgb(5,10,172)'],
+                [0.35, 'rgb(106,137,247)'],
+                [0.5, 'rgb(190,190,190)'],
+                [0.6, 'rgb(220,170,132)'],
+                [0.7, 'rgb(230,145,90)'],
+                [1, 'rgb(178,10,28)']
+            ]);
+            expect(traceOut.reversescale).toBe(false);
+            expect(traceOut.showscale).toBe(true);
+            expect(traceOut.colorbar).toBeDefined();
+        });
+
+        it('should not coerce colorscale and colorbar attributes when intensity is not present', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2]
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.cauto).toBeUndefined();
+            expect(traceOut.cmin).toBeUndefined();
+            expect(traceOut.cmax).toBeUndefined();
+            expect(traceOut.colorscale).toBeUndefined();
+            expect(traceOut.reversescale).toBeUndefined();
+            expect(traceOut.showscale).toBe(false);
+            expect(traceOut.colorbar).toBeUndefined();
+        });
+
+        it('should inherit layout.calendar', function() {
+            traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2]
+            };
+            supplyDefaults(traceIn, traceOut, defaultColor, Lib.extendFlat({calendar: 'islamic'}, layout));
+
+            // we always fill calendar attributes, because it's hard to tell if
+            // we're on a date axis at this point.
+            expect(traceOut.xcalendar).toBe('islamic');
+            expect(traceOut.ycalendar).toBe('islamic');
+            expect(traceOut.zcalendar).toBe('islamic');
+        });
+
+        it('should take its own calendars', function() {
+            var traceIn = {
+                x: [0, 1, 0, 1, 0, 1, 0, 1],
+                y: [0, 0, 1, 1, 0, 0, 1, 1],
+                z: [0, 0, 0, 0, 1, 1, 1, 1],
+                i: [0, 3, 4, 7, 0, 6, 1, 7, 0, 5, 2, 7],
+                j: [1, 2, 5, 6, 2, 4, 3, 5, 4, 1, 6, 3],
+                k: [3, 0, 7, 4, 6, 0, 7, 1, 5, 0, 7, 2],
+                xcalendar: 'coptic',
+                ycalendar: 'ethiopian',
+                zcalendar: 'mayan'
+            };
+
+            supplyDefaults(traceIn, traceOut, defaultColor, layout);
+            expect(traceOut.xcalendar).toBe('coptic');
+            expect(traceOut.ycalendar).toBe('ethiopian');
+            expect(traceOut.zcalendar).toBe('mayan');
+        });
+    });
 
     describe('restyle', function() {
         afterEach(destroyGraphDiv);

--- a/test/jasmine/tests/surface_test.js
+++ b/test/jasmine/tests/surface_test.js
@@ -1,18 +1,14 @@
-var Surface = require('@src/traces/surface');
 var Plotly = require('@lib/index');
+var Lib = require('@src/lib');
+var supplyDefaults = require('@src/traces/surface').supplyDefaults;
 var failTest = require('../assets/fail_test');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
-
-var Lib = require('@src/lib');
-
 
 describe('Test surface', function() {
     'use strict';
 
     describe('supplyDefaults', function() {
-        var supplyDefaults = Surface.supplyDefaults;
-
         var defaultColor = '#444';
         var layout = {_dfltTitle: {colorbar: 'cb'}};
 
@@ -106,6 +102,7 @@ describe('Test surface', function() {
                 [0.7, 'rgb(230,145,90)'],
                 [1, 'rgb(178,10,28)']
             ]);
+            expect(traceOut.reversescale).toBe(false);
             expect(traceOut.showscale).toBe(true);
             expect(traceOut.colorbar).toBeDefined();
         });


### PR DESCRIPTION
It appears there is no need for coercing `colorscale` and `reversescale` attributes of `mesh3d`.
Those attributes are handled by `colorscaleDefaults` function later in the `default` process in case the trace has `intensity`.

I addition, now the `contour` attributes won't be coerced when `contour.show` is disabled. See https://github.com/plotly/plotly.js/pull/4346/commits/67e7fbf43598d1d501f8419a7f6372c02f600ba4.

@alexcjohnson 
cc: @plotly/plotly_js 