### PR TITLE
Plots.resize: promises should always be resolved

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -104,7 +104,8 @@ plots.resize = function(gd) {
 
             Registry.call('relayout', gd, {autosize: true}).then(function() {
                 gd.changed = oldchanged;
-                resolve(gd);
+                // Only resolve if a new call hasn't been made!
+                if(gd._resolveResize === resolve) resolve(gd);
             });
         }, 100);
     });

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -76,15 +76,15 @@ plots.redrawText = function(gd) {
 plots.resize = function(gd) {
     gd = Lib.getGraphDiv(gd);
 
-    return new Promise(function(resolve, reject) {
+    var resolveLastResize;
+    var p = new Promise(function(resolve, reject) {
         if(!gd || Lib.isHidden(gd)) {
             reject(new Error('Resize must be passed a displayed plot div element.'));
         }
 
-        if(gd._rejectResize) gd._rejectResize();
-        gd._rejectResize = reject;
-
         if(gd._redrawTimer) clearTimeout(gd._redrawTimer);
+        if(gd._resolveResize) resolveLastResize = gd._resolveResize;
+        gd._resolveResize = resolve;
 
         gd._redrawTimer = setTimeout(function() {
             // return if there is nothing to resize or is hidden
@@ -108,6 +108,9 @@ plots.resize = function(gd) {
             });
         }, 100);
     });
+
+    if(resolveLastResize) resolveLastResize(p);
+    return p;
 };
 
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -105,7 +105,10 @@ plots.resize = function(gd) {
             Registry.call('relayout', gd, {autosize: true}).then(function() {
                 gd.changed = oldchanged;
                 // Only resolve if a new call hasn't been made!
-                if(gd._resolveResize === resolve) resolve(gd);
+                if(gd._resolveResize === resolve) {
+                    delete gd._resolveResize;
+                    resolve(gd);
+                }
             });
         }, 100);
     });

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -81,6 +81,9 @@ plots.resize = function(gd) {
             reject(new Error('Resize must be passed a displayed plot div element.'));
         }
 
+        if(gd._rejectResize) gd._rejectResize();
+        gd._rejectResize = reject;
+
         if(gd._redrawTimer) clearTimeout(gd._redrawTimer);
 
         gd._redrawTimer = setTimeout(function() {

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -421,10 +421,17 @@ describe('Test Plots', function() {
                 var p = [];
                 Plotly.newPlot(gd, [{y: [5, 2, 5]}])
                     .then(function() {
+                        gd.style.width = '500px';
+                        gd.style.height = '500px';
                         p.push(Plotly.Plots.resize(gd));
                         p.push(Plotly.Plots.resize(gd));
                         p.push(Plotly.Plots.resize(gd));
                         return Promise.all(p);
+                    })
+                    .then(function(v) {
+                        // Make sure they all resolve to the same value
+                        expect(v[0]).toEqual(v[1]);
+                        expect(v[1]).toEqual(v[2]);
                     })
                     .catch(failTest)
                     .then(done);

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -412,6 +412,27 @@ describe('Test Plots', function() {
                     .then(done);
             });
         });
+
+        describe('returns Promises', function() {
+            afterEach(destroyGraphDiv);
+
+            it('should reject or resolve them all', function(done) {
+                gd = createGraphDiv();
+                var p = [];
+                Plotly.newPlot(gd, [{y: [5, 2, 5]}])
+                    .then(function() {
+                        // First call should get rejected
+                        p.push(Plotly.Plots.resize(gd).catch(function() {
+                            return Promise.resolve(true);
+                        }));
+                        // because we call the function again within 100ms
+                        p.push(Plotly.Plots.resize(gd));
+                        return Promise.all(p);
+                    })
+                    .catch(failTest)
+                    .then(done);
+            });
+        });
     });
 
     describe('Plots.purge', function() {

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -416,16 +416,13 @@ describe('Test Plots', function() {
         describe('returns Promises', function() {
             afterEach(destroyGraphDiv);
 
-            it('should reject or resolve them all', function(done) {
+            it('should resolve them all', function(done) {
                 gd = createGraphDiv();
                 var p = [];
                 Plotly.newPlot(gd, [{y: [5, 2, 5]}])
                     .then(function() {
-                        // First call should get rejected
-                        p.push(Plotly.Plots.resize(gd).catch(function() {
-                            return Promise.resolve(true);
-                        }));
-                        // because we call the function again within 100ms
+                        p.push(Plotly.Plots.resize(gd));
+                        p.push(Plotly.Plots.resize(gd));
                         p.push(Plotly.Plots.resize(gd));
                         return Promise.all(p);
                     })


### PR DESCRIPTION
@Marc-Andre-Rivet pointed out to me that the promises returned by `Plotly.Plots.resize` would sometimes never complete. This PR fixes that by resolving all promises. If many calls are made one after the other, they will all resolve when the last resize operation is done!