### PR TITLE
Redirect plotly.js imports to dist builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.57.0",
   "description": "The open source javascript graphing library that powers plotly",
   "license": "MIT",
-  "main": "./lib/index.js",
+  "source": "./lib/index.js",
+  "main": "./dist/plotly-with-meta.js",
   "webpack": "./dist/plotly.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Follow up of #5189 and as suggested by @dy in https://github.com/plotly/plotly.js/issues/5182#issuecomment-701753791.
Changes required to be able to bump & import `plotly.js` in `chart-studio`.
Otherwise we have to downgrade `color*` modules to versions used before #5172.
Potential impacts:
 - faster and more stable imports/exports in production
 - may need some adjustments to keep development process smooth

@dmt0 
@plotly/plotly_js 