### PR TITLE
Option to set class on given shape using className attribute

### DIFF
--- a/src/components/shapes/draw.js
+++ b/src/components/shapes/draw.js
@@ -93,7 +93,8 @@ function drawOne(gd, index) {
         var attrs = {
             'data-index': index,
             'fill-rule': 'evenodd',
-            d: getPathString(gd, options)
+            d: getPathString(gd, options),
+            class: options._input.className
         };
         var lineColor = options.line.width ? options.line.color : 'rgba(0,0,0,0)';
 


### PR DESCRIPTION
I am trying to allow the functionality described here and open possible other uses:
https://community.plot.ly/t/lock-the-editing-of-few-shapes/25033/3

In this case you could set CSS for example: 
.shapelayer path.locked {
    pointer-events: none !important;
}