### PR TITLE
Fix heatmapgl supplyDefaults

### DIFF
--- a/src/traces/heatmap/xyz_defaults.js
+++ b/src/traces/heatmap/xyz_defaults.js
@@ -44,6 +44,8 @@ module.exports = function handleXYZDefaults(traceIn, traceOut, coerce, layout, x
         traceOut._length = null;
     }
 
+    if(traceIn.type === 'heatmapgl') return true; // until we handle calendars for heatmapgl
+
     var handleCalendarDefaults = Registry.getComponentMethod('calendars', 'handleTraceDefaults');
     handleCalendarDefaults(traceIn, traceOut, [xName, yName], layout);
 

--- a/src/traces/heatmapgl/defaults.js
+++ b/src/traces/heatmapgl/defaults.js
@@ -1,0 +1,33 @@
+/**
+* Copyright 2012-2020, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+var Lib = require('../../lib');
+
+var handleXYZDefaults = require('../heatmap/xyz_defaults');
+var colorscaleDefaults = require('../../components/colorscale/defaults');
+var attributes = require('./attributes');
+
+
+module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
+    function coerce(attr, dflt) {
+        return Lib.coerce(traceIn, traceOut, attributes, attr, dflt);
+    }
+
+    var validData = handleXYZDefaults(traceIn, traceOut, coerce, layout);
+    if(!validData) {
+        traceOut.visible = false;
+        return;
+    }
+
+    coerce('text');
+
+    colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: '', cLetter: 'z'});
+};

--- a/src/traces/heatmapgl/index.js
+++ b/src/traces/heatmapgl/index.js
@@ -10,7 +10,7 @@
 
 module.exports = {
     attributes: require('./attributes'),
-    supplyDefaults: require('../heatmap/defaults'),
+    supplyDefaults: require('./defaults'),
     colorbar: require('../heatmap/colorbar'),
 
     calc: require('../heatmap/calc'),

--- a/test/jasmine/tests/heatmapgl_test.js
+++ b/test/jasmine/tests/heatmapgl_test.js
@@ -1,0 +1,99 @@
+var supplyDefaults = require('@src/traces/heatmapgl').supplyDefaults;
+var Plots = require('@src/plots/plots');
+var Plotly = require('@lib/index');
+var schema = Plotly.PlotSchema.get();
+var attributeList = Object.getOwnPropertyNames(schema.traces.heatmapgl.attributes);
+
+describe('heatmapgl supplyDefaults', function() {
+    'use strict';
+
+    var traceIn;
+    var traceOut;
+
+    var defaultColor = '#444';
+    var layout = {
+        font: Plots.layoutAttributes.font,
+        _dfltTitle: {colorbar: 'cb'},
+        _subplots: {cartesian: ['xy'], xaxis: ['x'], yaxis: ['y']}
+    };
+
+    beforeEach(function() {
+        traceOut = {};
+    });
+
+    it('should set visible to false when z is empty', function() {
+        traceIn = {
+            z: []
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).toBe(false);
+
+        traceIn = {
+            z: [[]]
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).toBe(false);
+
+        traceIn = {
+            z: [[], [], []]
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).toBe(false);
+
+        traceIn = {
+            type: 'heatmapgl',
+            z: [[1, 2], []]
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).toBe(false);
+
+        traceIn = {
+            type: 'heatmapgl',
+            z: [[], [1, 2], [1, 2, 3]]
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).toBe(false);
+    });
+
+    it('should set visible to false when z is non-numeric', function() {
+        traceIn = {
+            type: 'heatmapgl',
+            z: [['a', 'b'], ['c', 'd']]
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).toBe(false);
+    });
+
+    it('should set visible to false when z isn\'t column not a 2d array', function() {
+        traceIn = {
+            x: [1, 1, 1, 2, 2],
+            y: [1, 2, 3, 1, 2],
+            z: [1, ['this is considered a column'], 1, 2, 3]
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).not.toBe(false);
+
+        traceIn = {
+            x: [1, 1, 1, 2, 2],
+            y: [1, 2, 3, 1, 2],
+            z: [[0], ['this is not considered a column'], 1, ['nor 2d']]
+        };
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        expect(traceOut.visible).toBe(false);
+    });
+
+    it('should only coerce attributes that are part of scheme', function() {
+        traceIn = {
+            type: 'heatmapgl',
+            z: [[0, 1], [1, 0]]
+        };
+
+        supplyDefaults(traceIn, traceOut, defaultColor, layout);
+        var allKeys = Object.getOwnPropertyNames(traceOut);
+        allKeys.forEach(function(key) {
+            if(key[0] !== '_') {
+                expect(attributeList.indexOf(key)).not.toBe(-1, key);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Fixes #4945.
Attributes namely `zsmooth`, `xgap`, `ygap`, `xcalendar`, `ycalendar`, `zhoverformat, `hoverongaps` and `hovertemplate` used to be get into the `fullData` although they were not part of the `heatmapgl` API at the moment.

@plotly/plotly_js 