### PR TITLE
sankey: introducing attributes (node|link).customdata

### DIFF
--- a/src/traces/sankey/attributes.js
+++ b/src/traces/sankey/attributes.js
@@ -207,6 +207,13 @@ var attrs = module.exports = overrideAll({
                 'If `link.color` is omitted, then by default, a translucent grey link will be used.'
             ].join(' ')
         },
+        customdata: {
+            valType: 'data_array',
+            editType: 'calc',
+            description: [
+                'Assigns extra data each link.'
+            ].join(' ')
+        },
         line: {
             color: {
                 valType: 'color',

--- a/src/traces/sankey/attributes.js
+++ b/src/traces/sankey/attributes.js
@@ -84,6 +84,9 @@ var attrs = module.exports = overrideAll({
         description: 'Sets the font for node labels'
     }),
 
+    // Remove top-level customdata
+    customdata: undefined,
+
     node: {
         label: {
             valType: 'data_array',

--- a/src/traces/sankey/attributes.js
+++ b/src/traces/sankey/attributes.js
@@ -135,7 +135,7 @@ var attrs = module.exports = overrideAll({
             valType: 'data_array',
             editType: 'calc',
             description: [
-                'Assigns extra data each node.'
+                'Assigns extra data to each node.'
             ].join(' ')
         },
         line: {
@@ -214,7 +214,7 @@ var attrs = module.exports = overrideAll({
             valType: 'data_array',
             editType: 'calc',
             description: [
-                'Assigns extra data each link.'
+                'Assigns extra data to each link.'
             ].join(' ')
         },
         line: {

--- a/src/traces/sankey/attributes.js
+++ b/src/traces/sankey/attributes.js
@@ -128,6 +128,13 @@ var attrs = module.exports = overrideAll({
                 'what is beneath the node.'
             ].join(' ')
         },
+        customdata: {
+            valType: 'data_array',
+            editType: 'calc',
+            description: [
+                'Assigns extra data each node.'
+            ].join(' ')
+        },
         line: {
             color: {
                 valType: 'color',

--- a/src/traces/sankey/calc.js
+++ b/src/traces/sankey/calc.js
@@ -116,6 +116,7 @@ function convertToD3Sankey(trace) {
     // Process nodes
     var totalCount = nodeCount + groups.length;
     var hasNodeColorArray = isArrayOrTypedArray(nodeSpec.color);
+    var hasNodeCustomdataArray = isArrayOrTypedArray(nodeSpec.customdata);
     var nodes = [];
     for(i = 0; i < totalCount; i++) {
         if(!linkedNodes[i]) continue;
@@ -126,7 +127,8 @@ function convertToD3Sankey(trace) {
             childrenNodes: [],
             pointNumber: i,
             label: l,
-            color: hasNodeColorArray ? nodeSpec.color[i] : nodeSpec.color
+            color: hasNodeColorArray ? nodeSpec.color[i] : nodeSpec.color,
+            customdata: hasNodeCustomdataArray ? nodeSpec.customdata[i] : nodeSpec.customdata
         });
     }
 

--- a/src/traces/sankey/calc.js
+++ b/src/traces/sankey/calc.js
@@ -22,6 +22,7 @@ function convertToD3Sankey(trace) {
 
     var links = [];
     var hasLinkColorArray = isArrayOrTypedArray(linkSpec.color);
+    var hasLinkCustomdataArray = isArrayOrTypedArray(linkSpec.customdata);
     var linkedNodes = {};
 
     var components = {};
@@ -103,6 +104,7 @@ function convertToD3Sankey(trace) {
             pointNumber: i,
             label: label,
             color: hasLinkColorArray ? linkSpec.color[i] : linkSpec.color,
+            customdata: hasLinkCustomdataArray ? linkSpec.customdata[i] : linkSpec.customdata,
             concentrationscale: concentrationscale,
             source: source,
             target: target,

--- a/src/traces/sankey/defaults.js
+++ b/src/traces/sankey/defaults.js
@@ -50,6 +50,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     coerceNode('color', nodeOut.label.map(function(d, i) {
         return Color.addOpacity(defaultNodePalette(i), 0.8);
     }));
+    coerceNode('customdata');
 
     // link attributes
     var linkIn = traceIn.link || {};

--- a/src/traces/sankey/defaults.js
+++ b/src/traces/sankey/defaults.js
@@ -74,6 +74,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
                 'rgba(0, 0, 0, 0.2)';
 
     coerceLink('color', Lib.repeat(defaultLinkColor, linkOut.value.length));
+    coerceLink('customdata');
 
     handleArrayContainerDefaults(linkIn, linkOut, {
         name: 'colorscales',

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -816,6 +816,7 @@ describe('sankey tests', function() {
         it('should show the correct hover labels when hovertemplate is specified', function(done) {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
+            mockCopy.data[0].node.customdata = [0, 0, 0, 0, '15']
 
             Plotly.plot(gd, mockCopy).then(function() {
                 _hover(404, 302);
@@ -836,7 +837,7 @@ describe('sankey tests', function() {
             // Test (node|link).hovertemplate
             .then(function() {
                 return Plotly.restyle(gd, {
-                    'node.hovertemplate': 'hovertemplate<br>%{value}<br>%{value:0.2f}<extra>%{fullData.name}</extra>',
+                    'node.hovertemplate': 'hovertemplate<br>%{value}<br>%{value:0.2f}<br>%{customdata}<extra>%{fullData.name}</extra>',
                     'link.hovertemplate': 'hovertemplate<br>source: %{source.label}<br>target: %{target.label}<br>size: %{value:0.0f}TWh<extra>%{fullData.name}</extra>'
                 });
             })
@@ -844,7 +845,7 @@ describe('sankey tests', function() {
                 _hover(404, 302);
 
                 assertLabel(
-                    [ 'hovertemplate', '447TWh', '447.48', 'trace 0'],
+                    [ 'hovertemplate', '447TWh', '447.48', '15', 'trace 0'],
                     ['rgb(148, 103, 189)', 'rgb(255, 255, 255)', 13, 'Arial', 'rgb(255, 255, 255)']
                 );
             })

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -816,7 +816,10 @@ describe('sankey tests', function() {
         it('should show the correct hover labels when hovertemplate is specified', function(done) {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
-            mockCopy.data[0].node.customdata = [0, 0, 0, 0, '15']
+            mockCopy.data[0].node.customdata = [];
+            mockCopy.data[0].node.customdata[4] = 'nodeCustomdata';
+            mockCopy.data[0].link.customdata = [];
+            mockCopy.data[0].link.customdata[61] = 'linkCustomdata';
 
             Plotly.plot(gd, mockCopy).then(function() {
                 _hover(404, 302);
@@ -838,14 +841,14 @@ describe('sankey tests', function() {
             .then(function() {
                 return Plotly.restyle(gd, {
                     'node.hovertemplate': 'hovertemplate<br>%{value}<br>%{value:0.2f}<br>%{customdata}<extra>%{fullData.name}</extra>',
-                    'link.hovertemplate': 'hovertemplate<br>source: %{source.label}<br>target: %{target.label}<br>size: %{value:0.0f}TWh<extra>%{fullData.name}</extra>'
+                    'link.hovertemplate': 'hovertemplate<br>source: %{source.label}<br>target: %{target.label}<br>size: %{value:0.0f}TWh<br>%{customdata}<extra>%{fullData.name}</extra>'
                 });
             })
             .then(function() {
                 _hover(404, 302);
 
                 assertLabel(
-                    [ 'hovertemplate', '447TWh', '447.48', '15', 'trace 0'],
+                    [ 'hovertemplate', '447TWh', '447.48', 'nodeCustomdata', 'trace 0'],
                     ['rgb(148, 103, 189)', 'rgb(255, 255, 255)', 13, 'Arial', 'rgb(255, 255, 255)']
                 );
             })
@@ -853,7 +856,7 @@ describe('sankey tests', function() {
                 _hover(450, 300);
 
                 assertLabel(
-                    ['hovertemplate', 'source: Solid', 'target: Industry', 'size: 46TWh', 'trace 0'],
+                    ['hovertemplate', 'source: Solid', 'target: Industry', 'size: 46TWh', 'linkCustomdata', 'trace 0'],
                     ['rgb(0, 0, 96)', 'rgb(255, 255, 255)', 13, 'Arial', 'rgb(255, 255, 255)']
                 );
             })

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -817,9 +817,9 @@ describe('sankey tests', function() {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
             mockCopy.data[0].node.customdata = [];
-            mockCopy.data[0].node.customdata[4] = 'nodeCustomdata';
+            mockCopy.data[0].node.customdata[4] = ['nodeCustomdata0', 'nodeCustomdata1'];
             mockCopy.data[0].link.customdata = [];
-            mockCopy.data[0].link.customdata[61] = 'linkCustomdata';
+            mockCopy.data[0].link.customdata[61] = ['linkCustomdata0', 'linkCustomdata1'];
 
             Plotly.plot(gd, mockCopy).then(function() {
                 _hover(404, 302);
@@ -840,15 +840,15 @@ describe('sankey tests', function() {
             // Test (node|link).hovertemplate
             .then(function() {
                 return Plotly.restyle(gd, {
-                    'node.hovertemplate': 'hovertemplate<br>%{value}<br>%{value:0.2f}<br>%{customdata}<extra>%{fullData.name}</extra>',
-                    'link.hovertemplate': 'hovertemplate<br>source: %{source.label}<br>target: %{target.label}<br>size: %{value:0.0f}TWh<br>%{customdata}<extra>%{fullData.name}</extra>'
+                    'node.hovertemplate': 'hovertemplate<br>%{value}<br>%{value:0.2f}<br>%{customdata[0]}/%{customdata[1]}<extra>%{fullData.name}</extra>',
+                    'link.hovertemplate': 'hovertemplate<br>source: %{source.label}<br>target: %{target.label}<br>size: %{value:0.0f}TWh<br>%{customdata[1]}<extra>%{fullData.name}</extra>'
                 });
             })
             .then(function() {
                 _hover(404, 302);
 
                 assertLabel(
-                    [ 'hovertemplate', '447TWh', '447.48', 'nodeCustomdata', 'trace 0'],
+                    [ 'hovertemplate', '447TWh', '447.48', 'nodeCustomdata0/nodeCustomdata1', 'trace 0'],
                     ['rgb(148, 103, 189)', 'rgb(255, 255, 255)', 13, 'Arial', 'rgb(255, 255, 255)']
                 );
             })
@@ -856,7 +856,7 @@ describe('sankey tests', function() {
                 _hover(450, 300);
 
                 assertLabel(
-                    ['hovertemplate', 'source: Solid', 'target: Industry', 'size: 46TWh', 'linkCustomdata', 'trace 0'],
+                    ['hovertemplate', 'source: Solid', 'target: Industry', 'size: 46TWh', 'linkCustomdata1', 'trace 0'],
                     ['rgb(0, 0, 96)', 'rgb(255, 255, 255)', 13, 'Arial', 'rgb(255, 255, 255)']
                 );
             })


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/issues/4243 by introducing attributes `node.customdata` and `link.customdata` as suggested in https://github.com/plotly/plotly.js/issues/4243#issuecomment-537563628.