### PR TITLE
bump tinycolor2 v1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10854,9 +10854,9 @@
       }
     },
     "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
     },
     "tinyqueue": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "strongly-connected-components": "^1.0.1",
     "superscript-text": "^1.0.0",
     "svg-path-sdf": "^1.1.3",
-    "tinycolor2": "^1.4.1",
+    "tinycolor2": "^1.4.2",
     "to-px": "1.0.1",
     "topojson-client": "^3.1.0",
     "webgl-context": "^2.2.0",


### PR DESCRIPTION
bump `tinycolor2`
@plotly/plotly_js 