### PR TITLE
Clear relinked cmin/cmax values in shared axes

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -2828,6 +2828,15 @@ plots.doCalcdata = function(gd, traces) {
         );
     }
 
+    // clear relinked cmin/cmax values in shared axes to start aggregation from scratch
+    for(var k in fullLayout._colorAxes) {
+        var cOpts = fullLayout[k];
+        if(cOpts.cauto !== false) {
+            delete cOpts.cmin;
+            delete cOpts.cmax;
+        }
+    }
+
     var hasCalcTransform = false;
 
     function transformCalci(i) {

--- a/test/jasmine/tests/colorscale_test.js
+++ b/test/jasmine/tests/colorscale_test.js
@@ -1101,6 +1101,42 @@ describe('Test colorscale restyle calls:', function() {
         .then(done);
     });
 
+    it('should update coloraxis cmin/cmax on color value changes', function(done) {
+        function fig(mc) {
+            return {
+                data: [{
+                    mode: 'markers',
+                    y: [1, 2, 3],
+                    marker: {
+                        coloraxis: 'coloraxis',
+                        color: mc
+                    }
+                }]
+            };
+        }
+
+        function _assert(msg, cmin, cmax) {
+            return function() {
+                var cOpts = gd._fullLayout.coloraxis;
+                expect(cOpts.cmin).toBe(cmin, msg + '| cmin');
+                expect(cOpts.cmax).toBe(cmax, msg + '| cmax');
+            };
+        }
+
+        Plotly.react(gd, fig([1, 2, 3]))
+        .then(_assert('marker.color [1,2,3]', 1, 3))
+        .then(function() { return Plotly.react(gd, fig([1, 5, 3])); })
+        .then(_assert('marker.color [1,5,3]', 1, 5))
+        .then(function() { return Plotly.react(gd, fig([1, 2, 3])); })
+        .then(_assert('back to marker.color [1,2,3]', 1, 3))
+        .then(function() { return Plotly.react(gd, fig([-1, 2, 3])); })
+        .then(_assert('marker.color [-1,2,3]', -1, 3))
+        .then(function() { return Plotly.react(gd, fig([1, 2, 3])); })
+        .then(_assert('back again to marker.color [1,2,3]', 1, 3))
+        .catch(failTest)
+        .then(done);
+    });
+
     it('should work with templates', function(done) {
         function _assert(msg, exp) {
             var mcc = [];


### PR DESCRIPTION
... early in `Plots.doCalcata`, such that the cross-trace cmin/cmax aggregation starts from scratch.

This fixes https://github.com/plotly/plotly.js/issues/4337 - a bug that originates from the first shared coloraxis implementation (cf https://github.com/plotly/plotly.js/pull/3803 https://github.com/plotly/plotly.js/commit/5bb341ebbb0d80eae121d986627ae5823e3ff4b1)

before: https://codepen.io/nicolaskruchten/pen/YzzLXmy?editors=0010
after: https://codepen.io/etpinard/pen/rNNPvxy?editors=0010

before: https://codepen.io/alexcjohnson/pen/JjjwBKE
after: https://codepen.io/etpinard/pen/gOOqzPE

cc @archmoj 
