### PR TITLE
Fixup default angle of markers on scattermapbox

### DIFF
--- a/src/traces/scattermapbox/attributes.js
+++ b/src/traces/scattermapbox/attributes.js
@@ -89,11 +89,13 @@ module.exports = overrideAll({
         },
         angle: {
             valType: 'number',
-            dflt: 0,
+            dflt: null,
             role: 'style',
             arrayOk: true,
             description: [
-                'Sets the marker rotation, in degrees clockwise.'
+                'Sets the marker rotation, in degrees clockwise.',
+                'When it is not defined or using null (i.e. default),',
+                'no rotation would be applied in perspective views.'
             ].join(' ')
         },
         allowoverlap: {

--- a/src/traces/scattermapbox/attributes.js
+++ b/src/traces/scattermapbox/attributes.js
@@ -89,13 +89,13 @@ module.exports = overrideAll({
         },
         angle: {
             valType: 'number',
-            dflt: null,
+            dflt: 'auto',
             role: 'style',
             arrayOk: true,
             description: [
-                'Sets the marker rotation, in degrees clockwise.',
-                'When it is not defined or using null (i.e. default),',
-                'no rotation would be applied in perspective views.'
+                'Sets the marker orientation from true North, in degrees clockwise.',
+                'When using the *auto* default, no rotation would be applied',
+                'in perspective views which is different from using a zero angle.'
             ].join(' ')
         },
         allowoverlap: {

--- a/src/traces/scattermapbox/convert.js
+++ b/src/traces/scattermapbox/convert.js
@@ -104,7 +104,7 @@ module.exports = function convert(gd, calcTrace) {
                 'icon-size': trace.marker.size / 10
             });
 
-            if('angle' in trace.marker) {
+            if('angle' in trace.marker && trace.marker.angle !== 'auto') {
                 Lib.extendFlat(symbol.layout, {
                 // unfortunately cant use {angle} do to this issue:
                 // https://github.com/mapbox/mapbox-gl-js/issues/873
@@ -258,7 +258,7 @@ function makeSymbolGeoJSON(calcTrace, gd) {
         getFillFunc(symbol) :
         blankFillFunc;
 
-    var fillAngle = (angle) ?
+    var fillAngle = (angle !== 'auto') ?
         getFillFunc(angle, true) :
         blankFillFunc;
 


### PR DESCRIPTION
The `dflt` for `angle` should be set to `null` not to zero.
Fixes
https://github.com/plotly/plotly.js/pull/4575#issuecomment-622037809

@plotly/plotly_js 
