### PR TITLE
bypass non-string ids when matching axes

### DIFF
--- a/src/plots/cartesian/axis_ids.js
+++ b/src/plots/cartesian/axis_ids.js
@@ -31,7 +31,7 @@ exports.name2id = function name2id(name) {
 };
 
 exports.cleanId = function cleanId(id, axLetter) {
-    if(!id.match(constants.AX_ID_PATTERN)) return;
+    if(typeof id !== 'string' || !id.match(constants.AX_ID_PATTERN)) return;
     if(axLetter && id.charAt(0) !== axLetter) return;
 
     var axNum = id.substr(1).replace(/^0+/, '');

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -5576,3 +5576,41 @@ describe('more react tests', function() {
         .then(done);
     });
 });
+
+describe('more matching axes tests', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('should bypass non-string id when matching ids', function(done) {
+        Plotly.newPlot(gd, {
+            data: [{
+                x: [0, 1],
+                y: [0, 1]
+            }, {
+                x: [0, 1],
+                y: [1, 2],
+                yaxis: 'y2'
+            }],
+            layout: {
+                xaxis: {
+                    anchor: 'y'
+                },
+                yaxis: {
+                    anchor: 'x'
+                },
+                yaxis2: {
+                    anchor: [], // bad input
+                    position: 0.1,
+                    overlaying: 'y'
+                }
+            }
+        })
+        .catch(failTest)
+        .then(done);
+    });
+});


### PR DESCRIPTION
Fixes #4844 

@plotly/plotly_js 