### PR TITLE
Accept ISO-8601 short time offset format

### DIFF
--- a/src/lib/dates.js
+++ b/src/lib/dates.js
@@ -27,9 +27,9 @@ var Registry = require('../registry');
 
 var utcFormat = d3.time.format.utc;
 
-var DATETIME_REGEXP = /^\s*(-?\d\d\d\d|\d\d)(-(\d?\d)(-(\d?\d)([ Tt]([01]?\d|2[0-3])(:([0-5]\d)(:([0-5]\d(\.\d+)?))?(Z|z|[+\-]\d\d:?\d\d)?)?)?)?)?\s*$/m;
+var DATETIME_REGEXP = /^\s*(-?\d\d\d\d|\d\d)(-(\d?\d)(-(\d?\d)([ Tt]([01]?\d|2[0-3])(:([0-5]\d)(:([0-5]\d(\.\d+)?))?(Z|z|[+\-]\d\d(:?\d\d)?)?)?)?)?)?\s*$/m;
 // special regex for chinese calendars to support yyyy-mmi-dd etc for intercalary months
-var DATETIME_REGEXP_CN = /^\s*(-?\d\d\d\d|\d\d)(-(\d?\di?)(-(\d?\d)([ Tt]([01]?\d|2[0-3])(:([0-5]\d)(:([0-5]\d(\.\d+)?))?(Z|z|[+\-]\d\d:?\d\d)?)?)?)?)?\s*$/m;
+var DATETIME_REGEXP_CN = /^\s*(-?\d\d\d\d|\d\d)(-(\d?\di?)(-(\d?\d)([ Tt]([01]?\d|2[0-3])(:([0-5]\d)(:([0-5]\d(\.\d+)?))?(Z|z|[+\-]\d\d(:?\d\d)?)?)?)?)?)?\s*$/m;
 
 // for 2-digit years, the first year we map them onto
 var YFIRST = new Date().getFullYear() - 70;
@@ -90,8 +90,9 @@ var MIN_MS, MAX_MS;
  *    -?YYYY-mm-dd<sep>HH:MM:SS.sss<tzInfo>?
  *
  * <sep>: space (our normal standard) or T or t (ISO-8601)
- * <tzInfo>: Z, z, or [+\-]HH:?MM and we THROW IT AWAY
+ * <tzInfo>: Z, z, [+\-]HH:?MM or [+\-]HH and we THROW IT AWAY
  * this format comes from https://tools.ietf.org/html/rfc3339#section-5.6
+ * and 4.2.5.1 Difference between local time and UTC of day (ISO-8601)
  * but we allow it even with a space as the separator
  *
  * May truncate after any full field, and sss can be any length

--- a/test/jasmine/tests/lib_date_test.js
+++ b/test/jasmine/tests/lib_date_test.js
@@ -82,6 +82,9 @@ describe('dates', function() {
                 ['2014-03-04 08:15:00.00z', new Date(2014, 2, 4, 8, 15)],
                 ['2014-03-04 08:15:34+1200', new Date(2014, 2, 4, 8, 15, 34)],
                 ['2014-03-04 08:15:34.567-05:45', new Date(2014, 2, 4, 8, 15, 34, 567)],
+
+                // iso8601 short time offset
+                ['2014-03-04T08:15:34-05', new Date(2014, 2, 4, 8, 15, 34)],
             ].forEach(function(v) {
                 // just for sub-millisecond precision tests, use timezoneoffset
                 // from the previous date object
@@ -157,7 +160,7 @@ describe('dates', function() {
                 '2015-01-01 12:60', '2015-01-01 12:-1', '2015-01-01 12:001', '2015-01-01 12:1', // bad minute
                 '2015-01-01 12:00:60', '2015-01-01 12:00:-1', '2015-01-01 12:00:001', '2015-01-01 12:00:1', // bad second
                 '2015-01-01T', '2015-01-01TT12:34', // bad ISO separators
-                '2015-01-01Z', '2015-01-01T12Z', '2015-01-01T12:34Z05:00', '2015-01-01 12:34+500', '2015-01-01 12:34-5:00' // bad TZ info
+                '2015-01-01Z', '2015-01-01T12Z', '2015-01-01T12:34Z05:00', '2015-01-01 12:34+500', '2015-01-01 12:34-5:00', '2015-01-01 12:34+5' // bad TZ info
             ].forEach(function(v) {
                 expect(Lib.dateTime2ms(v)).toBeUndefined(v);
             });


### PR DESCRIPTION
#1194 supports ISO8601 timestamp format.
`lib/dates.js` says it supports the ISO8601 time zone format.
In fact it supports the RFC3339 time offset format, not ISO8601.

time offset format of RFC3339 is:
```
time-numoffset  = ("+" / "-") time-hour ":" time-minute
```
https://tools.ietf.org/html/rfc3339#section-5.6

It always needs minutes.

In contract, ISO8601 time offset format can abbreviate minute if minute is 00.

```
The UTC offset is appended to the time in the same way that 'Z' was above,
in the form ±[hh]:[mm], ±[hh][mm], or ±[hh].
```
https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC

----

I noticed this problem while converting PostgreSQL response into chart.
Plotly.js does not allow the date and time output from PostgreSQL.

Example of datetime string from PostgreSQL: `1997-12-17 07:37:16-08` (minute of time offset is abbreviated)

```
The output format of the date/time types can be set to one of the four styles ISO 8601, SQL (Ingres), traditional POSTGRES (Unix date format), or German. The default is the ISO format.
```
https://www.postgresql.org/docs/12/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT