### PR TITLE
Relink matching axes categories during Plotly.relayout calls

### DIFF
--- a/src/lib/relink_private.js
+++ b/src/lib/relink_private.js
@@ -25,7 +25,6 @@ module.exports = function relinkPrivateKeys(toContainer, fromContainer) {
         var toVal = toContainer[k];
 
         if(toVal === fromVal) continue;
-        if(toContainer.matches && k === '_categoriesMap') continue;
 
         if(k.charAt(0) === '_' || typeof fromVal === 'function') {
             // if it already exists at this point, it's something

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2712,6 +2712,16 @@ function react(gd, data, layout, config) {
 
         applyUIRevisions(gd.data, gd.layout, oldFullData, oldFullLayout);
 
+        var allNames = Object.getOwnPropertyNames(oldFullLayout);
+        for(var q = 0; q < allNames.length; q++) {
+            var name = allNames[q];
+            var start = name.substring(0, 5);
+            if(start === 'xaxis' || start === 'yaxis') {
+                var emptyCategories = oldFullLayout[name]._emptyCategories;
+                if(emptyCategories) emptyCategories();
+            }
+        }
+
         // "true" skips updating calcdata and remapping arrays from calcTransforms,
         // which supplyDefaults usually does at the end, but we may need to NOT do
         // if the diff (which we haven't determined yet) says we'll recalc

--- a/src/plots/cartesian/set_convert.js
+++ b/src/plots/cartesian/set_convert.js
@@ -870,13 +870,13 @@ module.exports = function setConvert(ax, fullLayout) {
         }
     };
 
+    ax._emptyCategories = function() {
+        ax._categories = [];
+        ax._categoriesMap = {};
+    };
+
     // should skip if not category nor multicategory
     ax.clearCalc = function() {
-        var emptyCategories = function() {
-            ax._categories = [];
-            ax._categoriesMap = {};
-        };
-
         var matchGroups = fullLayout._axisMatchGroups;
 
         if(matchGroups && matchGroups.length) {
@@ -903,14 +903,14 @@ module.exports = function setConvert(ax, fullLayout) {
                         ax._categories = categories;
                         ax._categoriesMap = categoriesMap;
                     } else {
-                        emptyCategories();
+                        ax._emptyCategories();
                     }
                     break;
                 }
             }
-            if(!found) emptyCategories();
+            if(!found) ax._emptyCategories();
         } else {
-            emptyCategories();
+            ax._emptyCategories();
         }
 
         if(ax._initialCategories) {
@@ -924,12 +924,8 @@ module.exports = function setConvert(ax, fullLayout) {
     // returns the indices of the traces affected by the reordering
     ax.sortByInitialCategories = function() {
         var affectedTraces = [];
-        var emptyCategories = function() {
-            ax._categories = [];
-            ax._categoriesMap = {};
-        };
 
-        emptyCategories();
+        ax._emptyCategories();
 
         if(ax._initialCategories) {
             for(var j = 0; j < ax._initialCategories.length; j++) {

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -5580,7 +5580,7 @@ describe('more react tests', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('should sort catgories on matching axes using react', function(done) {
+    it('should sort catgories on matching axes using react and relink using relayout', function(done) {
         var fig = {
             data: [{
                 yaxis: 'y',
@@ -5689,6 +5689,16 @@ describe('more react tests', function() {
         .then(function() {
             // should get the same order with newPlot
             return Plotly.newPlot(gd, fig);
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis._categories).toEqual(['Z', '0', 'A']);
+            expect(gd._fullLayout.xaxis2._categories).toEqual(['Z', '0', 'A']);
+            expect(gd._fullLayout.xaxis._categoriesMap).toEqual({Z: 0, 0: 1, A: 2});
+            expect(gd._fullLayout.xaxis2._categoriesMap).toEqual({Z: 0, 0: 1, A: 2});
+        })
+        .then(function() {
+            // should get the same order with relayout
+            return Plotly.relayout(gd, 'width', 600);
         })
         .then(function() {
             expect(gd._fullLayout.xaxis._categories).toEqual(['Z', '0', 'A']);


### PR DESCRIPTION
Fixes #4971 (side effect of #4832) 
the regression introduced in `v1.54.2` 
i.e. by clearing categories only during `Plotly.react` calls.

@plotly/plotly_js 