### PR TITLE
enables loading locales before Plotly

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -65,6 +65,11 @@ register([
     require('./locale-en-us')
 ]);
 
+// locales that are present in the window should be loaded
+if(window.PlotlyLocales && window.PlotlyLocales.length) {
+    register(window.PlotlyLocales);
+}
+
 // plot icons
 exports.Icons = require('./fonts/ploticon');
 

--- a/src/core.js
+++ b/src/core.js
@@ -66,9 +66,9 @@ register([
 ]);
 
 // locales that are present in the window should be loaded
-if(window.PlotlyConfig && window.PlotlyConfig.locales) {
-    register(window.PlotlyConfig.locales);
-    delete window.PlotlyConfig.locales;
+if(window.PlotlyLocales && Array.isArray(window.PlotlyLocales)) {
+    register(window.PlotlyLocales);
+    delete window.PlotlyLocales;
 }
 
 // plot icons

--- a/src/core.js
+++ b/src/core.js
@@ -66,8 +66,9 @@ register([
 ]);
 
 // locales that are present in the window should be loaded
-if(window.PlotlyLocales && window.PlotlyLocales.length) {
+if(window.PlotlyLocales && Array.isArray(window.PlotlyLocales)) {
     register(window.PlotlyLocales);
+    delete window.PlotlyLocales;
 }
 
 // plot icons

--- a/src/core.js
+++ b/src/core.js
@@ -66,9 +66,9 @@ register([
 ]);
 
 // locales that are present in the window should be loaded
-if(window.PlotlyLocales && Array.isArray(window.PlotlyLocales)) {
-    register(window.PlotlyLocales);
-    delete window.PlotlyLocales;
+if(window.PlotlyConfig && window.PlotlyConfig.locales) {
+    register(window.PlotlyConfig.locales);
+    delete window.PlotlyConfig.locales;
 }
 
 // plot icons

--- a/tasks/util/wrap_locale.js
+++ b/tasks/util/wrap_locale.js
@@ -6,8 +6,8 @@ var intoStream = require('into-stream');
 
 var constants = require('./constants');
 
-var prefix = 'Plotly.register(';
-var suffix = ');';
+var prefix = 'var locale=';
+var suffix = ';if(typeof Plotly === \'undefined\') {window.PlotlyLocales = window.PlotlyLocales || []; window.PlotlyLocales.push(locale);} else {Plotly.register(locale);}';
 
 var moduleMarker = 'module.exports = ';
 

--- a/tasks/util/wrap_locale.js
+++ b/tasks/util/wrap_locale.js
@@ -7,7 +7,8 @@ var intoStream = require('into-stream');
 var constants = require('./constants');
 
 var prefix = 'var locale=';
-var suffix = ';if(typeof Plotly === \'undefined\') {window.PlotlyLocales = window.PlotlyLocales || []; window.PlotlyLocales.push(locale);} else {Plotly.register(locale);}';
+var suffix = ';window.PlotlyConfig = window.PlotlyConfig || {};';
+suffix += 'if(typeof Plotly === \'undefined\') {window.PlotlyConfig.locales = window.PlotlyConfig.locales || []; window.PlotlyConfig.locales.push(locale);} else {Plotly.register(locale);}';
 
 var moduleMarker = 'module.exports = ';
 

--- a/tasks/util/wrap_locale.js
+++ b/tasks/util/wrap_locale.js
@@ -7,8 +7,7 @@ var intoStream = require('into-stream');
 var constants = require('./constants');
 
 var prefix = 'var locale=';
-var suffix = ';window.PlotlyConfig = window.PlotlyConfig || {};';
-suffix += 'if(typeof Plotly === \'undefined\') {window.PlotlyConfig.locales = window.PlotlyConfig.locales || []; window.PlotlyConfig.locales.push(locale);} else {Plotly.register(locale);}';
+var suffix = ';if(typeof Plotly === \'undefined\') {window.PlotlyLocales = window.PlotlyLocales || []; window.PlotlyLocales.push(locale);} else {Plotly.register(locale);}';
 
 var moduleMarker = 'module.exports = ';
 


### PR DESCRIPTION
This PR enables loading locales before plotly.js is on the page and partially fixes #4146.

In the following Codepens, we expect months to be in French (it should be `Mai` instead of `May`):
[Before](https://codepen.io/antoinerg/pen/vYEeNrg)
[After](https://codepen.io/antoinerg/pen/zYxEqeJ)
