### PR TITLE
Fix histogram bingroup algo when calendars module is not registered

### DIFF
--- a/src/traces/histogram/cross_trace_defaults.js
+++ b/src/traces/histogram/cross_trace_defaults.js
@@ -55,7 +55,7 @@ module.exports = function crossTraceDefaults(fullData, fullLayout) {
         if(!groupName) groupName = fallbackGroupName;
 
         var axType = getAxisType(traceOut, binDir);
-        var calendar = traceOut[binDir + 'calendar'];
+        var calendar = traceOut[binDir + 'calendar'] || '';
         var binOpts = allBinOpts[groupName];
         var needsNewItem = true;
 

--- a/test/jasmine/tests/histogram_test.js
+++ b/test/jasmine/tests/histogram_test.js
@@ -479,7 +479,7 @@ describe('Test histogram', function() {
             );
         });
 
-        it('should not group traces across different calendars when the calendar module is not registered', function() {
+        it('should attempt to group traces when the *calendars* module is not registered', function() {
             var original = Registry.getComponentMethod;
             var cnt = 0;
 

--- a/test/jasmine/tests/histogram_test.js
+++ b/test/jasmine/tests/histogram_test.js
@@ -1,6 +1,7 @@
 var Plotly = require('@lib/index');
 var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
+var Registry = require('@src/registry');
 var setConvert = require('@src/plots/cartesian/set_convert');
 
 var supplyDefaults = require('@src/traces/histogram/defaults');
@@ -476,6 +477,35 @@ describe('Test histogram', function() {
                 'Attempted to group the bins of trace 1 set with a julian calendar ' +
                 'with bins on a gregorian calendar'
             );
+        });
+
+        it('should not group traces across different calendars when the calendar module is not registered', function() {
+            var original = Registry.getComponentMethod;
+            var cnt = 0;
+
+            spyOn(Registry, 'getComponentMethod').and.callFake(function() {
+                if(arguments[0] === 'calendars') {
+                    cnt++;
+                    return Lib.noop;
+                } else {
+                    return original.call(arguments);
+                }
+            });
+
+            gd = {
+                data: [
+                    {uid: 'a', type: 'histogram', x: [1, 3]},
+                    {uid: 'b', type: 'histogram', x: [1, 20]}
+                ],
+                layout: {barmode: 'stack'}
+            };
+            supplyAllDefaults(gd);
+
+            _assert('', [
+                ['xyx', [0, 1]]
+            ]);
+
+            expect(cnt).toBe(3, '# of Registry.getComponentMethod calls for *calendars* methods');
         });
 
         it('should force traces that "have to match" to have same bingroup (alignmentgroup case)', function() {


### PR DESCRIPTION
By adding a fallback in the trace calendar getter in `Histogram.crossTraceCalc` so that when the Calendars module isn't registered (thus making `_fullData[i].(x|y)calendar === undefined`), we're still able to group traces in the correct bin groups.

fixes https://github.com/plotly/plotly.js/issues/4429

- before: https://jsfiddle.net/c8gfb6rp/2/
- after: https://jsfiddle.net/Lg5ucrew/
  + w/ https://gist.github.com/etpinard/ff8d940dfb831b54d41baa4e58f6af9d#file-plotly-cartesian-js 
  + together with https://gitcdn.xyz/

Note also, that at present we only register `calendars` in the "main" plotly.js bundles:

https://github.com/plotly/plotly.js/blob/97ba9c3903844ef9fef10010b62089b481fdc764/lib/index.js#L92-L95

cc @archmoj 

