### PR TITLE
Fix hover for densitymapbox

### DIFF
--- a/src/traces/densitymapbox/index.js
+++ b/src/traces/densitymapbox/index.js
@@ -12,6 +12,7 @@ module.exports = {
     attributes: require('./attributes'),
     supplyDefaults: require('./defaults'),
     colorbar: require('../heatmap/colorbar'),
+    formatLabels: require('../scattermapbox/format_labels'),
     calc: require('./calc'),
     plot: require('./plot'),
     hoverPoints: require('./hover'),


### PR DESCRIPTION
... a bug introduced in the `texttemplate` fix of https://github.com/plotly/plotly.js/pull/4380

@archmoj I forgot to run a few `@noCI` tests on Friday. This PR should be merged before releasing `v1.51.2`