### PR TITLE
Improve description of sunburst/treemap outsidetextfont

### DIFF
--- a/src/traces/sunburst/attributes.js
+++ b/src/traces/sunburst/attributes.js
@@ -194,7 +194,15 @@ module.exports = {
     textfont: pieAttrs.textfont,
     insidetextorientation: pieAttrs.insidetextorientation,
     insidetextfont: pieAttrs.insidetextfont,
-    outsidetextfont: pieAttrs.outsidetextfont,
+    outsidetextfont: extendFlat({}, pieAttrs.outsidetextfont, {
+        description: [
+            'Sets the font used for `textinfo` lying outside the sector.',
+            'This option refers to the root of the hierarchy',
+            'presented at the center of a sunburst graph.',
+            'Please note that if a hierarchy has multiple root nodes,',
+            'this option won\'t have any effect and `insidetextfont` would be used.'
+        ].join(' ')
+    }),
 
     domain: domainAttrs({name: 'sunburst', trace: true, editType: 'calc'})
 };

--- a/src/traces/treemap/attributes.js
+++ b/src/traces/treemap/attributes.js
@@ -244,7 +244,15 @@ module.exports = {
 
     textfont: pieAttrs.textfont,
     insidetextfont: pieAttrs.insidetextfont,
-    outsidetextfont: pieAttrs.outsidetextfont,
+    outsidetextfont: extendFlat({}, pieAttrs.outsidetextfont, {
+        description: [
+            'Sets the font used for `textinfo` lying outside the sector.',
+            'This option refers to the root of the hierarchy',
+            'presented on top left corner of a treemap graph.',
+            'Please note that if a hierarchy has multiple root nodes,',
+            'this option won\'t have any effect and `insidetextfont` would be used.'
+        ].join(' ')
+    }),
 
     textposition: {
         valType: 'enumerated',


### PR DESCRIPTION
This PR adds info to the `outsidetextfont` attribute of `sunburst` and `treemap` traces i.e. to help clarify where outside text is presented. 
@plotly/plotly_js 
cc: @nicolaskruchten 