### PR TITLE
An option to ignore certain shapes when doing autosize

### DIFF
--- a/src/components/shapes/calc_autorange.js
+++ b/src/components/shapes/calc_autorange.js
@@ -23,6 +23,7 @@ module.exports = function calcAutorange(gd) {
 
     for(var i = 0; i < shapeList.length; i++) {
         var shape = shapeList[i];
+        if (shape._input.autorange==false) continue;
         shape._extremes = {};
 
         var ax, bounds;

--- a/src/components/shapes/calc_autorange.js
+++ b/src/components/shapes/calc_autorange.js
@@ -23,7 +23,7 @@ module.exports = function calcAutorange(gd) {
 
     for(var i = 0; i < shapeList.length; i++) {
         var shape = shapeList[i];
-        if (shape._input.autorange==false) continue;
+        if (shape._input.autorange === false) continue;
         shape._extremes = {};
 
         var ax, bounds;


### PR DESCRIPTION
In some cases it is useful to ignore some shapes when auto sizing as they might stretch beyond current range on purpose or we do not even care where they are. By adding an option autorange (default: true), we can individually remove some shapes from auto sizing algorithm.
