### PR TITLE
Allow configuration of horizontal legend max height (ratio || pixel)

### DIFF
--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -29,6 +29,24 @@ module.exports = {
         editType: 'legend',
         description: 'Sets the color of the border enclosing the legend.'
     },
+    hmaxheightratio: {
+        valType: 'number',
+        min: 2,
+        dflt: 2,
+        role: 'style',
+        editType: 'legend',
+        description: [
+	    'Sets the max height ratio (layout / ratio) of the visible legend when horizontaly aligned.',
+	    'Default value is 2; the legend will take up to 50% of the layout height before displaying a scrollbar',
+	].join(' ')
+    },
+    hmaxheight: {
+        valType: 'number',
+        min: 0,
+        role: 'style',
+        editType: 'legend',
+        description: 'Sets the max height (in px) of the horizontaly aligned legend.'
+    },
     borderwidth: {
         valType: 'number',
         min: 0,

--- a/src/components/legend/defaults.js
+++ b/src/components/legend/defaults.js
@@ -121,6 +121,8 @@ module.exports = function legendDefaults(layoutIn, layoutOut, fullData) {
     coerce('xanchor');
     coerce('y', defaultY);
     coerce('yanchor', defaultYAnchor);
+    coerce('hmaxheightratio');
+    coerce('hmaxheight');
     coerce('valign');
     Lib.noneOrAll(containerIn, containerOut, ['x', 'y']);
 

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -602,12 +602,18 @@ function computeLegendDimensions(gd, groups, traces, opts) {
     var isBelowPlotArea = opts.y < 0 || (opts.y === 0 && yanchor === 'top');
     var isAbovePlotArea = opts.y > 1 || (opts.y === 1 && yanchor === 'bottom');
 
-    // - if below/above plot area, give it the maximum potential margin-push value
+    // - if below/above plot area, give it the [user defined] maximum potential margin-push value
     // - otherwise, extend the height of the plot area
-    opts._maxHeight = Math.max(
-        (isBelowPlotArea || isAbovePlotArea) ? fullLayout.height / 2 : gs.h,
-        30
-    );
+    if (isBelowPlotArea || isAbovePlotArea) {
+        if (opts.hmaxheight !== undefined) {
+            opts._maxHeight = opts.hmaxheight;
+        } else { 
+            opts._maxHeight = fullLayout.height / opts.hmaxheightratio; 
+        }
+    }
+    else { 
+        opts._maxHeight = Math.max(gs.h, 30);
+    }
 
     var toggleRectWidth = 0;
     opts._width = 0;


### PR DESCRIPTION
Currently, horizontal legend max height is hardcode to 50% of the full layout height. It's not possible to configure an other behaviour.

https://github.com/plotly/plotly.js/blob/4ac68aa4c4367994743176916dc27419eba6dee6/src/components/legend/draw.js#L607-L610

This PR introduce two new legend properties to allow customization the max height ratio or directly the max height in pixel

```
  hmaxheightratio: {
        valType: 'number',
        min: 2,
        dflt: 2,
        role: 'style',
        editType: 'legend',
        description: [
	    'Sets the max height ratio (layout / ratio) of the visible legend when horizontaly aligned.',
	    'Default value is 2; the legend will take up to 50% of the layout height before displaying a scrollbar',
	].join(' ')
    },
    hmaxheight: {
        valType: 'number',
        min: 0,
        role: 'style',
        editType: 'legend',
        description: 'Sets the max height (in px) of the horizontaly aligned legend.'
    },
```