### PR TITLE
bump es6-promise v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3825,9 +3825,9 @@
       }
     },
     "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-set": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "d3-hierarchy": "^1.1.9",
     "d3-interpolate": "^1.4.0",
     "delaunay-triangulate": "^1.1.6",
-    "es6-promise": "^3.0.2",
+    "es6-promise": "^4.2.8",
     "fast-isnumeric": "^1.1.4",
     "gl-cone3d": "^1.5.2",
     "gl-contour2d": "^1.1.7",


### PR DESCRIPTION
Seems we could bump `es6-promise` to v4.
@plotly/plotly_js 
cc: @Marc-Andre-Rivet 