### PR TITLE
bump regl v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9160,9 +9160,9 @@
       }
     },
     "regl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.6.0.tgz",
-      "integrity": "sha512-g5uNq7jx3NZfPWL3jGeQpPset/XHwwW5SK88TY19/3cRHbNMFhEkGd6i3Ea274OyuJwy0YQT7MD3q7Rr0LzzdA=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.6.1.tgz",
+      "integrity": "sha512-7Z9rmpEqmLNwC9kCYCyfyu47eWZaQWeNpwZfwz99QueXN8B/Ow40DB0N+OeUeM/yu9pZAB01+JgJ+XghGveVoA=="
     },
     "regl-error2d": {
       "version": "2.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9160,9 +9160,9 @@
       }
     },
     "regl": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.11.tgz",
-      "integrity": "sha512-tmt6CRhRqbcsYDWNwv+iG7GGOXdgoOBC7lKzoPMgnzpt3WKBQ3c8i7AxgbvTRZzty29hrW92fAJeZkPFQehfWA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.6.0.tgz",
+      "integrity": "sha512-g5uNq7jx3NZfPWL3jGeQpPset/XHwwW5SK88TY19/3cRHbNMFhEkGd6i3Ea274OyuJwy0YQT7MD3q7Rr0LzzdA=="
     },
     "regl-error2d": {
       "version": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "parse-svg-path": "^0.1.2",
     "point-cluster": "^3.1.8",
     "polybooljs": "^1.2.0",
-    "regl": "^1.6.0",
+    "regl": "^1.6.1",
     "regl-error2d": "^2.0.8",
     "regl-line2d": "^3.0.15",
     "regl-scatter2d": "^3.1.8",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "parse-svg-path": "^0.1.2",
     "point-cluster": "^3.1.8",
     "polybooljs": "^1.2.0",
-    "regl": "1.3.11",
+    "regl": "^1.6.0",
     "regl-error2d": "^2.0.8",
     "regl-line2d": "^3.0.15",
     "regl-scatter2d": "^3.1.8",


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/4877 :tada:
Now we could bump `regl` version. 
huge thanks to @rreusser follow ups today, namely:
https://github.com/regl-project/regl/pull/562
https://github.com/regl-project/regl/pull/564
https://github.com/regl-project/regl/issues/565
https://github.com/regl-project/regl/pull/566
https://github.com/regl-project/regl/pull/567

It might be OK to publish this in a patch release; 
if @antoinerg could possibly test it with `orca`.

@plotly/plotly_js 