### PR TITLE
unified hover: honor layout.hoverlabel

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -992,6 +992,7 @@ function createHoverText(hoverData, opts, gd) {
                 title: {text: t0, font: fullLayout.hoverlabel.font},
                 font: fullLayout.hoverlabel.font,
                 bgcolor: fullLayout.hoverlabel.bgcolor || fullLayout.paper_bgcolor,
+                bordercolor: fullLayout.hoverlabel.bordercolor,
                 borderwidth: 1,
                 tracegroupgap: 7,
                 traceorder: fullLayout.legend ? fullLayout.legend.traceorder : undefined,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -989,8 +989,8 @@ function createHoverText(hoverData, opts, gd) {
         var mockLayoutIn = {
             showlegend: true,
             legend: {
-                title: {text: t0, font: fullLayout.font},
-                font: fullLayout.font,
+                title: {text: t0, font: fullLayout.hoverlabel.font},
+                font: fullLayout.hoverlabel.font,
                 bgcolor: fullLayout.hoverlabel.bgcolor,
                 borderwidth: 1,
                 tracegroupgap: 7,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -991,7 +991,7 @@ function createHoverText(hoverData, opts, gd) {
             legend: {
                 title: {text: t0, font: fullLayout.hoverlabel.font},
                 font: fullLayout.hoverlabel.font,
-                bgcolor: fullLayout.hoverlabel.bgcolor,
+                bgcolor: fullLayout.hoverlabel.bgcolor || fullLayout.paper_bgcolor,
                 borderwidth: 1,
                 tracegroupgap: 7,
                 traceorder: fullLayout.legend ? fullLayout.legend.traceorder : undefined,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -991,7 +991,7 @@ function createHoverText(hoverData, opts, gd) {
             legend: {
                 title: {text: t0, font: fullLayout.font},
                 font: fullLayout.font,
-                bgcolor: fullLayout.paper_bgcolor,
+                bgcolor: fullLayout.hoverlabel.bgcolor,
                 borderwidth: 1,
                 tracegroupgap: 7,
                 traceorder: fullLayout.legend ? fullLayout.legend.traceorder : undefined,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -991,7 +991,7 @@ function createHoverText(hoverData, opts, gd) {
             legend: {
                 title: {text: t0, font: fullLayout.hoverlabel.font},
                 font: fullLayout.hoverlabel.font,
-                bgcolor: fullLayout.hoverlabel.bgcolor || fullLayout.paper_bgcolor,
+                bgcolor: fullLayout.hoverlabel.bgcolor,
                 bordercolor: fullLayout.hoverlabel.bordercolor,
                 borderwidth: 1,
                 tracegroupgap: 7,

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -14,17 +14,25 @@ var isUnifiedHover = require('./helpers').isUnifiedHover;
 module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts) {
     opts = opts || {};
 
+    function inheritFontAttr(attr) {
+        if(!opts.font[attr]) {
+            if(contIn.legend && contIn.legend.font && contIn.legend.font[attr]) {
+                opts.font[attr] = contIn.legend.font[attr];
+            } else if(contIn.font && contIn.font[attr]) {
+                opts.font[attr] = contIn.font[attr];
+            }
+        }
+    }
+
     // In unified hover, inherit from legend if available
     if(contIn && isUnifiedHover(contIn.hovermode)) {
-        if(!opts.bgcolor && contIn.legend) opts.bgcolor = contIn.legend.bgcolor;
-        if(!opts.bordercolor && contIn.legend) opts.bordercolor = contIn.legend.bordercolor;
-        // Merge in decreasing order of importance layout.font, layout.legend.font and hoverlabel.font
-
-        var l = contIn.legend;
         if(!opts.font) opts.font = {};
-        if(!opts.font.size) opts.font.size = l && l.size ? l.size : contIn.font.size;
-        if(!opts.font.family) opts.font.family = l && l.family ? l.family : contIn.font.family;
-        if(!opts.font.color) opts.font.color = l && l.color ? l.color : contIn.font.color;
+        inheritFontAttr('size');
+        inheritFontAttr('family');
+        inheritFontAttr('color');
+
+        if(!opts.bgcolor && contIn.legend && contIn.legend.bgcolor) opts.bgcolor = contIn.legend.bgcolor;
+        if(!opts.bordercolor && contIn.legend && contIn.legend.bordercolor) opts.bordercolor = contIn.legend.bordercolor;
     }
 
     coerce('hoverlabel.bgcolor', opts.bgcolor);

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -9,9 +9,14 @@
 'use strict';
 
 var Lib = require('../../lib');
+var isUnifiedHover = require('./helpers').isUnifiedHover;
 
 module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts) {
     opts = opts || {};
+
+    if(contIn && isUnifiedHover(contIn.hovermode)) {
+        opts.bgcolor = contIn.legend ? contIn.legend.bgcolor : contIn.paper_bgcolor;
+    }
 
     coerce('hoverlabel.bgcolor', opts.bgcolor);
     coerce('hoverlabel.bordercolor', opts.bordercolor);

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -17,6 +17,7 @@ module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts
     // In unified hover, inherit from legend if available
     if(contIn && isUnifiedHover(contIn.hovermode)) {
         if(!opts.bgcolor && contIn.legend) opts.bgcolor = contIn.legend.bgcolor;
+        if(!opts.bordercolor && contIn.legend) opts.bordercolor = contIn.legend.bordercolor;
         // Merge in decreasing order of importance layout.font, layout.legend.font and hoverlabel.font
         opts.font = Lib.extendFlat({}, contIn.font, contIn.legend ? contIn.legend.font : {}, opts.font);
     }

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -14,8 +14,9 @@ var isUnifiedHover = require('./helpers').isUnifiedHover;
 module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts) {
     opts = opts || {};
 
+    // In unified hover, inherit from legend if available
     if(contIn && isUnifiedHover(contIn.hovermode)) {
-        if(!opts.bgcolor) opts.bgcolor = contIn.legend ? contIn.legend.bgcolor : contIn.paper_bgcolor;
+        if(!opts.bgcolor && contIn.legend) opts.bgcolor = contIn.legend.bgcolor;
         // Merge in decreasing order of importance layout.font, layout.legend.font and hoverlabel.font
         opts.font = Lib.extendFlat({}, contIn.font, contIn.legend ? contIn.legend.font : {}, opts.font);
     }

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var Lib = require('../../lib');
+var Color = require('../color');
 var isUnifiedHover = require('./helpers').isUnifiedHover;
 
 module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts) {
@@ -28,7 +29,7 @@ module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts
         inheritFontAttr('color');
 
         if(contOut.legend) {
-            if(!opts.bgcolor) opts.bgcolor = contOut.legend.bgcolor;
+            if(!opts.bgcolor) opts.bgcolor = Color.combine(contOut.legend.bgcolor, contOut.paper_bgcolor);
             if(!opts.bordercolor) opts.bordercolor = contOut.legend.bordercolor;
         } else {
             if(!opts.bgcolor) opts.bgcolor = contOut.paper_bgcolor;

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -15,7 +15,9 @@ module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts
     opts = opts || {};
 
     if(contIn && isUnifiedHover(contIn.hovermode)) {
-        opts.bgcolor = contIn.legend ? contIn.legend.bgcolor : contIn.paper_bgcolor;
+        if(!opts.bgcolor) opts.bgcolor = contIn.legend ? contIn.legend.bgcolor : contIn.paper_bgcolor;
+        // Merge in decreasing order of importance layout.font, layout.legend.font and hoverlabel.font
+        opts.font = Lib.extendFlat({}, contIn.font, contIn.legend ? contIn.legend.font : {}, opts.font);
     }
 
     coerce('hoverlabel.bgcolor', opts.bgcolor);

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -19,7 +19,12 @@ module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts
         if(!opts.bgcolor && contIn.legend) opts.bgcolor = contIn.legend.bgcolor;
         if(!opts.bordercolor && contIn.legend) opts.bordercolor = contIn.legend.bordercolor;
         // Merge in decreasing order of importance layout.font, layout.legend.font and hoverlabel.font
-        opts.font = Lib.extendFlat({}, contIn.font, contIn.legend ? contIn.legend.font : {}, opts.font);
+
+        var l = contIn.legend;
+        if(!opts.font) opts.font = {};
+        if(!opts.font.size) opts.font.size = l && l.size ? l.size : contIn.font.size;
+        if(!opts.font.family) opts.font.family = l && l.family ? l.family : contIn.font.family;
+        if(!opts.font.color) opts.font.color = l && l.color ? l.color : contIn.font.color;
     }
 
     coerce('hoverlabel.bgcolor', opts.bgcolor);

--- a/src/components/fx/hoverlabel_defaults.js
+++ b/src/components/fx/hoverlabel_defaults.js
@@ -16,23 +16,23 @@ module.exports = function handleHoverLabelDefaults(contIn, contOut, coerce, opts
 
     function inheritFontAttr(attr) {
         if(!opts.font[attr]) {
-            if(contIn.legend && contIn.legend.font && contIn.legend.font[attr]) {
-                opts.font[attr] = contIn.legend.font[attr];
-            } else if(contIn.font && contIn.font[attr]) {
-                opts.font[attr] = contIn.font[attr];
-            }
+            opts.font[attr] = contOut.legend ? contOut.legend.font[attr] : contOut.font[attr];
         }
     }
 
-    // In unified hover, inherit from legend if available
-    if(contIn && isUnifiedHover(contIn.hovermode)) {
+    // In unified hover, inherit from layout.legend if available or layout
+    if(contOut && isUnifiedHover(contOut.hovermode)) {
         if(!opts.font) opts.font = {};
         inheritFontAttr('size');
         inheritFontAttr('family');
         inheritFontAttr('color');
 
-        if(!opts.bgcolor && contIn.legend && contIn.legend.bgcolor) opts.bgcolor = contIn.legend.bgcolor;
-        if(!opts.bordercolor && contIn.legend && contIn.legend.bordercolor) opts.bordercolor = contIn.legend.bordercolor;
+        if(contOut.legend) {
+            if(!opts.bgcolor) opts.bgcolor = contOut.legend.bgcolor;
+            if(!opts.bordercolor) opts.bordercolor = contOut.legend.bordercolor;
+        } else {
+            if(!opts.bgcolor) opts.bgcolor = contOut.paper_bgcolor;
+        }
     }
 
     coerce('hoverlabel.bgcolor', opts.bgcolor);

--- a/src/components/fx/layout_defaults.js
+++ b/src/components/fx/layout_defaults.js
@@ -12,6 +12,7 @@ var Lib = require('../../lib');
 var isUnifiedHover = require('./helpers').isUnifiedHover;
 var layoutAttributes = require('./layout_attributes');
 var handleHoverModeDefaults = require('./hovermode_defaults');
+var handleHoverLabelDefaults = require('./hoverlabel_defaults');
 
 module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
     function coerce(attr, dflt) {
@@ -40,4 +41,6 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
     )) {
         layoutOut.dragmode = 'pan';
     }
+
+    handleHoverLabelDefaults(layoutIn, layoutOut, coerce);
 };

--- a/src/core.js
+++ b/src/core.js
@@ -42,8 +42,8 @@ register(require('./traces/scatter'));
 
 // register all registrable components modules
 register([
-    require('./components/fx'),
     require('./components/legend'),
+    require('./components/fx'),
     require('./components/annotations'),
     require('./components/annotations3d'),
     require('./components/shapes'),

--- a/src/core.js
+++ b/src/core.js
@@ -43,7 +43,7 @@ register(require('./traces/scatter'));
 // register all registrable components modules
 register([
     require('./components/legend'),
-    require('./components/fx'),
+    require('./components/fx'), // fx needs to come after legend
     require('./components/annotations'),
     require('./components/annotations3d'),
     require('./components/shapes'),

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4014,10 +4014,11 @@ describe('hovermode: (x|y)unified', function() {
         });
     }
 
-    function assertBgcolor(color) {
+    function assertRectColor(color, bordercolor) {
         var hover = getHoverLabel();
         var bg = hover.select('rect.bg');
-        expect(bg.node().style.fill).toBe(color);
+        if(color) expect(bg.node().style.fill).toBe(color);
+        if(bordercolor) expect(bg.node().style.stroke).toBe(bordercolor);
     }
 
     function assertSymbol(exp) {
@@ -4329,7 +4330,7 @@ describe('hovermode: (x|y)unified', function() {
             .then(done);
     });
 
-    it('label should have color of hoverlabel.bgcolor or legend.bgcolor or paper_bgcolor', function(done) {
+    it('label should have bgcolor/bordercolor from hoverlabel or legend or paper_bgcolor', function(done) {
         var mockCopy = Lib.extendDeep({}, mock);
         var bgcolor = [
             'rgb(10, 10, 10)',
@@ -4342,7 +4343,7 @@ describe('hovermode: (x|y)unified', function() {
             .then(function(gd) {
                 _hover(gd, { xval: 3 });
 
-                assertBgcolor('rgb(255, 255, 255)');
+                assertRectColor('rgb(255, 255, 255)', 'rgb(68, 68, 68)');
 
                 // Set paper_bgcolor
                 return Plotly.relayout(gd, 'paper_bgcolor', bgcolor[0]);
@@ -4350,33 +4351,37 @@ describe('hovermode: (x|y)unified', function() {
             .then(function(gd) {
                 _hover(gd, { xval: 3 });
 
-                assertBgcolor(bgcolor[0]);
+                assertRectColor(bgcolor[0]);
 
                 // Set legend.bgcolor which should win over paper_bgcolor
                 return Plotly.relayout(gd, {
                     'showlegend': true,
-                    'legend.bgcolor': bgcolor[1]
+                    'legend.bgcolor': bgcolor[1],
+                    'legend.bordercolor': bgcolor[1]
                 });
             })
             .then(function(gd) {
                 _hover(gd, { xval: 3 });
 
-                assertBgcolor(bgcolor[1]);
+                assertRectColor(bgcolor[1], bgcolor[1]);
 
                 // Set hoverlabel.bgcolor which should win over legend.bgcolor
-                return Plotly.relayout(gd, 'hoverlabel.bgcolor', bgcolor[2]);
+                return Plotly.relayout(gd, {
+                    'hoverlabel.bgcolor': bgcolor[2],
+                    'hoverlabel.bordercolor': bgcolor[2]
+                });
             })
             .then(function(gd) {
                 _hover(gd, { xval: 3 });
 
-                assertBgcolor(bgcolor[2]);
+                assertRectColor(bgcolor[2], bgcolor[2]);
 
                 // Finally, check that a hoverlabel.bgcolor defined in template wins
                 delete mockCopy.layout;
                 mockCopy.layout = {
                     hovermode: 'x unified',
-                    template: { layout: { hoverlabel: { bgcolor: bgcolor[3] } } },
-                    legend: { bgcolor: bgcolor[1] }
+                    template: { layout: { hoverlabel: { bgcolor: bgcolor[3], bordercolor: bgcolor[3] } } },
+                    legend: { bgcolor: bgcolor[1], bordercolor: bgcolor[1] }
                 };
 
                 return Plotly.newPlot(gd, mockCopy);
@@ -4384,7 +4389,7 @@ describe('hovermode: (x|y)unified', function() {
             .then(function(gd) {
                 _hover(gd, { xval: 3 });
 
-                assertBgcolor(bgcolor[3]);
+                assertRectColor(bgcolor[3], bgcolor[3]);
             })
             .catch(failTest)
             .then(done);

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4338,9 +4338,15 @@ describe('hovermode: (x|y)unified', function() {
             'rgb(40, 40, 40)'
         ];
 
-        // Set paper_bgcolor
-        mockCopy.layout.paper_bgcolor = bgcolor[0];
         Plotly.newPlot(gd, mockCopy)
+            .then(function(gd) {
+                _hover(gd, { xval: 3 });
+
+                assertBgcolor('rgb(255, 255, 255)');
+
+                // Set paper_bgcolor
+                return Plotly.relayout(gd, 'paper_bgcolor', bgcolor[0]);
+            })
             .then(function(gd) {
                 _hover(gd, { xval: 3 });
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4376,7 +4376,21 @@ describe('hovermode: (x|y)unified', function() {
 
                 assertRectColor(bgcolor[2], bgcolor[2]);
 
-                // Finally, check that a hoverlabel.bgcolor defined in template wins
+                // Check that a legend.bgcolor defined in template works
+                delete mockCopy.layout;
+                mockCopy.layout = {
+                    hovermode: 'x unified',
+                    template: { layout: { legend: { bgcolor: bgcolor[1], bordercolor: bgcolor[1] } } }
+                };
+
+                return Plotly.newPlot(gd, mockCopy);
+            })
+            .then(function(gd) {
+                _hover(gd, { xval: 3 });
+
+                assertRectColor(bgcolor[1], bgcolor[1]);
+
+                // Check that a hoverlabel.bgcolor defined in template wins
                 delete mockCopy.layout;
                 mockCopy.layout = {
                     hovermode: 'x unified',
@@ -4430,6 +4444,20 @@ describe('hovermode: (x|y)unified', function() {
                 _hover(gd, { xval: 3 });
 
                 assertFont('Arial', '22px', 'rgb(30, 30, 30)');
+
+                // Check that a legend.font defined in template wins
+                delete mockCopy.layout;
+                mockCopy.layout = {
+                    hovermode: 'x unified',
+                    template: { layout: { legend: {font: {size: 5, family: 'Mono', color: 'rgb(5, 5, 5)'}}}},
+                };
+
+                return Plotly.newPlot(gd, mockCopy);
+            })
+            .then(function() {
+                _hover(gd, { xval: 3 });
+
+                assertFont('Mono', '5px', 'rgb(5, 5, 5)');
 
                 // Finally, check that a hoverlabel.font defined in template wins
                 delete mockCopy.layout;


### PR DESCRIPTION
Fixes #4683

TODO
- [x] honor `bordercolor` (https://github.com/plotly/plotly.js/pull/4687/commits/531fe79de9f74bdc4394a38d2fc4b07d807657bf)
- [x] make sure `hoverlabel.bgcolor` is opaque by default (https://github.com/plotly/plotly.js/commit/cc8ca1c3071565a5ad2b3fda1907ebd170b1419b)