### PR TITLE
Fix legend title react

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -94,6 +94,8 @@ module.exports = function draw(gd, opts) {
             .text(title.text);
 
         textLayout(titleEl, scrollBox, gd, opts); // handle mathjax or multi-line text and compute title height
+    } else {
+        scrollBox.selectAll('.legendtitletext').remove();
     }
 
     var scrollBar = Lib.ensureSingle(legend, 'rect', 'scrollbar', function(s) {

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -818,6 +818,42 @@ describe('legend relayout update', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('should be able to clear legend title using react', function(done) {
+        var data = [{
+            type: 'scatter',
+            x: [0, 1],
+            y: [1, 0]
+        }];
+
+        Plotly.newPlot(gd, {
+            data: data,
+            layout: {
+                showlegend: true,
+                legend: {
+                    title: {
+                        text: 'legend<br>title'
+                    }
+                }
+            }
+        })
+        .then(function() {
+            expect(d3.selectAll('.legendtitletext')[0].length).toBe(1);
+        })
+        .then(function() {
+            Plotly.react(gd, {
+                data: data,
+                layout: {
+                    showlegend: true
+                }
+            });
+        })
+        .then(function() {
+            expect(d3.selectAll('.legendtitletext')[0].length).toBe(0);
+        })
+        .catch(failTest)
+        .then(done);
+    });
 });
 
 describe('legend orientation change:', function() {


### PR DESCRIPTION
Fixes #4779 | [before](https://codepen.io/MojtabaSamimi/pen/PoPapzd?editors=0010) vs [after](https://codepen.io/MojtabaSamimi/pen/MWaXpjw?editors=1000).

@plotly/plotly_js 