### PR TITLE
Fix to make identical bundles on different nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4879,9 +4879,8 @@
       }
     },
     "gl-line3d": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.1.11.tgz",
-      "integrity": "sha512-EitFKPEEYdn/ivFOxJ8khSi0BzNum4sXZFLq6SQq21MX5YPCYb0o+XzjpWNuU32BoXORBC78B1JTiQqnTaWhWQ==",
+      "version": "git://github.com/gl-vis/gl-line3d.git#66628995ce0cd532dba0f526e2f0357c7acea5c8",
+      "from": "git://github.com/gl-vis/gl-line3d.git#66628995ce0cd532dba0f526e2f0357c7acea5c8",
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.0.8",
@@ -4889,7 +4888,6 @@
         "gl-texture2d": "^2.0.2",
         "gl-vao": "^1.1.3",
         "glsl-out-of-range": "^1.0.4",
-        "glsl-read-float": "^1.0.0",
         "glslify": "^7.0.0",
         "ndarray": "^1.0.16"
       },
@@ -5285,11 +5283,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.4.tgz",
       "integrity": "sha512-fCcDu2LCQ39VBvfe1FbhuazXEf0CqMZI9OYXrYlL6uUARG48CTAbL04+tZBtVM0zo1Ljx4OLu2AxNquq++lxWQ=="
-    },
-    "glsl-read-float": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/glsl-read-float/-/glsl-read-float-1.1.0.tgz",
-      "integrity": "sha1-37CIsBYtz8xW/E7d0vhuGMrDLyY="
     },
     "glsl-resolve": {
       "version": "0.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4879,17 +4879,17 @@
       }
     },
     "gl-line3d": {
-      "version": "git://github.com/gl-vis/gl-line3d.git#66628995ce0cd532dba0f526e2f0357c7acea5c8",
-      "from": "git://github.com/gl-vis/gl-line3d.git#66628995ce0cd532dba0f526e2f0357c7acea5c8",
+      "version": "git://github.com/gl-vis/gl-line3d.git#1514fbaf898e5929c77b03dfb5ec6d08edbcd80a",
+      "from": "git://github.com/gl-vis/gl-line3d.git#1514fbaf898e5929c77b03dfb5ec6d08edbcd80a",
       "requires": {
         "binary-search-bounds": "^2.0.4",
-        "gl-buffer": "^2.0.8",
+        "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.0.2",
-        "gl-vao": "^1.1.3",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
         "glsl-out-of-range": "^1.0.4",
         "glslify": "^7.0.0",
-        "ndarray": "^1.0.16"
+        "ndarray": "^1.0.18"
       },
       "dependencies": {
         "binary-search-bounds": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4879,8 +4879,9 @@
       }
     },
     "gl-line3d": {
-      "version": "git://github.com/gl-vis/gl-line3d.git#1514fbaf898e5929c77b03dfb5ec6d08edbcd80a",
-      "from": "git://github.com/gl-vis/gl-line3d.git#1514fbaf898e5929c77b03dfb5ec6d08edbcd80a",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.2.0.tgz",
+      "integrity": "sha512-du9GDF87DMfllND2pBjySyHhFaza9upw4t2GMoXn11/I38atO6+saiznuhKmfxuDnyxGdmmZF6/HPauk0owKDA==",
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "gl-contour2d": "^1.1.6",
     "gl-error3d": "^1.0.15",
     "gl-heatmap2d": "^1.0.5",
-    "gl-line3d": "git://github.com/gl-vis/gl-line3d.git#1514fbaf898e5929c77b03dfb5ec6d08edbcd80a",
+    "gl-line3d": "1.2.0",
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.3.0",
     "gl-plot2d": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "gl-contour2d": "^1.1.6",
     "gl-error3d": "^1.0.15",
     "gl-heatmap2d": "^1.0.5",
-    "gl-line3d": "^1.1.11",
+    "gl-line3d": "git://github.com/gl-vis/gl-line3d.git#66628995ce0cd532dba0f526e2f0357c7acea5c8",
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.3.0",
     "gl-plot2d": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "gl-contour2d": "^1.1.6",
     "gl-error3d": "^1.0.15",
     "gl-heatmap2d": "^1.0.5",
-    "gl-line3d": "git://github.com/gl-vis/gl-line3d.git#66628995ce0cd532dba0f526e2f0357c7acea5c8",
+    "gl-line3d": "git://github.com/gl-vis/gl-line3d.git#1514fbaf898e5929c77b03dfb5ec6d08edbcd80a",
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.3.0",
     "gl-plot2d": "^1.4.3",


### PR DESCRIPTION
Possibly since v.1.36.1 a random number was attached to one of the GLSL variables of shader programs used in `gl-line3d` module e.g. `encode_float_1540259130(pixelArcLength)` resulting in non-deterministic bundles as reported in https://github.com/plotly/streambed/issues/13816.

This PR fixes this issue by removing one linking step within `gl-line3d` module.

@plotly/plotly_js 
cc: @nicolaskruchten @dmt0 @tarzzz