### PR TITLE
Record last actual margins when plot involving too many redraws

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -2032,6 +2032,7 @@ plots.doAutoMargin = function(gd) {
         if(fullLayout._redrawFromAutoMarginCount < maxNumberOfRedraws) {
             return Registry.call('plot', gd);
         } else {
+            fullLayout._size = oldMargins;
             Lib.warn('Too many auto-margin redraws.');
         }
     }

--- a/test/jasmine/tests/pie_test.js
+++ b/test/jasmine/tests/pie_test.js
@@ -1007,7 +1007,7 @@ describe('Pie traces', function() {
             textposition: [['outside', 'outside', 'inside', 'inside', 'outside']],
             'outsidetextfont.size': 12
         }, {
-            t: '~=', l: 'shrunk',
+            t: '~=', l: '~=',
             b: 'grew', r: 'grew'
         }))
         .then(check('automargin:false', {automargin: false}, {

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -318,5 +318,37 @@ describe('Plotly.toImage', function() {
             .catch(failTest)
             .then(done);
         });
+
+        it('record and export computed margins with "Too many auto-margin redraws"', function(done) {
+            Plotly.toImage({
+                data: [{
+                    x: [
+                        'a',
+                        'b',
+                        'looooooooooooooooooooooooooooooooooog',
+                        'd'
+                    ]
+                }],
+                layout: {
+                    width: 400,
+                    height: 400,
+                    paper_bgcolor: 'lightblue',
+                    xaxis: {
+                        automargin: true
+                    },
+                    yaxis: {
+                        automargin: true
+                    }
+                }
+            }, imgOpts)
+            .then(function(fig) {
+                fig = JSON.parse(fig);
+                var computed = fig.layout.computed;
+                expect(computed.margin.b).toBeGreaterThan(80);
+                expect(computed.margin.r).toBeGreaterThan(80);
+            })
+            .catch(failTest)
+            .then(done);
+        });
     });
 });


### PR DESCRIPTION
Fixes #5213.

[DEMO](https://codepen.io/MojtabaSamimi/pen/vYKXdXJ?editors=0010)

@plotly/plotly_js 