### PR TITLE
Bump mapbox-gl to 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,29 +48,48 @@
         "commander": "^2.15.1"
       }
     },
-    "@mapbox/geojson-area": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
-      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
-      "requires": {
-        "wgs84": "0.0.0"
-      }
-    },
     "@mapbox/geojson-rewind": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.1.tgz",
-      "integrity": "sha512-mxo2MEr7izA1uOXcDsw99Kgg6xW3P4H2j4n1lmldsgviIelpssvP+jQDivFKOHrOVJDpTTi5oZJvRcHtU9Uufw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.0.tgz",
+      "integrity": "sha512-73l/qJQgj/T/zO1JXVfuVvvKDgikD/7D/rHAD28S9BG1OTstgmftrmqfCx4U+zQAmtsB6HcDA3a7ymdnJZAQgg==",
       "requires": {
-        "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
-        "minimist": "^1.2.5",
-        "sharkdown": "^0.1.0"
+        "concat-stream": "~2.0.0",
+        "minimist": "^1.2.5"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         }
       }
     },
@@ -473,11 +492,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "any-promise": {
       "version": "1.3.0",
@@ -1669,15 +1683,6 @@
       "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
       "requires": {
         "element-size": "^1.1.1"
-      }
-    },
-    "cardinal": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~0.4.0"
       }
     },
     "caseless": {
@@ -7403,32 +7408,32 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.9.1.tgz",
-      "integrity": "sha512-jpBcqh+4qpOkj8RdxRdvwKPA8gzNYyMQ8HOcXgZYuEM5nKevRDjD3cEs+rUxi1JuYj4t8bIk68Lfh7aQQC1MjQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.0.tgz",
+      "integrity": "sha512-SrJXcR9s5yEsPuW2kKKumA1KqYW9RrL8j7ZcIh6glRQ/x3lwNMfwz/UEJAJcVNgeX+fiwzuBoDIdeGB/vSkZLQ==",
       "requires": {
-        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
         "@mapbox/unitbezier": "^0.0.0",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.2",
+        "csscolorparser": "~1.0.3",
         "earcut": "^2.2.2",
         "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.0.0",
+        "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "0.0.8",
+        "minimist": "^1.2.5",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
         "supercluster": "^7.0.0",
-        "tinyqueue": "^2.0.0",
+        "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       },
       "dependencies": {
@@ -7436,11 +7441,6 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
           "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ=="
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -9580,21 +9580,6 @@
         "strip-indent": "^1.0.1"
       }
     },
-    "redeyed": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
-      "requires": {
-        "esprima": "~1.0.4"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-        }
-      }
-    },
     "reduce-simplicial-complex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
@@ -10362,23 +10347,6 @@
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
     },
-    "sharkdown": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
-      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
-      "requires": {
-        "cardinal": "~0.4.2",
-        "minimist": "0.0.5",
-        "split": "~0.2.10"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
-        }
-      }
-    },
     "shasum": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
@@ -10842,14 +10810,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
-    },
-    "split": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "requires": {
-        "through": "2"
-      }
     },
     "split-polygon": {
       "version": "1.0.0",
@@ -13452,11 +13412,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.0.0.tgz",
       "integrity": "sha512-jTZAeJnc6D+yAOjygbJOs33kVQIk5H6fj9SFDOhIKjsf9HiAzL/c+tAJsc8ASWafvhNkH+wJZms47pmajkhatA==",
       "dev": true
-    },
-    "wgs84": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
-      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
     "is-mobile": "^2.2.1",
-    "mapbox-gl": "1.9.1",
+    "mapbox-gl": "1.10.0",
     "matrix-camera-controller": "^2.1.3",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",

--- a/src/plots/mapbox/constants.js
+++ b/src/plots/mapbox/constants.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var requiredVersion = '1.9.1';
+var requiredVersion = '1.10.0';
 
 var stylesNonMapbox = {
     'open-street-map': {


### PR DESCRIPTION
A new `mapbox-gl` minor is out with some improvements and security fixes.
The tests were passed on the CI and locally.
It may be a good idea to upgrade to this version instead of `1.9.1` cc: https://github.com/plotly/plotly.js/pull/4752 in the next minor.

@plotly/plotly_js 