### PR TITLE
Bump and control the version of lodash in dev-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6427,9 +6427,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.18",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.18.tgz",
-      "integrity": "sha512-au4L1q0HKcaaa37qOdpWWhwzDnB/taYJfRiKULnaT+Ml9UaBIjJ2SOJMeLtSeeLT+zUdyFMm0+ts+j4eeuUpIA==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.memoize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6427,9 +6427,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.18.tgz",
+      "integrity": "sha512-au4L1q0HKcaaa37qOdpWWhwzDnB/taYJfRiKULnaT+Ml9UaBIjJ2SOJMeLtSeeLT+zUdyFMm0+ts+j4eeuUpIA==",
       "dev": true
     },
     "lodash.memoize": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "karma-spec-reporter": "0.0.32",
     "karma-verbose-reporter": "0.0.6",
     "karma-viewport": "^1.0.6",
+    "lodash": "^4.17.18",
     "madge": "^3.9.2",
     "minify-stream": "^2.0.1",
     "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "karma-spec-reporter": "0.0.32",
     "karma-verbose-reporter": "0.0.6",
     "karma-viewport": "^1.0.6",
-    "lodash": "^4.17.18",
+    "lodash": "^4.17.19",
     "madge": "^3.9.2",
     "minify-stream": "^2.0.1",
     "minimist": "^1.2.5",


### PR DESCRIPTION
Addressing 12 audit warnings https://www.npmjs.com/advisories/1523.

@alexcjohnson 