### PR TITLE
Deleted "steps" attribute from test/image/mocks/indicator_attrs.json …

### DIFF
--- a/test/image/mocks/indicator_attrs.json
+++ b/test/image/mocks/indicator_attrs.json
@@ -123,19 +123,6 @@
                     "exponentformat": "none",
                     "showexponent": "all"
                 },
-                "steps": {
-                    "color": "red",
-                    "line": {
-                        "color": "blue",
-                        "width": 2
-                    },
-                    "thickness": 0.5,
-                    "range": [
-                        -100,
-                        100
-                    ],
-                    "name": "name"
-                },
                 "threshold": {
                     "line": {
                         "color": "green",


### PR DESCRIPTION
As discussed in issue #4707 @nicolaskruchten indicated the the mock may not be correct. I changed as per the description. @archmoj  may also be interested in checking this change (related #4733).
