### PR TITLE
Preserve gl3d scene aspectratio after orthographic scroll zoom

### DIFF
--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -471,12 +471,12 @@ proto.recoverContext = function() {
 var axisProperties = [ 'xaxis', 'yaxis', 'zaxis' ];
 
 function computeTraceBounds(scene, trace, bounds) {
-    var sceneLayout = scene.fullSceneLayout;
+    var fullSceneLayout = scene.fullSceneLayout;
 
     for(var d = 0; d < 3; d++) {
         var axisName = axisProperties[d];
         var axLetter = axisName.charAt(0);
-        var ax = sceneLayout[axisName];
+        var ax = fullSceneLayout[axisName];
         var coords = trace[axLetter];
         var calendar = trace[axLetter + 'calendar'];
         var len = trace['_' + axLetter + 'length'];
@@ -509,13 +509,13 @@ function computeTraceBounds(scene, trace, bounds) {
 }
 
 function computeAnnotationBounds(scene, bounds) {
-    var sceneLayout = scene.fullSceneLayout;
-    var annotations = sceneLayout.annotations || [];
+    var fullSceneLayout = scene.fullSceneLayout;
+    var annotations = fullSceneLayout.annotations || [];
 
     for(var d = 0; d < 3; d++) {
         var axisName = axisProperties[d];
         var axLetter = axisName.charAt(0);
-        var ax = sceneLayout[axisName];
+        var ax = fullSceneLayout[axisName];
 
         for(var j = 0; j < annotations.length; j++) {
             var ann = annotations[j];

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -246,6 +246,7 @@ proto.initializeGLPlot = function() {
                     y: s * o.y,
                     z: s * o.z
                 });
+                scene._aspectmode = 'manual';
             }
 
             relayoutCallback(scene);
@@ -729,7 +730,7 @@ proto.plot = function(sceneData, fullLayout, layout) {
      * Dynamically set the aspect ratio depending on the users aspect settings
      */
     var aspectRatio;
-    var aspectmode = fullSceneLayout.aspectmode;
+    var aspectmode = scene._aspectmode || fullSceneLayout.aspectmode;
     if(aspectmode === 'cube') {
         aspectRatio = [1, 1, 1];
     } else if(aspectmode === 'manual') {
@@ -762,6 +763,7 @@ proto.plot = function(sceneData, fullLayout, layout) {
     } else {
         throw new Error('scene.js aspectRatio was not one of the enumerated types');
     }
+    scene._aspectmode = aspectmode;
 
     /*
      * Write aspect Ratio back to user data and fullLayout so that it is modifies as user

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -725,6 +725,8 @@ proto.plot = function(sceneData, fullLayout, layout) {
         });
     }
 
+    var aspectmode = fullSceneLayout.aspectmode;
+
     var axesScaleRatio = [1, 1, 1];
 
     // Compute axis scale per category
@@ -741,7 +743,7 @@ proto.plot = function(sceneData, fullLayout, layout) {
     var axisAutoScaleFactor = 4;
     var aspectRatio;
 
-    if(fullSceneLayout.aspectmode === 'auto') {
+    if(aspectmode === 'auto') {
         if(Math.max.apply(null, axesScaleRatio) / Math.min.apply(null, axesScaleRatio) <= axisAutoScaleFactor) {
             /*
              * USE DATA MODE WHEN AXIS RANGE DIMENSIONS ARE RELATIVELY EQUAL
@@ -754,11 +756,11 @@ proto.plot = function(sceneData, fullLayout, layout) {
              */
             aspectRatio = [1, 1, 1];
         }
-    } else if(fullSceneLayout.aspectmode === 'cube') {
+    } else if(aspectmode === 'cube') {
         aspectRatio = [1, 1, 1];
-    } else if(fullSceneLayout.aspectmode === 'data') {
+    } else if(aspectmode === 'data') {
         aspectRatio = axesScaleRatio;
-    } else if(fullSceneLayout.aspectmode === 'manual') {
+    } else if(aspectmode === 'manual') {
         var userRatio = fullSceneLayout.aspectratio;
         aspectRatio = [userRatio.x, userRatio.y, userRatio.z];
     } else {

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -246,7 +246,7 @@ proto.initializeGLPlot = function() {
                     y: s * o.y,
                     z: s * o.z
                 });
-                scene._aspectmode = 'manual';
+                scene.fullSceneLayout.aspectmode = layout[scene.id].aspectmode = 'manual';
             }
 
             relayoutCallback(scene);
@@ -730,7 +730,7 @@ proto.plot = function(sceneData, fullLayout, layout) {
      * Dynamically set the aspect ratio depending on the users aspect settings
      */
     var aspectRatio;
-    var aspectmode = scene._aspectmode || fullSceneLayout.aspectmode;
+    var aspectmode = fullSceneLayout.aspectmode;
     if(aspectmode === 'cube') {
         aspectRatio = [1, 1, 1];
     } else if(aspectmode === 'manual') {
@@ -763,7 +763,6 @@ proto.plot = function(sceneData, fullLayout, layout) {
     } else {
         throw new Error('scene.js aspectRatio was not one of the enumerated types');
     }
-    scene._aspectmode = aspectmode;
 
     /*
      * Write aspect Ratio back to user data and fullLayout so that it is modifies as user

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -748,18 +748,14 @@ proto.plot = function(sceneData, fullLayout, layout) {
         if(aspectmode === 'data') {
             aspectRatio = axesScaleRatio;
         } else { // i.e. 'auto' option
-            var axisAutoScaleFactor = 4;
-
-            if(Math.max.apply(null, axesScaleRatio) / Math.min.apply(null, axesScaleRatio) <= axisAutoScaleFactor) {
-                /*
-                * USE DATA MODE WHEN AXIS RANGE DIMENSIONS ARE RELATIVELY EQUAL
-                */
-
+            if(
+                Math.max.apply(null, axesScaleRatio) /
+                Math.min.apply(null, axesScaleRatio) <= 4
+            ) {
+                // USE DATA MODE WHEN AXIS RANGE DIMENSIONS ARE RELATIVELY EQUAL
                 aspectRatio = axesScaleRatio;
             } else {
-                /*
-                * USE EQUAL MODE WHEN AXIS RANGE DIMENSIONS ARE HIGHLY UNEQUAL
-                */
+                // USE EQUAL MODE WHEN AXIS RANGE DIMENSIONS ARE HIGHLY UNEQUAL
                 aspectRatio = [1, 1, 1];
             }
         }

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -726,24 +726,26 @@ proto.plot = function(sceneData, fullLayout, layout) {
     }
 
     var aspectmode = fullSceneLayout.aspectmode;
+    var axesScaleRatio;
+    if(aspectmode === 'auto' || aspectmode === 'data') {
+        axesScaleRatio = [1, 1, 1];
 
-    var axesScaleRatio = [1, 1, 1];
-
-    // Compute axis scale per category
-    for(i = 0; i < 3; ++i) {
-        axis = fullSceneLayout[axisProperties[i]];
-        axisType = axis.type;
-        var axisRatio = axisTypeRatios[axisType];
-        axesScaleRatio[i] = Math.pow(axisRatio.acc, 1.0 / axisRatio.count) / dataScale[i];
+        // Compute axis scale per category
+        for(i = 0; i < 3; ++i) {
+            axis = fullSceneLayout[axisProperties[i]];
+            axisType = axis.type;
+            var axisRatio = axisTypeRatios[axisType];
+            axesScaleRatio[i] = Math.pow(axisRatio.acc, 1.0 / axisRatio.count) / dataScale[i];
+        }
     }
 
     /*
      * Dynamically set the aspect ratio depending on the users aspect settings
      */
-    var axisAutoScaleFactor = 4;
     var aspectRatio;
-
     if(aspectmode === 'auto') {
+        var axisAutoScaleFactor = 4;
+
         if(Math.max.apply(null, axesScaleRatio) / Math.min.apply(null, axesScaleRatio) <= axisAutoScaleFactor) {
             /*
              * USE DATA MODE WHEN AXIS RANGE DIMENSIONS ARE RELATIVELY EQUAL

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -730,10 +730,13 @@ proto.plot = function(sceneData, fullLayout, layout) {
      */
     var aspectRatio;
     var aspectmode = fullSceneLayout.aspectmode;
-    var axesScaleRatio;
-    if(aspectmode === 'auto' || aspectmode === 'data') {
-        axesScaleRatio = [1, 1, 1];
-
+    if(aspectmode === 'cube') {
+        aspectRatio = [1, 1, 1];
+    } else if(aspectmode === 'manual') {
+        var userRatio = fullSceneLayout.aspectratio;
+        aspectRatio = [userRatio.x, userRatio.y, userRatio.z];
+    } else if(aspectmode === 'auto' || aspectmode === 'data') {
+        var axesScaleRatio = [1, 1, 1];
         // Compute axis scale per category
         for(i = 0; i < 3; ++i) {
             axis = fullSceneLayout[axisProperties[i]];
@@ -741,30 +744,25 @@ proto.plot = function(sceneData, fullLayout, layout) {
             var axisRatio = axisTypeRatios[axisType];
             axesScaleRatio[i] = Math.pow(axisRatio.acc, 1.0 / axisRatio.count) / dataScale[i];
         }
-    }
 
-    if(aspectmode === 'cube') {
-        aspectRatio = [1, 1, 1];
-    } else if(aspectmode === 'manual') {
-        var userRatio = fullSceneLayout.aspectratio;
-        aspectRatio = [userRatio.x, userRatio.y, userRatio.z];
-    } else if(aspectmode === 'auto') {
-        var axisAutoScaleFactor = 4;
-
-        if(Math.max.apply(null, axesScaleRatio) / Math.min.apply(null, axesScaleRatio) <= axisAutoScaleFactor) {
-            /*
-             * USE DATA MODE WHEN AXIS RANGE DIMENSIONS ARE RELATIVELY EQUAL
-             */
-
+        if(aspectmode === 'data') {
             aspectRatio = axesScaleRatio;
-        } else {
-            /*
-             * USE EQUAL MODE WHEN AXIS RANGE DIMENSIONS ARE HIGHLY UNEQUAL
-             */
-            aspectRatio = [1, 1, 1];
+        } else { // i.e. 'auto' option
+            var axisAutoScaleFactor = 4;
+
+            if(Math.max.apply(null, axesScaleRatio) / Math.min.apply(null, axesScaleRatio) <= axisAutoScaleFactor) {
+                /*
+                * USE DATA MODE WHEN AXIS RANGE DIMENSIONS ARE RELATIVELY EQUAL
+                */
+
+                aspectRatio = axesScaleRatio;
+            } else {
+                /*
+                * USE EQUAL MODE WHEN AXIS RANGE DIMENSIONS ARE HIGHLY UNEQUAL
+                */
+                aspectRatio = [1, 1, 1];
+            }
         }
-    } else if(aspectmode === 'data') {
-        aspectRatio = axesScaleRatio;
     } else {
         throw new Error('scene.js aspectRatio was not one of the enumerated types');
     }

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -725,6 +725,10 @@ proto.plot = function(sceneData, fullLayout, layout) {
         });
     }
 
+    /*
+     * Dynamically set the aspect ratio depending on the users aspect settings
+     */
+    var aspectRatio;
     var aspectmode = fullSceneLayout.aspectmode;
     var axesScaleRatio;
     if(aspectmode === 'auto' || aspectmode === 'data') {
@@ -739,11 +743,12 @@ proto.plot = function(sceneData, fullLayout, layout) {
         }
     }
 
-    /*
-     * Dynamically set the aspect ratio depending on the users aspect settings
-     */
-    var aspectRatio;
-    if(aspectmode === 'auto') {
+    if(aspectmode === 'cube') {
+        aspectRatio = [1, 1, 1];
+    } else if(aspectmode === 'manual') {
+        var userRatio = fullSceneLayout.aspectratio;
+        aspectRatio = [userRatio.x, userRatio.y, userRatio.z];
+    } else if(aspectmode === 'auto') {
         var axisAutoScaleFactor = 4;
 
         if(Math.max.apply(null, axesScaleRatio) / Math.min.apply(null, axesScaleRatio) <= axisAutoScaleFactor) {
@@ -758,13 +763,8 @@ proto.plot = function(sceneData, fullLayout, layout) {
              */
             aspectRatio = [1, 1, 1];
         }
-    } else if(aspectmode === 'cube') {
-        aspectRatio = [1, 1, 1];
     } else if(aspectmode === 'data') {
         aspectRatio = axesScaleRatio;
-    } else if(aspectmode === 'manual') {
-        var userRatio = fullSceneLayout.aspectratio;
-        aspectRatio = [userRatio.x, userRatio.y, userRatio.z];
     } else {
         throw new Error('scene.js aspectRatio was not one of the enumerated types');
     }


### PR DESCRIPTION
Fixes #4514 restyle part
After refactoring parts of the gl3d/scene code related to computing `aspectratio`,
this PR fixes the bug in commit https://github.com/plotly/plotly.js/commit/e29aceb930208840dc27e5d2bdac782332fab505.
[Demo](https://codepen.io/MojtabaSamimi/pen/vYONaww?editors=1000) | Please change scales using scroll, then select a point. It shouldn't display initial scales.

@plotly/plotly_js 