### PR TITLE
ensure newRng stays in bounds

### DIFF
--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -99,6 +99,15 @@ module.exports = function(gd) {
                 ];
             }
 
+            // make sure the slider's axis range (axRng) doesn't go above the
+            // axis max or below the axis min (rng)
+            if(axRng[1] > rng[1]) {
+                newRng[1] = rng[1];
+            }
+            if(axRng[0] < rng[0]) {
+                newRng[0] = rng[0];
+            }
+
             opts.range = opts._input.range = Lib.simpleMap(newRng, axisOpts.l2r);
         }
 

--- a/src/components/rangeslider/draw.js
+++ b/src/components/rangeslider/draw.js
@@ -99,15 +99,6 @@ module.exports = function(gd) {
                 ];
             }
 
-            // make sure the slider's axis range (axRng) doesn't go above the
-            // axis max or below the axis min (rng)
-            if(axRng[1] > rng[1]) {
-                newRng[1] = rng[1];
-            }
-            if(axRng[0] < rng[0]) {
-                newRng[0] = rng[0];
-            }
-
             opts.range = opts._input.range = Lib.simpleMap(newRng, axisOpts.l2r);
         }
 
@@ -214,18 +205,27 @@ function setupDragElement(rangeSlider, gd, axisOpts, opts) {
             switch(target) {
                 case slideBox:
                     cursor = 'ew-resize';
+                    if(minVal + delta > axisOpts._length || maxVal + delta < 0) {
+                        return;
+                    }
                     pixelMin = minVal + delta;
                     pixelMax = maxVal + delta;
                     break;
 
                 case grabAreaMin:
                     cursor = 'col-resize';
+                    if(minVal + delta > axisOpts._length) {
+                        return;
+                    }
                     pixelMin = minVal + delta;
                     pixelMax = maxVal;
                     break;
 
                 case grabAreaMax:
                     cursor = 'col-resize';
+                    if(maxVal + delta < 0) {
+                        return;
+                    }
                     pixelMin = minVal;
                     pixelMax = maxVal + delta;
                     break;

--- a/test/jasmine/tests/range_slider_test.js
+++ b/test/jasmine/tests/range_slider_test.js
@@ -190,12 +190,48 @@ describe('Visible rangesliders', function() {
             return slide(start, sliderY, end, sliderY);
         })
         .then(function() {
-            var maskMax = getRangeSliderChild(3);
-            var handleMax = getRangeSliderChild(6);
+            var maskMin = getRangeSliderChild(3);
+            var handleMin = getRangeSliderChild(6);
 
             expect(gd.layout.xaxis.range).toBeCloseToArray([0, 45.04], -0.5);
-            expect(+maskMax.getAttribute('width')).toBeCloseTo(-diff);
-            testTranslate1D(handleMax, dataMaxStart + diff);
+            expect(+maskMin.getAttribute('width')).toBeCloseTo(-diff);
+            testTranslate1D(handleMin, dataMaxStart + diff);
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('should not exceed slider bounds left to right', function(done) {
+        var start = 940;
+        var end = 990;
+
+        plotMock().then(function() {
+            gd._fullLayout.xaxis.d2p(49);
+
+            expect(gd.layout.xaxis.range).toBeCloseToArray([0, 49]);
+
+            return slide(start, sliderY, end, sliderY);
+        })
+        .then(function() {
+            expect(gd.layout.xaxis.range).toBeCloseToArray([0, 49], -0.5);
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('should not exceed slider bounds right to left', function(done) {
+        var start = 0;
+        var end = -50;
+
+        plotMock().then(function() {
+            gd._fullLayout.xaxis.d2p(-49);
+
+            expect(gd.layout.xaxis.range).toBeCloseToArray([0, 49]);
+
+            return slide(start, sliderY, end, sliderY);
+        })
+        .then(function() {
+            expect(gd.layout.xaxis.range).toBeCloseToArray([0, 49], -0.5);
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
Created a few checks to make sure the slider's range doesn't go out of its normal bounds. This is an attempt to fix the bug outlined by this [gif](https://aws1.discourse-cdn.com/business7/uploads/plot/original/2X/2/28399259ce54005c63f46e4c2920a887593aa3c2.gif).

I'm not sure what the preferred behavior would be when you do drag the slider to the max/min bounds, but what this solution does is snap the slider back to the graph's corresponding max/min x value when the slider is dragged past the max/min.