### PR TITLE
Disable plotly server URL by default

### DIFF
--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -34,10 +34,10 @@ var configAttributes = {
         valType: 'string',
         dflt: '',
         description: [
-            'When set it determines base URL e.g. \'https://plotly.com\' for',
-            'the \'Edit in Chart Studio\' (aka sendDataToCloud) mode bar button',
+            'When set it determines base URL for',
+            'the \'Edit in Chart Studio\' `showEditInChartStudio`/`showSendToCloud` mode bar button',
             'and the showLink/sendData on-graph link.',
-            'To enable sending your data to Plotly\'s public cloud, you need to',
+            'To enable sending your data to Chart Studio Cloud, you need to',
             'set both `plotlyServerURL` to \'https://chart-studio.plotly.com\' and',
             'also set `showSendToCloud` to true.'
         ].join(' ')
@@ -265,7 +265,7 @@ var configAttributes = {
         dflt: false,
         description: [
             'Should we include a ModeBar button, labeled "Edit in Chart Studio",',
-            'that sends this chart to plotly.com (formerly plot.ly) or another plotly server',
+            'that sends this chart to chart-studio.plotly.com (formerly plot.ly) or another plotly server',
             'as specified by `plotlyServerURL` for editing, export, etc? Prior to version 1.43.0',
             'this button was included by default, now it is opt-in using this flag.',
             'Note that this button can (depending on `plotlyServerURL` being set) send your data',

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -34,8 +34,9 @@ var configAttributes = {
         valType: 'string',
         dflt: '',
         description: [
-            'Sets base URL for the \'Edit in Chart Studio\' (aka sendDataToCloud) mode bar button',
-            'and the showLink/sendData on-graph link'
+            'When set it determines base URL for',
+            'the \'Edit in Chart Studio\' (aka sendDataToCloud) mode bar button',
+            'and the showLink/sendData on-graph link.'
         ].join(' ')
     },
 

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -34,7 +34,7 @@ var configAttributes = {
         valType: 'string',
         dflt: '',
         description: [
-            'When set it determines base URL for',
+            'When set it determines base URL e.g. \'https://plotly.com\' for',
             'the \'Edit in Chart Studio\' (aka sendDataToCloud) mode bar button',
             'and the showLink/sendData on-graph link.'
         ].join(' ')

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -36,7 +36,10 @@ var configAttributes = {
         description: [
             'When set it determines base URL e.g. \'https://plotly.com\' for',
             'the \'Edit in Chart Studio\' (aka sendDataToCloud) mode bar button',
-            'and the showLink/sendData on-graph link.'
+            'and the showLink/sendData on-graph link.',
+            'To enable sending your data to Plotly\'s public cloud, you need to',
+            'set both `plotlyServerURL` to \'https://chart-studio.plotly.com\' and',
+            'also set `showSendToCloud` to true.'
         ].join(' ')
     },
 

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -32,7 +32,7 @@ var configAttributes = {
 
     plotlyServerURL: {
         valType: 'string',
-        dflt: 'https://plot.ly',
+        dflt: '',
         description: [
             'Sets base URL for the \'Edit in Chart Studio\' (aka sendDataToCloud) mode bar button',
             'and the showLink/sendData on-graph link'
@@ -261,10 +261,10 @@ var configAttributes = {
         dflt: false,
         description: [
             'Should we include a ModeBar button, labeled "Edit in Chart Studio",',
-            'that sends this chart to plot.ly or another plotly server as specified',
-            'by `plotlyServerURL` for editing, export, etc? Prior to version 1.43.0',
+            'that sends this chart to plotly.com (formerly plot.ly) or another plotly server',
+            'as specified by `plotlyServerURL` for editing, export, etc? Prior to version 1.43.0',
             'this button was included by default, now it is opt-in using this flag.',
-            'Note that this button can (depending on `plotlyServerURL`) send your data',
+            'Note that this button can (depending on `plotlyServerURL` being set) send your data',
             'to an external server. However that server does not persist your data',
             'until you arrive at the Chart Studio and explicitly click "Save".'
         ].join(' ')

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -215,9 +215,10 @@ function positionPlayWithData(gd, container) {
 }
 
 plots.sendDataToCloud = function(gd) {
-    gd.emit('plotly_beforeexport');
-
     var baseUrl = (window.PLOTLYENV || {}).BASE_URL || gd._context.plotlyServerURL;
+    if(!baseUrl) return;
+
+    gd.emit('plotly_beforeexport');
 
     var hiddenformDiv = d3.select(gd)
         .append('div')

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -509,8 +509,7 @@ describe('config argument', function() {
                 expect(gd._context.plotlyServerURL).toBe('');
 
                 Plotly.Plots.sendDataToCloud(gd);
-                expect(form.action.substring(0, 17)).toBe('http://localhost:');
-                expect(form.method).toBe('post');
+                expect(form).toBe(undefined);
             })
             .catch(failTest)
             .then(done);

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -501,13 +501,30 @@ describe('config argument', function() {
 
         afterEach(destroyGraphDiv);
 
-        it('should default to plotly cloud', function(done) {
+        it('should not default to an external plotly cloud', function(done) {
             Plotly.plot(gd, [], {})
             .then(function() {
-                expect(gd._context.plotlyServerURL).toBe('https://plot.ly');
+                expect(gd._context.plotlyServerURL).not.toBe('https://plot.ly');
+                expect(gd._context.plotlyServerURL).not.toBe('https://plotly.com');
+                expect(gd._context.plotlyServerURL).toBe('');
 
                 Plotly.Plots.sendDataToCloud(gd);
-                expect(form.action).toBe('https://plot.ly/external');
+                expect(form.action.substring(0, 17)).toBe('http://localhost:');
+                expect(form.method).toBe('post');
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
+        it('should be able to connect to plotly cloud when set to https://plotly.com', function(done) {
+            Plotly.plot(gd, [], {}, {
+                plotlyServerURL: 'https://plotly.com'
+            })
+            .then(function() {
+                expect(gd._context.plotlyServerURL).toBe('https://plotly.com');
+
+                Plotly.Plots.sendDataToCloud(gd);
+                expect(form.action).toBe('https://plotly.com/external');
                 expect(form.method).toBe('post');
             })
             .catch(failTest)

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -505,7 +505,7 @@ describe('config argument', function() {
             Plotly.plot(gd, [], {})
             .then(function() {
                 expect(gd._context.plotlyServerURL).not.toBe('https://plot.ly');
-                expect(gd._context.plotlyServerURL).not.toBe('https://plotly.com');
+                expect(gd._context.plotlyServerURL).not.toBe('https://chart-studio.plotly.com');
                 expect(gd._context.plotlyServerURL).toBe('');
 
                 Plotly.Plots.sendDataToCloud(gd);
@@ -515,15 +515,15 @@ describe('config argument', function() {
             .then(done);
         });
 
-        it('should be able to connect to plotly cloud when set to https://plotly.com', function(done) {
+        it('should be able to connect to Chart Studio Cloud when set to https://chart-studio.plotly.com', function(done) {
             Plotly.plot(gd, [], {}, {
-                plotlyServerURL: 'https://plotly.com'
+                plotlyServerURL: 'https://chart-studio.plotly.com'
             })
             .then(function() {
-                expect(gd._context.plotlyServerURL).toBe('https://plotly.com');
+                expect(gd._context.plotlyServerURL).toBe('https://chart-studio.plotly.com');
 
                 Plotly.Plots.sendDataToCloud(gd);
-                expect(form.action).toBe('https://plotly.com/external');
+                expect(form.action).toBe('https://chart-studio.plotly.com/external');
                 expect(form.method).toBe('post');
             })
             .catch(failTest)


### PR DESCRIPTION
Resolves #4689 
This PR changes the default value for `config.plotlyServerURL` option to empty string in https://github.com/plotly/plotly.js/commit/514aef4b444e12cb8cf80c2b0407e2b4802f4558.
Please also note that empty string would be ignored in `Plotly.sendDataToCloud` in https://github.com/plotly/plotly.js/commit/f6611843ecda399cca16f8a81da5d01f72070070,
Therefore in order to `Edit in Chart Studio` (using `modebar` buttons `editInChartStudio` or `sendDataToCloud`) the `config.plotlyServerURL` is required.

@plotly/plotly_js 