### PR TITLE
fix for spikedistance set to infinity

### DIFF
--- a/src/traces/bar/hover.js
+++ b/src/traces/bar/hover.js
@@ -39,7 +39,6 @@ function hoverOnBars(pointData, xval, yval, hovermode) {
     var isClosest = (hovermode === 'closest');
     var isWaterfall = (trace.type === 'waterfall');
     var maxHoverDistance = pointData.maxHoverDistance;
-    var maxSpikeDistance = pointData.maxSpikeDistance;
 
     var posVal, sizeVal, posLetter, sizeLetter, dx, dy, pRangeCalc;
 
@@ -161,7 +160,7 @@ function hoverOnBars(pointData, xval, yval, hovermode) {
     pointData.valueLabel = hoverLabelText(sa, pointData[sizeLetter + 'LabelVal']);
 
     // spikelines always want "closest" distance regardless of hovermode
-    pointData.spikeDistance = (sizeFn(di) + thisBarPositionFn(di)) / 2 + maxSpikeDistance - maxHoverDistance;
+    pointData.spikeDistance = (sizeFn(di) + thisBarPositionFn(di)) / 2;
     // they also want to point to the data value, regardless of where the label goes
     // in case of bars shifted within groups
     pointData[posLetter + 'Spike'] = pa.c2p(di.p, true);

--- a/test/jasmine/tests/hover_spikeline_test.js
+++ b/test/jasmine/tests/hover_spikeline_test.js
@@ -404,6 +404,33 @@ describe('spikeline hover', function() {
         .then(done);
     });
 
+    it('correctly responds to setting the spikedistance to -1 by increasing ' +
+        'the range of search for points to draw the spikelines to Infinity in a bar trace', function(done) {
+        var _mock = {
+            data: [{type: 'bar', y: [5, 6, 8, 10]}],
+            layout: {xaxis: {showspikes: true}}
+        };
+
+        Plotly.plot(gd, _mock).then(function() {
+            _hover({xval: 0, yval: 2});
+            _assert(
+                [[147.5, 370, 147.5, 241.75]],
+                []
+            );
+
+            _setSpikedistance(-1);
+        })
+        .then(function() {
+            _hover({xval: 0, yval: 2});
+            _assert(
+                [[147.5, 370, 147.5, 241.75]],
+                []
+            );
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
     it('correctly responds to setting the spikedistance to 0 by disabling ' +
         'the search for points to draw the spikelines', function(done) {
         var _mock = makeMock('toaxis', 'closest');


### PR DESCRIPTION
Fixes #4626 and https://github.com/plotly/plotly.js/issues/3805

Commit https://github.com/plotly/plotly.js/commit/9d1325c75c1526caf174f0c4c93504c8c71c8e81 adds a test which fail.

For #4626:
Before: https://codepen.io/antoinerg/pen/BaNYJve
After: https://codepen.io/antoinerg/pen/oNXEENy

For #3805:
Before: https://codepen.io/anon/pen/eoPXJE
After: https://codepen.io/antoinerg/pen/ExjQQYw

cc @archmoj @alexcjohnson @etpinard 