### PR TITLE
horizontal legend width should be layout width

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -742,6 +742,9 @@ function computeLegendDimensions(gd, groups, traces, opts) {
             opts._titleWidth + 2 * (bw + constants.titlePad)
         )
     );
+    if (!isVertical) {
+        opts._width = gs.w;
+    }
 
     opts._height = Math.ceil(
         Math.max(


### PR DESCRIPTION
Currently, horizontal legend width is set to the width of its longer text. It make the display of the scrollbar a little bit disturbing,

![Capture_hlegend_broken](https://user-images.githubusercontent.com/18233250/91641106-9fdbef00-ea22-11ea-9fb5-e234d45fddf4.PNG)

This PR fix horizontal legend width and set it to the full layout width: 

![Capture_hlegend_fixed](https://user-images.githubusercontent.com/18233250/91641119-a66a6680-ea22-11ea-99d8-606fa0edca34.PNG)

