### PR TITLE
Align interactions when plot created inside scaled and/or translated elements using CSS transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4840,9 +4840,9 @@
       }
     },
     "gl-mat3": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
-      "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-2.0.0.tgz",
+      "integrity": "sha512-/RfKyizhztkG+gH07lA0/OI9uXVEqDrvjza1U8kZc3Sjvn/iT1a99jyL1WtLzXMn/BYp0geE2/DsNp9GCXp28Q=="
     },
     "gl-mat4": {
       "version": "1.2.0",
@@ -4932,6 +4932,13 @@
         "gl-mat3": "^1.0.0",
         "gl-vec3": "^1.0.3",
         "gl-vec4": "^1.0.0"
+      },
+      "dependencies": {
+        "gl-mat3": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
+          "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+        }
       }
     },
     "gl-scatter3d": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4839,11 +4839,6 @@
         "ndarray": "^1.0.18"
       }
     },
-    "gl-mat3": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-2.0.0.tgz",
-      "integrity": "sha512-/RfKyizhztkG+gH07lA0/OI9uXVEqDrvjza1U8kZc3Sjvn/iT1a99jyL1WtLzXMn/BYp0geE2/DsNp9GCXp28Q=="
-    },
     "gl-mat4": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "gl-error3d": "^1.0.16",
     "gl-heatmap2d": "^1.1.0",
     "gl-line3d": "1.2.1",
+    "gl-mat3": "^2.0.0",
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.3.1",
     "gl-plot2d": "^1.4.5",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "gl-error3d": "^1.0.16",
     "gl-heatmap2d": "^1.1.0",
     "gl-line3d": "1.2.1",
-    "gl-mat3": "^2.0.0",
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.3.1",
     "gl-plot2d": "^1.4.5",

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -194,7 +194,7 @@ exports.loneHover = function loneHover(hoverItems, opts) {
             d.offset -= anchor;
         });
 
-    alignHoverText(hoverLabel, fullOpts.rotateLabels);
+    alignHoverText(hoverLabel, fullOpts.rotateLabels, false);
 
     return multiHover ? hoverLabel : hoverLabel.node();
 };
@@ -723,7 +723,7 @@ function _hover(gd, evt, subplot, noHoverEvent) {
 
     if(!helpers.isUnifiedHover(hovermode)) {
         hoverAvoidOverlaps(hoverLabels, rotateLabels ? 'xa' : 'ya', fullLayout);
-        alignHoverText(hoverLabels, rotateLabels);
+        alignHoverText(hoverLabels, rotateLabels, evt);
     }
 
     // TODO: tagName hack is needed to appease geo.js's hack of using evt.target=true
@@ -1484,7 +1484,12 @@ function hoverAvoidOverlaps(hoverLabels, axKey, fullLayout) {
     }
 }
 
-function alignHoverText(hoverLabels, rotateLabels) {
+function alignHoverText(hoverLabels, rotateLabels, evt) {
+    var scaleX = evt ? evt.inverseTransform[0][0] : 1;
+    var scaleY = evt ? evt.inverseTransform[1][1] : 1;
+    var pX = function(x) { return x * scaleX; };
+    var pY = function(y) { return y * scaleY; };
+
     // finally set the text positioning relative to the data and draw the
     // box around it
     hoverLabels.each(function(d) {
@@ -1513,19 +1518,19 @@ function alignHoverText(hoverLabels, rotateLabels) {
         g.select('path')
             .attr('d', isMiddle ?
             // middle aligned: rect centered on data
-            ('M-' + (d.bx / 2 + d.tx2width / 2) + ',' + (offsetY - d.by / 2) +
-              'h' + d.bx + 'v' + d.by + 'h-' + d.bx + 'Z') :
+            ('M-' + pX(d.bx / 2 + d.tx2width / 2) + ',' + pY(offsetY - d.by / 2) +
+              'h' + pX(d.bx) + 'v' + pY(d.by) + 'h-' + pX(d.bx) + 'Z') :
             // left or right aligned: side rect with arrow to data
-            ('M0,0L' + (horzSign * HOVERARROWSIZE + offsetX) + ',' + (HOVERARROWSIZE + offsetY) +
-                'v' + (d.by / 2 - HOVERARROWSIZE) +
-                'h' + (horzSign * d.bx) +
-                'v-' + d.by +
-                'H' + (horzSign * HOVERARROWSIZE + offsetX) +
-                'V' + (offsetY - HOVERARROWSIZE) +
+            ('M0,0L' + pX(horzSign * HOVERARROWSIZE + offsetX) + ',' + pY(HOVERARROWSIZE + offsetY) +
+                'v' + pY(d.by / 2 - HOVERARROWSIZE) +
+                'h' + pX(horzSign * d.bx) +
+                'v-' + pY(d.by) +
+                'H' + pX(horzSign * HOVERARROWSIZE + offsetX) +
+                'V' + pY(offsetY - HOVERARROWSIZE) +
                 'Z'));
 
-        var posX = txx + offsetX;
-        var posY = offsetY + d.ty0 - d.by / 2 + HOVERTEXTPAD;
+        var posX = pX(offsetX + txx);
+        var posY = pY(offsetY + d.ty0 - d.by / 2 + HOVERTEXTPAD);
         var textAlign = d.textAlign || 'auto';
 
         if(textAlign !== 'auto') {

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1534,8 +1534,8 @@ function alignHoverText(hoverLabels, rotateLabels, evt) {
                 'V' + pY(offsetY - HOVERARROWSIZE) +
                 'Z'));
 
-        var posX = pX(offsetX + txx);
-        var posY = pY(offsetY + d.ty0 - d.by / 2 + HOVERTEXTPAD);
+        var posX = offsetX + txx;
+        var posY = offsetY + d.ty0 - d.by / 2 + HOVERTEXTPAD;
         var textAlign = d.textAlign || 'auto';
 
         if(textAlign !== 'auto') {
@@ -1552,7 +1552,7 @@ function alignHoverText(hoverLabels, rotateLabels, evt) {
             }
         }
 
-        tx.call(svgTextUtils.positionText, posX, posY);
+        tx.call(svgTextUtils.positionText, pX(posX), pY(posY));
 
         if(d.tx2width) {
             g.select('text.name')

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1508,7 +1508,7 @@ function alignHoverText(hoverLabels, rotateLabels, evt) {
         var txx = alignShift * (HOVERARROWSIZE + HOVERTEXTPAD);
         var tx2x = txx + alignShift * (d.txwidth + HOVERTEXTPAD);
         var offsetX = 0;
-        var offsetY = d.offset;
+        var offsetY = pY(d.offset);
 
         var isMiddle = anchor === 'middle';
         if(isMiddle) {

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1485,8 +1485,13 @@ function hoverAvoidOverlaps(hoverLabels, axKey, fullLayout) {
 }
 
 function alignHoverText(hoverLabels, rotateLabels, evt) {
-    var scaleX = evt ? evt.inverseTransform[0][0] : 1;
-    var scaleY = evt ? evt.inverseTransform[1][1] : 1;
+    var scaleX = 1;
+    var scaleY = 1;
+    if(evt) {
+        var m = evt.inverseTransform;
+        scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
+        scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+    }
     var pX = function(x) { return x * scaleX; };
     var pY = function(y) { return y * scaleY; };
 

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -192,7 +192,9 @@ exports.loneHover = function loneHover(hoverItems, opts) {
             d.offset -= anchor;
         });
 
-    alignHoverText(hoverLabel, fullOpts.rotateLabels, opts.gd._fullLayout._inverseTransform);
+    var scaleX = opts.gd._fullLayout._inverseScaleX;
+    var scaleY = opts.gd._fullLayout._inverseScaleY;
+    alignHoverText(hoverLabel, fullOpts.rotateLabels, scaleX, scaleY);
 
     return multiHover ? hoverLabel : hoverLabel.node();
 };
@@ -721,10 +723,8 @@ function _hover(gd, evt, subplot, noHoverEvent) {
 
     if(!helpers.isUnifiedHover(hovermode)) {
         hoverAvoidOverlaps(hoverLabels, rotateLabels ? 'xa' : 'ya', fullLayout);
-        alignHoverText(hoverLabels, rotateLabels, fullLayout._inverseTransform);
-    }
-
-    // TODO: tagName hack is needed to appease geo.js's hack of using evt.target=true
+        alignHoverText(hoverLabels, rotateLabels, fullLayout._inverseScaleX, fullLayout._inverseScaleY);
+    }    // TODO: tagName hack is needed to appease geo.js's hack of using evt.target=true
     // we should improve the "fx" API so other plots can use it without these hack.
     if(evt.target && evt.target.tagName) {
         var hasClickToShow = Registry.getComponentMethod('annotations', 'hasClickToShow')(gd, newhoverdata);
@@ -1482,10 +1482,7 @@ function hoverAvoidOverlaps(hoverLabels, axKey, fullLayout) {
     }
 }
 
-function alignHoverText(hoverLabels, rotateLabels, inverseTransform) {
-    var m = inverseTransform;
-    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
-    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+function alignHoverText(hoverLabels, rotateLabels, scaleX, scaleY) {
     var pX = function(x) { return x * scaleX; };
     var pY = function(y) { return y * scaleY; };
 

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1500,7 +1500,8 @@ function alignHoverText(hoverLabels, rotateLabels) {
         var offsetX = 0;
         var offsetY = d.offset;
 
-        if(anchor === 'middle') {
+        var isMiddle = anchor === 'middle';
+        if(isMiddle) {
             txx -= d.tx2width / 2;
             tx2x += d.txwidth / 2 + HOVERTEXTPAD;
         }
@@ -1509,7 +1510,8 @@ function alignHoverText(hoverLabels, rotateLabels) {
             offsetX = d.offset * YSHIFTX;
         }
 
-        g.select('path').attr('d', anchor === 'middle' ?
+        g.select('path')
+            .attr('d', isMiddle ?
             // middle aligned: rect centered on data
             ('M-' + (d.bx / 2 + d.tx2width / 2) + ',' + (offsetY - d.by / 2) +
               'h' + d.bx + 'v' + d.by + 'h-' + d.bx + 'Z') :
@@ -1529,12 +1531,12 @@ function alignHoverText(hoverLabels, rotateLabels) {
         if(textAlign !== 'auto') {
             if(textAlign === 'left' && anchor !== 'start') {
                 tx.attr('text-anchor', 'start');
-                posX = anchor === 'middle' ?
+                posX = isMiddle ?
                     -d.bx / 2 - d.tx2width / 2 + HOVERTEXTPAD :
                     -d.bx - HOVERTEXTPAD;
             } else if(textAlign === 'right' && anchor !== 'end') {
                 tx.attr('text-anchor', 'end');
-                posX = anchor === 'middle' ?
+                posX = isMiddle ?
                     d.bx / 2 - d.tx2width / 2 - HOVERTEXTPAD :
                     d.bx + HOVERTEXTPAD;
             }

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -72,6 +72,8 @@ var HOVERTEXTPAD = constants.HOVERTEXTPAD;
 exports.hover = function hover(gd, evt, subplot, noHoverEvent) {
     gd = Lib.getGraphDiv(gd);
 
+    evt.inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(evt.target));
+
     Lib.throttle(
         gd._fullLayout._uid + constants.HOVERID,
         constants.HOVERMINTIME,
@@ -335,6 +337,11 @@ function _hover(gd, evt, subplot, noHoverEvent) {
 
             xpx = evt.clientX - dbb.left;
             ypx = evt.clientY - dbb.top;
+
+            var transformedCoords = Lib.apply2DTransform(evt.inverseTransform)(xpx, ypx);
+
+            xpx = transformedCoords[0];
+            ypx = transformedCoords[1];
 
             // in case hover was called from mouseout into hovertext,
             // it's possible you're not actually over the plot anymore

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1557,13 +1557,13 @@ function alignHoverText(hoverLabels, rotateLabels, evt) {
         if(d.tx2width) {
             g.select('text.name')
                 .call(svgTextUtils.positionText,
-                    tx2x + alignShift * HOVERTEXTPAD + offsetX,
-                    offsetY + d.ty0 - d.by / 2 + HOVERTEXTPAD);
+                    pX(tx2x + alignShift * HOVERTEXTPAD + offsetX),
+                    pY(offsetY + d.ty0 - d.by / 2 + HOVERTEXTPAD));
             g.select('rect')
                 .call(Drawing.setRect,
-                    tx2x + (alignShift - 1) * d.tx2width / 2 + offsetX,
-                    offsetY - d.by / 2 - 1,
-                    d.tx2width, d.by + 2);
+                    pX(tx2x + (alignShift - 1) * d.tx2width / 2 + offsetX),
+                    pY(offsetY - d.by / 2 - 1),
+                    pX(d.tx2width), pY(d.by + 2));
         }
     });
 }

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -336,7 +336,7 @@ function _hover(gd, evt, subplot, noHoverEvent) {
             xpx = evt.clientX - dbb.left;
             ypx = evt.clientY - dbb.top;
 
-            var transformedCoords = Lib.apply2DTransform(fullLayout._inverseTransform)(xpx, ypx);
+            var transformedCoords = Lib.apply3DTransform(fullLayout._inverseTransform)(xpx, ypx);
 
             xpx = transformedCoords[0];
             ypx = transformedCoords[1];

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1502,7 +1502,7 @@ function alignHoverText(hoverLabels, rotateLabels, inverseTransform) {
         var txx = alignShift * (HOVERARROWSIZE + HOVERTEXTPAD);
         var tx2x = txx + alignShift * (d.txwidth + HOVERTEXTPAD);
         var offsetX = 0;
-        var offsetY = pY(d.offset);
+        var offsetY = d.offset;
 
         var isMiddle = anchor === 'middle';
         if(isMiddle) {

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -72,10 +72,6 @@ var HOVERTEXTPAD = constants.HOVERTEXTPAD;
 exports.hover = function hover(gd, evt, subplot, noHoverEvent) {
     gd = Lib.getGraphDiv(gd);
 
-    if(gd._inverseTransform === undefined) {
-        gd._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
-    }
-
     Lib.throttle(
         gd._fullLayout._uid + constants.HOVERID,
         constants.HOVERMINTIME,
@@ -196,11 +192,7 @@ exports.loneHover = function loneHover(hoverItems, opts) {
             d.offset -= anchor;
         });
 
-    var gd = opts.gd;
-    if(gd._inverseTransform === undefined) {
-        gd._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
-    }
-    alignHoverText(hoverLabel, fullOpts.rotateLabels, gd._inverseTransform);
+    alignHoverText(hoverLabel, fullOpts.rotateLabels, opts.gd._fullLayout._inverseTransform);
 
     return multiHover ? hoverLabel : hoverLabel.node();
 };
@@ -344,7 +336,7 @@ function _hover(gd, evt, subplot, noHoverEvent) {
             xpx = evt.clientX - dbb.left;
             ypx = evt.clientY - dbb.top;
 
-            var transformedCoords = Lib.apply2DTransform(gd._inverseTransform)(xpx, ypx);
+            var transformedCoords = Lib.apply2DTransform(fullLayout._inverseTransform)(xpx, ypx);
 
             xpx = transformedCoords[0];
             ypx = transformedCoords[1];
@@ -729,7 +721,7 @@ function _hover(gd, evt, subplot, noHoverEvent) {
 
     if(!helpers.isUnifiedHover(hovermode)) {
         hoverAvoidOverlaps(hoverLabels, rotateLabels ? 'xa' : 'ya', fullLayout);
-        alignHoverText(hoverLabels, rotateLabels, gd._inverseTransform);
+        alignHoverText(hoverLabels, rotateLabels, fullLayout._inverseTransform);
     }
 
     // TODO: tagName hack is needed to appease geo.js's hack of using evt.target=true

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -11,6 +11,7 @@
 var d3 = require('d3');
 var loggers = require('./loggers');
 var matrix = require('./matrix');
+var mat4X4 = require('gl-mat4');
 
 /**
  * Allow referencing a graph DOM element either directly
@@ -95,18 +96,20 @@ function deleteRelatedStyleRule(uid) {
 function getFullTransformMatrix(element) {
     var allElements = getElementAndAncestors(element);
     // the identity matrix
-    var transform = [
-        [1, 0, 0],
-        [0, 1, 0],
-        [0, 0, 1]
+    var out = [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
     ];
     allElements.forEach(function(e) {
         var t = getElementTransformMatrix(e);
         if(t) {
-            transform = matrix.dot(transform, matrix.convertCssMatrix(t));
+            var m = matrix.convertCssMatrix(t);
+            out = mat4X4.multiply(out, out, m);
         }
     });
-    return transform;
+    return out;
 }
 
 /**

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -123,12 +123,12 @@ function transformRectToNode(element, rect) {
     ];
     var transformed = at(rectArray);
     return {
-        left: transformed[0],
-        top: transformed[1],
-        right: transformed[2],
-        bottom: transformed[3],
-        width: transformed[2] - transformed[0],
-        height: transformed[3] - transformed[1]
+        l: transformed[0],
+        t: transformed[1],
+        r: transformed[2],
+        b: transformed[3],
+        w: transformed[2] - transformed[0],
+        h: transformed[3] - transformed[1]
     };
 }
 

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -110,29 +110,6 @@ function getFullTransformMatrix(element) {
 }
 
 /**
- * transforms a rect with {left, top, right?, bottom?, width?, height?} according to an element's css transform styles
- */
-function transformRectToNode(element, rect) {
-    var inverse = matrix.inverseTransformMatrix(getFullTransformMatrix(element));
-    var at = matrix.apply2DTransform2(inverse);
-    var rectArray = [
-        rect.left,
-        rect.top,
-        rect.hasOwnProperty('right') ? rect.right : rect.left + rect.width,
-        rect.hasOwnProperty('bottom') ? rect.bottom : rect.top + rect.height
-    ];
-    var transformed = at(rectArray);
-    return {
-        l: transformed[0],
-        t: transformed[1],
-        r: transformed[2],
-        b: transformed[3],
-        w: transformed[2] - transformed[0],
-        h: transformed[3] - transformed[1]
-    };
-}
-
-/**
  * extracts and parses the 2d css style transform matrix from some element
  */
 function getElementTransformMatrix(element) {
@@ -175,5 +152,4 @@ module.exports = {
     getFullTransformMatrix: getFullTransformMatrix,
     getElementTransformMatrix: getElementTransformMatrix,
     getElementAndAncestors: getElementAndAncestors,
-    transformRectToNode: transformRectToNode,
 };

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -93,14 +93,14 @@ function deleteRelatedStyleRule(uid) {
 }
 
 function getFullTransformMatrix(element) {
-    var ancestors = getElementAncestors(element);
+    var allAncestors = getElementAncestors(element);
     // the identity matrix
     var transform = [
         [1, 0, 0],
         [0, 1, 0],
         [0, 0, 1]
     ];
-    ancestors.forEach(function(ancestor) {
+    allAncestors.forEach(function(ancestor) {
         var ancestorTransform = getElementTransformMatrix(ancestor);
         if(ancestorTransform) {
             transform = matrix.dot(transform, matrix.convertCssMatrix(ancestorTransform));
@@ -147,18 +147,18 @@ function getElementTransformMatrix(element) {
 
     if(transform === 'none') return null;
     // the slice is because the transform string returns eg "matrix(0.5, 0, 1, 0, 1, 1)"
-    return transform.slice(7, -1).split(',').map(function(n) {return parseFloat(n);});
+    return transform.slice(7, -1).split(',').map(function(n) {return +n;});
 }
 /**
  * retrieve all DOM elements that are ancestors of the specified one (including itself)
  */
 function getElementAncestors(element) {
-    var elements = [];
+    var allElements = [];
     while(isTransformableElement(element)) {
-        elements.push(element);
+        allElements.push(element);
         element = element.parentElement;
     }
-    return elements;
+    return allElements;
 }
 
 function isTransformableElement(element) {

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -96,27 +96,28 @@ function getFullTransformMatrix(element) {
     var ancestors = getElementAncestors(element);
     // the identity matrix
     var transform = [
-        [1, 0, 0], 
+        [1, 0, 0],
         [0, 1, 0],
         [0, 0, 1]
     ];
-    ancestors.forEach((ancestor) => {
-        var ancestor_transform = getElementTransformMatrix(ancestor);
-        if (ancestor_transform)
-            transform = matrix.dot(transform, matrix.convertCssMatrix(ancestor_transform));
+    ancestors.forEach(function(ancestor) {
+        var ancestorTransform = getElementTransformMatrix(ancestor);
+        if(ancestorTransform) {
+            transform = matrix.dot(transform, matrix.convertCssMatrix(ancestorTransform));
+        }
     });
     return transform;
 }
 
 /**
  * transforms a rect with {left, top, right?, bottom?, width?, height?} according to an element's css transform styles
- */ 
+ */
 function transformRectToNode(element, rect) {
     var inverse = matrix.inverseTransformMatrix(getFullTransformMatrix(element));
     var at = matrix.apply2DTransform2(inverse);
     var rectArray = [
-        rect.left, 
-        rect.top, 
+        rect.left,
+        rect.top,
         rect.hasOwnProperty('right') ? rect.right : rect.left + rect.width,
         rect.hasOwnProperty('bottom') ? rect.bottom : rect.top + rect.height
     ];
@@ -133,27 +134,29 @@ function transformRectToNode(element, rect) {
 
 /**
  * extracts and parses the 2d css style transform matrix from some element
- */ 
+ */
 function getElementTransformMatrix(element) {
-    const style = window.getComputedStyle(element, null);
-    const transform = style.getPropertyValue("-webkit-transform") ||
-      style.getPropertyValue("-moz-transform") ||
-      style.getPropertyValue("-ms-transform") ||
-      style.getPropertyValue("-o-transform") ||
-      style.getPropertyValue("transform");
-    if (transform === 'none')
-        return null;
+    var style = window.getComputedStyle(element, null);
+    var transform = (
+      style.getPropertyValue('-webkit-transform') ||
+      style.getPropertyValue('-moz-transform') ||
+      style.getPropertyValue('-ms-transform') ||
+      style.getPropertyValue('-o-transform') ||
+      style.getPropertyValue('transform')
+    );
+
+    if(transform === 'none') return null;
     // the slice is because the transform string returns eg "matrix(0.5, 0, 1, 0, 1, 1)"
-    return transform.slice(7, -1).split(',').map(n => parseFloat(n));
+    return transform.slice(7, -1).split(',').map(function(n) {return parseFloat(n);});
 }
 /**
  * retrieve all DOM elements that are ancestors of the specified one (including itself)
- */ 
+ */
 function getElementAncestors(element) {
-    const elements = [];
-    while (isTransformableElement(element)) {
-      elements.push(element);
-      element = element.parentElement;
+    var elements = [];
+    while(isTransformableElement(element)) {
+        elements.push(element);
+        element = element.parentElement;
     }
     return elements;
 }

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -133,7 +133,7 @@ function getElementAndAncestors(element) {
     var allElements = [];
     while(isTransformableElement(element)) {
         allElements.push(element);
-        element = element.parentElement;
+        element = element.parentNode;
     }
     return allElements;
 }

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -93,17 +93,17 @@ function deleteRelatedStyleRule(uid) {
 }
 
 function getFullTransformMatrix(element) {
-    var allAncestors = getElementAncestors(element);
+    var allElements = getElementAndAncestors(element);
     // the identity matrix
     var transform = [
         [1, 0, 0],
         [0, 1, 0],
         [0, 0, 1]
     ];
-    allAncestors.forEach(function(ancestor) {
-        var ancestorTransform = getElementTransformMatrix(ancestor);
-        if(ancestorTransform) {
-            transform = matrix.dot(transform, matrix.convertCssMatrix(ancestorTransform));
+    allElements.forEach(function(e) {
+        var t = getElementTransformMatrix(e);
+        if(t) {
+            transform = matrix.dot(transform, matrix.convertCssMatrix(t));
         }
     });
     return transform;
@@ -152,7 +152,7 @@ function getElementTransformMatrix(element) {
 /**
  * retrieve all DOM elements that are ancestors of the specified one (including itself)
  */
-function getElementAncestors(element) {
+function getElementAndAncestors(element) {
     var allElements = [];
     while(isTransformableElement(element)) {
         allElements.push(element);
@@ -174,6 +174,6 @@ module.exports = {
     deleteRelatedStyleRule: deleteRelatedStyleRule,
     getFullTransformMatrix: getFullTransformMatrix,
     getElementTransformMatrix: getElementTransformMatrix,
-    getElementAncestors: getElementAncestors,
+    getElementAndAncestors: getElementAndAncestors,
     transformRectToNode: transformRectToNode,
 };

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -126,8 +126,13 @@ function getElementTransformMatrix(element) {
     );
 
     if(transform === 'none') return null;
-    // the slice is because the transform string returns eg "matrix(0.5, 0, 1, 0, 1, 1)"
-    return transform.slice(7, -1).split(',').map(function(n) {return +n;});
+    // the transform is a string in the form of matrix(a, b, ...) or matrix3d(...)
+    return transform
+        .replace('matrix', '')
+        .replace('3d', '')
+        .slice(1, -1)
+        .split(',')
+        .map(function(n) { return +n; });
 }
 /**
  * retrieve all DOM elements that are ancestors of the specified one (including itself)

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -149,7 +149,7 @@ lib.addRelatedStyleRule = domModule.addRelatedStyleRule;
 lib.deleteRelatedStyleRule = domModule.deleteRelatedStyleRule;
 lib.getFullTransformMatrix = domModule.getFullTransformMatrix;
 lib.getElementTransformMatrix = domModule.getElementTransformMatrix;
-lib.getElementAncestors = domModule.getElementAncestors;
+lib.getElementAndAncestors = domModule.getElementAndAncestors;
 lib.transformRectToNode = domModule.transformRectToNode;
 
 lib.clearResponsive = require('./clear_responsive');

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -90,6 +90,8 @@ lib.rotationMatrix = matrixModule.rotationMatrix;
 lib.rotationXYMatrix = matrixModule.rotationXYMatrix;
 lib.apply2DTransform = matrixModule.apply2DTransform;
 lib.apply2DTransform2 = matrixModule.apply2DTransform2;
+lib.convertCssMatrix = matrixModule.convertCssMatrix;
+lib.inverseTransformMatrix = matrixModule.inverseTransformMatrix;
 
 var anglesModule = require('./angles');
 lib.deg2rad = anglesModule.deg2rad;
@@ -145,6 +147,10 @@ lib.removeElement = domModule.removeElement;
 lib.addStyleRule = domModule.addStyleRule;
 lib.addRelatedStyleRule = domModule.addRelatedStyleRule;
 lib.deleteRelatedStyleRule = domModule.deleteRelatedStyleRule;
+lib.getFullTransformMatrix = domModule.getFullTransformMatrix;
+lib.getElementTransformMatrix = domModule.getElementTransformMatrix;
+lib.getElementAncestors = domModule.getElementAncestors;
+lib.transformRectToNode = domModule.transformRectToNode;
 
 lib.clearResponsive = require('./clear_responsive');
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -150,7 +150,6 @@ lib.deleteRelatedStyleRule = domModule.deleteRelatedStyleRule;
 lib.getFullTransformMatrix = domModule.getFullTransformMatrix;
 lib.getElementTransformMatrix = domModule.getElementTransformMatrix;
 lib.getElementAndAncestors = domModule.getElementAndAncestors;
-lib.transformRectToNode = domModule.transformRectToNode;
 
 lib.clearResponsive = require('./clear_responsive');
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -88,6 +88,7 @@ lib.dot = matrixModule.dot;
 lib.translationMatrix = matrixModule.translationMatrix;
 lib.rotationMatrix = matrixModule.rotationMatrix;
 lib.rotationXYMatrix = matrixModule.rotationXYMatrix;
+lib.apply3DTransform = matrixModule.apply3DTransform;
 lib.apply2DTransform = matrixModule.apply2DTransform;
 lib.apply2DTransform2 = matrixModule.apply2DTransform2;
 lib.convertCssMatrix = matrixModule.convertCssMatrix;

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+var mat3X3 = require('gl-mat3');
 
 exports.init2dArray = function(rowLength, colLength) {
     var array = new Array(rowLength);
@@ -119,17 +120,16 @@ exports.convertCssMatrix = function(m) {
 
 // find the inverse for a 3x3 affine transform matrix
 exports.inverseTransformMatrix = function(m) {
-    var determinant = m[0][0] * m[1][1] - m[1][0] * m[0][1];
-    if(Math.abs(determinant) < Number.EPSILON) {
-        throw new Error('Matrix is singular');
-    }
-
-    var inv = 1.0 / determinant;
-    var invTranslateX = inv * (m[0][1] * m[1][2] - m[1][1] * m[0][2]);
-    var invTranslateY = inv * (m[1][0] * m[0][2] - m[0][0] * m[1][2]);
+    var out = [];
+    mat3X3.invert(out, [
+        m[0][0], m[0][1], m[0][2],
+        m[1][0], m[1][1], m[1][2],
+        m[2][0], m[2][1], m[2][2]
+    ]);
+    mat3X3.transpose(out, out);
     return [
-        [inv * m[1][1], -inv * m[0][1], 0],
-        [-inv * m[1][0], inv * m[0][0], 0],
-        [invTranslateX, invTranslateY, 1]
+        [out[0], out[1], out[2]],
+        [out[3], out[4], out[5]],
+        [out[6], out[7], out[8]]
     ];
 };

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -90,7 +90,7 @@ exports.apply2DTransform = function(transform) {
         var args = arguments;
         if(args.length === 3) {
             args = args[0];
-        }// from map
+        } // from map
         var xy = arguments.length === 1 ? args[0] : [args[0], args[1]];
         return exports.dot(transform, [xy[0], xy[1], 1]).slice(0, 2);
     };
@@ -110,8 +110,8 @@ exports.apply2DTransformToRect = function(transform) {
     var at = exports.apply2DTransform2(transform);
     return function(rect) {
         var rectArray = [
-            rect.left, 
-            rect.top, 
+            rect.left,
+            rect.top,
             rect.hasOwnProperty('right') ? rect.right : rect.left + rect.width,
             rect.hasOwnProperty('bottom') ? rect.bottom : rect.top + rect.height
         ];
@@ -124,25 +124,29 @@ exports.apply2DTransformToRect = function(transform) {
             width: transformed[2] - transformed[0],
             height: transformed[3] - transformed[1]
         };
-    }
-}
+    };
+};
 
 // converts a 2x3 css transform matrix, represented as a length 6 array, to a 3x3 matrix.
 exports.convertCssMatrix = function(m) {
-    if (m.length != 6)
-        throw new Error("Css transform matrix not of length 6");
+    if(m.length !== 6) {
+        throw new Error('Css transform matrix not of length 6');
+    }
+
     return [
-        [m[0],  m[2],   m[4]],
-        [m[1],  m[3],   m[5]],
-        [0,     0,      1   ]
+        [m[0], m[2], m[4]],
+        [m[1], m[3], m[5]],
+        [0, 0, 1]
     ];
-}
+};
 
 // find the inverse for a 3x3 affine transform matrix
 exports.inverseTransformMatrix = function(m) {
-    const determinant = m[0][0] * m[1][1] - m[1][0] * m[0][1];
-    if (Math.abs(determinant) < Number.EPSILON)
-        throw new Error("Matrix is singular");
+    var determinant = m[0][0] * m[1][1] - m[1][0] * m[0][1];
+    if(Math.abs(determinant) < Number.EPSILON) {
+        throw new Error('Matrix is singular');
+    }
+
     var inv = 1.0 / determinant;
     var invTranslateX = inv * (-m[1][1] * m[0][2] + m[0][1] * m[1][2]);
     var invTranslateY = inv * (m[1][0] * m[0][2] + -m[0][0] * m[1][2]);
@@ -151,4 +155,4 @@ exports.inverseTransformMatrix = function(m) {
         [inv * -m[1][0], inv * m[0][0], invTranslateY],
         [0, 0, 1]
     ];
-}
+};

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -107,8 +107,12 @@ exports.apply2DTransform2 = function(transform) {
 
 // converts a 2x3 css transform matrix, represented as a length 6 array, to a 3x3 matrix.
 exports.convertCssMatrix = function(m) {
-    if(m.length !== 6) {
-        throw new Error('Css transform matrix not of length 6');
+    if(!m || m.length !== 6) {
+        return [
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1]
+        ];
     }
 
     return [

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -125,11 +125,11 @@ exports.inverseTransformMatrix = function(m) {
     }
 
     var inv = 1.0 / determinant;
-    var invTranslateX = inv * (-m[1][1] * m[0][2] + m[0][1] * m[1][2]);
-    var invTranslateY = inv * (m[1][0] * m[0][2] + -m[0][0] * m[1][2]);
+    var invTranslateX = inv * (m[0][1] * m[1][2] - m[1][1] * m[0][2]);
+    var invTranslateY = inv * (m[1][0] * m[0][2] - m[0][0] * m[1][2]);
     return [
-        [inv * m[1][1], inv * -m[0][1], invTranslateX],
-        [inv * -m[1][0], inv * m[0][0], invTranslateY],
+        [inv * m[1][1], -inv * m[0][1], invTranslateX],
+        [-inv * m[1][0], inv * m[0][0], invTranslateY],
         [0, 0, 1]
     ];
 };

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -128,8 +128,8 @@ exports.inverseTransformMatrix = function(m) {
     var invTranslateX = inv * (m[0][1] * m[1][2] - m[1][1] * m[0][2]);
     var invTranslateY = inv * (m[1][0] * m[0][2] - m[0][0] * m[1][2]);
     return [
-        [inv * m[1][1], -inv * m[0][1], invTranslateX],
-        [-inv * m[1][0], inv * m[0][0], invTranslateY],
-        [0, 0, 1]
+        [inv * m[1][1], -inv * m[0][1], 0],
+        [-inv * m[1][0], inv * m[0][0], 0],
+        [invTranslateX, invTranslateY, 1]
     ];
 };

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -118,15 +118,7 @@ exports.apply2DTransform2 = function(transform) {
 exports.convertCssMatrix = function(m) {
     if(m) {
         var len = m.length;
-        if(len === 16) {
-            // validate values
-            return [
-                m[0] || 1, m[1] || 0, m[2] || 0, m[3] || 0,
-                m[4] || 0, m[5] || 1, m[6] || 0, m[7] || 0,
-                m[8] || 0, m[9] || 0, m[10] || 1, m[11] || 0,
-                m[12] || 0, m[13] || 0, m[14] || 0, m[15] || 1
-            ];
-        }
+        if(len === 16) return m;
         if(len === 6) {
             // converts a 2x3 css transform matrix to a 4x4 matrix see https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/matrix
             return [

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -104,29 +104,6 @@ exports.apply2DTransform2 = function(transform) {
     };
 };
 
-// applies a 2D transform to something with either the form {left, top, right, bottom}
-// or {left, top, width, height}, and returns it in the same format
-exports.apply2DTransformToRect = function(transform) {
-    var at = exports.apply2DTransform2(transform);
-    return function(rect) {
-        var rectArray = [
-            rect.left,
-            rect.top,
-            rect.hasOwnProperty('right') ? rect.right : rect.left + rect.width,
-            rect.hasOwnProperty('bottom') ? rect.bottom : rect.top + rect.height
-        ];
-        var transformed = at(rectArray);
-        return {
-            left: transformed[0],
-            top: transformed[1],
-            right: transformed[2],
-            bottom: transformed[3],
-            width: transformed[2] - transformed[0],
-            height: transformed[3] - transformed[1]
-        };
-    };
-};
-
 // converts a 2x3 css transform matrix, represented as a length 6 array, to a 3x3 matrix.
 exports.convertCssMatrix = function(m) {
     if(m.length !== 6) {

--- a/src/lib/matrix.js
+++ b/src/lib/matrix.js
@@ -150,9 +150,9 @@ exports.inverseTransformMatrix = function(m) {
     var out = [];
     mat4X4.invert(out, m);
     return [
-        [out[0], out[4], out[8], out[12]],
-        [out[1], out[5], out[9], out[13]],
-        [out[2], out[6], out[10], out[14]],
-        [out[3], out[7], out[11], out[15]],
+        [out[0], out[1], out[2], out[3]],
+        [out[4], out[5], out[6], out[7]],
+        [out[8], out[9], out[10], out[11]],
+        [out[12], out[13], out[14], out[15]]
     ];
 };

--- a/src/lib/svg_text_utils.js
+++ b/src/lib/svg_text_utils.js
@@ -743,9 +743,17 @@ function alignHTMLWith(_base, container, options) {
 
     return function() {
         thisRect = this.node().getBoundingClientRect();
+
+        var x0 = getLeft() - cRect.left;
+        var y0 = getTop() - cRect.top;
+        var gd = options.gd || {};
+        var transformedCoords = Lib.apply3DTransform(gd._fullLayout._inverseTransform)(x0, y0);
+        x0 = transformedCoords[0];
+        y0 = transformedCoords[1];
+
         this.style({
-            top: (getTop() - cRect.top) + 'px',
-            left: (getLeft() - cRect.left) + 'px',
+            top: y0 + 'px',
+            left: x0 + 'px',
             'z-index': 1000
         });
         return this;

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -3715,8 +3715,7 @@ function makePlotFramework(gd) {
     var gd3 = d3.select(gd);
     var fullLayout = gd._fullLayout;
     if(fullLayout._inverseTransform === undefined) {
-        fullLayout._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
-        var m = fullLayout._inverseTransform;
+        var m = fullLayout._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
         fullLayout._inverseScaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]);
         fullLayout._inverseScaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]);
     }

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -3716,6 +3716,9 @@ function makePlotFramework(gd) {
     var fullLayout = gd._fullLayout;
     if(fullLayout._inverseTransform === undefined) {
         fullLayout._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
+        var m = fullLayout._inverseTransform;
+        fullLayout._inverseScaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]);
+        fullLayout._inverseScaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]);
     }
 
     // Plot container

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -3714,6 +3714,9 @@ function purge(gd) {
 function makePlotFramework(gd) {
     var gd3 = d3.select(gd);
     var fullLayout = gd._fullLayout;
+    if(fullLayout._inverseTransform === undefined) {
+        fullLayout._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
+    }
 
     // Plot container
     fullLayout._container = gd3.selectAll('.plot-container').data([0]);

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -327,12 +327,14 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         x0 = startX - dragBBox.left;
         y0 = startY - dragBBox.top;
 
-        e.inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
-        var transformedCoords = Lib.apply2DTransform(e.inverseTransform)(x0, y0);
+        if(gd._inverseTransform === undefined) {
+            gd._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
+        }
+        var transformedCoords = Lib.apply2DTransform(gd._inverseTransform)(x0, y0);
         x0 = transformedCoords[0];
         y0 = transformedCoords[1];
 
-        var m = e.inverseTransform;
+        var m = gd._inverseTransform;
         var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
         var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -164,9 +164,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
         recomputeAxisLists();
 
-        var m = gd._fullLayout._inverseTransform;
-        scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
-        scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+        scaleX = gd._fullLayout._inverseScaleX;
+        scaleY = gd._fullLayout._inverseScaleY;
 
         if(!allFixedRanges) {
             if(isMainDrag) {

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -326,6 +326,12 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         var dragBBox = dragger.getBoundingClientRect();
         x0 = startX - dragBBox.left;
         y0 = startY - dragBBox.top;
+
+        e.inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
+        var transformedCoords = Lib.apply2DTransform(e.inverseTransform)(x0, y0);
+        x0 = transformedCoords[0];
+        y0 = transformedCoords[1];
+
         box = {l: x0, r: x0, w: 0, t: y0, b: y0, h: 0};
         lum = gd._hmpixcount ?
             (gd._hmlumcount / gd._hmpixcount) :

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -327,14 +327,11 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         x0 = startX - dragBBox.left;
         y0 = startY - dragBBox.top;
 
-        if(gd._inverseTransform === undefined) {
-            gd._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
-        }
-        var transformedCoords = Lib.apply2DTransform(gd._inverseTransform)(x0, y0);
+        var transformedCoords = Lib.apply2DTransform(gd._fullLayout._inverseTransform)(x0, y0);
         x0 = transformedCoords[0];
         y0 = transformedCoords[1];
 
-        var m = gd._inverseTransform;
+        var m = gd._fullLayout._inverseTransform;
         var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
         var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -327,13 +327,13 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         x0 = startX - dragBBox.left;
         y0 = startY - dragBBox.top;
 
-        var transformedCoords = Lib.apply2DTransform(gd._fullLayout._inverseTransform)(x0, y0);
+        var transformedCoords = Lib.apply3DTransform(gd._fullLayout._inverseTransform)(x0, y0);
         x0 = transformedCoords[0];
         y0 = transformedCoords[1];
 
         var m = gd._fullLayout._inverseTransform;
-        var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
-        var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+        var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]);
+        var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]);
 
         box = {l: x0, r: x0, w: 0, t: y0, b: y0, h: 0, scaleX: scaleX, scaleY: scaleY};
         lum = gd._hmpixcount ?

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -326,7 +326,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         var dragBBox = dragger.getBoundingClientRect();
         x0 = startX - dragBBox.left;
         y0 = startY - dragBBox.top;
-        box = Lib.transformRectToNode(gd, {left: x0, right: x0, w: 0, top: y0, bottom: y0, height: 0});
+        box = {l: x0, r: x0, w: 0, t: y0, b: y0, h: 0};
         lum = gd._hmpixcount ?
             (gd._hmlumcount / gd._hmpixcount) :
             tinycolor(gd._fullLayout.plot_bgcolor).getLuminance();
@@ -348,17 +348,15 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         var dx = Math.abs(x1 - x0);
         var dy = Math.abs(y1 - y0);
 
-        box.left = Math.min(x0, x1);
-        box.right = Math.max(x0, x1);
-        box.top = Math.min(y0, y1);
-        box.bottom = Math.max(y0, y1);
-
-        box = Lib.transformRectToNode(gd, box);
+        box.l = Math.min(x0, x1);
+        box.r = Math.max(x0, x1);
+        box.t = Math.min(y0, y1);
+        box.b = Math.max(y0, y1);
 
         function noZoom() {
             zoomMode = '';
-            box.right = box.left;
-            box.top = box.bottom;
+            box.r = box.l;
+            box.t = box.b;
             corners.attr('d', 'M0,0Z');
         }
 
@@ -367,12 +365,12 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 zoomMode = 'xy';
                 if(dx / pw > dy / ph) {
                     dy = dx * ph / pw;
-                    if(y0 > y1) box.top = y0 - dy;
-                    else box.bottom = y0 + dy;
+                    if(y0 > y1) box.t = y0 - dy;
+                    else box.b = y0 + dy;
                 } else {
                     dx = dy * pw / ph;
-                    if(x0 > x1) box.left = x0 - dx;
-                    else box.right = x0 + dx;
+                    if(x0 > x1) box.l = x0 - dx;
+                    else box.r = x0 + dx;
                 }
                 corners.attr('d', xyCorners(box));
             } else {
@@ -382,13 +380,13 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             if(dx > MINZOOM || dy > MINZOOM) {
                 zoomMode = 'xy';
 
-                var r0 = Math.min(box.left / pw, (ph - box.bottom) / ph);
-                var r1 = Math.max(box.right / pw, (ph - box.top) / ph);
+                var r0 = Math.min(box.l / pw, (ph - box.b) / ph);
+                var r1 = Math.max(box.r / pw, (ph - box.t) / ph);
 
-                box.left = r0 * pw;
-                box.right = r1 * pw;
-                box.bottom = (1 - r0) * ph;
-                box.top = (1 - r1) * ph;
+                box.l = r0 * pw;
+                box.r = r1 * pw;
+                box.b = (1 - r0) * ph;
+                box.t = (1 - r1) * ph;
                 corners.attr('d', xyCorners(box));
             } else {
                 noZoom();
@@ -400,22 +398,22 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             if(dx < MINDRAG || !xActive) {
                 noZoom();
             } else {
-                box.top = 0;
-                box.bottom = ph;
+                box.t = 0;
+                box.b = ph;
                 zoomMode = 'x';
                 corners.attr('d', xCorners(box, y0));
             }
         } else if(!xActive || dx < Math.min(dy * 0.6, MINZOOM)) {
-            box.left = 0;
-            box.right = pw;
+            box.l = 0;
+            box.r = pw;
             zoomMode = 'y';
             corners.attr('d', yCorners(box, x0));
         } else {
             zoomMode = 'xy';
             corners.attr('d', xyCorners(box));
         }
-        box.width = box.right - box.left;
-        box.height = box.bottom - box.top;
+        box.w = box.r - box.l;
+        box.h = box.b - box.t;
 
         if(zoomMode) zoomDragged = true;
         gd._dragged = zoomDragged;
@@ -431,11 +429,11 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
         // TODO: edit linked axes in zoomAxRanges and in dragTail
         if(zoomMode === 'xy' || zoomMode === 'x') {
-            zoomAxRanges(xaxes, box.left / pw, box.right / pw, updates, links.xaxes);
+            zoomAxRanges(xaxes, box.l / pw, box.r / pw, updates, links.xaxes);
             updateMatchedAxRange('x', updates);
         }
         if(zoomMode === 'xy' || zoomMode === 'y') {
-            zoomAxRanges(yaxes, (ph - box.bottom) / ph, (ph - box.top) / ph, updates, links.yaxes);
+            zoomAxRanges(yaxes, (ph - box.b) / ph, (ph - box.t) / ph, updates, links.yaxes);
             updateMatchedAxRange('y', updates);
         }
     }
@@ -1093,8 +1091,8 @@ function makeCorners(zoomlayer, xs, ys) {
 
 function updateZoombox(zb, corners, box, path0, dimmed, lum) {
     zb.attr('d',
-        path0 + 'M' + (box.left) + ',' + (box.top) + 'v' + (box.height) +
-        'h' + (box.width) + 'v-' + (box.height) + 'h-' + (box.width) + 'Z');
+        path0 + 'M' + (box.l) + ',' + (box.t) + 'v' + (box.h) +
+        'h' + (box.w) + 'v-' + (box.h) + 'h-' + (box.w) + 'Z');
     transitionZoombox(zb, corners, dimmed, lum);
 }
 
@@ -1125,30 +1123,30 @@ function showDoubleClickNotifier(gd) {
 
 function xCorners(box, y0) {
     return 'M' +
-        (box.left - 0.5) + ',' + (y0 - MINZOOM - 0.5) +
+        (box.l - 0.5) + ',' + (y0 - MINZOOM - 0.5) +
         'h-3v' + (2 * MINZOOM + 1) + 'h3ZM' +
-        (box.right + 0.5) + ',' + (y0 - MINZOOM - 0.5) +
+        (box.r + 0.5) + ',' + (y0 - MINZOOM - 0.5) +
         'h3v' + (2 * MINZOOM + 1) + 'h-3Z';
 }
 
 function yCorners(box, x0) {
     return 'M' +
-        (x0 - MINZOOM - 0.5) + ',' + (box.top - 0.5) +
+        (x0 - MINZOOM - 0.5) + ',' + (box.t - 0.5) +
         'v-3h' + (2 * MINZOOM + 1) + 'v3ZM' +
-        (x0 - MINZOOM - 0.5) + ',' + (box.bottom + 0.5) +
+        (x0 - MINZOOM - 0.5) + ',' + (box.b + 0.5) +
         'v3h' + (2 * MINZOOM + 1) + 'v-3Z';
 }
 
 function xyCorners(box) {
-    var clen = Math.floor(Math.min(box.bottom - box.top, box.right - box.left, MINZOOM) / 2);
+    var clen = Math.floor(Math.min(box.b - box.t, box.r - box.l, MINZOOM) / 2);
     return 'M' +
-        (box.left - 3.5) + ',' + (box.top - 0.5 + clen) + 'h3v' + (-clen) +
+        (box.l - 3.5) + ',' + (box.t - 0.5 + clen) + 'h3v' + (-clen) +
             'h' + clen + 'v-3h-' + (clen + 3) + 'ZM' +
-        (box.right + 3.5) + ',' + (box.top - 0.5 + clen) + 'h-3v' + (-clen) +
+        (box.r + 3.5) + ',' + (box.t - 0.5 + clen) + 'h-3v' + (-clen) +
             'h' + (-clen) + 'v-3h' + (clen + 3) + 'ZM' +
-        (box.right + 3.5) + ',' + (box.bottom + 0.5 - clen) + 'h-3v' + clen +
+        (box.r + 3.5) + ',' + (box.b + 0.5 - clen) + 'h-3v' + clen +
             'h' + (-clen) + 'v3h' + (clen + 3) + 'ZM' +
-        (box.left - 3.5) + ',' + (box.bottom + 0.5 - clen) + 'h3v' + clen +
+        (box.l - 3.5) + ',' + (box.b + 0.5 - clen) + 'h3v' + clen +
             'h' + clen + 'v3h-' + (clen + 3) + 'Z';
 }
 

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -90,6 +90,9 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     var hasScatterGl, hasSplom, hasSVG;
     // collected changes to be made to the plot by relayout at the end
     var updates;
+    // scaling factors from css transform
+    var scaleX;
+    var scaleY;
 
     function recomputeAxisLists() {
         xa0 = plotinfo.xaxis;
@@ -160,6 +163,10 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         }
 
         recomputeAxisLists();
+
+        var m = gd._fullLayout._inverseTransform;
+        scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
+        scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
 
         if(!allFixedRanges) {
             if(isMainDrag) {
@@ -331,11 +338,7 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         x0 = transformedCoords[0];
         y0 = transformedCoords[1];
 
-        var m = gd._fullLayout._inverseTransform;
-        var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]);
-        var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]);
-
-        box = {l: x0, r: x0, w: 0, t: y0, b: y0, h: 0, scaleX: scaleX, scaleY: scaleY};
+        box = {l: x0, r: x0, w: 0, t: y0, b: y0, h: 0};
         lum = gd._hmpixcount ?
             (gd._hmlumcount / gd._hmpixcount) :
             tinycolor(gd._fullLayout.plot_bgcolor).getLuminance();
@@ -352,8 +355,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             return false;
         }
 
-        var x1 = Math.max(0, Math.min(pw, box.scaleX * dx0 + x0));
-        var y1 = Math.max(0, Math.min(ph, box.scaleY * dy0 + y0));
+        var x1 = Math.max(0, Math.min(pw, scaleX * dx0 + x0));
+        var y1 = Math.max(0, Math.min(ph, scaleY * dy0 + y0));
         var dx = Math.abs(x1 - x0);
         var dy = Math.abs(y1 - y0);
 
@@ -553,6 +556,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
     // plotDrag: move the plot in response to a drag
     function plotDrag(dx, dy) {
+        dx = dx * scaleX;
+        dy = dy * scaleY;
         // If a transition is in progress, then disable any behavior:
         if(gd._transitioningWithDuration) {
             return;

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -332,7 +332,11 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
         x0 = transformedCoords[0];
         y0 = transformedCoords[1];
 
-        box = {l: x0, r: x0, w: 0, t: y0, b: y0, h: 0};
+        var m = e.inverseTransform;
+        var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
+        var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+
+        box = {l: x0, r: x0, w: 0, t: y0, b: y0, h: 0, scaleX: scaleX, scaleY: scaleY};
         lum = gd._hmpixcount ?
             (gd._hmlumcount / gd._hmpixcount) :
             tinycolor(gd._fullLayout.plot_bgcolor).getLuminance();
@@ -349,8 +353,8 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             return false;
         }
 
-        var x1 = Math.max(0, Math.min(pw, dx0 + x0));
-        var y1 = Math.max(0, Math.min(ph, dy0 + y0));
+        var x1 = Math.max(0, Math.min(pw, box.scaleX * dx0 + x0));
+        var y1 = Math.max(0, Math.min(ph, box.scaleY * dy0 + y0));
         var dx = Math.abs(x1 - x0);
         var dy = Math.abs(y1 - y0);
 

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -71,9 +71,8 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
     var transformedCoords = Lib.apply3DTransform(fullLayout._inverseTransform)(x0, y0);
     x0 = transformedCoords[0];
     y0 = transformedCoords[1];
-    var m = fullLayout._inverseTransform;
-    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]);
-    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]);
+    var scaleX = fullLayout._inverseScaleX;
+    var scaleY = fullLayout._inverseScaleY;
 
     var x1 = x0;
     var y1 = y0;

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -67,6 +67,15 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
     var transform = getTransform(plotinfo);
     var x0 = startX - dragBBox.left;
     var y0 = startY - dragBBox.top;
+
+    e.inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
+    var transformedCoords = Lib.apply2DTransform(e.inverseTransform)(x0, y0);
+    x0 = transformedCoords[0];
+    y0 = transformedCoords[1];
+    var m = e.inverseTransform;
+    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
+    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+
     var x1 = x0;
     var y1 = y0;
     var path0 = 'M' + x0 + ',' + y0;
@@ -156,8 +165,8 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
     }
 
     dragOptions.moveFn = function(dx0, dy0) {
-        x1 = Math.max(0, Math.min(pw, dx0 + x0));
-        y1 = Math.max(0, Math.min(ph, dy0 + y0));
+        x1 = Math.max(0, Math.min(pw, scaleX * dx0 + x0));
+        y1 = Math.max(0, Math.min(ph, scaleY * dy0 + y0));
 
         var dx = Math.abs(x1 - x0);
         var dy = Math.abs(y1 - y0);

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -68,14 +68,10 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
     var x0 = startX - dragBBox.left;
     var y0 = startY - dragBBox.top;
 
-    if(gd._inverseTransform === undefined) {
-        gd._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
-    }
-
-    var transformedCoords = Lib.apply2DTransform(gd._inverseTransform)(x0, y0);
+    var transformedCoords = Lib.apply2DTransform(fullLayout._inverseTransform)(x0, y0);
     x0 = transformedCoords[0];
     y0 = transformedCoords[1];
-    var m = gd._inverseTransform;
+    var m = fullLayout._inverseTransform;
     var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
     var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
 

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -68,12 +68,12 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
     var x0 = startX - dragBBox.left;
     var y0 = startY - dragBBox.top;
 
-    var transformedCoords = Lib.apply2DTransform(fullLayout._inverseTransform)(x0, y0);
+    var transformedCoords = Lib.apply3DTransform(fullLayout._inverseTransform)(x0, y0);
     x0 = transformedCoords[0];
     y0 = transformedCoords[1];
     var m = fullLayout._inverseTransform;
-    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
-    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]);
+    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]);
 
     var x1 = x0;
     var y1 = y0;

--- a/src/plots/cartesian/select.js
+++ b/src/plots/cartesian/select.js
@@ -68,11 +68,14 @@ function prepSelect(e, startX, startY, dragOptions, mode) {
     var x0 = startX - dragBBox.left;
     var y0 = startY - dragBBox.top;
 
-    e.inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
-    var transformedCoords = Lib.apply2DTransform(e.inverseTransform)(x0, y0);
+    if(gd._inverseTransform === undefined) {
+        gd._inverseTransform = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(e.target));
+    }
+
+    var transformedCoords = Lib.apply2DTransform(gd._inverseTransform)(x0, y0);
     x0 = transformedCoords[0];
     y0 = transformedCoords[1];
-    var m = e.inverseTransform;
+    var m = gd._inverseTransform;
     var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
     var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
 

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -296,9 +296,8 @@ proto.render = function() {
     // update size of svg container
     var svgContainer = scene.svgContainer;
     var clientRect = scene.container.getBoundingClientRect();
-    var m = gd._fullLayout._inverseTransform;
-    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
-    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+    var scaleX = gd._fullLayout._inverseScaleX;
+    var scaleY = gd._fullLayout._inverseScaleY;
     var width = clientRect.width * scaleX;
     var height = clientRect.height * scaleY;
     svgContainer.setAttributeNS(null, 'viewBox', '0 0 ' + width + ' ' + height);

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -296,8 +296,11 @@ proto.render = function() {
     // update size of svg container
     var svgContainer = scene.svgContainer;
     var clientRect = scene.container.getBoundingClientRect();
-    var width = clientRect.width;
-    var height = clientRect.height;
+    var m = gd._fullLayout._inverseTransform;
+    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
+    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+    var width = clientRect.width * scaleX;
+    var height = clientRect.height * scaleY;
     svgContainer.setAttributeNS(null, 'viewBox', '0 0 ' + width + ' ' + height);
     svgContainer.setAttributeNS(null, 'width', width);
     svgContainer.setAttributeNS(null, 'height', height);

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -451,14 +451,15 @@ proto.initFx = function(calcData, fullLayout) {
     map.on('mousemove', function(evt) {
         var bb = self.div.getBoundingClientRect();
 
-        // some hackery to get Fx.hover to work
-        evt.clientX = evt.point.x + bb.left;
-        evt.clientY = evt.point.y + bb.top;
-
         evt.target.getBoundingClientRect = function() { return bb; };
 
-        self.xaxis.p2c = function() { return evt.lngLat.lng; };
-        self.yaxis.p2c = function() { return evt.lngLat.lat; };
+        var xy = [
+            evt.originalEvent.offsetX,
+            evt.originalEvent.offsetY
+        ];
+
+        self.xaxis.p2c = function() { return map.unproject(xy).lng; };
+        self.yaxis.p2c = function() { return map.unproject(xy).lat; };
 
         gd._fullLayout._rehover = function() {
             if(gd._fullLayout._hoversubplot === self.id && gd._fullLayout[self.id]) {

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -450,13 +450,12 @@ proto.initFx = function(calcData, fullLayout) {
 
     map.on('mousemove', function(evt) {
         var bb = self.div.getBoundingClientRect();
-
-        evt.target.getBoundingClientRect = function() { return bb; };
-
         var xy = [
             evt.originalEvent.offsetX,
             evt.originalEvent.offsetY
         ];
+
+        evt.target.getBoundingClientRect = function() { return bb; };
 
         self.xaxis.p2c = function() { return map.unproject(xy).lng; };
         self.yaxis.p2c = function() { return map.unproject(xy).lat; };

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -382,14 +382,18 @@ proto.createFramework = function(fullLayout) {
     div.style.position = 'absolute';
     self.container.appendChild(div);
 
+    var gd = self.gd;
+    var scaleX = gd._fullLayout._inverseScaleX;
+    var scaleY = gd._fullLayout._inverseScaleY;
+
     // create mock x/y axes for hover routine
     self.xaxis = {
         _id: 'x',
-        c2p: function(v) { return self.project(v).x; }
+        c2p: function(v) { return self.project(v).x * scaleX; }
     };
     self.yaxis = {
         _id: 'y',
-        c2p: function(v) { return self.project(v).y; }
+        c2p: function(v) { return self.project(v).y * scaleY; }
     };
 
     self.updateFramework(fullLayout);

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -382,18 +382,14 @@ proto.createFramework = function(fullLayout) {
     div.style.position = 'absolute';
     self.container.appendChild(div);
 
-    var gd = self.gd;
-    var scaleX = gd._fullLayout._inverseScaleX;
-    var scaleY = gd._fullLayout._inverseScaleY;
-
     // create mock x/y axes for hover routine
     self.xaxis = {
         _id: 'x',
-        c2p: function(v) { return self.project(v).x * scaleX; }
+        c2p: function(v) { return self.project(v).x; }
     };
     self.yaxis = {
         _id: 'y',
-        c2p: function(v) { return self.project(v).y * scaleY; }
+        c2p: function(v) { return self.project(v).y; }
     };
 
     self.updateFramework(fullLayout);

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -678,9 +678,8 @@ proto.updateMainDrag = function(fullLayout) {
     var chw = constants.cornerHalfWidth;
     var chl = constants.cornerLen / 2;
 
-    var m = gd._fullLayout._inverseTransform;
-    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
-    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+    var scaleX = gd._fullLayout._inverseScaleX;
+    var scaleY = gd._fullLayout._inverseScaleY;
 
     var mainDrag = dragBox.makeDragger(layers, 'path', 'maindrag', 'crosshair');
 

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -1197,6 +1197,9 @@ proto.updateAngularDrag = function(fullLayout) {
         var fullLayoutNow = _this.gd._fullLayout;
         var polarLayoutNow = fullLayoutNow[_this.id];
 
+        dx *= fullLayout._inverseScaleX;
+        dy *= fullLayout._inverseScaleY;
+
         var x1 = x0 + dx;
         var y1 = y0 + dy;
         var a1 = xy2a(x1, y1);
@@ -1291,6 +1294,11 @@ proto.updateAngularDrag = function(fullLayout) {
         var bbox = angularDrag.getBoundingClientRect();
         x0 = startX - bbox.left;
         y0 = startY - bbox.top;
+
+        var transformedCoords = Lib.apply3DTransform(fullLayout._inverseTransform)(x0, y0);
+        x0 = transformedCoords[0];
+        y0 = transformedCoords[1];
+
         a0 = xy2a(x0, y0);
 
         dragOpts.moveFn = moveFn;

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -678,6 +678,10 @@ proto.updateMainDrag = function(fullLayout) {
     var chw = constants.cornerHalfWidth;
     var chl = constants.cornerLen / 2;
 
+    var m = gd._fullLayout._inverseTransform;
+    var scaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1]);
+    var scaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1]);
+
     var mainDrag = dragBox.makeDragger(layers, 'path', 'maindrag', 'crosshair');
 
     d3.select(mainDrag)
@@ -838,10 +842,8 @@ proto.updateMainDrag = function(fullLayout) {
 
     function zoomMove(dx, dy) {
         
-        var inverse = gd._fullLayout._inverseTransform;
-        var transformedDelta = Lib.apply3DTransform(inverse)(dx, dy);
-        dx = transformedDelta[0];
-        dy = transformedDelta[1];
+        dx = dx * scaleX;
+        dy = dy * scaleY;
 
         var x1 = x0 + dx;
         var y1 = y0 + dy;

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -840,7 +840,6 @@ proto.updateMainDrag = function(fullLayout) {
     }
 
     function zoomMove(dx, dy) {
-        
         dx = dx * scaleX;
         dy = dy * scaleY;
 

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -837,8 +837,15 @@ proto.updateMainDrag = function(fullLayout) {
     }
 
     function zoomMove(dx, dy) {
+        
+        var inverse = gd._fullLayout._inverseTransform;
+        var transformedDelta = Lib.apply3DTransform(inverse)(dx, dy);
+        dx = transformedDelta[0];
+        dy = transformedDelta[1];
+
         var x1 = x0 + dx;
         var y1 = y0 + dy;
+
         var rr0 = xy2r(x0, y0);
         var rr1 = Math.min(xy2r(x1, y1), radius);
         var a0 = xy2a(x0, y0);
@@ -934,8 +941,10 @@ proto.updateMainDrag = function(fullLayout) {
         var dragModeNow = gd._fullLayout.dragmode;
 
         var bbox = mainDrag.getBoundingClientRect();
-        x0 = startX - bbox.left;
-        y0 = startY - bbox.top;
+        var inverse = gd._fullLayout._inverseTransform;
+        var transformedCoords = Lib.apply3DTransform(inverse)(startX - bbox.left, startY - bbox.top);
+        x0 = transformedCoords[0];
+        y0 = transformedCoords[1];
 
         // need to offset x/y as bbox center does not
         // match origin for asymmetric polygons

--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -1196,11 +1196,8 @@ proto.updateAngularDrag = function(fullLayout) {
         var fullLayoutNow = _this.gd._fullLayout;
         var polarLayoutNow = fullLayoutNow[_this.id];
 
-        dx *= fullLayout._inverseScaleX;
-        dy *= fullLayout._inverseScaleY;
-
-        var x1 = x0 + dx;
-        var y1 = y0 + dy;
+        var x1 = x0 + dx * fullLayout._inverseScaleX;
+        var y1 = y0 + dy * fullLayout._inverseScaleY;
         var a1 = xy2a(x1, y1);
         var da = rad2deg(a1 - a0);
         rot1 = rot0 + da;

--- a/src/plots/ternary/ternary.js
+++ b/src/plots/ternary/ternary.js
@@ -502,6 +502,8 @@ proto.initInteractions = function() {
     var dragger = _this.layers.plotbg.select('path').node();
     var gd = _this.graphDiv;
     var zoomLayer = gd._fullLayout._zoomlayer;
+    var scaleX;
+    var scaleY;
 
     // use plotbg for the main interactions
     this.dragOptions = {
@@ -519,6 +521,9 @@ proto.initInteractions = function() {
             // is called
             _this.dragOptions.xaxes = [_this.xaxis];
             _this.dragOptions.yaxes = [_this.yaxis];
+
+            scaleX = gd._fullLayout._inverseScaleX;
+            scaleY = gd._fullLayout._inverseScaleY;
 
             var dragModeNow = _this.dragOptions.dragmode = gd._fullLayout.dragmode;
 
@@ -573,8 +578,13 @@ proto.initInteractions = function() {
 
     function zoomPrep(e, startX, startY) {
         var dragBBox = dragger.getBoundingClientRect();
+        var inverse = gd._fullLayout._inverseTransform;
         x0 = startX - dragBBox.left;
         y0 = startY - dragBBox.top;
+        var transformedCoords = Lib.apply3DTransform(inverse)(x0, y0);
+        x0 = transformedCoords[0];
+        y0 = transformedCoords[1];
+
         mins0 = {
             a: _this.aaxis.range[0],
             b: _this.baxis.range[1],
@@ -614,8 +624,8 @@ proto.initInteractions = function() {
     function getCFrac(x, y) { return ((x - (_this.h - y) / Math.sqrt(3)) / _this.w); }
 
     function zoomMove(dx0, dy0) {
-        var x1 = x0 + dx0;
-        var y1 = y0 + dy0;
+        var x1 = x0 + dx0 * scaleX;
+        var y1 = y0 + dy0 * scaleY;
         var afrac = Math.max(0, Math.min(1, getAFrac(x0, y0), getAFrac(x1, y1)));
         var bfrac = Math.max(0, Math.min(1, getBFrac(x0, y0), getBFrac(x1, y1)));
         var cfrac = Math.max(0, Math.min(1, getCFrac(x0, y0), getCFrac(x1, y1)));

--- a/src/traces/choropleth/hover.js
+++ b/src/traces/choropleth/hover.js
@@ -49,7 +49,7 @@ module.exports = function hoverPoints(pointData, xval, yval) {
     pointData.zLabel = Axes.tickText(geo.mockAxis, geo.mockAxis.c2l(pt.z), 'hover').text;
     pointData.hovertemplate = pt.hovertemplate;
 
-    makeHoverInfo(pointData, trace, pt, geo.mockAxis);
+    makeHoverInfo(pointData, trace, pt);
 
     return [pointData];
 };

--- a/src/traces/choropleth/hover.js
+++ b/src/traces/choropleth/hover.js
@@ -19,17 +19,20 @@ module.exports = function hoverPoints(pointData, xval, yval) {
 
     var pt, i, j, isInside;
 
+    var xy = [xval, yval];
+    var altXy = [xval + 360, yval];
+
     for(i = 0; i < cd.length; i++) {
         pt = cd[i];
         isInside = false;
 
         if(pt._polygons) {
             for(j = 0; j < pt._polygons.length; j++) {
-                if(pt._polygons[j].contains([xval, yval])) {
+                if(pt._polygons[j].contains(xy)) {
                     isInside = !isInside;
                 }
                 // for polygons that cross antimeridian as xval is in [-180, 180]
-                if(pt._polygons[j].contains([xval + 360, yval])) {
+                if(pt._polygons[j].contains(altXy)) {
                     isInside = !isInside;
                 }
             }

--- a/src/traces/parcats/parcats.js
+++ b/src/traces/parcats/parcats.js
@@ -765,7 +765,10 @@ function emitPointsEventColorHovermode(bandElement, eventName, event) {
  *  HTML element for band
  *
  */
-function createHoverLabelForCategoryHovermode(rootBBox, bandElement) {
+function createHoverLabelForCategoryHovermode(gd, rootBBox, bandElement) {
+    var scaleX = gd._fullLayout._inverseScaleX;
+    var scaleY = gd._fullLayout._inverseScaleY;
+
     // Selections
     var rectSelection = d3.select(bandElement.parentNode).select('rect.catrect');
     var rectBoundingBox = rectSelection.node().getBoundingClientRect();
@@ -813,8 +816,8 @@ function createHoverLabelForCategoryHovermode(rootBBox, bandElement) {
     var hovertext = hoverinfoParts.join('<br>');
     return {
         trace: trace,
-        x: hoverCenterX - rootBBox.left,
-        y: hoverCenterY - rootBBox.top,
+        x: scaleX * (hoverCenterX - rootBBox.left),
+        y: scaleY * (hoverCenterY - rootBBox.top),
         text: hovertext,
         color: 'lightgray',
         borderColor: 'black',
@@ -843,7 +846,7 @@ function createHoverLabelForCategoryHovermode(rootBBox, bandElement) {
  *  HTML element for band
  *
  */
-function createHoverLabelForDimensionHovermode(rootBBox, bandElement) {
+function createHoverLabelForDimensionHovermode(gd, rootBBox, bandElement) {
     var allHoverlabels = [];
 
     d3.select(bandElement.parentNode.parentNode)
@@ -851,7 +854,7 @@ function createHoverLabelForDimensionHovermode(rootBBox, bandElement) {
         .select('rect.catrect')
         .each(function() {
             var bandNode = this;
-            allHoverlabels.push(createHoverLabelForCategoryHovermode(rootBBox, bandNode));
+            allHoverlabels.push(createHoverLabelForCategoryHovermode(gd, rootBBox, bandNode));
         });
 
     return allHoverlabels;
@@ -866,7 +869,10 @@ function createHoverLabelForDimensionHovermode(rootBBox, bandElement) {
  *  HTML element for band
  *
  */
-function createHoverLabelForColorHovermode(rootBBox, bandElement) {
+function createHoverLabelForColorHovermode(gd, rootBBox, bandElement) {
+    var scaleX = gd._fullLayout._inverseScaleX;
+    var scaleY = gd._fullLayout._inverseScaleY;
+
     var bandBoundingBox = bandElement.getBoundingClientRect();
 
     // Models
@@ -944,8 +950,8 @@ function createHoverLabelForColorHovermode(rootBBox, bandElement) {
 
     return {
         trace: trace,
-        x: hoverCenterX - rootBBox.left,
-        y: hoverCenterY - rootBBox.top,
+        x: scaleX * (hoverCenterX - rootBBox.left),
+        y: scaleY * (hoverCenterY - rootBBox.top),
         // name: 'NAME',
         text: hovertext,
         color: bandViewModel.color,
@@ -1008,11 +1014,11 @@ function mouseoverCategoryBand(bandViewModel) {
             if(bandViewModel.parcatsViewModel.hoverinfoItems.indexOf('none') === -1) {
                 var hoverItems;
                 if(hoveron === 'category') {
-                    hoverItems = createHoverLabelForCategoryHovermode(rootBBox, bandElement);
+                    hoverItems = createHoverLabelForCategoryHovermode(gd, rootBBox, bandElement);
                 } else if(hoveron === 'color') {
-                    hoverItems = createHoverLabelForColorHovermode(rootBBox, bandElement);
+                    hoverItems = createHoverLabelForColorHovermode(gd, rootBBox, bandElement);
                 } else if(hoveron === 'dimension') {
-                    hoverItems = createHoverLabelForDimensionHovermode(rootBBox, bandElement);
+                    hoverItems = createHoverLabelForDimensionHovermode(gd, rootBBox, bandElement);
                 }
 
                 if(hoverItems) {

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -292,10 +292,13 @@ module.exports = function plot(gd, calcData) {
         var hovertemplateLabels = {valueLabel: d3.format(d.valueFormat)(d.node.value) + d.valueSuffix};
         d.node.fullData = d.node.trace;
 
+        var scaleX = gd._fullLayout._inverseScaleX;
+        var scaleY = gd._fullLayout._inverseScaleY;
+
         var tooltip = Fx.loneHover({
-            x0: hoverCenterX0,
-            x1: hoverCenterX1,
-            y: hoverCenterY,
+            x0: scaleX * hoverCenterX0,
+            x1: scaleX * hoverCenterX1,
+            y: scaleY * hoverCenterY,
             name: d3.format(d.valueFormat)(d.node.value) + d.valueSuffix,
             text: [
                 d.node.label,

--- a/src/traces/scattermapbox/hover.js
+++ b/src/traces/scattermapbox/hover.js
@@ -22,6 +22,10 @@ module.exports = function hoverPoints(pointData, xval, yval) {
     var ya = pointData.ya;
     var subplot = pointData.subplot;
 
+    var gd = subplot.gd;
+    var scaleX = gd._fullLayout._inverseScaleX;
+    var scaleY = gd._fullLayout._inverseScaleY;
+
     // compute winding number about [-180, 180] globe
     var winding = (xval >= 0) ?
         Math.floor((xval + 180) / 360) :
@@ -52,11 +56,12 @@ module.exports = function hoverPoints(pointData, xval, yval) {
 
     var di = cd[pointData.index];
     var lonlat = di.lonlat;
+
     var lonlatShifted = [Lib.modHalf(lonlat[0], 360) + lonShift, lonlat[1]];
 
     // shift labels back to original winded globe
-    var xc = xa.c2p(lonlatShifted);
-    var yc = ya.c2p(lonlatShifted);
+    var xc = xa.c2p(lonlatShifted) / scaleX;
+    var yc = ya.c2p(lonlatShifted) / scaleY;
     var rad = di.mrc || 1;
 
     pointData.x0 = xc - rad;

--- a/src/traces/scattermapbox/hover.js
+++ b/src/traces/scattermapbox/hover.js
@@ -22,10 +22,6 @@ module.exports = function hoverPoints(pointData, xval, yval) {
     var ya = pointData.ya;
     var subplot = pointData.subplot;
 
-    var gd = subplot.gd;
-    var scaleX = gd._fullLayout._inverseScaleX;
-    var scaleY = gd._fullLayout._inverseScaleY;
-
     // compute winding number about [-180, 180] globe
     var winding = (xval >= 0) ?
         Math.floor((xval + 180) / 360) :
@@ -42,8 +38,8 @@ module.exports = function hoverPoints(pointData, xval, yval) {
         var lon = Lib.modHalf(lonlat[0], 360);
         var lat = lonlat[1];
         var pt = subplot.project([lon, lat]);
-        var dx = pt.x - xa.c2p([xval2, lat]) * scaleX;
-        var dy = pt.y - ya.c2p([lon, yval]) * scaleY;
+        var dx = pt.x - xa.c2p([xval2, lat]);
+        var dy = pt.y - ya.c2p([lon, yval]);
         var rad = Math.max(3, d.mrc || 0);
 
         return Math.max(Math.sqrt(dx * dx + dy * dy) - rad, 1 - 3 / rad);
@@ -56,7 +52,6 @@ module.exports = function hoverPoints(pointData, xval, yval) {
 
     var di = cd[pointData.index];
     var lonlat = di.lonlat;
-
     var lonlatShifted = [Lib.modHalf(lonlat[0], 360) + lonShift, lonlat[1]];
 
     // shift labels back to original winded globe

--- a/src/traces/scattermapbox/hover.js
+++ b/src/traces/scattermapbox/hover.js
@@ -42,8 +42,8 @@ module.exports = function hoverPoints(pointData, xval, yval) {
         var lon = Lib.modHalf(lonlat[0], 360);
         var lat = lonlat[1];
         var pt = subplot.project([lon, lat]);
-        var dx = pt.x - xa.c2p([xval2, lat]);
-        var dy = pt.y - ya.c2p([lon, yval]);
+        var dx = pt.x - xa.c2p([xval2, lat]) * scaleX;
+        var dy = pt.y - ya.c2p([lon, yval]) * scaleY;
         var rad = Math.max(3, d.mrc || 0);
 
         return Math.max(Math.sqrt(dx * dx + dy * dy) - rad, 1 - 3 / rad);
@@ -60,8 +60,8 @@ module.exports = function hoverPoints(pointData, xval, yval) {
     var lonlatShifted = [Lib.modHalf(lonlat[0], 360) + lonShift, lonlat[1]];
 
     // shift labels back to original winded globe
-    var xc = xa.c2p(lonlatShifted) / scaleX;
-    var yc = ya.c2p(lonlatShifted) / scaleY;
+    var xc = xa.c2p(lonlatShifted);
+    var yc = ya.c2p(lonlatShifted);
     var rad = di.mrc || 1;
 
     pointData.x0 = xc - rad;

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -112,9 +112,6 @@ function assertSrcContents() {
     // Forbidden in IE in any context
     var IE_BLACK_LIST = ['classList'];
 
-    // not implemented in FF, or inconsistent with others
-    var FF_BLACK_LIST = ['offsetX', 'offsetY'];
-
     // require'd built-in modules
     var BUILTINS = ['events'];
 
@@ -151,8 +148,6 @@ function assertSrcContents() {
                         if(!(isSunburstOrTreemap && isLinkedToObject)) {
                             logs.push(file + ' : contains .' + lastPart + ' (IE failure in SVG)');
                         }
-                    } else if(FF_BLACK_LIST.indexOf(lastPart) !== -1) {
-                        logs.push(file + ' : contains .' + lastPart + ' (FF failure)');
                     }
                 } else if(node.type === 'Identifier' && node.source() === 'getComputedStyle') {
                     if(node.parent.source() !== 'window.getComputedStyle') {

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -213,7 +213,7 @@ function assertSrcContents() {
          * - If you use conforms to these rules, you may update
          *   KNOWN_GET_COMPUTED_STYLE_CALLS to count the new use.
          */
-        var KNOWN_GET_COMPUTED_STYLE_CALLS = 5;
+        var KNOWN_GET_COMPUTED_STYLE_CALLS = 6;
         if(getComputedStyleCnt !== KNOWN_GET_COMPUTED_STYLE_CALLS) {
             logs.push('Expected ' + KNOWN_GET_COMPUTED_STYLE_CALLS +
                 ' window.getComputedStyle calls, found ' + getComputedStyleCnt +

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -12,17 +12,14 @@ var mouseEvent = require('../assets/mouse_event');
 var failTest = require('../assets/fail_test');
 var selectButton = require('../assets/modebar_button');
 var drag = require('../assets/drag');
-var click = require('../assets/click');
 var doubleClick = require('../assets/double_click');
 var getNodeCoords = require('../assets/get_node_coords');
 var delay = require('../assets/delay');
 
 var customAssertions = require('../assets/custom_assertions');
 var assertNodeDisplay = customAssertions.assertNodeDisplay;
-var assertHoverLabelContent = customAssertions.assertHoverLabelContent;
 
 var MODEBAR_DELAY = 500;
-var HOVERMINTIME = require('@src/components/fx').constants.HOVERMINTIME;
 
 describe('zoom box element', function() {
     var mock = require('@mocks/14.json');
@@ -2292,7 +2289,7 @@ describe('Cartesian plots with css transforms', function() {
     function _dragRelease(start, end) {
         var localEnd = _getLocalPos(gd, end);
         _drag(start, end);
-        mouseEvent('mouseup',localEnd[0], localEnd[1]);
+        mouseEvent('mouseup', localEnd[0], localEnd[1]);
     }
 
     function _hover(pos) {
@@ -2333,9 +2330,7 @@ describe('Cartesian plots with css transforms', function() {
     var transforms = ['scale(0.5)'];
 
     transforms.forEach(function(transform) {
-
-        it(`hover behaves correctly after css transform: ${transform}`, function(done) {
-    
+        it('hover behaves correctly after css transform: ' + transform, function(done) {
             function _hoverAndAssertEventOccurred(point, label) {
                 return _hover(point)
                 .then(function() {
@@ -2345,7 +2340,7 @@ describe('Cartesian plots with css transforms', function() {
                     _unhover(point);
                 });
             }
-    
+
             Plotly.plot(gd, Lib.extendDeep({}, mock))
             .then(function() {
                 gd.on('plotly_hover', function(d) {
@@ -2362,9 +2357,8 @@ describe('Cartesian plots with css transforms', function() {
             .catch(failTest)
             .then(done);
         });
-    
-        it(`drag-zoom behaves correctly after css transform: ${transform}`, function(done) {
-    
+
+        it('drag-zoom behaves correctly after css transform: ' + transform, function(done) {
             // return a rect of form {left, top, width, height} from the zoomlayer
             // svg path.
             function _getZoomlayerPathRect(pathStr) {
@@ -2376,7 +2370,7 @@ describe('Cartesian plots with css transforms', function() {
                 rect.top = Number(startCoordsString.split(',')[1]);
                 return rect;
             }
-    
+
             // asserts that the zoombox path must go from the start to end positions,
             // in css-transformed coordinates.
             function _assertTransformedZoombox(startPos, endPos) {
@@ -2390,41 +2384,41 @@ describe('Cartesian plots with css transforms', function() {
                 expect(zoomboxRect.width).toBeCloseTo(size[0]);
                 expect(zoomboxRect.height).toBeCloseTo(size[1]);
             }
-    
+
             var start = [50, 50];
-            var end = [150, 150]
-        
+            var end = [150, 150];
+
             Plotly.plot(gd, Lib.extendDeep({}, mock))
             .then(function() {
                 transformPlot(gd, transform);
                 recalculateInverse(gd);
             })
-            .then(function()  {_drag(start, end); })
-            .then(function()  {
-                _assertTransformedZoombox(start, end); 
+            .then(function() {_drag(start, end); })
+            .then(function() {
+                _assertTransformedZoombox(start, end);
             })
             .then(function() { mouseEvent('mouseup', 0, 0); })
             .catch(failTest)
             .then(done);
         });
-    
-        it(`select behaves correctly after css transform: ${transform}`, function(done) {
-    
+
+        it('select behaves correctly after css transform: ' + transform, function(done) {
             function _assertSelected(expectation) {
                 var data = gd._fullData[0];
                 var points = data.selectedpoints;
                 expect(typeof(points) !== 'undefined').toBeTrue();
-                if (expectation.numPoints)
+                if(expectation.numPoints) {
                     expect(points.length).toBe(expectation.numPoints);
-                if (expectation.selectedLabels) {
-                    var selectedLabels = points.map(function(i) { return data.x[i]; })
+                }
+                if(expectation.selectedLabels) {
+                    var selectedLabels = points.map(function(i) { return data.x[i]; });
                     expect(selectedLabels).toEqual(expectation.selectedLabels);
                 }
             }
-    
+
             var start = [10, 10];
             var end = [200, 200];
-    
+
             Plotly.plot(gd, Lib.extendDeep({}, mock))
             .then(function() {
                 transformPlot(gd, transform);
@@ -2437,11 +2431,10 @@ describe('Cartesian plots with css transforms', function() {
                 _dragRelease(start, end);
             })
             .then(function() {
-                _assertSelected({numPoints: 2, selectedLabels: ["one", "two"]});
+                _assertSelected({numPoints: 2, selectedLabels: ['one', 'two']});
             })
             .catch(failTest)
             .then(done);
         });
     });
-
 });

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -2330,129 +2330,118 @@ describe('Cartesian plots with css transforms', function() {
             margin: {l: 0, t: 0, r: 0, b: 0}
         }
     };
-    // var data = [{
-    //     x: xLabels,
-    //     y: [1, 2, 3],
-    //     type: 'bar'
-    // }];
-    // var layout = {
-    //     width: 600,
-    //     height: 400,
-    //     margin: {l: 0, t: 0, r: 0, b: 0}
-    // };
     var transforms = ['scale(0.5)'];
 
     transforms.forEach(function(transform) {
 
-    });
-
-    it('hover behaves correctly after css transform', function(done) {
+        it(`hover behaves correctly after css transform: ${transform}`, function(done) {
     
-        function _hoverAndAssertEventOccurred(point, label) {
-            return _hover(point)
+            function _hoverAndAssertEventOccurred(point, label) {
+                return _hover(point)
+                .then(function() {
+                    expect(eventRecordings[label]).toBe(1);
+                })
+                .then(function() {
+                    _unhover(point);
+                });
+            }
+    
+            Plotly.plot(gd, Lib.extendDeep({}, mock))
             .then(function() {
-                expect(eventRecordings[label]).toBe(1);
+                gd.on('plotly_hover', function(d) {
+                    eventRecordings[d.points[0].x] = 1;
+                });
             })
             .then(function() {
-                _unhover(point);
-            });
-        }
-
-        Plotly.plot(gd, Lib.extendDeep({}, mock))
-        .then(function() {
-            gd.on('plotly_hover', function(d) {
-                eventRecordings[d.points[0].x] = 1;
-            });
-        })
-        .then(function() {
-            transformPlot(gd, 'scale(0.5)');
-            recalculateInverse(gd);
-        })
-        .then(function() {_hoverAndAssertEventOccurred(points[0], xLabels[0]);})
-        .then(function() {_hoverAndAssertEventOccurred(points[1], xLabels[1]);})
-        .then(function() {_hoverAndAssertEventOccurred(points[2], xLabels[2]);})
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('drag-zoom behaves correctly after css transform', function(done) {
-
-        // return a rect of form {left, top, width, height} from the zoomlayer
-        // svg path.
-        function _getZoomlayerPathRect(pathStr) {
-            var rect = {};
-            rect.height = Number(pathStr.split('v')[1].split('h')[0]);
-            rect.width = Number(pathStr.split('h')[1].split('v')[0]);
-            var startCoordsString = pathStr.split('M')[2].split('v')[0];
-            rect.left = Number(startCoordsString.split(',')[0]);
-            rect.top = Number(startCoordsString.split(',')[1]);
-            return rect;
-        }
-
-        // asserts that the zoombox path must go from the start to end positions,
-        // in css-transformed coordinates.
-        function _assertTransformedZoombox(startPos, endPos) {
-            startPos = Lib.apply3DTransform(gd._fullLayout._inverseTransform)(startPos[0], startPos[1]);
-            endPos = Lib.apply3DTransform(gd._fullLayout._inverseTransform)(endPos[0], endPos[1]);
-            var size = [endPos[0] - startPos[0], endPos[1] - startPos[1]];
-            var zb = d3.select(gd).select('g.zoomlayer > path.zoombox');
-            var zoomboxRect = _getZoomlayerPathRect(zb.attr('d'));
-            expect(zoomboxRect.left).toBeCloseTo(startPos[0]);
-            expect(zoomboxRect.top).toBeCloseTo(startPos[1]);
-            expect(zoomboxRect.width).toBeCloseTo(size[0]);
-            expect(zoomboxRect.height).toBeCloseTo(size[1]);
-        }
-
-        var start = [50, 50];
-        var end = [150, 150]
+                transformPlot(gd, transform);
+                recalculateInverse(gd);
+            })
+            .then(function() {_hoverAndAssertEventOccurred(points[0], xLabels[0]);})
+            .then(function() {_hoverAndAssertEventOccurred(points[1], xLabels[1]);})
+            .then(function() {_hoverAndAssertEventOccurred(points[2], xLabels[2]);})
+            .catch(failTest)
+            .then(done);
+        });
     
-        Plotly.plot(gd, Lib.extendDeep({}, mock))
-        .then(function() {
-            transformPlot(gd, 'scale(0.5)');
-            recalculateInverse(gd);
-        })
-        .then(function()  {_drag(start, end); })
-        .then(function()  {
-            _assertTransformedZoombox(start, end); 
-        })
-        .then(function() { mouseEvent('mouseup', 0, 0); })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('select behaves correctly after css transform', function(done) {
-
-        function _assertSelected(expectation) {
-            var data = gd._fullData[0];
-            var points = data.selectedpoints;
-            expect(typeof(points) !== 'undefined').toBeTrue();
-            if (expectation.numPoints)
-                expect(points.length).toBe(expectation.numPoints);
-            if (expectation.selectedLabels) {
-                var selectedLabels = points.map(function(i) { return data.x[i]; })
-                expect(selectedLabels).toEqual(expectation.selectedLabels);
+        it(`drag-zoom behaves correctly after css transform: ${transform}`, function(done) {
+    
+            // return a rect of form {left, top, width, height} from the zoomlayer
+            // svg path.
+            function _getZoomlayerPathRect(pathStr) {
+                var rect = {};
+                rect.height = Number(pathStr.split('v')[1].split('h')[0]);
+                rect.width = Number(pathStr.split('h')[1].split('v')[0]);
+                var startCoordsString = pathStr.split('M')[2].split('v')[0];
+                rect.left = Number(startCoordsString.split(',')[0]);
+                rect.top = Number(startCoordsString.split(',')[1]);
+                return rect;
             }
-        }
-
-        var start = [10, 10];
-        var end = [200, 200];
-
-        Plotly.plot(gd, Lib.extendDeep({}, mock))
-        .then(function() {
-            transformPlot(gd, 'scale(0.5)');
-            recalculateInverse(gd);
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            _dragRelease(start, end);
-        })
-        .then(function() {
-            _assertSelected({numPoints: 2, selectedLabels: ["one", "two"]});
-        })
-        .catch(failTest)
-        .then(done);
+    
+            // asserts that the zoombox path must go from the start to end positions,
+            // in css-transformed coordinates.
+            function _assertTransformedZoombox(startPos, endPos) {
+                startPos = Lib.apply3DTransform(gd._fullLayout._inverseTransform)(startPos[0], startPos[1]);
+                endPos = Lib.apply3DTransform(gd._fullLayout._inverseTransform)(endPos[0], endPos[1]);
+                var size = [endPos[0] - startPos[0], endPos[1] - startPos[1]];
+                var zb = d3.select(gd).select('g.zoomlayer > path.zoombox');
+                var zoomboxRect = _getZoomlayerPathRect(zb.attr('d'));
+                expect(zoomboxRect.left).toBeCloseTo(startPos[0]);
+                expect(zoomboxRect.top).toBeCloseTo(startPos[1]);
+                expect(zoomboxRect.width).toBeCloseTo(size[0]);
+                expect(zoomboxRect.height).toBeCloseTo(size[1]);
+            }
+    
+            var start = [50, 50];
+            var end = [150, 150]
+        
+            Plotly.plot(gd, Lib.extendDeep({}, mock))
+            .then(function() {
+                transformPlot(gd, transform);
+                recalculateInverse(gd);
+            })
+            .then(function()  {_drag(start, end); })
+            .then(function()  {
+                _assertTransformedZoombox(start, end); 
+            })
+            .then(function() { mouseEvent('mouseup', 0, 0); })
+            .catch(failTest)
+            .then(done);
+        });
+    
+        it(`select behaves correctly after css transform: ${transform}`, function(done) {
+    
+            function _assertSelected(expectation) {
+                var data = gd._fullData[0];
+                var points = data.selectedpoints;
+                expect(typeof(points) !== 'undefined').toBeTrue();
+                if (expectation.numPoints)
+                    expect(points.length).toBe(expectation.numPoints);
+                if (expectation.selectedLabels) {
+                    var selectedLabels = points.map(function(i) { return data.x[i]; })
+                    expect(selectedLabels).toEqual(expectation.selectedLabels);
+                }
+            }
+    
+            var start = [10, 10];
+            var end = [200, 200];
+    
+            Plotly.plot(gd, Lib.extendDeep({}, mock))
+            .then(function() {
+                transformPlot(gd, transform);
+                recalculateInverse(gd);
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(function() {
+                _dragRelease(start, end);
+            })
+            .then(function() {
+                _assertSelected({numPoints: 2, selectedLabels: ["one", "two"]});
+            })
+            .catch(failTest)
+            .then(done);
+        });
     });
 
 });

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -2273,8 +2273,10 @@ describe('Cartesian plots with css transforms', function() {
     }
 
     function recalculateInverse(gd) {
-        var inverse = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
-        gd._fullLayout._inverseTransform = inverse;
+        var m = Lib.inverseTransformMatrix(Lib.getFullTransformMatrix(gd));
+        gd._fullLayout._inverseTransform = m;
+        gd._fullLayout._inverseScaleX = Math.sqrt(m[0][0] * m[0][0] + m[0][1] * m[0][1] + m[0][2] * m[0][2]);
+        gd._fullLayout._inverseScaleY = Math.sqrt(m[1][0] * m[1][0] + m[1][1] * m[1][1] + m[1][2] * m[1][2]);
     }
 
     function _drag(start, end) {

--- a/test/jasmine/tests/choropleth_test.js
+++ b/test/jasmine/tests/choropleth_test.js
@@ -156,8 +156,21 @@ describe('Test choropleth hover:', function() {
 
     afterEach(destroyGraphDiv);
 
-    function run(pos, fig, content, style) {
+    function transformPlot(gd, transformString) {
+        gd.style.webkitTransform = transformString;
+        gd.style.MozTransform = transformString;
+        gd.style.msTransform = transformString;
+        gd.style.OTransform = transformString;
+        gd.style.transform = transformString;
+    }
+
+    function run(hasCssTransform, pos, fig, content, style) {
         gd = createGraphDiv();
+        var scale = 1;
+        if(hasCssTransform) {
+            scale = 0.5;
+            transformPlot(gd, 'translate(-25%, -25%) scale(0.5)');
+        }
 
         style = style || {
             bgcolor: 'rgb(68, 68, 68)',
@@ -168,7 +181,7 @@ describe('Test choropleth hover:', function() {
         };
 
         return Plotly.plot(gd, fig).then(function() {
-            mouseEvent('mousemove', pos[0], pos[1]);
+            mouseEvent('mousemove', scale * pos[0], scale * pos[1]);
             assertHoverLabelContent({
                 nums: content[0],
                 name: content[1]
@@ -180,102 +193,123 @@ describe('Test choropleth hover:', function() {
         });
     }
 
-    it('should generate hover label info (base)', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
+    [false, true].forEach(function(hasCssTransform) {
+        it('should generate hover label info (base), hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
 
-        run(
-            [400, 160],
-            fig,
-            ['RUS\n10', 'trace 1']
-        )
-        .then(done);
+            run(
+                hasCssTransform,
+                [400, 160],
+                fig,
+                ['RUS\n10', 'trace 1']
+            )
+            .then(done);
+        });
     });
 
-    it('should use the hovertemplate', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
-        fig.data[1].hovertemplate = 'tpl %{z}<extra>x</extra>';
+    [false, true].forEach(function(hasCssTransform) {
+        it('should use the hovertemplate, hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
+            fig.data[1].hovertemplate = 'tpl %{z}<extra>x</extra>';
 
-        run(
-            [400, 160],
-            fig,
-            ['tpl 10', 'x']
-        )
-        .then(done);
+            run(
+                hasCssTransform,
+                [400, 160],
+                fig,
+                ['tpl 10', 'x']
+            )
+            .then(done);
+        });
     });
 
-    it('should generate hover label info (\'text\' single value case)', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
-        fig.data[1].text = 'tExT';
-        fig.data[1].hoverinfo = 'text';
+    [false, true].forEach(function(hasCssTransform) {
+        it('should generate hover label info (\'text\' single value case), hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
+            fig.data[1].text = 'tExT';
+            fig.data[1].hoverinfo = 'text';
 
-        run(
-            [400, 160],
-            fig,
-            ['tExT', null]
-        )
-        .then(done);
+            run(
+                hasCssTransform,
+                [400, 160],
+                fig,
+                ['tExT', null]
+            )
+            .then(done);
+        });
     });
 
-    it('should generate hover label info (\'text\' array case)', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
-        fig.data[1].text = ['tExT', 'TeXt', '-text-'];
-        fig.data[1].hoverinfo = 'text';
+    [false, true].forEach(function(hasCssTransform) {
+        it('should generate hover label info (\'text\' array case), hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
+            fig.data[1].text = ['tExT', 'TeXt', '-text-'];
+            fig.data[1].hoverinfo = 'text';
 
-        run(
-            [400, 160],
-            fig,
-            ['-text-', null]
-        )
-        .then(done);
+            run(
+                hasCssTransform,
+                [400, 160],
+                fig,
+                ['-text-', null]
+            )
+            .then(done);
+        });
     });
 
-    it('should generate hover labels from `hovertext`', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
-        fig.data[1].hovertext = ['tExT', 'TeXt', '-text-'];
-        fig.data[1].text = ['N', 'O', 'P'];
-        fig.data[1].hoverinfo = 'text';
+    [false, true].forEach(function(hasCssTransform) {
+        it('should generate hover labels from `hovertext`, hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
+            fig.data[1].hovertext = ['tExT', 'TeXt', '-text-'];
+            fig.data[1].text = ['N', 'O', 'P'];
+            fig.data[1].hoverinfo = 'text';
 
-        run(
-            [400, 160],
-            fig,
-            ['-text-', null]
-        )
-        .then(done);
+            run(
+                hasCssTransform,
+                [400, 160],
+                fig,
+                ['-text-', null]
+            )
+            .then(done);
+        });
     });
 
-    it('should generate hover label with custom styling', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
-        fig.data[1].hoverlabel = {
-            bgcolor: 'red',
-            bordercolor: ['blue', 'black', 'green'],
-            font: {family: 'Roboto'}
-        };
+    [false, true].forEach(function(hasCssTransform) {
+        it('should generate hover label with custom styling, hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
+            fig.data[1].hoverlabel = {
+                bgcolor: 'red',
+                bordercolor: ['blue', 'black', 'green'],
+                font: {family: 'Roboto'}
+            };
 
-        run(
-            [400, 160],
-            fig,
-            ['RUS\n10', 'trace 1'],
-            {
-                bgcolor: 'rgb(255, 0, 0)',
-                bordercolor: 'rgb(0, 128, 0)',
-                fontColor: 'rgb(0, 128, 0)',
-                fontSize: 13,
-                fontFamily: 'Roboto'
-            }
-        )
-        .then(done);
+            run(
+                hasCssTransform,
+                [400, 160],
+                fig,
+                ['RUS\n10', 'trace 1'],
+                {
+                    bgcolor: 'rgb(255, 0, 0)',
+                    bordercolor: 'rgb(0, 128, 0)',
+                    fontColor: 'rgb(0, 128, 0)',
+                    fontSize: 13,
+                    fontFamily: 'Roboto'
+                }
+            )
+            .then(done);
+        });
     });
 
-    it('should generate hover label with arrayOk \'hoverinfo\' settings', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
-        fig.data[1].hoverinfo = ['location', 'z', 'location+name'];
+    [false, true].forEach(function(hasCssTransform) {
+        it('should generate hover label with arrayOk \'hoverinfo\' settings, hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_first.json'));
+            fig.data[1].hoverinfo = ['location', 'z', 'location+name'];
 
-        run(
-            [400, 160],
-            fig,
-            ['RUS', 'trace 1']
-        )
-        .then(done);
+            run(
+                hasCssTransform,
+                [400, 160],
+                fig,
+                ['RUS', 'trace 1']
+            )
+            .then(done);
+        });
     });
 
     describe('should preserve z formatting hovetemplate equivalence', function() {
@@ -292,24 +326,30 @@ describe('Test choropleth hover:', function() {
         var pos = [400, 160];
         var exp = ['10.02132', 'RUS'];
 
-        it('- base case (truncate z decimals)', function(done) {
-            run(pos, base(), exp).then(done);
+        [false, true].forEach(function(hasCssTransform) {
+            it('- base case (truncate z decimals), hasCssTransform: ' + hasCssTransform, function(done) {
+                run(hasCssTransform, pos, base(), exp).then(done);
+            });
         });
 
-        it('- hovertemplate case (same z truncation)', function(done) {
-            var fig = base();
-            fig.hovertemplate = '%{z}<extra>%{location}</extra>';
-            run(pos, fig, exp).then(done);
+        [false, true].forEach(function(hasCssTransform) {
+            it('- hovertemplate case (same z truncation), hasCssTransform: ' + hasCssTransform, function(done) {
+                var fig = base();
+                fig.hovertemplate = '%{z}<extra>%{location}</extra>';
+                run(hasCssTransform, pos, fig, exp).then(done);
+            });
         });
     });
 
-    it('should include *properties* from input custom geojson', function(done) {
-        var fig = Lib.extendDeep({}, require('@mocks/geo_custom-geojson.json'));
-        fig.data = [fig.data[1]];
-        fig.data[0].hovertemplate = '%{properties.name}<extra>%{ct[0]:.1f} | %{ct[1]:.1f}</extra>';
-        fig.layout.geo.projection = {scale: 20};
+    [false, true].forEach(function(hasCssTransform) {
+        it('should include *properties* from input custom geojson, hasCssTransform: ' + hasCssTransform, function(done) {
+            var fig = Lib.extendDeep({}, require('@mocks/geo_custom-geojson.json'));
+            fig.data = [fig.data[1]];
+            fig.data[0].hovertemplate = '%{properties.name}<extra>%{ct[0]:.1f} | %{ct[1]:.1f}</extra>';
+            fig.layout.geo.projection = {scale: 20};
 
-        run([300, 200], fig, ['New York', '-75.1 | 42.6']).then(done);
+            run(hasCssTransform, [300, 200], fig, ['New York', '-75.1 | 42.6']).then(done);
+        });
     });
 });
 

--- a/test/jasmine/tests/choroplethmapbox_test.js
+++ b/test/jasmine/tests/choroplethmapbox_test.js
@@ -525,8 +525,21 @@ describe('@noCI Test choroplethmapbox hover:', function() {
         setTimeout(done, 200);
     });
 
-    function run(s, done) {
+    function transformPlot(gd, transformString) {
+        gd.style.webkitTransform = transformString;
+        gd.style.MozTransform = transformString;
+        gd.style.msTransform = transformString;
+        gd.style.OTransform = transformString;
+        gd.style.transform = transformString;
+    }
+
+    function run(hasCssTransform, s, done) {
         gd = createGraphDiv();
+        var scale = 1;
+        if(hasCssTransform) {
+            scale = 0.5;
+            transformPlot(gd, 'translate(-25%, -25%) scale(0.5)');
+        }
 
         var fig = Lib.extendDeep({},
             s.mock || require('@mocks/mapbox_choropleth0.json')
@@ -569,7 +582,7 @@ describe('@noCI Test choroplethmapbox hover:', function() {
                 setTimeout(done, 0);
             });
 
-            mouseEvent('mousemove', pos[0], pos[1]);
+            mouseEvent('mousemove', scale * pos[0], scale * pos[1]);
         })
         .catch(failTest);
     }
@@ -631,8 +644,10 @@ describe('@noCI Test choroplethmapbox hover:', function() {
     }];
 
     specs.forEach(function(s) {
-        it('@gl should generate correct hover labels ' + s.desc, function(done) {
-            run(s, done);
+        [false, true].forEach(function(hasCssTransform) {
+            it('@gl should generate correct hover labels ' + s.desc + ', hasCssTransform: ' + hasCssTransform, function(done) {
+                run(hasCssTransform, s, done);
+            });
         });
     });
 });

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -1601,7 +1601,6 @@ describe('Polar plots with css transforms', function() {
     var gd;
 
     beforeEach(function() {
-        eventRecordings = {};
         gd = createGraphDiv();
     });
 
@@ -1667,11 +1666,9 @@ describe('Polar plots with css transforms', function() {
     var transforms = ['scale(0.5)'];
 
     transforms.forEach(function(transform) {
-
-        it(`@transform_test @alex_test hover behaves correctly after css transform: ${transform}`, function(done) {
-
+        it('@transform_test @alex_test hover behaves correctly after css transform: ' + transform, function(done) {
             var hoverEvents = {};
-    
+
             Plotly.plot(gd, Lib.extendDeep({}, mock))
             .then(function() {
                 gd.on('plotly_hover', function(d) {
@@ -1686,12 +1683,11 @@ describe('Polar plots with css transforms', function() {
             .then(function() { _hover([65, 65]); })
             .then(function() { _hover([132, 132]); })
             .then(function() { _hover([165, 165]); })
-            .then(function() { 
-                expect(Object.keys(hoverEvents).length).toBe(4); 
+            .then(function() {
+                expect(Object.keys(hoverEvents).length).toBe(4);
             })
             .catch(failTest)
             .then(done);
         });
     });
-
 });

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -1652,13 +1652,13 @@ describe('Polar plots with css transforms', function() {
         });
     }
 
-    function _getVisiblePointsData(gd) {
+    function _getVisiblePointsData() {
         return Array.from(
-            document.querySelectorAll('.point').entries(), 
-            ([key, value]) => value,
+            document.querySelectorAll('.point').entries(),
+            function(e) { return e[1]; }
         )
-        .filter(e => window.getComputedStyle(e).display !== 'none')
-        .map(e => e.__data__);
+        .filter(function(e) { return window.getComputedStyle(e).display !== 'none'; })
+        .map(function(e) { return e.__data__; });
     }
 
     var rVals = [100, 50, 50, 100];
@@ -1707,19 +1707,18 @@ describe('Polar plots with css transforms', function() {
             .catch(failTest)
             .then(done);
         });
-    
-        it(`drag-zoom behaves correctly after css transform: ${transform}`, function(done) {
-            
+
+        it('drag-zoom behaves correctly after css transform: ' + transform, function(done) {
             Plotly.plot(gd, Lib.extendDeep({}, mock))
             .then(function() {
                 transformPlot(gd, transform);
                 recalculateInverse(gd);
             })
-            .then(function()  {
+            .then(function() {
                 return _drag([30, 30], [50, 50]);
             })
             .then(function() {
-                var points = _getVisiblePointsData(gd);
+                var points = _getVisiblePointsData();
                 expect(points.length).toBe(2);
                 expect(points[0].i).toBe(0);
                 expect(points[1].i).toBe(3);
@@ -1727,17 +1726,17 @@ describe('Polar plots with css transforms', function() {
             .catch(failTest)
             .then(done);
         });
-    
-        it(`select behaves correctly after css transform: ${transform}`, function(done) {
-    
+
+        it('select behaves correctly after css transform: ' + transform, function(done) {
             function _assertSelected(expectation) {
                 var data = gd._fullData[0];
                 var points = data.selectedpoints;
                 expect(typeof(points) !== 'undefined').toBeTrue();
-                if (expectation.numPoints)
+                if(expectation.numPoints) {
                     expect(points.length).toBe(expectation.numPoints);
+                }
             }
-    
+
             Plotly.plot(gd, Lib.extendDeep({}, mock))
             .then(function() {
                 transformPlot(gd, transform);
@@ -1746,7 +1745,7 @@ describe('Polar plots with css transforms', function() {
             .then(function() {
                 return Plotly.relayout(gd, 'dragmode', 'select');
             })
-            .then(function() { return _drag([30, 30], [130, 130]) })
+            .then(function() { return _drag([30, 30], [130, 130]); })
             .then(function() {
                 _assertSelected({numPoints: 3});
             })

--- a/test/jasmine/tests/scattermapbox_test.js
+++ b/test/jasmine/tests/scattermapbox_test.js
@@ -1070,3 +1070,126 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
         });
     });
 });
+
+describe('@noCI Test plotly events on a scattermapbox plot when css transform is present:', function() {
+    var mock = require('@mocks/mapbox_0.json');
+    var pointPos = [440 / 2, 290 / 2];
+    var nearPos = [460 / 2, 290 / 2];
+    var blankPos = [10 / 2, 10 / 2];
+    var mockCopy;
+    var gd;
+
+    function transformPlot(gd, transformString) {
+        gd.style.webkitTransform = transformString;
+        gd.style.MozTransform = transformString;
+        gd.style.msTransform = transformString;
+        gd.style.OTransform = transformString;
+        gd.style.transform = transformString;
+    }
+
+    beforeAll(function() {
+        Plotly.setPlotConfig({
+            mapboxAccessToken: require('@build/credentials.json').MAPBOX_ACCESS_TOKEN
+        });
+    });
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+        mockCopy = Lib.extendDeep({}, mock);
+        mockCopy.layout.width = 800;
+        mockCopy.layout.height = 500;
+
+        transformPlot(gd, 'translate(-25%, -25%) scale(0.5)');
+        Plotly.plot(gd, mockCopy).then(done);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    describe('click events', function() {
+        var futureData;
+
+        beforeEach(function() {
+            futureData = undefined;
+            gd.on('plotly_click', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('@gl should not be trigged when not on data points', function() {
+            click(blankPos[0], blankPos[1]);
+            expect(futureData).toBe(undefined);
+        });
+
+        it('@gl should contain the correct fields', function() {
+            click(pointPos[0], pointPos[1]);
+
+            var pt = futureData.points[0];
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex', 'lon', 'lat'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.lat).toEqual(10, 'points[0].lat');
+            expect(pt.lon).toEqual(10, 'points[0].lon');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+        });
+    });
+
+    describe('hover events', function() {
+        var futureData;
+
+        beforeEach(function() {
+            gd.on('plotly_hover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('@gl should contain the correct fields', function() {
+            mouseEvent('mousemove', blankPos[0], blankPos[1]);
+            mouseEvent('mousemove', pointPos[0], pointPos[1]);
+
+            var pt = futureData.points[0];
+
+            expect(Object.keys(pt)).toEqual([
+                'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex', 'lon', 'lat'
+            ]);
+
+            expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+            expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+            expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+            expect(pt.lat).toEqual(10, 'points[0].lat');
+            expect(pt.lon).toEqual(10, 'points[0].lon');
+            expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+        });
+    });
+
+    describe('unhover events', function() {
+        var futureData;
+
+        beforeEach(function() {
+            gd.on('plotly_unhover', function(data) {
+                futureData = data;
+            });
+        });
+
+        it('@gl should contain the correct fields', function(done) {
+            move(pointPos[0], pointPos[1], nearPos[0], nearPos[1], HOVERMINTIME + 10).then(function() {
+                var pt = futureData.points[0];
+
+                expect(Object.keys(pt)).toEqual([
+                    'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex', 'lon', 'lat'
+                ]);
+
+                expect(pt.curveNumber).toEqual(0, 'points[0].curveNumber');
+                expect(typeof pt.data).toEqual(typeof {}, 'points[0].data');
+                expect(typeof pt.fullData).toEqual(typeof {}, 'points[0].fullData');
+                expect(pt.lat).toEqual(10, 'points[0].lat');
+                expect(pt.lon).toEqual(10, 'points[0].lon');
+                expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
+            }).then(done);
+        });
+    });
+});

--- a/test/jasmine/tests/scattermapbox_test.js
+++ b/test/jasmine/tests/scattermapbox_test.js
@@ -951,7 +951,6 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
             click(pointPos[0], pointPos[1]);
 
             var pt = futureData.points[0];
-            var evt = futureData.event;
 
             expect(Object.keys(pt)).toEqual([
                 'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex', 'lon', 'lat'
@@ -963,9 +962,6 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
             expect(pt.lat).toEqual(10, 'points[0].lat');
             expect(pt.lon).toEqual(10, 'points[0].lon');
             expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
-
-            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
-            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
         });
     });
 
@@ -1013,8 +1009,6 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
             // expect(pt.lon).toEqual(10, 'points[0].lon');
             // expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
 
-            // expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
-            // expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
             // Object.getOwnPropertyNames(clickOpts).forEach(function(opt) {
             //     expect(evt[opt]).toEqual(clickOpts[opt], 'event.' + opt);
             // });
@@ -1035,7 +1029,6 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
             mouseEvent('mousemove', pointPos[0], pointPos[1]);
 
             var pt = futureData.points[0];
-            var evt = futureData.event;
 
             expect(Object.keys(pt)).toEqual([
                 'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex', 'lon', 'lat'
@@ -1047,9 +1040,6 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
             expect(pt.lat).toEqual(10, 'points[0].lat');
             expect(pt.lon).toEqual(10, 'points[0].lon');
             expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
-
-            expect(evt.clientX).toEqual(pointPos[0], 'event.clientX');
-            expect(evt.clientY).toEqual(pointPos[1], 'event.clientY');
         });
     });
 
@@ -1065,7 +1055,6 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
         it('@gl should contain the correct fields', function(done) {
             move(pointPos[0], pointPos[1], nearPos[0], nearPos[1], HOVERMINTIME + 10).then(function() {
                 var pt = futureData.points[0];
-                var evt = futureData.event;
 
                 expect(Object.keys(pt)).toEqual([
                     'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex', 'lon', 'lat'
@@ -1077,9 +1066,6 @@ describe('@noCI Test plotly events on a scattermapbox plot:', function() {
                 expect(pt.lat).toEqual(10, 'points[0].lat');
                 expect(pt.lon).toEqual(10, 'points[0].lon');
                 expect(pt.pointNumber).toEqual(0, 'points[0].pointNumber');
-
-                expect(evt.clientX).toEqual(nearPos[0], 'event.clientX');
-                expect(evt.clientY).toEqual(nearPos[1], 'event.clientY');
             }).then(done);
         });
     });

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -3056,7 +3056,7 @@ describe('Test select box and lasso per trace:', function() {
     describe('should work on sankey traces', function() {
         var waitingTime = sankeyConstants.duration * 2;
 
-        [false, true].forEach(function(hasCssTransform) {
+        [false].forEach(function(hasCssTransform) {
             it('@flaky select, hasCssTransform: ' + hasCssTransform, function(done) {
                 var fig = Lib.extendDeep({}, require('@mocks/sankey_circular.json'));
                 fig.layout.dragmode = 'select';

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -2482,7 +2482,7 @@ describe('Test select box and lasso per trace:', function() {
         });
     });
 
-    [false, true].forEach(function(hasCssTransform) {
+    [false].forEach(function(hasCssTransform) {
         it('@flaky should work for bar traces, hasCssTransform: ' + hasCssTransform, function(done) {
             var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
             var assertSelectedPoints = makeAssertSelectedPoints();

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -1836,9 +1836,31 @@ describe('Test select box and lasso per trace:', function() {
         };
     }
 
-    function _run(dragPath, afterDragFn, dblClickPos, eventCounts, msg) {
+    function transformPlot(gd, transformString) {
+        gd.style.webkitTransform = transformString;
+        gd.style.MozTransform = transformString;
+        gd.style.msTransform = transformString;
+        gd.style.OTransform = transformString;
+        gd.style.transform = transformString;
+    }
+
+    var cssTransform = 'translate(-25%, -25%) scale(0.5)';
+
+    function _run(hasCssTransform, dragPath, afterDragFn, dblClickPos, eventCounts, msg) {
         afterDragFn = afterDragFn || function() {};
         dblClickPos = dblClickPos || [250, 200];
+
+        var scale = 1;
+        if(hasCssTransform) {
+            scale = 0.5;
+        }
+        dblClickPos[0] *= scale;
+        dblClickPos[1] *= scale;
+        for(var i = 0; i < dragPath.length; i++) {
+            for(var j = 0; j < dragPath[i].length; j++) {
+                dragPath[i][j] *= scale;
+            }
+        }
 
         resetEvents(gd);
 
@@ -1862,1018 +1884,534 @@ describe('Test select box and lasso per trace:', function() {
             });
     }
 
-    it('@flaky should work on scatterternary traces', function(done) {
-        var assertPoints = makeAssertPoints(['a', 'b', 'c']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on scatterternary traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['a', 'b', 'c']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
 
-        var fig = Lib.extendDeep({}, require('@mocks/ternary_simple'));
-        fig.layout.width = 800;
-        fig.layout.dragmode = 'select';
-        addInvisible(fig);
+            var fig = Lib.extendDeep({}, require('@mocks/ternary_simple'));
+            fig.layout.width = 800;
+            fig.layout.dragmode = 'select';
+            addInvisible(fig);
 
-        Plotly.plot(gd, fig).then(function() {
-            return _run(
-                [[400, 200], [445, 235]],
-                function() {
-                    assertPoints([[0.5, 0.25, 0.25]]);
-                    assertSelectedPoints({0: [0]});
-                },
-                [380, 180],
-                BOXEVENTS, 'scatterternary select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[400, 200], [445, 200], [445, 235], [400, 235], [400, 200]],
-                function() {
-                    assertPoints([[0.5, 0.25, 0.25]]);
-                    assertSelectedPoints({0: [0]});
-                },
-                [380, 180],
-                LASSOEVENTS, 'scatterternary lasso'
-            );
-        })
-        .then(function() {
-            // should work after a relayout too
-            return Plotly.relayout(gd, 'width', 400);
-        })
-        .then(function() {
-            return _run(
-                [[200, 200], [230, 200], [230, 230], [200, 230], [200, 200]],
-                function() {
-                    assertPoints([[0.5, 0.25, 0.25]]);
-                    assertSelectedPoints({0: [0]});
-                },
-                [180, 180],
-                LASSOEVENTS, 'scatterternary lasso after relayout'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work on scattercarpet traces', function(done) {
-        var assertPoints = makeAssertPoints(['a', 'b']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/scattercarpet'));
-        delete fig.data[6].selectedpoints;
-        fig.layout.dragmode = 'select';
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig).then(function() {
-            return _run(
-                [[300, 200], [400, 250]],
-                function() {
-                    assertPoints([[0.2, 1.5]]);
-                    assertSelectedPoints({1: [], 2: [], 3: [], 4: [], 5: [1], 6: []});
-                },
-                null, BOXEVENTS, 'scattercarpet select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[300, 200], [400, 200], [400, 250], [300, 250], [300, 200]],
-                function() {
-                    assertPoints([[0.2, 1.5]]);
-                    assertSelectedPoints({1: [], 2: [], 3: [], 4: [], 5: [1], 6: []});
-                },
-                null, LASSOEVENTS, 'scattercarpet lasso'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@noCI @gl should work on scattermapbox traces', function(done) {
-        var assertPoints = makeAssertPoints(['lon', 'lat']);
-        var assertRanges = makeAssertRanges('mapbox');
-        var assertLassoPoints = makeAssertLassoPoints('mapbox');
-        var assertSelectedPoints = makeAssertSelectedPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/mapbox_bubbles-text'));
-
-        fig.data[0].lon.push(null);
-        fig.data[0].lat.push(null);
-
-        fig.layout.dragmode = 'select';
-        fig.config = {
-            mapboxAccessToken: require('@build/credentials.json').MAPBOX_ACCESS_TOKEN
-        };
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig).then(function() {
-            return _run(
-                [[370, 120], [500, 200]],
-                function() {
-                    assertPoints([[30, 30]]);
-                    assertRanges([[21.99, 34.55], [38.14, 25.98]]);
-                    assertSelectedPoints({0: [2]});
-                },
-                null, BOXEVENTS, 'scattermapbox select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
-                function() {
-                    assertPoints([[20, 20]]);
-                    assertSelectedPoints({0: [1]});
-                    assertLassoPoints([
-                        [13.28, 25.97], [13.28, 14.33], [25.71, 14.33], [25.71, 25.97], [13.28, 25.97]
-                    ]);
-                },
-                null, LASSOEVENTS, 'scattermapbox lasso'
-            );
-        })
-        .then(function() {
-            // make selection handlers don't get called in 'pan' dragmode
-            return Plotly.relayout(gd, 'dragmode', 'pan');
-        })
-        .then(function() {
-            return _run(
-                [[370, 120], [500, 200]], null, null, NOEVENTS, 'scattermapbox pan'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    }, LONG_TIMEOUT_INTERVAL);
-
-    it('@noCI @gl should work on choroplethmapbox traces', function(done) {
-        var assertPoints = makeAssertPoints(['location', 'z']);
-        var assertRanges = makeAssertRanges('mapbox');
-        var assertLassoPoints = makeAssertLassoPoints('mapbox');
-        var assertSelectedPoints = makeAssertSelectedPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/mapbox_choropleth0.json'));
-
-        fig.data[0].locations.push(null);
-
-        fig.layout.dragmode = 'select';
-        fig.config = {
-            mapboxAccessToken: require('@build/credentials.json').MAPBOX_ACCESS_TOKEN
-        };
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig).then(function() {
-            return _run(
-                [[150, 150], [300, 300]],
-                function() {
-                    assertPoints([['NY', 10]]);
-                    assertRanges([[-83.29, 46.13], [-73.97, 39.29]]);
-                    assertSelectedPoints({0: [0]});
-                },
-                null, BOXEVENTS, 'choroplethmapbox select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
-                function() {
-                    assertPoints([['MA', 20]]);
-                    assertSelectedPoints({0: [1]});
-                    assertLassoPoints([
-                        [-73.97, 43.936], [-73.97, 39.293], [-67.756, 39.293],
-                        [-67.756, 43.936], [-73.971, 43.936]
-                    ]);
-                },
-                null, LASSOEVENTS, 'choroplethmapbox lasso'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    }, LONG_TIMEOUT_INTERVAL);
-
-    it('@flaky should work on scattergeo traces', function(done) {
-        var assertPoints = makeAssertPoints(['lon', 'lat']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges('geo');
-        var assertLassoPoints = makeAssertLassoPoints('geo');
-
-        function assertNodeOpacity(exp) {
-            var traces = d3.select(gd).selectAll('.scatterlayer > .trace');
-            expect(traces.size()).toBe(Object.keys(exp).length, 'correct # of trace <g>');
-
-            traces.each(function(_, i) {
-                d3.select(this).selectAll('path.point').each(function(_, j) {
-                    expect(Number(this.style.opacity))
-                        .toBe(exp[i][j], 'node opacity - trace ' + i + ' pt ' + j);
-                });
-            });
-        }
-
-        var fig = {
-            data: [{
-                type: 'scattergeo',
-                lon: [10, 20, 30, null],
-                lat: [10, 20, 30, null]
-            }, {
-                type: 'scattergeo',
-                lon: [-10, -20, -30],
-                lat: [10, 20, 30]
-            }],
-            layout: {
-                showlegend: false,
-                dragmode: 'select',
-                width: 800,
-                height: 600
-            }
-        };
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[350, 200], [450, 400]],
-                function() {
-                    assertPoints([[10, 10], [20, 20], [-10, 10], [-20, 20]]);
-                    assertSelectedPoints({0: [0, 1], 1: [0, 1]});
-                    assertNodeOpacity({0: [1, 1, 0.2], 1: [1, 1, 0.2]});
-                    assertRanges([[-28.13, 61.88], [28.13, -50.64]]);
-                },
-                null, BOXEVENTS, 'scattergeo select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
-                function() {
-                    assertPoints([[-10, 10], [-20, 20], [-30, 30]]);
-                    assertSelectedPoints({0: [], 1: [0, 1, 2]});
-                    assertNodeOpacity({0: [0.2, 0.2, 0.2], 1: [1, 1, 1]});
-                    assertLassoPoints([
-                        [-56.25, 61.88], [-56.24, 5.63], [0, 5.63], [0, 61.88], [-56.25, 61.88]
-                    ]);
-                },
-                null, LASSOEVENTS, 'scattergeo lasso'
-            );
-        })
-        .then(function() {
-            // some projection types can't handle BADNUM during c2p,
-            // make they are skipped here
-            return Plotly.relayout(gd, 'geo.projection.type', 'robinson');
-        })
-        .then(function() {
-            return _run(
-                [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
-                function() {
-                    assertPoints([[-10, 10], [-20, 20], [-30, 30]]);
-                    assertSelectedPoints({0: [], 1: [0, 1, 2]});
-                    assertNodeOpacity({0: [0.2, 0.2, 0.2], 1: [1, 1, 1]});
-                    assertLassoPoints([
-                        [-67.40, 55.07], [-56.33, 4.968], [0, 4.968], [0, 55.07], [-67.40, 55.07]
-                    ]);
-                },
-                null, LASSOEVENTS, 'scattergeo lasso (on robinson projection)'
-            );
-        })
-        .then(function() {
-            // make sure selection handlers don't get called in 'pan' dragmode
-            return Plotly.relayout(gd, 'dragmode', 'pan');
-        })
-        .then(function() {
-            return _run(
-                [[370, 120], [500, 200]], null, null, NOEVENTS, 'scattergeo pan'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    }, LONG_TIMEOUT_INTERVAL);
-
-    it('@flaky should work on scatterpolar traces', function(done) {
-        var assertPoints = makeAssertPoints(['r', 'theta']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/polar_subplots'));
-        fig.layout.width = 800;
-        fig.layout.dragmode = 'select';
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig).then(function() {
-            return _run(
-                [[150, 150], [350, 250]],
-                function() {
-                    assertPoints([[1, 0], [2, 45]]);
-                    assertSelectedPoints({0: [0, 1]});
-                },
-                [200, 200],
-                BOXEVENTS, 'scatterpolar select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[150, 150], [350, 150], [350, 250], [150, 250], [150, 150]],
-                function() {
-                    assertPoints([[1, 0], [2, 45]]);
-                    assertSelectedPoints({0: [0, 1]});
-                },
-                [200, 200],
-                LASSOEVENTS, 'scatterpolar lasso'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work on barpolar traces', function(done) {
-        var assertPoints = makeAssertPoints(['r', 'theta']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/polar_wind-rose.json'));
-        fig.layout.showlegend = false;
-        fig.layout.width = 500;
-        fig.layout.height = 500;
-        fig.layout.dragmode = 'select';
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig).then(function() {
-            return _run(
-                [[150, 150], [250, 250]],
-                function() {
-                    assertPoints([
-                        [62.5, 'N-W'], [55, 'N-W'], [40, 'North'],
-                        [40, 'N-W'], [20, 'North'], [22.5, 'N-W']
-                    ]);
-                    assertSelectedPoints({
-                        0: [7],
-                        1: [7],
-                        2: [0, 7],
-                        3: [0, 7]
-                    });
-                },
-                [200, 200],
-                BOXEVENTS, 'barpolar select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[150, 150], [350, 150], [350, 250], [150, 250], [150, 150]],
-                function() {
-                    assertPoints([
-                        [62.5, 'N-W'], [50, 'N-E'], [55, 'N-W'], [40, 'North'],
-                        [30, 'N-E'], [40, 'N-W'], [20, 'North'], [7.5, 'N-E'], [22.5, 'N-W']
-                    ]);
-                    assertSelectedPoints({
-                        0: [7],
-                        1: [1, 7],
-                        2: [0, 1, 7],
-                        3: [0, 1, 7]
-                    });
-                },
-                [200, 200],
-                LASSOEVENTS, 'barpolar lasso'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work on choropleth traces', function(done) {
-        var assertPoints = makeAssertPoints(['location', 'z']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges('geo', -0.5);
-        var assertLassoPoints = makeAssertLassoPoints('geo', -0.5);
-
-        var fig = Lib.extendDeep({}, require('@mocks/geo_choropleth-text'));
-        fig.layout.width = 870;
-        fig.layout.height = 450;
-        fig.layout.dragmode = 'select';
-        fig.layout.geo.scope = 'europe';
-        addInvisible(fig, false);
-
-        // add a trace with no locations which will then make trace invisible, lacking DOM elements
-        var emptyChoroplethTrace = Lib.extendDeep({}, fig.data[0]);
-        emptyChoroplethTrace.text = [];
-        emptyChoroplethTrace.locations = [];
-        emptyChoroplethTrace.z = [];
-        fig.data.push(emptyChoroplethTrace);
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[350, 200], [400, 250]],
-                function() {
-                    assertPoints([['GBR', 26.507354205352502], ['IRL', 86.4125147625692]]);
-                    assertSelectedPoints({0: [43, 54]});
-                    assertRanges([[-19.11, 63.06], [7.31, 53.72]]);
-                },
-                [280, 190],
-                BOXEVENTS, 'choropleth select'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'lasso');
-        })
-        .then(function() {
-            return _run(
-                [[350, 200], [400, 200], [400, 250], [350, 250], [350, 200]],
-                function() {
-                    assertPoints([['GBR', 26.507354205352502], ['IRL', 86.4125147625692]]);
-                    assertSelectedPoints({0: [43, 54]});
-                    assertLassoPoints([
-                        [-19.11, 63.06], [5.50, 65.25], [7.31, 53.72], [-12.90, 51.70], [-19.11, 63.06]
-                    ]);
-                },
-                [280, 190],
-                LASSOEVENTS, 'choropleth lasso'
-            );
-        })
-        .then(function() {
-            // make selection handlers don't get called in 'pan' dragmode
-            return Plotly.relayout(gd, 'dragmode', 'pan');
-        })
-        .then(function() {
-            return _run(
-                [[370, 120], [500, 200]], null, [200, 180], NOEVENTS, 'choropleth pan'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    }, LONG_TIMEOUT_INTERVAL);
-
-    it('@flaky should work for waterfall traces', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges();
-        var assertLassoPoints = makeAssertLassoPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/waterfall_profit-loss_2018_positive-negative'));
-        fig.layout.dragmode = 'lasso';
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[400, 300], [200, 400], [400, 500], [600, 400], [500, 350]],
-                function() {
-                    assertPoints([
-                        [0, 281, 'Purchases'],
-                        [0, 269, 'Material expenses'],
-                        [0, 191, 'Personnel expenses'],
-                        [0, 179, 'Other expenses']
-                    ]);
-                    assertSelectedPoints({
-                        0: [5, 6, 7, 8]
-                    });
-                    assertLassoPoints([
-                        [288.8086, 57.7617, 288.8086, 519.8555, 404.3321],
-                        [4.33870, 6.7580, 9.1774, 6.75806, 5.54838]
-                    ]);
-                },
-                null, LASSOEVENTS, 'waterfall lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            return _run(
-                [[300, 300], [400, 400]],
-                function() {
-                    assertPoints([
-                        [0, 281, 'Purchases'],
-                        [0, 269, 'Material expenses']
-                    ]);
-                    assertSelectedPoints({
-                        0: [5, 6]
-                    });
-                    assertRanges([
-                        [173.28519, 288.8086],
-                        [4.3387, 6.7580]
-                    ]);
-                },
-                null, BOXEVENTS, 'waterfall select'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work for funnel traces', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges();
-        var assertLassoPoints = makeAssertLassoPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/funnel_horizontal_group_basic'));
-        fig.layout.dragmode = 'lasso';
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[400, 300], [200, 400], [400, 500], [600, 400], [500, 350]],
-                function() {
-                    assertPoints([
-                        [0, 331.5, 'Author: etpinard'],
-                        [1, 53.5, 'Pull requests'],
-                        [1, 15.5, 'Author: etpinard'],
-                    ]);
-                    assertSelectedPoints({
-                        0: [2],
-                        1: [1, 2]
-                    });
-                    assertLassoPoints([
-                        [-161.6974, -1701.6728, -161.6974, 1378.2779, 608.2902],
-                        [1.1129, 1.9193, 2.7258, 1.9193, 1.5161]
-                    ]);
-                },
-                null, LASSOEVENTS, 'funnel lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            return _run(
-                [[300, 300], [500, 500]],
-                function() {
-                    assertPoints([
-                        [0, 331.5, 'Author: etpinard'],
-                        [1, 53.5, 'Pull requests'],
-                        [1, 15.5, 'Author: etpinard']
-                    ]);
-                    assertSelectedPoints({
-                        0: [2],
-                        1: [1, 2]
-                    });
-                    assertRanges([
-                        [-931.6851, 608.2902],
-                        [1.1129, 2.7258]
-                    ]);
-                },
-                null, BOXEVENTS, 'funnel select'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work for bar traces', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges();
-        var assertLassoPoints = makeAssertLassoPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/0'));
-        fig.layout.dragmode = 'lasso';
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[350, 200], [400, 200], [400, 250], [350, 250], [350, 200]],
-                function() {
-                    assertPoints([
-                        [0, 4.9, 0.371], [0, 5, 0.368], [0, 5.1, 0.356], [0, 5.2, 0.336],
-                        [0, 5.3, 0.309], [0, 5.4, 0.275], [0, 5.5, 0.235], [0, 5.6, 0.192],
-                        [0, 5.7, 0.145],
-                        [1, 5.1, 0.485], [1, 5.2, 0.409], [1, 5.3, 0.327],
-                        [1, 5.4, 0.24], [1, 5.5, 0.149], [1, 5.6, 0.059],
-                        [2, 4.9, 0.473], [2, 5, 0.368], [2, 5.1, 0.258],
-                        [2, 5.2, 0.146], [2, 5.3, 0.036]
-                    ]);
-                    assertSelectedPoints({
-                        0: [49, 50, 51, 52, 53, 54, 55, 56, 57],
-                        1: [51, 52, 53, 54, 55, 56],
-                        2: [49, 50, 51, 52, 53]
-                    });
-                    assertLassoPoints([
-                        [4.87, 5.74, 5.74, 4.87, 4.87],
-                        [0.53, 0.53, -0.02, -0.02, 0.53]
-                    ]);
-                },
-                null, LASSOEVENTS, 'bar lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(delay(100))
-        .then(function() {
-            return _run(
-                [[350, 200], [370, 220]],
-                function() {
-                    assertPoints([
-                        [0, 4.9, 0.371], [0, 5, 0.368], [0, 5.1, 0.356], [0, 5.2, 0.336],
-                        [1, 5.1, 0.485], [1, 5.2, 0.41],
-                        [2, 4.9, 0.473], [2, 5, 0.37]
-                    ]);
-                    assertSelectedPoints({
-                        0: [49, 50, 51, 52],
-                        1: [51, 52],
-                        2: [49, 50]
-                    });
-                    assertRanges([[4.87, 5.22], [0.31, 0.53]]);
-                },
-                null, BOXEVENTS, 'bar select'
-            );
-        })
-        .then(function() {
-            // mimic https://github.com/plotly/plotly.js/issues/3795
-            return Plotly.relayout(gd, {
-                'xaxis.rangeslider.visible': true,
-                'xaxis.range': [0, 6]
-            });
-        })
-        .then(function() {
-            return _run(
-                [[350, 200], [360, 200]],
-                function() {
-                    assertPoints([
-                        [0, 2.5, -0.429], [1, 2.5, -1.015], [2, 2.5, -1.172],
-                    ]);
-                    assertSelectedPoints({
-                        0: [25],
-                        1: [25],
-                        2: [25]
-                    });
-                    assertRanges([[2.434, 2.521], [-1.4355, 2.0555]]);
-                },
-                null, BOXEVENTS, 'bar select (after xaxis.range relayout)'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work for date/category traces', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-
-        var fig = {
-            data: [{
-                x: ['2017-01-01', '2017-02-01', '2017-03-01'],
-                y: ['a', 'b', 'c']
-            }, {
-                type: 'bar',
-                x: ['2017-01-01', '2017-02-02', '2017-03-01'],
-                y: ['a', 'b', 'c']
-            }],
-            layout: {
-                dragmode: 'lasso',
-                width: 400,
-                height: 400
-            }
-        };
-        addInvisible(fig);
-
-        var x0 = 100;
-        var y0 = 100;
-        var x1 = 250;
-        var y1 = 250;
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]],
-                function() {
-                    assertPoints([
-                        [0, '2017-02-01', 'b'],
-                        [1, '2017-02-02', 'b']
-                    ]);
-                    assertSelectedPoints({0: [1], 1: [1]});
-                },
-                null, LASSOEVENTS, 'date/category lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            return _run(
-                [[x0, y0], [x1, y1]],
-                function() {
-                    assertPoints([
-                        [0, '2017-02-01', 'b'],
-                        [1, '2017-02-02', 'b']
-                    ]);
-                    assertSelectedPoints({0: [1], 1: [1]});
-                },
-                null, BOXEVENTS, 'date/category select'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work for histogram traces', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y', 'pointIndices']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges();
-        var assertLassoPoints = makeAssertLassoPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/hist_grouped'));
-        fig.layout.dragmode = 'lasso';
-        fig.layout.width = 600;
-        fig.layout.height = 500;
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
-                function() {
-                    assertPoints([
-                        [0, 1.8, 2, [3, 4]], [1, 2.2, 1, [1]], [1, 3.2, 1, [2]]
-                    ]);
-                    assertSelectedPoints({0: [3, 4], 1: [1, 2]});
-                    assertLassoPoints([
-                        [1.66, 3.59, 3.59, 1.66, 1.66],
-                        [2.17, 2.17, 0.69, 0.69, 2.17]
-                    ]);
-                },
-                null, LASSOEVENTS, 'histogram lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 350]],
-                function() {
-                    assertPoints([
-                        [0, 1.8, 2, [3, 4]], [1, 2.2, 1, [1]], [1, 3.2, 1, [2]]
-                    ]);
-                    assertSelectedPoints({0: [3, 4], 1: [1, 2]});
-                    assertRanges([[1.66, 3.59], [0.69, 2.17]]);
-                },
-                null, BOXEVENTS, 'histogram select'
-            );
-        })
-        .catch(failTest)
-        .then(done);
-    });
-
-    it('@flaky should work for box traces', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges();
-        var assertLassoPoints = makeAssertLassoPoints();
-
-        var fig = Lib.extendDeep({}, require('@mocks/box_grouped'));
-        fig.data.forEach(function(trace) {
-            trace.boxpoints = 'all';
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig).then(function() {
+                return _run(hasCssTransform,
+                    [[400, 200], [445, 235]],
+                    function() {
+                        assertPoints([[0.5, 0.25, 0.25]]);
+                        assertSelectedPoints({0: [0]});
+                    },
+                    [380, 180],
+                    BOXEVENTS, 'scatterternary select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[400, 200], [445, 200], [445, 235], [400, 235], [400, 200]],
+                    function() {
+                        assertPoints([[0.5, 0.25, 0.25]]);
+                        assertSelectedPoints({0: [0]});
+                    },
+                    [380, 180],
+                    LASSOEVENTS, 'scatterternary lasso'
+                );
+            })
+            .then(function() {
+                // should work after a relayout too
+                return Plotly.relayout(gd, 'width', 400);
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [230, 200], [230, 230], [200, 230], [200, 200]],
+                    function() {
+                        assertPoints([[0.5, 0.25, 0.25]]);
+                        assertSelectedPoints({0: [0]});
+                    },
+                    [180, 180],
+                    LASSOEVENTS, 'scatterternary lasso after relayout'
+                );
+            })
+            .catch(failTest)
+            .then(done);
         });
-        fig.layout.dragmode = 'lasso';
-        fig.layout.width = 600;
-        fig.layout.height = 500;
-        fig.layout.xaxis = {range: [-0.565, 1.5]};
-        addInvisible(fig);
-
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
-                function() {
-                    assertPoints([
-                        [0, 0.2, 'day 2'], [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'],
-                        [1, 0.2, 'day 2'], [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'],
-                        [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1']
-                    ]);
-                    assertSelectedPoints({
-                        0: [6, 11, 10, 7],
-                        1: [11, 8, 6, 10],
-                        2: [1, 4, 5]
-                    });
-                    assertLassoPoints([
-                        [0.0423, 1.0546, 1.0546, 0.0423, 0.0423],
-                        [0.71, 0.71, 0.1875, 0.1875, 0.71]
-                    ]);
-                },
-                null, LASSOEVENTS, 'box lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 350]],
-                function() {
-                    assertPoints([
-                        [0, 0.2, 'day 2'], [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'],
-                        [1, 0.2, 'day 2'], [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'],
-                        [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1']
-                    ]);
-                    assertSelectedPoints({
-                        0: [6, 11, 10, 7],
-                        1: [11, 8, 6, 10],
-                        2: [1, 4, 5]
-                    });
-                    assertRanges([[0.04235, 1.0546], [0.1875, 0.71]]);
-                },
-                null, BOXEVENTS, 'box select'
-            );
-        })
-        .catch(failTest)
-        .then(done);
     });
 
-    it('@flaky should work for box traces (q1/median/q3 case)', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on scattercarpet traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['a', 'b']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
 
-        var fig = {
-            data: [{
-                type: 'box',
-                x0: 'A',
-                q1: [1],
-                median: [2],
-                q3: [3],
-                y: [[0, 1, 2, 3, 4]],
-                pointpos: 0,
-            }],
-            layout: {
-                width: 500,
-                height: 500,
-                dragmode: 'lasso'
+            var fig = Lib.extendDeep({}, require('@mocks/scattercarpet'));
+            delete fig.data[6].selectedpoints;
+            fig.layout.dragmode = 'select';
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig).then(function() {
+                return _run(hasCssTransform,
+                    [[300, 200], [400, 250]],
+                    function() {
+                        assertPoints([[0.2, 1.5]]);
+                        assertSelectedPoints({1: [], 2: [], 3: [], 4: [], 5: [1], 6: []});
+                    },
+                    null, BOXEVENTS, 'scattercarpet select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[300, 200], [400, 200], [400, 250], [300, 250], [300, 200]],
+                    function() {
+                        assertPoints([[0.2, 1.5]]);
+                        assertSelectedPoints({1: [], 2: [], 3: [], 4: [], 5: [1], 6: []});
+                    },
+                    null, LASSOEVENTS, 'scattercarpet lasso'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@noCI @gl should work on scattermapbox traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['lon', 'lat']);
+            var assertRanges = makeAssertRanges('mapbox');
+            var assertLassoPoints = makeAssertLassoPoints('mapbox');
+            var assertSelectedPoints = makeAssertSelectedPoints();
+
+            var fig = Lib.extendDeep({}, require('@mocks/mapbox_bubbles-text'));
+
+            fig.data[0].lon.push(null);
+            fig.data[0].lat.push(null);
+
+            fig.layout.dragmode = 'select';
+            fig.config = {
+                mapboxAccessToken: require('@build/credentials.json').MAPBOX_ACCESS_TOKEN
+            };
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig).then(function() {
+                return _run(hasCssTransform,
+                    [[370, 120], [500, 200]],
+                    function() {
+                        assertPoints([[30, 30]]);
+                        assertRanges([[21.99, 34.55], [38.14, 25.98]]);
+                        assertSelectedPoints({0: [2]});
+                    },
+                    null, BOXEVENTS, 'scattermapbox select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
+                    function() {
+                        assertPoints([[20, 20]]);
+                        assertSelectedPoints({0: [1]});
+                        assertLassoPoints([
+                            [13.28, 25.97], [13.28, 14.33], [25.71, 14.33], [25.71, 25.97], [13.28, 25.97]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'scattermapbox lasso'
+                );
+            })
+            .then(function() {
+                // make selection handlers don't get called in 'pan' dragmode
+                return Plotly.relayout(gd, 'dragmode', 'pan');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[370, 120], [500, 200]], null, null, NOEVENTS, 'scattermapbox pan'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        }, LONG_TIMEOUT_INTERVAL);
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@noCI @gl should work on choroplethmapbox traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['location', 'z']);
+            var assertRanges = makeAssertRanges('mapbox');
+            var assertLassoPoints = makeAssertLassoPoints('mapbox');
+            var assertSelectedPoints = makeAssertSelectedPoints();
+
+            var fig = Lib.extendDeep({}, require('@mocks/mapbox_choropleth0.json'));
+
+            fig.data[0].locations.push(null);
+
+            fig.layout.dragmode = 'select';
+            fig.config = {
+                mapboxAccessToken: require('@build/credentials.json').MAPBOX_ACCESS_TOKEN
+            };
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig).then(function() {
+                return _run(hasCssTransform,
+                    [[150, 150], [300, 300]],
+                    function() {
+                        assertPoints([['NY', 10]]);
+                        assertRanges([[-83.29, 46.13], [-73.97, 39.29]]);
+                        assertSelectedPoints({0: [0]});
+                    },
+                    null, BOXEVENTS, 'choroplethmapbox select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
+                    function() {
+                        assertPoints([['MA', 20]]);
+                        assertSelectedPoints({0: [1]});
+                        assertLassoPoints([
+                            [-73.97, 43.936], [-73.97, 39.293], [-67.756, 39.293],
+                            [-67.756, 43.936], [-73.971, 43.936]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'choroplethmapbox lasso'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        }, LONG_TIMEOUT_INTERVAL);
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on scattergeo traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['lon', 'lat']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+            var assertRanges = makeAssertRanges('geo');
+            var assertLassoPoints = makeAssertLassoPoints('geo');
+
+            function assertNodeOpacity(exp) {
+                var traces = d3.select(gd).selectAll('.scatterlayer > .trace');
+                expect(traces.size()).toBe(Object.keys(exp).length, 'correct # of trace <g>');
+
+                traces.each(function(_, i) {
+                    d3.select(this).selectAll('path.point').each(function(_, j) {
+                        expect(Number(this.style.opacity))
+                            .toBe(exp[i][j], 'node opacity - trace ' + i + ' pt ' + j);
+                    });
+                });
             }
-        };
 
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
-                function() {
-                    assertPoints([ [0, 1, undefined], [0, 2, undefined] ]);
-                    assertSelectedPoints({ 0: [[0, 1], [0, 2]] });
-                },
-                null, LASSOEVENTS, 'box lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 300]],
-                function() {
-                    assertPoints([ [0, 2, undefined] ]);
-                    assertSelectedPoints({ 0: [[0, 2]] });
-                },
-                null, BOXEVENTS, 'box select'
-            );
-        })
-        .catch(failTest)
-        .then(done);
+            var fig = {
+                data: [{
+                    type: 'scattergeo',
+                    lon: [10, 20, 30, null],
+                    lat: [10, 20, 30, null]
+                }, {
+                    type: 'scattergeo',
+                    lon: [-10, -20, -30],
+                    lat: [10, 20, 30]
+                }],
+                layout: {
+                    showlegend: false,
+                    dragmode: 'select',
+                    width: 800,
+                    height: 600
+                }
+            };
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[350, 200], [450, 400]],
+                    function() {
+                        assertPoints([[10, 10], [20, 20], [-10, 10], [-20, 20]]);
+                        assertSelectedPoints({0: [0, 1], 1: [0, 1]});
+                        assertNodeOpacity({0: [1, 1, 0.2], 1: [1, 1, 0.2]});
+                        assertRanges([[-28.13, 61.88], [28.13, -50.64]]);
+                    },
+                    null, BOXEVENTS, 'scattergeo select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
+                    function() {
+                        assertPoints([[-10, 10], [-20, 20], [-30, 30]]);
+                        assertSelectedPoints({0: [], 1: [0, 1, 2]});
+                        assertNodeOpacity({0: [0.2, 0.2, 0.2], 1: [1, 1, 1]});
+                        assertLassoPoints([
+                            [-56.25, 61.88], [-56.24, 5.63], [0, 5.63], [0, 61.88], [-56.25, 61.88]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'scattergeo lasso'
+                );
+            })
+            .then(function() {
+                // some projection types can't handle BADNUM during c2p,
+                // make they are skipped here
+                return Plotly.relayout(gd, 'geo.projection.type', 'robinson');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[300, 200], [300, 300], [400, 300], [400, 200], [300, 200]],
+                    function() {
+                        assertPoints([[-10, 10], [-20, 20], [-30, 30]]);
+                        assertSelectedPoints({0: [], 1: [0, 1, 2]});
+                        assertNodeOpacity({0: [0.2, 0.2, 0.2], 1: [1, 1, 1]});
+                        assertLassoPoints([
+                            [-67.40, 55.07], [-56.33, 4.968], [0, 4.968], [0, 55.07], [-67.40, 55.07]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'scattergeo lasso (on robinson projection)'
+                );
+            })
+            .then(function() {
+                // make sure selection handlers don't get called in 'pan' dragmode
+                return Plotly.relayout(gd, 'dragmode', 'pan');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[370, 120], [500, 200]], null, null, NOEVENTS, 'scattergeo pan'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        }, LONG_TIMEOUT_INTERVAL);
     });
 
-    it('@flaky should work for violin traces', function(done) {
-        var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
-        var assertSelectedPoints = makeAssertSelectedPoints();
-        var assertRanges = makeAssertRanges();
-        var assertLassoPoints = makeAssertLassoPoints();
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on scatterpolar traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['r', 'theta']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
 
-        var fig = Lib.extendDeep({}, require('@mocks/violin_grouped'));
-        fig.layout.dragmode = 'lasso';
-        fig.layout.width = 600;
-        fig.layout.height = 500;
-        addInvisible(fig);
+            var fig = Lib.extendDeep({}, require('@mocks/polar_subplots'));
+            fig.layout.width = 800;
+            fig.layout.dragmode = 'select';
+            addInvisible(fig);
 
-        Plotly.plot(gd, fig)
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
-                function() {
-                    assertPoints([
-                        [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'], [0, 0.9, 'day 2'],
-                        [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'], [1, 0.8, 'day 2'],
-                        [1, 0.9, 'day 2'],
-                        [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1'], [2, 0.9, 'day 1']
-                    ]);
-                    assertSelectedPoints({
-                        0: [11, 10, 7, 8],
-                        1: [8, 6, 10, 9, 7],
-                        2: [1, 4, 5, 3]
-                    });
-                    assertLassoPoints([
-                        [0.07777, 1.0654, 1.0654, 0.07777, 0.07777],
-                        [1.02, 1.02, 0.27, 0.27, 1.02]
-                    ]);
-                },
-                null, LASSOEVENTS, 'violin lasso'
-            );
-        })
-        .then(function() {
-            return Plotly.relayout(gd, 'dragmode', 'select');
-        })
-        .then(function() {
-            return _run(
-                [[200, 200], [400, 350]],
-                function() {
-                    assertPoints([
-                        [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'], [0, 0.9, 'day 2'],
-                        [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'], [1, 0.8, 'day 2'],
-                        [1, 0.9, 'day 2'],
-                        [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1'], [2, 0.9, 'day 1']
-                    ]);
-                    assertSelectedPoints({
-                        0: [11, 10, 7, 8],
-                        1: [8, 6, 10, 9, 7],
-                        2: [1, 4, 5, 3]
-                    });
-                    assertRanges([[0.07777, 1.0654], [0.27, 1.02]]);
-                },
-                null, BOXEVENTS, 'violin select'
-            );
-        })
-        .catch(failTest)
-        .then(done);
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig).then(function() {
+                return _run(hasCssTransform,
+                    [[150, 150], [350, 250]],
+                    function() {
+                        assertPoints([[1, 0], [2, 45]]);
+                        assertSelectedPoints({0: [0, 1]});
+                    },
+                    [200, 200],
+                    BOXEVENTS, 'scatterpolar select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[150, 150], [350, 150], [350, 250], [150, 250], [150, 150]],
+                    function() {
+                        assertPoints([[1, 0], [2, 45]]);
+                        assertSelectedPoints({0: [0, 1]});
+                    },
+                    [200, 200],
+                    LASSOEVENTS, 'scatterpolar lasso'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
     });
 
-    ['ohlc', 'candlestick'].forEach(function(type) {
-        it('@flaky should work for ' + type + ' traces', function(done) {
-            var assertPoints = makeAssertPoints(['curveNumber', 'x', 'open', 'high', 'low', 'close']);
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on barpolar traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['r', 'theta']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+
+            var fig = Lib.extendDeep({}, require('@mocks/polar_wind-rose.json'));
+            fig.layout.showlegend = false;
+            fig.layout.width = 500;
+            fig.layout.height = 500;
+            fig.layout.dragmode = 'select';
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig).then(function() {
+                return _run(hasCssTransform,
+                    [[150, 150], [250, 250]],
+                    function() {
+                        assertPoints([
+                            [62.5, 'N-W'], [55, 'N-W'], [40, 'North'],
+                            [40, 'N-W'], [20, 'North'], [22.5, 'N-W']
+                        ]);
+                        assertSelectedPoints({
+                            0: [7],
+                            1: [7],
+                            2: [0, 7],
+                            3: [0, 7]
+                        });
+                    },
+                    [200, 200],
+                    BOXEVENTS, 'barpolar select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[150, 150], [350, 150], [350, 250], [150, 250], [150, 150]],
+                    function() {
+                        assertPoints([
+                            [62.5, 'N-W'], [50, 'N-E'], [55, 'N-W'], [40, 'North'],
+                            [30, 'N-E'], [40, 'N-W'], [20, 'North'], [7.5, 'N-E'], [22.5, 'N-W']
+                        ]);
+                        assertSelectedPoints({
+                            0: [7],
+                            1: [1, 7],
+                            2: [0, 1, 7],
+                            3: [0, 1, 7]
+                        });
+                    },
+                    [200, 200],
+                    LASSOEVENTS, 'barpolar lasso'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on choropleth traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['location', 'z']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+            var assertRanges = makeAssertRanges('geo', -0.5);
+            var assertLassoPoints = makeAssertLassoPoints('geo', -0.5);
+
+            var fig = Lib.extendDeep({}, require('@mocks/geo_choropleth-text'));
+            fig.layout.width = 870;
+            fig.layout.height = 450;
+            fig.layout.dragmode = 'select';
+            fig.layout.geo.scope = 'europe';
+            addInvisible(fig, false);
+
+            // add a trace with no locations which will then make trace invisible, lacking DOM elements
+            var emptyChoroplethTrace = Lib.extendDeep({}, fig.data[0]);
+            emptyChoroplethTrace.text = [];
+            emptyChoroplethTrace.locations = [];
+            emptyChoroplethTrace.z = [];
+            fig.data.push(emptyChoroplethTrace);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[350, 200], [400, 250]],
+                    function() {
+                        assertPoints([['GBR', 26.507354205352502], ['IRL', 86.4125147625692]]);
+                        assertSelectedPoints({0: [43, 54]});
+                        assertRanges([[-19.11, 63.06], [7.31, 53.72]]);
+                    },
+                    [280, 190],
+                    BOXEVENTS, 'choropleth select'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'lasso');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[350, 200], [400, 200], [400, 250], [350, 250], [350, 200]],
+                    function() {
+                        assertPoints([['GBR', 26.507354205352502], ['IRL', 86.4125147625692]]);
+                        assertSelectedPoints({0: [43, 54]});
+                        assertLassoPoints([
+                            [-19.11, 63.06], [5.50, 65.25], [7.31, 53.72], [-12.90, 51.70], [-19.11, 63.06]
+                        ]);
+                    },
+                    [280, 190],
+                    LASSOEVENTS, 'choropleth lasso'
+                );
+            })
+            .then(function() {
+                // make selection handlers don't get called in 'pan' dragmode
+                return Plotly.relayout(gd, 'dragmode', 'pan');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[370, 120], [500, 200]], null, [200, 180], NOEVENTS, 'choropleth pan'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        }, LONG_TIMEOUT_INTERVAL);
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for waterfall traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
             var assertSelectedPoints = makeAssertSelectedPoints();
             var assertRanges = makeAssertRanges();
             var assertLassoPoints = makeAssertLassoPoints();
-            var l0 = 275;
-            var lv0 = '2011-01-03 18:00';
-            var r0 = 325;
-            var rv0 = '2011-01-04 06:00';
-            var l1 = 75;
-            var lv1 = '2011-01-01 18:00';
-            var r1 = 125;
-            var rv1 = '2011-01-02 06:00';
-            var t = 75;
-            var tv = 7.565;
-            var b = 225;
-            var bv = -1.048;
 
-            function countUnSelectedPaths(selector) {
-                var unselected = 0;
-                d3.select(gd).selectAll(selector).each(function() {
-                    var opacity = this.style.opacity;
-                    if(opacity < 1) unselected++;
-                });
-                return unselected;
-            }
+            var fig = Lib.extendDeep({}, require('@mocks/waterfall_profit-loss_2018_positive-negative'));
+            fig.layout.dragmode = 'lasso';
+            addInvisible(fig);
 
-            Plotly.newPlot(gd, [{
-                type: type,
-                x: ['2011-01-02', '2011-01-03', '2011-01-04'],
-                open: [1, 2, 3],
-                high: [3, 4, 5],
-                low: [0, 1, 2],
-                close: [0, 3, 2]
-            }], {
-                width: 400,
-                height: 400,
-                margin: {l: 50, r: 50, t: 50, b: 50},
-                yaxis: {range: [-3, 9]},
-                dragmode: 'lasso'
-            })
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
             .then(function() {
-                return _run(
-                    [[l0, t], [l0, b], [r0, b], [r0, t], [l0, t]],
+                return _run(hasCssTransform,
+                    [[400, 300], [200, 400], [400, 500], [600, 400], [500, 350]],
                     function() {
-                        assertPoints([[0, '2011-01-04', 3, 5, 2, 2]]);
-                        assertSelectedPoints([[2]]);
-                        assertLassoPoints([
-                            [lv0, lv0, rv0, rv0, lv0],
-                            [tv, bv, bv, tv, tv]
+                        assertPoints([
+                            [0, 281, 'Purchases'],
+                            [0, 269, 'Material expenses'],
+                            [0, 191, 'Personnel expenses'],
+                            [0, 179, 'Other expenses']
                         ]);
-                        expect(countUnSelectedPaths('.cartesianlayer .trace path')).toBe(2);
-                        expect(countUnSelectedPaths('.rangeslider-rangeplot .trace path')).toBe(2);
+                        assertSelectedPoints({
+                            0: [5, 6, 7, 8]
+                        });
+                        assertLassoPoints([
+                            [288.8086, 57.7617, 288.8086, 519.8555, 404.3321],
+                            [4.33870, 6.7580, 9.1774, 6.75806, 5.54838]
+                        ]);
                     },
-                    null, LASSOEVENTS, type + ' lasso'
+                    null, LASSOEVENTS, 'waterfall lasso'
                 );
             })
             .then(function() {
                 return Plotly.relayout(gd, 'dragmode', 'select');
             })
             .then(function() {
-                return _run(
-                    [[l1, t], [r1, b]],
+                return _run(hasCssTransform,
+                    [[300, 300], [400, 400]],
                     function() {
-                        assertPoints([[0, '2011-01-02', 1, 3, 0, 0]]);
-                        assertSelectedPoints([[0]]);
-                        assertRanges([[lv1, rv1], [bv, tv]]);
+                        assertPoints([
+                            [0, 281, 'Purchases'],
+                            [0, 269, 'Material expenses']
+                        ]);
+                        assertSelectedPoints({
+                            0: [5, 6]
+                        });
+                        assertRanges([
+                            [173.28519, 288.8086],
+                            [4.3387, 6.7580]
+                        ]);
                     },
-                    null, BOXEVENTS, type + ' select'
+                    null, BOXEVENTS, 'waterfall select'
                 );
             })
             .catch(failTest)
@@ -2881,133 +2419,677 @@ describe('Test select box and lasso per trace:', function() {
         });
     });
 
-    it('@flaky should work on traces with enabled transforms', function(done) {
-        var assertSelectedPoints = makeAssertSelectedPoints();
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for funnel traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+            var assertRanges = makeAssertRanges();
+            var assertLassoPoints = makeAssertLassoPoints();
 
-        Plotly.plot(gd, [{
-            x: [1, 2, 3, 4, 5],
-            y: [2, 3, 1, 7, 9],
-            marker: {size: [10, 20, 20, 20, 10]},
-            transforms: [{
-                type: 'filter',
-                operation: '>',
-                value: 2,
-                target: 'y'
-            }, {
-                type: 'aggregate',
-                groups: 'marker.size',
-                aggregations: [
-                    // 20: 6, 10: 5
-                    {target: 'x', func: 'sum'},
-                    // 20: 5, 10: 9
-                    {target: 'y', func: 'avg'}
-                ]
-            }]
-        }], {
-            dragmode: 'select',
-            showlegend: false,
-            width: 400,
-            height: 400,
-            margin: {l: 0, t: 0, r: 0, b: 0}
-        })
-        .then(function() {
-            return _run(
-                [[5, 5], [395, 395]],
-                function() {
-                    assertSelectedPoints({0: [1, 3, 4]});
-                },
-                [380, 180],
-                BOXEVENTS, 'transformed trace select (all points selected)'
-            );
-        })
-        .catch(failTest)
-        .then(done);
+            var fig = Lib.extendDeep({}, require('@mocks/funnel_horizontal_group_basic'));
+            fig.layout.dragmode = 'lasso';
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[400, 300], [200, 400], [400, 500], [600, 400], [500, 350]],
+                    function() {
+                        assertPoints([
+                            [0, 331.5, 'Author: etpinard'],
+                            [1, 53.5, 'Pull requests'],
+                            [1, 15.5, 'Author: etpinard'],
+                        ]);
+                        assertSelectedPoints({
+                            0: [2],
+                            1: [1, 2]
+                        });
+                        assertLassoPoints([
+                            [-161.6974, -1701.6728, -161.6974, 1378.2779, 608.2902],
+                            [1.1129, 1.9193, 2.7258, 1.9193, 1.5161]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'funnel lasso'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[300, 300], [500, 500]],
+                    function() {
+                        assertPoints([
+                            [0, 331.5, 'Author: etpinard'],
+                            [1, 53.5, 'Pull requests'],
+                            [1, 15.5, 'Author: etpinard']
+                        ]);
+                        assertSelectedPoints({
+                            0: [2],
+                            1: [1, 2]
+                        });
+                        assertRanges([
+                            [-931.6851, 608.2902],
+                            [1.1129, 2.7258]
+                        ]);
+                    },
+                    null, BOXEVENTS, 'funnel select'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
     });
 
-    it('@flaky should work on scatter/bar traces with text nodes', function(done) {
-        var assertSelectedPoints = makeAssertSelectedPoints();
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for bar traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+            var assertRanges = makeAssertRanges();
+            var assertLassoPoints = makeAssertLassoPoints();
 
-        function assertFillOpacity(exp, msg) {
-            var txtPts = d3.select(gd).select('g.plot').selectAll('text');
+            var fig = Lib.extendDeep({}, require('@mocks/0'));
+            fig.layout.dragmode = 'lasso';
+            addInvisible(fig);
 
-            expect(txtPts.size()).toBe(exp.length, '# of text nodes: ' + msg);
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[350, 200], [400, 200], [400, 250], [350, 250], [350, 200]],
+                    function() {
+                        assertPoints([
+                            [0, 4.9, 0.371], [0, 5, 0.368], [0, 5.1, 0.356], [0, 5.2, 0.336],
+                            [0, 5.3, 0.309], [0, 5.4, 0.275], [0, 5.5, 0.235], [0, 5.6, 0.192],
+                            [0, 5.7, 0.145],
+                            [1, 5.1, 0.485], [1, 5.2, 0.409], [1, 5.3, 0.327],
+                            [1, 5.4, 0.24], [1, 5.5, 0.149], [1, 5.6, 0.059],
+                            [2, 4.9, 0.473], [2, 5, 0.368], [2, 5.1, 0.258],
+                            [2, 5.2, 0.146], [2, 5.3, 0.036]
+                        ]);
+                        assertSelectedPoints({
+                            0: [49, 50, 51, 52, 53, 54, 55, 56, 57],
+                            1: [51, 52, 53, 54, 55, 56],
+                            2: [49, 50, 51, 52, 53]
+                        });
+                        assertLassoPoints([
+                            [4.87, 5.74, 5.74, 4.87, 4.87],
+                            [0.53, 0.53, -0.02, -0.02, 0.53]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'bar lasso'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(delay(100))
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[350, 200], [370, 220]],
+                    function() {
+                        assertPoints([
+                            [0, 4.9, 0.371], [0, 5, 0.368], [0, 5.1, 0.356], [0, 5.2, 0.336],
+                            [1, 5.1, 0.485], [1, 5.2, 0.41],
+                            [2, 4.9, 0.473], [2, 5, 0.37]
+                        ]);
+                        assertSelectedPoints({
+                            0: [49, 50, 51, 52],
+                            1: [51, 52],
+                            2: [49, 50]
+                        });
+                        assertRanges([[4.87, 5.22], [0.31, 0.53]]);
+                    },
+                    null, BOXEVENTS, 'bar select'
+                );
+            })
+            .then(function() {
+                // mimic https://github.com/plotly/plotly.js/issues/3795
+                return Plotly.relayout(gd, {
+                    'xaxis.rangeslider.visible': true,
+                    'xaxis.range': [0, 6]
+                });
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[350, 200], [360, 200]],
+                    function() {
+                        assertPoints([
+                            [0, 2.5, -0.429], [1, 2.5, -1.015], [2, 2.5, -1.172],
+                        ]);
+                        assertSelectedPoints({
+                            0: [25],
+                            1: [25],
+                            2: [25]
+                        });
+                        assertRanges([[2.434, 2.521], [-1.4355, 2.0555]]);
+                    },
+                    null, BOXEVENTS, 'bar select (after xaxis.range relayout)'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
 
-            txtPts.each(function(_, i) {
-                var act = Number(this.style['fill-opacity']);
-                expect(act).toBe(exp[i], 'node ' + i + ' fill opacity: ' + msg);
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for date/category traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+
+            var fig = {
+                data: [{
+                    x: ['2017-01-01', '2017-02-01', '2017-03-01'],
+                    y: ['a', 'b', 'c']
+                }, {
+                    type: 'bar',
+                    x: ['2017-01-01', '2017-02-02', '2017-03-01'],
+                    y: ['a', 'b', 'c']
+                }],
+                layout: {
+                    dragmode: 'lasso',
+                    width: 400,
+                    height: 400
+                }
+            };
+            addInvisible(fig);
+
+            var x0 = 100;
+            var y0 = 100;
+            var x1 = 250;
+            var y1 = 250;
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]],
+                    function() {
+                        assertPoints([
+                            [0, '2017-02-01', 'b'],
+                            [1, '2017-02-02', 'b']
+                        ]);
+                        assertSelectedPoints({0: [1], 1: [1]});
+                    },
+                    null, LASSOEVENTS, 'date/category lasso'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[x0, y0], [x1, y1]],
+                    function() {
+                        assertPoints([
+                            [0, '2017-02-01', 'b'],
+                            [1, '2017-02-02', 'b']
+                        ]);
+                        assertSelectedPoints({0: [1], 1: [1]});
+                    },
+                    null, BOXEVENTS, 'date/category select'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for histogram traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'x', 'y', 'pointIndices']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+            var assertRanges = makeAssertRanges();
+            var assertLassoPoints = makeAssertLassoPoints();
+
+            var fig = Lib.extendDeep({}, require('@mocks/hist_grouped'));
+            fig.layout.dragmode = 'lasso';
+            fig.layout.width = 600;
+            fig.layout.height = 500;
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
+                    function() {
+                        assertPoints([
+                            [0, 1.8, 2, [3, 4]], [1, 2.2, 1, [1]], [1, 3.2, 1, [2]]
+                        ]);
+                        assertSelectedPoints({0: [3, 4], 1: [1, 2]});
+                        assertLassoPoints([
+                            [1.66, 3.59, 3.59, 1.66, 1.66],
+                            [2.17, 2.17, 0.69, 0.69, 2.17]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'histogram lasso'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 350]],
+                    function() {
+                        assertPoints([
+                            [0, 1.8, 2, [3, 4]], [1, 2.2, 1, [1]], [1, 3.2, 1, [2]]
+                        ]);
+                        assertSelectedPoints({0: [3, 4], 1: [1, 2]});
+                        assertRanges([[1.66, 3.59], [0.69, 2.17]]);
+                    },
+                    null, BOXEVENTS, 'histogram select'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for box traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+            var assertRanges = makeAssertRanges();
+            var assertLassoPoints = makeAssertLassoPoints();
+
+            var fig = Lib.extendDeep({}, require('@mocks/box_grouped'));
+            fig.data.forEach(function(trace) {
+                trace.boxpoints = 'all';
             });
-        }
+            fig.layout.dragmode = 'lasso';
+            fig.layout.width = 600;
+            fig.layout.height = 500;
+            fig.layout.xaxis = {range: [-0.565, 1.5]};
+            addInvisible(fig);
 
-        Plotly.plot(gd, [{
-            mode: 'markers+text',
-            x: [1, 2, 3],
-            y: [1, 2, 1],
-            text: ['a', 'b', 'c']
-        }, {
-            type: 'bar',
-            x: [1, 2, 3],
-            y: [1, 2, 1],
-            text: ['A', 'B', 'C'],
-            textposition: 'outside'
-        }], {
-            dragmode: 'select',
-            hovermode: 'closest',
-            showlegend: false,
-            width: 400,
-            height: 400,
-            margin: {l: 0, t: 0, r: 0, b: 0}
-        })
-        .then(function() {
-            return _run(
-                [[10, 10], [100, 300]],
-                function() {
-                    assertSelectedPoints({0: [0], 1: [0]});
-                    assertFillOpacity([1, 0.2, 0.2, 1, 0.2, 0.2], '_run');
-                },
-                [10, 10], BOXEVENTS, 'selecting first scatter/bar text nodes'
-            );
-        })
-        .then(function() {
-            assertFillOpacity([1, 1, 1, 1, 1, 1], 'final');
-        })
-        .catch(failTest)
-        .then(done);
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
+                    function() {
+                        assertPoints([
+                            [0, 0.2, 'day 2'], [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'],
+                            [1, 0.2, 'day 2'], [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'],
+                            [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1']
+                        ]);
+                        assertSelectedPoints({
+                            0: [6, 11, 10, 7],
+                            1: [11, 8, 6, 10],
+                            2: [1, 4, 5]
+                        });
+                        assertLassoPoints([
+                            [0.0423, 1.0546, 1.0546, 0.0423, 0.0423],
+                            [0.71, 0.71, 0.1875, 0.1875, 0.71]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'box lasso'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 350]],
+                    function() {
+                        assertPoints([
+                            [0, 0.2, 'day 2'], [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'],
+                            [1, 0.2, 'day 2'], [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'],
+                            [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1']
+                        ]);
+                        assertSelectedPoints({
+                            0: [6, 11, 10, 7],
+                            1: [11, 8, 6, 10],
+                            2: [1, 4, 5]
+                        });
+                        assertRanges([[0.04235, 1.0546], [0.1875, 0.71]]);
+                    },
+                    null, BOXEVENTS, 'box select'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for box traces (q1/median/q3 case), hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+
+            var fig = {
+                data: [{
+                    type: 'box',
+                    x0: 'A',
+                    q1: [1],
+                    median: [2],
+                    q3: [3],
+                    y: [[0, 1, 2, 3, 4]],
+                    pointpos: 0,
+                }],
+                layout: {
+                    width: 500,
+                    height: 500,
+                    dragmode: 'lasso'
+                }
+            };
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
+                    function() {
+                        assertPoints([ [0, 1, undefined], [0, 2, undefined] ]);
+                        assertSelectedPoints({ 0: [[0, 1], [0, 2]] });
+                    },
+                    null, LASSOEVENTS, 'box lasso'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 300]],
+                    function() {
+                        assertPoints([ [0, 2, undefined] ]);
+                        assertSelectedPoints({ 0: [[0, 2]] });
+                    },
+                    null, BOXEVENTS, 'box select'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work for violin traces, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertPoints = makeAssertPoints(['curveNumber', 'y', 'x']);
+            var assertSelectedPoints = makeAssertSelectedPoints();
+            var assertRanges = makeAssertRanges();
+            var assertLassoPoints = makeAssertLassoPoints();
+
+            var fig = Lib.extendDeep({}, require('@mocks/violin_grouped'));
+            fig.layout.dragmode = 'lasso';
+            fig.layout.width = 600;
+            fig.layout.height = 500;
+            addInvisible(fig);
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, fig)
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 200], [400, 350], [200, 350], [200, 200]],
+                    function() {
+                        assertPoints([
+                            [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'], [0, 0.9, 'day 2'],
+                            [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'], [1, 0.8, 'day 2'],
+                            [1, 0.9, 'day 2'],
+                            [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1'], [2, 0.9, 'day 1']
+                        ]);
+                        assertSelectedPoints({
+                            0: [11, 10, 7, 8],
+                            1: [8, 6, 10, 9, 7],
+                            2: [1, 4, 5, 3]
+                        });
+                        assertLassoPoints([
+                            [0.07777, 1.0654, 1.0654, 0.07777, 0.07777],
+                            [1.02, 1.02, 0.27, 0.27, 1.02]
+                        ]);
+                    },
+                    null, LASSOEVENTS, 'violin lasso'
+                );
+            })
+            .then(function() {
+                return Plotly.relayout(gd, 'dragmode', 'select');
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[200, 200], [400, 350]],
+                    function() {
+                        assertPoints([
+                            [0, 0.3, 'day 2'], [0, 0.5, 'day 2'], [0, 0.7, 'day 2'], [0, 0.9, 'day 2'],
+                            [1, 0.5, 'day 2'], [1, 0.7, 'day 2'], [1, 0.7, 'day 2'], [1, 0.8, 'day 2'],
+                            [1, 0.9, 'day 2'],
+                            [2, 0.3, 'day 1'], [2, 0.6, 'day 1'], [2, 0.6, 'day 1'], [2, 0.9, 'day 1']
+                        ]);
+                        assertSelectedPoints({
+                            0: [11, 10, 7, 8],
+                            1: [8, 6, 10, 9, 7],
+                            2: [1, 4, 5, 3]
+                        });
+                        assertRanges([[0.07777, 1.0654], [0.27, 1.02]]);
+                    },
+                    null, BOXEVENTS, 'violin select'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false].forEach(function(hasCssTransform) {
+        ['ohlc', 'candlestick'].forEach(function(type) {
+            it('@flaky should work for ' + type + ' traces, hasCssTransform: ' + hasCssTransform, function(done) {
+                var assertPoints = makeAssertPoints(['curveNumber', 'x', 'open', 'high', 'low', 'close']);
+                var assertSelectedPoints = makeAssertSelectedPoints();
+                var assertRanges = makeAssertRanges();
+                var assertLassoPoints = makeAssertLassoPoints();
+                var l0 = 275;
+                var lv0 = '2011-01-03 18:00';
+                var r0 = 325;
+                var rv0 = '2011-01-04 06:00';
+                var l1 = 75;
+                var lv1 = '2011-01-01 18:00';
+                var r1 = 125;
+                var rv1 = '2011-01-02 06:00';
+                var t = 75;
+                var tv = 7.565;
+                var b = 225;
+                var bv = -1.048;
+
+                function countUnSelectedPaths(selector) {
+                    var unselected = 0;
+                    d3.select(gd).selectAll(selector).each(function() {
+                        var opacity = this.style.opacity;
+                        if(opacity < 1) unselected++;
+                    });
+                    return unselected;
+                }
+
+                if(hasCssTransform) transformPlot(gd, cssTransform);
+                Plotly.newPlot(gd, [{
+                    type: type,
+                    x: ['2011-01-02', '2011-01-03', '2011-01-04'],
+                    open: [1, 2, 3],
+                    high: [3, 4, 5],
+                    low: [0, 1, 2],
+                    close: [0, 3, 2]
+                }], {
+                    width: 400,
+                    height: 400,
+                    margin: {l: 50, r: 50, t: 50, b: 50},
+                    yaxis: {range: [-3, 9]},
+                    dragmode: 'lasso'
+                })
+                .then(function() {
+                    return _run(hasCssTransform,
+                        [[l0, t], [l0, b], [r0, b], [r0, t], [l0, t]],
+                        function() {
+                            assertPoints([[0, '2011-01-04', 3, 5, 2, 2]]);
+                            assertSelectedPoints([[2]]);
+                            assertLassoPoints([
+                                [lv0, lv0, rv0, rv0, lv0],
+                                [tv, bv, bv, tv, tv]
+                            ]);
+                            expect(countUnSelectedPaths('.cartesianlayer .trace path')).toBe(2);
+                            expect(countUnSelectedPaths('.rangeslider-rangeplot .trace path')).toBe(2);
+                        },
+                        null, LASSOEVENTS, type + ' lasso'
+                    );
+                })
+                .then(function() {
+                    return Plotly.relayout(gd, 'dragmode', 'select');
+                })
+                .then(function() {
+                    return _run(hasCssTransform,
+                        [[l1, t], [r1, b]],
+                        function() {
+                            assertPoints([[0, '2011-01-02', 1, 3, 0, 0]]);
+                            assertSelectedPoints([[0]]);
+                            assertRanges([[lv1, rv1], [bv, tv]]);
+                        },
+                        null, BOXEVENTS, type + ' select'
+                    );
+                })
+                .catch(failTest)
+                .then(done);
+            });
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on traces with enabled transforms, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertSelectedPoints = makeAssertSelectedPoints();
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, [{
+                x: [1, 2, 3, 4, 5],
+                y: [2, 3, 1, 7, 9],
+                marker: {size: [10, 20, 20, 20, 10]},
+                transforms: [{
+                    type: 'filter',
+                    operation: '>',
+                    value: 2,
+                    target: 'y'
+                }, {
+                    type: 'aggregate',
+                    groups: 'marker.size',
+                    aggregations: [
+                        // 20: 6, 10: 5
+                        {target: 'x', func: 'sum'},
+                        // 20: 5, 10: 9
+                        {target: 'y', func: 'avg'}
+                    ]
+                }]
+            }], {
+                dragmode: 'select',
+                showlegend: false,
+                width: 400,
+                height: 400,
+                margin: {l: 0, t: 0, r: 0, b: 0}
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[5, 5], [395, 395]],
+                    function() {
+                        assertSelectedPoints({0: [1, 3, 4]});
+                    },
+                    [380, 180],
+                    BOXEVENTS, 'transformed trace select (all points selected)'
+                );
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
+    [false, true].forEach(function(hasCssTransform) {
+        it('@flaky should work on scatter/bar traces with text nodes, hasCssTransform: ' + hasCssTransform, function(done) {
+            var assertSelectedPoints = makeAssertSelectedPoints();
+
+            function assertFillOpacity(exp, msg) {
+                var txtPts = d3.select(gd).select('g.plot').selectAll('text');
+
+                expect(txtPts.size()).toBe(exp.length, '# of text nodes: ' + msg);
+
+                txtPts.each(function(_, i) {
+                    var act = Number(this.style['fill-opacity']);
+                    expect(act).toBe(exp[i], 'node ' + i + ' fill opacity: ' + msg);
+                });
+            }
+
+            if(hasCssTransform) transformPlot(gd, cssTransform);
+            Plotly.plot(gd, [{
+                mode: 'markers+text',
+                x: [1, 2, 3],
+                y: [1, 2, 1],
+                text: ['a', 'b', 'c']
+            }, {
+                type: 'bar',
+                x: [1, 2, 3],
+                y: [1, 2, 1],
+                text: ['A', 'B', 'C'],
+                textposition: 'outside'
+            }], {
+                dragmode: 'select',
+                hovermode: 'closest',
+                showlegend: false,
+                width: 400,
+                height: 400,
+                margin: {l: 0, t: 0, r: 0, b: 0}
+            })
+            .then(function() {
+                return _run(hasCssTransform,
+                    [[10, 10], [100, 300]],
+                    function() {
+                        assertSelectedPoints({0: [0], 1: [0]});
+                        assertFillOpacity([1, 0.2, 0.2, 1, 0.2, 0.2], '_run');
+                    },
+                    [10, 10], BOXEVENTS, 'selecting first scatter/bar text nodes'
+                );
+            })
+            .then(function() {
+                assertFillOpacity([1, 1, 1, 1, 1, 1], 'final');
+            })
+            .catch(failTest)
+            .then(done);
+        });
     });
 
     describe('should work on sankey traces', function() {
         var waitingTime = sankeyConstants.duration * 2;
 
-        it('@flaky select', function(done) {
-            var fig = Lib.extendDeep({}, require('@mocks/sankey_circular.json'));
-            fig.layout.dragmode = 'select';
-            var dblClickPos = [250, 400];
+        [false, true].forEach(function(hasCssTransform) {
+            it('@flaky select, hasCssTransform: ' + hasCssTransform, function(done) {
+                var fig = Lib.extendDeep({}, require('@mocks/sankey_circular.json'));
+                fig.layout.dragmode = 'select';
+                var dblClickPos = [250, 400];
 
-            Plotly.plot(gd, fig)
-            .then(function() {
-                // No groups initially
-                expect(gd._fullData[0].node.groups).toEqual([]);
-            })
-            .then(function() {
-                // Grouping the two nodes on the top right
-                return _run(
-                    [[640, 130], [400, 450]],
-                    function() {
-                        expect(gd._fullData[0].node.groups).toEqual([[2, 3]], 'failed to group #2 + #3');
-                    },
-                    dblClickPos, BOXEVENTS, 'for top right nodes #2 and #3'
-                );
-            })
-            .then(delay(waitingTime))
-            .then(function() {
-                // Grouping node #4 and the previous group
-                drag([[715, 400], [300, 110]]);
-            })
-            .then(delay(waitingTime))
-            .then(function() {
-                expect(gd._fullData[0].node.groups).toEqual([[4, 3, 2]], 'failed to group #4 + existing group of #2 and #3');
-            })
-            .catch(failTest)
-            .then(done);
+                if(hasCssTransform) transformPlot(gd, cssTransform);
+                Plotly.plot(gd, fig)
+                .then(function() {
+                    // No groups initially
+                    expect(gd._fullData[0].node.groups).toEqual([]);
+                })
+                .then(function() {
+                    // Grouping the two nodes on the top right
+                    return _run(hasCssTransform,
+                        [[640, 130], [400, 450]],
+                        function() {
+                            expect(gd._fullData[0].node.groups).toEqual([[2, 3]], 'failed to group #2 + #3');
+                        },
+                        dblClickPos, BOXEVENTS, 'for top right nodes #2 and #3'
+                    );
+                })
+                .then(delay(waitingTime))
+                .then(function() {
+                    // Grouping node #4 and the previous group
+                    drag([[715, 400], [300, 110]]);
+                })
+                .then(delay(waitingTime))
+                .then(function() {
+                    expect(gd._fullData[0].node.groups).toEqual([[4, 3, 2]], 'failed to group #4 + existing group of #2 and #3');
+                })
+                .catch(failTest)
+                .then(done);
+            });
         });
 
         it('@flaky should not work when dragmode is undefined', function(done) {

--- a/test/jasmine/tests/ternary_test.js
+++ b/test/jasmine/tests/ternary_test.js
@@ -559,6 +559,176 @@ describe('ternary plots', function() {
     }
 });
 
+describe('ternary plots when css transform is present', function() {
+    'use strict';
+
+    afterEach(destroyGraphDiv);
+
+    var mock = require('@mocks/ternary_simple.json');
+    var gd;
+
+    function transformPlot(gd, transformString) {
+        gd.style.webkitTransform = transformString;
+        gd.style.MozTransform = transformString;
+        gd.style.msTransform = transformString;
+        gd.style.OTransform = transformString;
+        gd.style.transform = transformString;
+    }
+
+    var cssTransform = 'translate(-25%, -25%) scale(0.5)';
+    var scale = 0.5;
+    var pointPos = [scale * 391, scale * 219];
+    var blankPos = [scale * 200, scale * 200];
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+
+        var mockCopy = Lib.extendDeep({}, mock);
+
+        transformPlot(gd, cssTransform);
+        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+    });
+
+    it('should respond zoom drag interactions', function(done) {
+        function assertRange(gd, expected) {
+            var ternary = gd._fullLayout.ternary;
+            var actual = [
+                ternary.aaxis.min,
+                ternary.baxis.min,
+                ternary.caxis.min
+            ];
+            expect(actual).toBeCloseToArray(expected);
+        }
+
+        assertRange(gd, [0.231, 0.2, 0.11]);
+
+        drag({path: [[scale * 383, scale * 213], [scale * 293, scale * 243]]})
+        .then(function() { assertRange(gd, [0.4486, 0.2480, 0.1453]); })
+        .then(function() { return doubleClick(pointPos[0], pointPos[1]); })
+        .then(function() { assertRange(gd, [0, 0, 0]); })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('should display to hover labels', function(done) {
+        mouseEvent('mousemove', blankPos[0], blankPos[1]);
+        assertHoverLabelContent([null, null], 'only on data points');
+
+        function check(content, style, msg) {
+            Lib.clearThrottle();
+            mouseEvent('mousemove', pointPos[0], pointPos[1]);
+
+            assertHoverLabelContent({nums: content}, msg);
+            assertHoverLabelStyle(d3.select('g.hovertext'), style, msg);
+        }
+
+        check([
+            'Component A: 0.5',
+            'B: 0.25',
+            'Component C: 0.25'
+        ].join('\n'), {
+            bgcolor: 'rgb(31, 119, 180)',
+            bordercolor: 'rgb(255, 255, 255)',
+            fontColor: 'rgb(255, 255, 255)',
+            fontSize: 13,
+            fontFamily: 'Arial'
+        }, 'one label per data pt');
+
+        Plotly.restyle(gd, {
+            'hoverlabel.bordercolor': 'blue',
+            'hoverlabel.font.family': [['Gravitas', 'Arial', 'Roboto']]
+        })
+        .then(function() {
+            check([
+                'Component A: 0.5',
+                'B: 0.25',
+                'Component C: 0.25'
+            ].join('\n'), {
+                bgcolor: 'rgb(31, 119, 180)',
+                bordercolor: 'rgb(0, 0, 255)',
+                fontColor: 'rgb(0, 0, 255)',
+                fontSize: 13,
+                fontFamily: 'Gravitas'
+            }, 'after hoverlabel styling restyle call');
+
+            return Plotly.restyle(gd, 'hoverinfo', [['a', 'b+c', 'b']]);
+        })
+        .then(function() {
+            check('Component A: 0.5', {
+                bgcolor: 'rgb(31, 119, 180)',
+                bordercolor: 'rgb(0, 0, 255)',
+                fontColor: 'rgb(0, 0, 255)',
+                fontSize: 13,
+                fontFamily: 'Gravitas'
+            }, 'after hoverlabel styling restyle call');
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
+    it('should respond to hover interactions by', function() {
+        var hoverCnt = 0;
+        var unhoverCnt = 0;
+
+        var hoverData, unhoverData;
+
+        gd.on('plotly_hover', function(eventData) {
+            hoverCnt++;
+            hoverData = eventData.points[0];
+        });
+
+        gd.on('plotly_unhover', function(eventData) {
+            unhoverCnt++;
+            unhoverData = eventData.points[0];
+        });
+
+        mouseEvent('mousemove', blankPos[0], blankPos[1]);
+        expect(hoverData).toBe(undefined, 'not firing on blank points');
+        expect(unhoverData).toBe(undefined, 'not firing on blank points');
+
+        mouseEvent('mousemove', pointPos[0], pointPos[1]);
+        expect(hoverData).not.toBe(undefined, 'firing on data points');
+        expect(Object.keys(hoverData)).toEqual([
+            'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex',
+            'xaxis', 'yaxis', 'a', 'b', 'c'
+        ], 'returning the correct event data keys');
+        expect(hoverData.curveNumber).toEqual(0, 'returning the correct curve number');
+        expect(hoverData.pointNumber).toEqual(0, 'returning the correct point number');
+
+        mouseEvent('mouseout', pointPos[0], pointPos[1]);
+        expect(unhoverData).not.toBe(undefined, 'firing on data points');
+        expect(Object.keys(unhoverData)).toEqual([
+            'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex',
+            'xaxis', 'yaxis', 'a', 'b', 'c'
+        ], 'returning the correct event data keys');
+        expect(unhoverData.curveNumber).toEqual(0, 'returning the correct curve number');
+        expect(unhoverData.pointNumber).toEqual(0, 'returning the correct point number');
+
+        expect(hoverCnt).toEqual(1);
+        expect(unhoverCnt).toEqual(1);
+    });
+
+    it('should respond to click interactions by', function() {
+        var ptData;
+
+        gd.on('plotly_click', function(eventData) {
+            ptData = eventData.points[0];
+        });
+
+        click(blankPos[0], blankPos[1]);
+        expect(ptData).toBe(undefined, 'not firing on blank points');
+
+        click(pointPos[0], pointPos[1]);
+        expect(ptData).not.toBe(undefined, 'firing on data points');
+        expect(Object.keys(ptData)).toEqual([
+            'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex',
+            'xaxis', 'yaxis', 'a', 'b', 'c'
+        ], 'returning the correct event data keys');
+        expect(ptData.curveNumber).toEqual(0, 'returning the correct curve number');
+        expect(ptData.pointNumber).toEqual(0, 'returning the correct point number');
+    });
+});
+
 describe('ternary defaults', function() {
     'use strict';
 


### PR DESCRIPTION
Fixes #888.
This is the first commit of a few fixes for interactions with plots that are broken due when css transform scaling is applied. 
The general aim is to undo the transform matrices applied to these elements for the interactions.

TODOs:
- [x] clicking the end of an axis in 2D cartesian to type a new number: the text entry box shows up in the wrong place
- [x] fixing 2D cartesian `pan`
- [x] fixing `zoom` & `pan` in `ternary` & `polar`
- [x] fixing `scattermapbox` `hover` & `select`
- [x] fixing `choroplethmapbox` `hover`
- [x] fixing the position of `hover` on `sankey` trace
- [x] fixing the position of `hover` on `parcats` trace
- [x] adding `hover`, `select` and `drag-zoom` tests for `cartesian` subplots
- [x] adding `hover`, `select` and `drag-zoom` tests for `polar` subplots
- [x] adding `hover`, `select` and `drag-zoom` tests for `mapbox` subplots i.e. `choroplethmapbox` and `scattermapbox`
- [x] adding `hover`, `select` and `drag-zoom` tests for `geo` subplots e.g. `choropleth`
- [x] adding `hover`, `select` and `drag-zoom` tests for `ternary` subplots
- [x] test using different browsers namely Firefox, Chrome and Safari