### PR TITLE
Provide computed margins in full-json export

### DIFF
--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -265,6 +265,15 @@ module.exports = {
         },
         editType: 'plot'
     },
+    computed: {
+        valType: 'any',
+        role: 'info',
+        editType: 'none',
+        description: [
+            'Placeholder for exporting automargin-impacting values namely',
+            '`margin.t`, `margin.b`, `margin.l` and `margin.r` in *full-json* mode.',
+        ].join(' ')
+    },
     paper_bgcolor: {
         valType: 'color',
         role: 'style',

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -2164,7 +2164,7 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults, includeConfi
         obj.layout = stripObj(layout);
         if(useDefaults) {
             var gs = layout._size;
-            obj.layout._computed = {
+            obj.layout.computed = {
                 margin: {
                     b: gs.b,
                     l: gs.l,

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -2160,7 +2160,20 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults, includeConfi
             return d;
         })
     };
-    if(!dataonly) { obj.layout = stripObj(layout); }
+    if(!dataonly) {
+        obj.layout = stripObj(layout);
+        if(useDefaults) {
+            var gs = layout._size;
+            obj.layout._computed = {
+                margin: {
+                    b: gs.b,
+                    l: gs.l,
+                    r: gs.r,
+                    t: gs.t
+                }
+            };
+        }
+    }
 
     if(gd.framework && gd.framework.isPolar) obj = gd.framework.getConfig();
 

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -6,6 +6,7 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var failTest = require('../assets/fail_test');
 var subplotMock = require('@mocks/multiple_subplots.json');
+var pieAutoMargin = require('@mocks/pie_automargin');
 
 var FORMATS = ['png', 'jpeg', 'webp', 'svg'];
 
@@ -297,6 +298,22 @@ describe('Plotly.toImage', function() {
                 });
                 expect(fig.data[0].mode).toBe('lines+markers', 'contain default mode');
                 expect(fig.version).toBe(Plotly.version, 'contains Plotly version');
+            })
+            .catch(failTest)
+            .then(done);
+        });
+
+        it('export computed margins', function(done) {
+            Plotly.toImage(pieAutoMargin, imgOpts)
+            .then(function(fig) {
+                fig = JSON.parse(fig);
+                var computed = fig.layout._computed;
+                expect(computed).toBeDefined('no computed');
+                expect(computed.margin).toBeDefined('no computed margin');
+                expect(computed.margin.t).toBeDefined('no top');
+                expect(computed.margin.l).toBeDefined('no left');
+                expect(computed.margin.r).toBeDefined('no right');
+                expect(computed.margin.b).toBeDefined('no bottom');
             })
             .catch(failTest)
             .then(done);

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -307,7 +307,7 @@ describe('Plotly.toImage', function() {
             Plotly.toImage(pieAutoMargin, imgOpts)
             .then(function(fig) {
                 fig = JSON.parse(fig);
-                var computed = fig.layout._computed;
+                var computed = fig.layout.computed;
                 expect(computed).toBeDefined('no computed');
                 expect(computed.margin).toBeDefined('no computed margin');
                 expect(computed.margin.t).toBeDefined('no top');


### PR DESCRIPTION
Resolves #5185.

@plotly/plotly_js 