### PR TITLE
check-node-version: accept any nodejs version in 12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "start-image_viewer": "node devtools/image_viewer/server.js",
     "start": "npm run start-test_dashboard",
     "baseline": "node tasks/baseline.js",
-    "preversion": "check-node-version --node 12.13 --npm 6.13 && npm-link-check && npm ls --prod",
+    "preversion": "check-node-version --node 12 --npm 6.13 && npm-link-check && npm ls --prod",
     "version": "npm run build && git add -A dist src build",
     "postversion": "node -e \"console.log('Version bumped and committed. If ok, run: git push && git push --tags')\"",
     "postpublish": "node tasks/sync_packages.js",


### PR DESCRIPTION
I was wondering if we could loosen the requirement for nodejs from `12.13` to `12` to accommodate developers that may not be running this specific version and may not want to install nvm. Do you see any risk in doing that? Also, the latest 12 version is `12.16.1`.

cc @alexcjohnson @etpinard 