### PR TITLE
adding support for defining groups in data.transforms.groups using ty…

### DIFF
--- a/src/transforms/groupby.js
+++ b/src/transforms/groupby.js
@@ -172,7 +172,7 @@ function transformOne(trace, state) {
     var groups = trace.transforms[transformIndex].groups;
     var originalPointsAccessor = pointsAccessorFunction(trace.transforms, opts);
 
-    if(!(Array.isArray(groups)) || groups.length === 0) {
+    if(!(Lib.isArrayOrTypedArray(groups)) || groups.length === 0) {
         return [trace];
     }
 

--- a/test/jasmine/tests/transform_groupby_test.js
+++ b/test/jasmine/tests/transform_groupby_test.js
@@ -333,7 +333,7 @@ describe('groupby', function() {
             .then(done);
         });
 
-        it ('Plotly.plot should group points properly using typed array', function(done) {
+        it('Plotly.plot should group points properly using typed array', function(done) {
             var data = Lib.extendDeep([], mockDataWithTypedArrayGroups);
 
             var gd = createGraphDiv();
@@ -347,7 +347,7 @@ describe('groupby', function() {
             })
             .catch(failTest)
             .then(done);
-        })
+        });
     });
 
     describe('many-to-many transforms', function() {

--- a/test/jasmine/tests/transform_groupby_test.js
+++ b/test/jasmine/tests/transform_groupby_test.js
@@ -53,6 +53,20 @@ describe('groupby', function() {
             }]
         }];
 
+        var mockDataWithTypedArrayGroups = [{
+            mode: 'markers',
+            x: [20, 11, 12, 0, 1, 2, 3],
+            y: [1, 2, 3, 2, 5, 2, 0],
+            transforms: [{
+                type: 'groupby',
+                groups: new Uint8Array([2, 1, 2, 2, 2, 1, 1]),
+                styles: [
+                    {target: 1, value: {marker: {color: 'green'}}},
+                    {target: 2, value: {marker: {color: 'black'}}}
+                ]
+            }]
+        }];
+
         afterEach(destroyGraphDiv);
 
         it('Plotly.plot should plot the transform traces', function(done) {
@@ -318,6 +332,22 @@ describe('groupby', function() {
             .catch(failTest)
             .then(done);
         });
+
+        it ('Plotly.plot should group points properly using typed array', function(done) {
+            var data = Lib.extendDeep([], mockDataWithTypedArrayGroups);
+
+            var gd = createGraphDiv();
+
+            Plotly.plot(gd, data).then(function() {
+                expect(gd._fullData.length).toEqual(2);
+                expect(gd._fullData[0].x).toEqual([20, 12, 0, 1]);
+                expect(gd._fullData[0].y).toEqual([1, 3, 2, 5]);
+                expect(gd._fullData[1].x).toEqual([11, 2, 3]);
+                expect(gd._fullData[1].y).toEqual([2, 2, 0]);
+            })
+            .catch(failTest)
+            .then(done);
+        })
     });
 
     describe('many-to-many transforms', function() {


### PR DESCRIPTION
the idea here is just to allow groups to be defined in data.transforms using typed arrays as well as regular arrays, to save on space