### PR TITLE
Downgrade ecstatic to last "available" version on npm 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,12 +1714,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
-      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
-      "dev": true
-    },
     "check-node-version": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.0.2.tgz",
@@ -3490,17 +3484,15 @@
       }
     },
     "ecstatic": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-4.1.2.tgz",
-      "integrity": "sha512-lnrAOpU2f7Ra8dm1pW0D1ucyUxQIEk8RjFrvROg1YqCV0ueVu9hzgiSEbSyROqXDDiHREdqC4w3AwOTb23P4UQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "dev": true,
       "requires": {
-        "charset": "^1.0.1",
         "he": "^1.1.1",
-        "mime": "^2.4.1",
+        "mime": "^1.6.0",
         "minimist": "^1.1.0",
-        "on-finished": "^2.3.0",
-        "url-join": "^4.0.0"
+        "url-join": "^2.0.5"
       }
     },
     "edges-to-adjacency-list": {
@@ -7485,9 +7477,9 @@
       }
     },
     "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -12123,9 +12115,9 @@
       }
     },
     "url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
     },
     "use": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "chttps": "^1.0.6",
     "deep-equal": "^2.0.1",
     "derequire": "^2.0.6",
-    "ecstatic": "^4.1.2",
+    "ecstatic": "^3.3.2",
     "eslint": "^6.8.0",
     "falafel": "^2.1.0",
     "fs-extra": "^2.0.0",


### PR DESCRIPTION
The `ecstatic` v4 module has been deprecated!
See https://www.npmjs.com/package/ecstatic
and https://github.com/jfhbrook/node-ecstatic/issues/259.

This PR reverts the version of `ecstatic` from 4.0.0 to 3.3.2 which was upgraded in #4475.

@plotly/plotly_js 