### PR TITLE
Fix typo in plotinfo keys

### DIFF
--- a/src/plots/cartesian/index.js
+++ b/src/plots/cartesian/index.js
@@ -412,7 +412,7 @@ function makeSubplotData(gd) {
             overlays.push(id);
         } else {
             plotinfo.mainplot = undefined;
-            plotinfo.mainPlotinfo = undefined;
+            plotinfo.mainplotinfo = undefined;
             regulars.push(id);
         }
     }


### PR DESCRIPTION
The key `mainplotinfo` used in other places not `mainPlotinfo`. 
This line was added in #2831.

@plotly/plotly_js 

