### PR TITLE
Add `eng` exponentformat for engineering notation

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1042,7 +1042,7 @@ function autoTickRound(ax) {
 
         var maxend = Math.max(Math.abs(rng[0]), Math.abs(rng[1]));
         var rangeexp = Math.floor(Math.log(maxend) / Math.LN10 + 0.01);
-        if(Math.abs(rangeexp) > 3) {
+        if(Math.abs(rangeexp) > 3 || ax.exponentformat === 'eng') {
             if(isSIFormat(ax.exponentformat) && !beyondSI(rangeexp)) {
                 ax._tickexponent = 3 * Math.round((rangeexp - 1) / 3);
             } else ax._tickexponent = rangeexp;
@@ -1496,7 +1496,7 @@ function num2frac(num) {
 var SIPREFIXES = ['f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T'];
 
 function isSIFormat(exponentFormat) {
-    return exponentFormat === 'SI' || exponentFormat === 'B';
+    return exponentFormat === 'SI' || exponentFormat === 'B' || exponentFormat === 'eng';
 }
 
 // are we beyond the range of common SI prefixes?

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -665,7 +665,7 @@ module.exports = {
     },
     exponentformat: {
         valType: 'enumerated',
-        values: ['none', 'e', 'E', 'power', 'SI', 'B'],
+        values: ['none', 'e', 'E', 'power', 'SI', 'B', 'eng'],
         dflt: 'B',
         role: 'style',
         editType: 'ticks',
@@ -677,7 +677,8 @@ module.exports = {
             'If *E*, 1E+9.',
             'If *power*, 1x10^9 (with 9 in a super script).',
             'If *SI*, 1G.',
-            'If *B*, 1B.'
+            'If *B*, 1B.',
+            '*eng* works like *SI*, except it also uses prefixes for milli- and kilo-.'
         ].join(' ')
     },
     separatethousands: {

--- a/src/traces/carpet/axis_attributes.js
+++ b/src/traces/carpet/axis_attributes.js
@@ -269,7 +269,7 @@ module.exports = {
     },
     exponentformat: {
         valType: 'enumerated',
-        values: ['none', 'e', 'E', 'power', 'SI', 'B'],
+        values: ['none', 'e', 'E', 'power', 'SI', 'B', 'eng'],
         dflt: 'B',
         role: 'style',
         editType: 'calc',
@@ -281,7 +281,8 @@ module.exports = {
             'If *E*, 1E+9.',
             'If *power*, 1x10^9 (with 9 in a super script).',
             'If *SI*, 1G.',
-            'If *B*, 1B.'
+            'If *B*, 1B.',
+            '*eng* works like *SI*, except it also uses prefixes for milli- and kilo-.'
         ].join(' ')
     },
     separatethousands: {


### PR DESCRIPTION
Works just like `SI`, except it uses the kilo prefix for 1000 and uses the milli prefix (which `SI` doesn't).

# Existing `SI`:

![image](https://user-images.githubusercontent.com/408363/91469994-855f1580-e86a-11ea-9ac5-8a1e4410d743.png)
![image](https://user-images.githubusercontent.com/408363/91469928-6d879180-e86a-11ea-9fa2-2f521b04f3a3.png)
![image](https://user-images.githubusercontent.com/408363/91470128-b2abc380-e86a-11ea-80a2-0f31fdc9a196.png)

# New `eng`

![image](https://user-images.githubusercontent.com/408363/91469599-f81bc100-e869-11ea-975a-7d1580abf787.png)
![image](https://user-images.githubusercontent.com/408363/91469813-48931e80-e86a-11ea-9251-28d104c99f6f.png)
![image](https://user-images.githubusercontent.com/408363/91470441-1930e180-e86b-11ea-8db2-0b8e8b4e3587.png)
