### PR TITLE
test_dashboard fix for ie11

### DIFF
--- a/devtools/test_dashboard/index.html
+++ b/devtools/test_dashboard/index.html
@@ -7,10 +7,10 @@
 </head>
 <body>
   <header>
-    <img src="http://images.plot.ly/logo/plotlyjs-logo@2x.png" onClick="Tabs.reload();">
+    <img src="http://images.plot.ly/logo/plotlyjs-logo@2x.png" onClick="Tabs.reload();" />
     <span id="reload-time"></span>
 
-    <input id="mocks-search" type="text" placeholder="mocks search"></input>
+    <input id="mocks-search" type="text" placeholder="mocks search" />
   </header>
 
   <section id="mocks-list"></section>


### PR DESCRIPTION
not sure if anyone else still uses `test_dashboard` (`npm start`) but I needed these two fixes to get it to run in IE11. There's still an error later on about calling `forEach` on a `NodeList` from `querySelectorAll` but that one didn't stop me from getting the graph I wanted so I didn't hunt that down 😅 