### PR TITLE
Bump version of bl module in glslify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5164,8 +5164,9 @@
       }
     },
     "glslify": {
-      "version": "git://github.com/glslify/glslify.git#6d2affe0a79abbc8da9f8684ba62e29bf6c5f6ce",
-      "from": "git://github.com/glslify/glslify.git#6d2affe0a79abbc8da9f8684ba62e29bf6c5f6ce",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
       "requires": {
         "bl": "^2.2.1",
         "concat-stream": "^1.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -915,9 +915,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -5164,11 +5164,10 @@
       }
     },
     "glslify": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.0.tgz",
-      "integrity": "sha512-6NJb9iq+6m4VhYitldiaJs4VB4wPaWNHr+DQ34fTsDVcq+5p9GsKNkJTm91A5IFcpuRQmL5VABEZ0rvB7VEoNQ==",
+      "version": "git://github.com/glslify/glslify.git#6d2affe0a79abbc8da9f8684ba62e29bf6c5f6ce",
+      "from": "git://github.com/glslify/glslify.git#6d2affe0a79abbc8da9f8684ba62e29bf6c5f6ce",
       "requires": {
-        "bl": "^1.0.1",
+        "bl": "^2.2.1",
         "concat-stream": "^1.5.2",
         "duplexify": "^3.4.5",
         "falafel": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.5.2",
     "gl-text": "^1.1.8",
-    "glslify": "^7.1.0",
+    "glslify": "git://github.com/glslify/glslify.git#6d2affe0a79abbc8da9f8684ba62e29bf6c5f6ce",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
     "is-mobile": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.5.2",
     "gl-text": "^1.1.8",
-    "glslify": "git://github.com/glslify/glslify.git#6d2affe0a79abbc8da9f8684ba62e29bf6c5f6ce",
+    "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
     "is-mobile": "^2.2.2",


### PR DESCRIPTION
Addressing:
https://github.com/plotly/plotly.js/network/alert/package-lock.json/bl/open
https://github.com/advisories/GHSA-pp7h-53gx-mx7r

By patching `glslify`.

@plotly/plotly_js