### PR TITLE
Handle NaN positions in funnel & waterfall and skip connectors over rangebreaks 

### DIFF
--- a/src/traces/funnel/plot.js
+++ b/src/traces/funnel/plot.js
@@ -11,6 +11,7 @@
 var d3 = require('d3');
 var Lib = require('../../lib');
 var Drawing = require('../../components/drawing');
+var BADNUM = require('../../constants/numerical').BADNUM;
 var barPlot = require('../bar/plot');
 var clearMinTextSize = require('../bar/uniform_text').clearMinTextSize;
 
@@ -66,13 +67,20 @@ function plotConnectorRegions(gd, plotinfo, cdModule, traceLayer) {
 
             var shape = '';
 
-            if(x[3] !== undefined && y[3] !== undefined) {
+            if(
+                x[0] !== BADNUM && y[0] !== BADNUM &&
+                x[1] !== BADNUM && y[1] !== BADNUM &&
+                x[2] !== BADNUM && y[2] !== BADNUM &&
+                x[3] !== BADNUM && y[3] !== BADNUM
+            ) {
                 if(isHorizontal) {
                     shape += 'M' + x[0] + ',' + y[1] + 'L' + x[2] + ',' + y[2] + 'H' + x[3] + 'L' + x[1] + ',' + y[1] + 'Z';
                 } else {
                     shape += 'M' + x[1] + ',' + y[1] + 'L' + x[2] + ',' + y[3] + 'V' + y[2] + 'L' + x[1] + ',' + y[0] + 'Z';
                 }
             }
+
+            if(shape === '') shape = 'M0,0Z';
 
             Lib.ensureSingle(d3.select(this), 'path')
                 .attr('d', shape)

--- a/src/traces/waterfall/plot.js
+++ b/src/traces/waterfall/plot.js
@@ -11,6 +11,7 @@
 var d3 = require('d3');
 var Lib = require('../../lib');
 var Drawing = require('../../components/drawing');
+var BADNUM = require('../../constants/numerical').BADNUM;
 var barPlot = require('../bar/plot');
 var clearMinTextSize = require('../bar/uniform_text').clearMinTextSize;
 
@@ -66,31 +67,36 @@ function plotConnectors(gd, plotinfo, cdModule, traceLayer) {
 
             var shape = '';
 
-            if(mode === 'spanning') {
-                if(!di.isSum && i > 0) {
-                    if(isHorizontal) {
-                        shape += 'M' + x[0] + ',' + y[1] + 'V' + y[0];
-                    } else {
-                        shape += 'M' + x[1] + ',' + y[0] + 'H' + x[0];
+            if(
+                x[0] !== BADNUM && y[0] !== BADNUM &&
+                x[1] !== BADNUM && y[1] !== BADNUM
+            ) {
+                if(mode === 'spanning') {
+                    if(!di.isSum && i > 0) {
+                        if(isHorizontal) {
+                            shape += 'M' + x[0] + ',' + y[1] + 'V' + y[0];
+                        } else {
+                            shape += 'M' + x[1] + ',' + y[0] + 'H' + x[0];
+                        }
                     }
                 }
-            }
 
-            if(mode !== 'between') {
-                if(di.isSum || i < len - 1) {
-                    if(isHorizontal) {
-                        shape += 'M' + x[1] + ',' + y[0] + 'V' + y[1];
-                    } else {
-                        shape += 'M' + x[0] + ',' + y[1] + 'H' + x[1];
+                if(mode !== 'between') {
+                    if(di.isSum || i < len - 1) {
+                        if(isHorizontal) {
+                            shape += 'M' + x[1] + ',' + y[0] + 'V' + y[1];
+                        } else {
+                            shape += 'M' + x[0] + ',' + y[1] + 'H' + x[1];
+                        }
                     }
                 }
-            }
 
-            if(x[2] !== undefined && y[2] !== undefined) {
-                if(isHorizontal) {
-                    shape += 'M' + x[1] + ',' + y[1] + 'V' + y[2];
-                } else {
-                    shape += 'M' + x[1] + ',' + y[1] + 'H' + x[2];
+                if(x[2] !== BADNUM && y[2] !== BADNUM) {
+                    if(isHorizontal) {
+                        shape += 'M' + x[1] + ',' + y[1] + 'V' + y[2];
+                    } else {
+                        shape += 'M' + x[1] + ',' + y[1] + 'H' + x[2];
+                    }
                 }
             }
 

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -2932,7 +2932,7 @@ describe('bar tweening', function() {
           .then(done);
     });
 
-    it('handle NaN positions on vertical bars', function(done) {
+    it('handle BADNUM positions on vertical bars', function(done) {
         var y1 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         var y2 = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
         var mockCopy = {

--- a/test/jasmine/tests/funnel_test.js
+++ b/test/jasmine/tests/funnel_test.js
@@ -17,6 +17,7 @@ var rgb = color.rgb;
 var customAssertions = require('../assets/custom_assertions');
 var assertHoverLabelContent = customAssertions.assertHoverLabelContent;
 var checkTextTemplate = require('../assets/check_texttemplate');
+var checkTransition = require('../assets/check_transitions');
 var Fx = require('@src/components/fx');
 
 var d3 = require('d3');
@@ -1028,6 +1029,54 @@ describe('A funnel plot', function() {
         })
         .then(function() {
             _assertNumberOfFunnelConnectorNodes(4);
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('handle BADNUM positions', function(done) {
+        var y1 = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+        var y2 = y1; // no transition now
+        var mockCopy = {
+            data: [
+                {
+                    type: 'funnel',
+                    x: [
+                        0,
+                        1,
+                        '',
+                        'NaN',
+                        NaN,
+                        Infinity,
+                        -Infinity,
+                        undefined,
+                        null,
+                        9,
+                        10
+                    ],
+                    y: y1
+                }
+            ],
+            layout: {
+                width: 400,
+                height: 300
+            }
+        };
+
+        var barTests = [
+            [0, '.point path', 'attr', 'd', ['M12,12V108H12V12Z', 'M12,12V108H23V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M23,12V108H120V12Z', 'M120,12V108H228V12Z']]
+        ];
+
+        var connectorTests = [
+            [0, '.regions path', 'attr', 'd', ['M12,108L12,12H23L12,108Z', 'M23,108L120,12H228L120,108Z', 'M0,0Z']]
+        ];
+
+        var animateOpts = {data: [{y: y2}]};
+        var transitionOpts = false; // use default
+
+        checkTransition(gd, mockCopy, animateOpts, transitionOpts, barTests)
+        .then(function() {
+            return checkTransition(gd, mockCopy, animateOpts, transitionOpts, connectorTests);
         })
         .catch(failTest)
         .then(done);

--- a/test/jasmine/tests/funnel_test.js
+++ b/test/jasmine/tests/funnel_test.js
@@ -1035,13 +1035,13 @@ describe('A funnel plot', function() {
     });
 
     it('handle BADNUM positions', function(done) {
-        var y1 = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
-        var y2 = y1; // no transition now
+        var x1 = [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+        var x2 = x1; // no transition now
         var mockCopy = {
             data: [
                 {
                     type: 'funnel',
-                    x: [
+                    y: [
                         0,
                         1,
                         '',
@@ -1054,24 +1054,24 @@ describe('A funnel plot', function() {
                         9,
                         10
                     ],
-                    y: y1
+                    x: x1
                 }
             ],
             layout: {
-                width: 400,
-                height: 300
+                width: 800,
+                height: 600
             }
         };
 
         var barTests = [
-            [0, '.point path', 'attr', 'd', ['M12,12V108H12V12Z', 'M12,12V108H23V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M120,12V108H120V12Z', 'M23,12V108H120V12Z', 'M120,12V108H228V12Z']]
+            [0, '.point path', 'attr', 'd', ['M245,4V34H395V4Z', 'M251,42V73H389V42Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M306,347V378H334V347Z', 'M313,386V416H327V386Z']]
         ];
 
         var connectorTests = [
-            [0, '.regions path', 'attr', 'd', ['M12,108L12,12H23L12,108Z', 'M23,108L120,12H228L120,108Z', 'M0,0Z']]
+            [0, '.regions path', 'attr', 'd', ['M245,34L251,42H389L395,34Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M306,378L313,386H327L334,378Z', 'M0,0Z']]
         ];
 
-        var animateOpts = {data: [{y: y2}]};
+        var animateOpts = {data: [{x: x2}]};
         var transitionOpts = false; // use default
 
         checkTransition(gd, mockCopy, animateOpts, transitionOpts, barTests)

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -17,6 +17,7 @@ var rgb = color.rgb;
 var customAssertions = require('../assets/custom_assertions');
 var assertHoverLabelContent = customAssertions.assertHoverLabelContent;
 var checkTextTemplate = require('../assets/check_texttemplate');
+var checkTransition = require('../assets/check_transitions');
 var Fx = require('@src/components/fx');
 
 var d3 = require('d3');
@@ -972,6 +973,54 @@ describe('A waterfall plot', function() {
         })
         .then(function() {
             _assertNumberOfWaterfallConnectorNodes(4);
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('handle BADNUM positions', function(done) {
+        var y1 = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+        var y2 = y1; // no transition now
+        var mockCopy = {
+            data: [
+                {
+                    type: 'waterfall',
+                    x: [
+                        0,
+                        1,
+                        '',
+                        'NaN',
+                        NaN,
+                        Infinity,
+                        -Infinity,
+                        undefined,
+                        null,
+                        9,
+                        10
+                    ],
+                    y: y1
+                }
+            ],
+            layout: {
+                width: 400,
+                height: 300
+            }
+        };
+
+        var barTests = [
+            [0, '.point path', 'attr', 'd', ['M2,121V109H20V121Z', 'M24,111V98H41V111Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M199,28V15H216V28Z', 'M220,17V5H238V17Z']]
+        ];
+
+        var connectorTests = [
+            [0, '.line path', 'attr', 'd', ['M20,110H24', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M0,0Z', 'M216,16H220', 'M0,0Z']]
+        ];
+
+        var animateOpts = {data: [{y: y2}]};
+        var transitionOpts = false; // use default
+
+        checkTransition(gd, mockCopy, animateOpts, transitionOpts, barTests)
+        .then(function() {
+            return checkTransition(gd, mockCopy, animateOpts, transitionOpts, connectorTests);
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
Follow up of #4614, 
this PR fixes #4631 for `funnel` & `waterfall`.
As well it fixes error in drawing a `connector` over a `rangebreak`.

[Before](https://codepen.io/MojtabaSamimi/pen/GRJGwBR?editors=0010) | [After](https://codepen.io/MojtabaSamimi/pen/OJVErmm?editors=0010).

TODO:
- [x] fix `waterfall` and add test
- [x] fix `funnel` and add test

@plotly/plotly_js 