### PR TITLE
Fix Missing WebGL Message  #4765

### DIFF
--- a/src/lib/prepare_regl.js
+++ b/src/lib/prepare_regl.js
@@ -48,7 +48,7 @@ module.exports = function prepareRegl(gd, extensions) {
         } catch(e) {
             success = false;
         }
-        
+
         if(!d.regl) success = false;
 
         if(success) {

--- a/src/lib/prepare_regl.js
+++ b/src/lib/prepare_regl.js
@@ -48,6 +48,8 @@ module.exports = function prepareRegl(gd, extensions) {
         } catch(e) {
             success = false;
         }
+        
+        if(!d.regl) success = false;
 
         if(success) {
             this.addEventListener('webglcontextlost', function(event) {


### PR DESCRIPTION
Fix for https://github.com/plotly/plotly.js/issues/4765
Becuase ```d.regl = createRegl ()``` returns null if webGL is not enabled ,
there fore ``` if(!d.regl) success = false;``` fixes issue

Thanks for your interest in plotly.js!

 
