### PR TITLE
Bump glslify v7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5146,11 +5146,11 @@
       }
     },
     "glslify": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-      "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.0.tgz",
+      "integrity": "sha512-6NJb9iq+6m4VhYitldiaJs4VB4wPaWNHr+DQ34fTsDVcq+5p9GsKNkJTm91A5IFcpuRQmL5VABEZ0rvB7VEoNQ==",
       "requires": {
-        "bl": "^1.0.0",
+        "bl": "^1.0.1",
         "concat-stream": "^1.5.2",
         "duplexify": "^3.4.5",
         "falafel": "^2.1.0",
@@ -5159,10 +5159,10 @@
         "glsl-token-whitespace-trim": "^1.0.0",
         "glslify-bundle": "^5.0.0",
         "glslify-deps": "^1.2.5",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.5",
         "resolve": "^1.1.5",
         "stack-trace": "0.0.9",
-        "static-eval": "^2.0.0",
+        "static-eval": "^2.0.5",
         "through2": "^2.0.1",
         "xtend": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.5.2",
     "gl-text": "^1.1.8",
-    "glslify": "^7.0.0",
+    "glslify": "^7.1.0",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
     "is-mobile": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "read-last-lines": "^1.7.2",
     "requirejs": "^2.3.6",
     "run-series": "^1.1.8",
-    "static-eval": "^2.0.5",
     "through2": "^4.0.2",
     "true-case-path": "^2.2.1",
     "watchify": "^3.11.1"

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "lodash": "^4.17.20",
     "madge": "^3.9.2",
     "minify-stream": "^2.0.1",
-    "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
     "node-sass": "^4.14.1",
     "npm-link-check": "^4.0.0",


### PR DESCRIPTION
:tada: [glslify](https://www.npmjs.com/package/glslify) v7.1.0 is out with some fixes. 
With this upgrade we don't need to set the versions of `static-eval` and `minimist` sub-modules in the `package.json` file.

For more info please visit following PRs:
https://github.com/glslify/glslify/pull/133
https://github.com/glslify/glslify/pull/134
https://github.com/glslify/glslify/pull/135
https://github.com/glslify/glslify/pull/136
https://github.com/glslify/glslify/pull/137

@plotly/plotly_js 
