### PR TITLE
Bump mapbox-gl v1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6752,9 +6752,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.12.0.tgz",
+      "integrity": "sha512-B3URR4qY9R/Bx+DKqP8qmGCai8IOZYMSZF7ZSvcCZaYTaOYhQQi8ErTEDZtFMOR0ZPj7HFWOkkhl5SqvDfpJpA==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -6776,7 +6776,7 @@
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
+        "supercluster": "^7.1.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       }
@@ -10488,9 +10488,9 @@
       }
     },
     "supercluster": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.0.0.tgz",
-      "integrity": "sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.0.tgz",
+      "integrity": "sha512-LDasImUAFMhTqhK+cUXfy9C2KTUqJ3gucLjmNLNFmKWOnDUBxLFLH9oKuXOTCLveecmxh8fbk8kgh6Q0gsfe2w==",
       "requires": {
         "kdbush": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "has-passive-events": "^1.0.0",
     "image-size": "^0.7.5",
     "is-mobile": "^2.2.2",
-    "mapbox-gl": "1.10.1",
+    "mapbox-gl": "1.12.0",
     "matrix-camera-controller": "^2.1.3",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",

--- a/src/plots/mapbox/constants.js
+++ b/src/plots/mapbox/constants.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var requiredVersion = '1.10.1';
+var requiredVersion = '1.12.0';
 
 var stylesNonMapbox = {
     'open-street-map': {

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -2365,9 +2365,13 @@ describe('Test Plotly.react + interactions under uirevision:', function() {
             expect(gd._fullLayout._preGUI).toEqual({});
         })
         .then(function() { return _drag([200, 200], [250, 250]); })
-        .then(function() { _assertGUI('before'); })
+        .then(
+            gd.on('plotly_relayout', function() { _assertGUI('before'); })
+        )
         .then(_react)
-        .then(function() { _assertGUI('after'); })
+        .then(
+            gd.on('plotly_relayout', function() { _assertGUI('after'); })
+        )
         .catch(failTest)
         .then(done);
     });


### PR DESCRIPTION
Attempt bumping `mapbox-gl` to the latest version that could resolve #4926.

TODO: 
- [ ] figure out why two `noCI` tests are failing locally using `npm run test-jasmine -- mapbox`

@jonmmease this is not urgent at the moment. But it might be nice to be able to upgrade.

cc: @plotly/plotly_js 