### PR TITLE
Mention the full-json option in the Plotly.toImage warning

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1246,11 +1246,10 @@ lib.ensureUniformFontSize = function(gd, baseFont) {
 };
 
 /**
- * provide a human-readable lists with an optional ending separator such as A, B, C and D
+ * provide a human-readable list e.g. "A, B, C and D" with an ending separator
  *
  * @param {array} arr : the array to join
  * @param {string} mainSeparator : main separator
- * @param {string} lastSeparator : optional last separator
  *
  * @return {string} : joined list
  */

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1256,7 +1256,7 @@ lib.ensureUniformFontSize = function(gd, baseFont) {
  */
 lib.join2 = function(arr, mainSeparator, lastSeparator) {
     var len = arr.length;
-    if(len > 2 && lastSeparator) {
+    if(len > 1 && lastSeparator) {
         return arr.slice(0, -1).join(mainSeparator) + lastSeparator + arr[len - 1];
     }
     return arr.join(mainSeparator);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1250,12 +1250,13 @@ lib.ensureUniformFontSize = function(gd, baseFont) {
  *
  * @param {array} arr : the array to join
  * @param {string} mainSeparator : main separator
+ * @param {string} lastSeparator : last separator
  *
  * @return {string} : joined list
  */
 lib.join2 = function(arr, mainSeparator, lastSeparator) {
     var len = arr.length;
-    if(len > 1 && lastSeparator) {
+    if(len > 1) {
         return arr.slice(0, -1).join(mainSeparator) + lastSeparator + arr[len - 1];
     }
     return arr.join(mainSeparator);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1244,3 +1244,20 @@ lib.ensureUniformFontSize = function(gd, baseFont) {
     );
     return out;
 };
+
+/**
+ * provide a human-readable lists with an optional ending separator such as A, B, C and D
+ *
+ * @param {array} arr : the array to join
+ * @param {string} mainSeparator : main separator
+ * @param {string} lastSeparator : optional last separator
+ *
+ * @return {string} : joined list
+ */
+lib.join2 = function(arr, mainSeparator, lastSeparator) {
+    var len = arr.length;
+    if(len > 2 && lastSeparator) {
+        return arr.slice(0, -1).join(mainSeparator) + lastSeparator + arr[len - 1];
+    }
+    return arr.join(mainSeparator);
+};

--- a/src/plot_api/to_image.js
+++ b/src/plot_api/to_image.js
@@ -116,7 +116,7 @@ function toImage(gd, opts) {
     }
 
     if(!isImpliedOrValid('format')) {
-        throw new Error('Image format is not jpeg, png, svg or webp.');
+        throw new Error('Export format is not ' + Lib.join2(attrs.format.values, ', ', ' or ') + '.');
     }
 
     var fullOpts = {};

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -65,7 +65,7 @@ describe('Plotly.toImage', function() {
         Plotly.plot(gd, fig.data, fig.layout)
         .then(function(gd) {
             expect(function() { Plotly.toImage(gd, {format: 'x'}); })
-                .toThrow(new Error('Image format is not jpeg, png, svg or webp.'));
+                .toThrow(new Error('Export format is not png, jpeg, webp, svg or full-json.'));
         })
         .catch(failTest)
         .then(done);


### PR DESCRIPTION
Follow up PR #4593, `full-json` option should also be mentioned in `Plotly.toImage` warnings.
Besides I added a function called `Lib.join2` for listing items with different separator for ending item, 
which may be of interest in other places.

@plotly/plotly_js 