### PR TITLE
bump mapbox-gl to v1.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6784,9 +6784,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.0.tgz",
-      "integrity": "sha512-SrJXcR9s5yEsPuW2kKKumA1KqYW9RrL8j7ZcIh6glRQ/x3lwNMfwz/UEJAJcVNgeX+fiwzuBoDIdeGB/vSkZLQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
     "is-mobile": "^2.2.1",
-    "mapbox-gl": "1.10.0",
+    "mapbox-gl": "1.10.1",
     "matrix-camera-controller": "^2.1.3",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",

--- a/src/plots/mapbox/constants.js
+++ b/src/plots/mapbox/constants.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var requiredVersion = '1.10.0';
+var requiredVersion = '1.10.1';
 
 var stylesNonMapbox = {
     'open-street-map': {


### PR DESCRIPTION
The first v1.10 patch fixes https://github.com/mapbox/mapbox-gl-js/releases/tag/v1.10.1

@plotly/plotly_js 