### PR TITLE
Detect correct device in the second attempt to create 3-D scene

### DIFF
--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -149,12 +149,9 @@ proto.tryCreatePlot = function() {
         if(scene.staticMode) {
             success = false;
         } else { // try second time
-            // make fresh object for options
-            opts = scene.prepareOptions();
-
             try {
                 // invert preserveDrawingBuffer setup which could be resulted from is-mobile not detecting the right device
-                opts.glOptions.preserveDrawingBuffer = !opts.glOptions.preserveDrawingBuffer;
+                isMobile = opts.glOptions.preserveDrawingBuffer = !opts.glOptions.preserveDrawingBuffer;
 
                 scene.glplot = createPlot(opts);
             } catch(e) {

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -151,6 +151,13 @@ proto.tryCreatePlot = function() {
         } else { // try second time
             try {
                 // invert preserveDrawingBuffer setup which could be resulted from is-mobile not detecting the right device
+                Lib.warn([
+                    'webgl setup failed possibly due to',
+                    isMobile ? 'disabling' : 'enabling',
+                    'preserveDrawingBuffer config.',
+                    'The device may not be supported by isMobile module!',
+                    'Inverting preserveDrawingBuffer option in second attempt to create webgl scene.'
+                ].join(' '));
                 isMobile = opts.glOptions.preserveDrawingBuffer = !opts.glOptions.preserveDrawingBuffer;
 
                 scene.glplot = createPlot(opts);


### PR DESCRIPTION
Follow up of  and 4546 and #4548, and in regards with a number of comments from users experiencing webgl setup e.g.
https://github.com/plotly/plotly.js/issues/3640#issuecomment-505355009
https://github.com/plotly/plotly.js/issues/3640#issuecomment-474091716
https://github.com/plotly/plotly.js/issues/3640#issuecomment-529726285
https://github.com/plotly/plotly.js/issues/3640#issuecomment-566523569
this PR uses a different webgl config for `preserveDrawingBuffer` in the second attempt to create `gl3d` scene. With this in place the graph should be displayed instead of a webgl error namely 
`Error: WebGL warning: checkFramebufferStatus: Framebuffer not complete` 
even if `is-mobile` module was unable to detect the correct device.

[Demo](https://codepen.io/MojtabaSamimi/pen/qBdWVjB?editors=1000)

@plotly/plotly_js 
cc: @hoerup