### PR TITLE
add the word background to bgcolor description so it will get indexed by algolia

### DIFF
--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -269,7 +269,7 @@ module.exports = {
         role: 'style',
         dflt: colorAttrs.background,
         editType: 'plot',
-        description: 'Sets the color of paper where the graph is drawn.'
+        description: 'Sets the background color of the paper where the graph is drawn.'
     },
     plot_bgcolor: {
         // defined here, but set in cartesian.supplyLayoutDefaults
@@ -279,7 +279,7 @@ module.exports = {
         dflt: colorAttrs.background,
         editType: 'layoutstyle',
         description: [
-            'Sets the color of plotting area in-between x and y axes.'
+            'Sets the background color of the plotting area in-between x and y axes.'
         ].join(' ')
     },
     separators: {


### PR DESCRIPTION
The purpose of this PR is to update the description for the `paper_bgcolor` and `plot_bgcolor` layout attributes to add the word `background`. 

This is so that users who search for `background` in the search bar on https://plot.ly/javascript will see these attributes as results. 