### PR TITLE
Force default dims for downloadImage to null

### DIFF
--- a/src/snapshot/download.js
+++ b/src/snapshot/download.js
@@ -31,6 +31,8 @@ function downloadImage(gd, opts) {
 
     opts = opts || {};
     opts.format = opts.format || 'png';
+    opts.width = opts.width || null;
+    opts.height = opts.height || null;
     opts.imageDataOnly = true;
 
     return new Promise(function(resolve, reject) {

--- a/src/traces/image/calc.js
+++ b/src/traces/image/calc.js
@@ -13,9 +13,7 @@ var constants = require('./constants');
 var isNumeric = require('fast-isnumeric');
 var Axes = require('../../plots/cartesian/axes');
 var maxRowLength = require('../../lib').maxRowLength;
-var sizeOf = require('image-size');
-var dataUri = require('../../snapshot/helpers').IMAGE_URL_PREFIX;
-var Buffer = require('buffer/').Buffer;  // note: the trailing slash is important!
+var getImageSize = require('./helpers').getImageSize;
 
 module.exports = function calc(gd, trace) {
     var h;
@@ -95,11 +93,4 @@ function makeScaler(trace) {
         }
         return c;
     };
-}
-
-// Get image size
-function getImageSize(src) {
-    var data = src.replace(dataUri, '');
-    var buff = new Buffer(data, 'base64');
-    return sizeOf(buff);
 }

--- a/src/traces/image/helpers.js
+++ b/src/traces/image/helpers.js
@@ -1,0 +1,19 @@
+/**
+* Copyright 2012-2020, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+var sizeOf = require('image-size');
+var dataUri = require('../../snapshot/helpers').IMAGE_URL_PREFIX;
+var Buffer = require('buffer/').Buffer;  // note: the trailing slash is important!
+
+exports.getImageSize = function(src) {
+    var data = src.replace(dataUri, '');
+    var buff = new Buffer(data, 'base64');
+    return sizeOf(buff);
+};


### PR DESCRIPTION
Another variation on #5205 to address the class of issue of which #5202 is an exemplar ... closes https://github.com/plotly/plotly.js/issues/1576