### PR TITLE
Fix median transform aggregation

### DIFF
--- a/src/transforms/aggregate.js
+++ b/src/transforms/aggregate.js
@@ -374,7 +374,7 @@ function getAggregateFunction(opts, conversions) {
                     if(vi !== BADNUM) sortCalc.push(vi);
                 }
                 if(!sortCalc.length) return BADNUM;
-                sortCalc.sort();
+                sortCalc.sort(Lib.sorterAsc);
                 var mid = (sortCalc.length - 1) / 2;
                 return c2d((sortCalc[Math.floor(mid)] + sortCalc[Math.ceil(mid)]) / 2);
             };

--- a/test/jasmine/tests/transform_aggregate_test.js
+++ b/test/jasmine/tests/transform_aggregate_test.js
@@ -360,4 +360,28 @@ describe('aggregate', function() {
         .catch(failTest)
         .then(done);
     });
+
+    it('use numeric sort function for median', function() {
+        var subject = ['M', 'M', 'M'];
+        var score = [2, 10, 11];
+
+        var data = [{
+            type: 'scatter',
+            x: subject,
+            y: score,
+            mode: 'markers',
+            transforms: [{
+                type: 'aggregate',
+                groups: subject,
+                aggregations: [
+                    { target: 'y', func: 'median' },
+                ]
+            }]
+        }];
+
+        Plotly.newPlot(gd, data);
+
+        var traceOut = gd._fullData[0];
+        expect(traceOut.y[0]).toBe(10);
+    });
 });


### PR DESCRIPTION
Fixes #4966 by using numeric sort function instaed of default.

@plotly/plotly_js 