### PR TITLE
Print error before calling throw

### DIFF
--- a/tasks/util/common.js
+++ b/tasks/util/common.js
@@ -2,9 +2,14 @@ var fs = require('fs');
 var exec = require('child_process').exec;
 var falafel = require('falafel');
 
+function _throw(err) {
+    console.log(err);
+    throw err;
+}
+
 exports.execCmd = function(cmd, cb, errorCb) {
     cb = cb ? cb : function() {};
-    errorCb = errorCb ? errorCb : function(err) { if(err) throw err; };
+    errorCb = errorCb ? errorCb : function(err) { if(err) _throw(err); };
 
     exec(cmd, function(err) {
         errorCb(err);
@@ -15,7 +20,7 @@ exports.execCmd = function(cmd, cb, errorCb) {
 
 exports.writeFile = function(filePath, content, cb) {
     fs.writeFile(filePath, content, function(err) {
-        if(err) throw err;
+        if(err) _throw(err);
         if(cb) cb();
     });
 };
@@ -63,7 +68,7 @@ exports.touch = function(filePath) {
 };
 
 exports.throwOnError = function(err) {
-    if(err) throw err;
+    if(err) _throw(err);
 };
 
 exports.findModuleList = function(pathToIndex) {


### PR DESCRIPTION
Logging errors in `tasks` & `tests` would make it easier to debug and write new tests.

@plotly/plotly_js