### PR TITLE
Apply utf-8 charset in test_dashboard

### DIFF
--- a/devtools/test_dashboard/index.html
+++ b/devtools/test_dashboard/index.html
@@ -24,7 +24,7 @@
   <script>document.write("<scri"+"pt src='../../dist/extras/request_animation_frame.js'></scr"+"ipt>");</script> -->
 
   <script src="../../dist/extras/mathjax/MathJax.js?config=TeX-AMS-MML_SVG"></script>
-  <script id="source" src="../../build/plotly.js"></script>
-  <script src="../../build/test_dashboard-bundle.js"></script>
+  <script id="source" src="../../build/plotly.js" charset="utf-8"></script>
+  <script src="../../build/test_dashboard-bundle.js" charset="utf-8"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes non-ASCII characters in test_dashboard.

@plotly/plotly_js 