### PR TITLE
sunburst & treemap root color attribute

### DIFF
--- a/src/traces/sunburst/attributes.js
+++ b/src/traces/sunburst/attributes.js
@@ -220,12 +220,12 @@ module.exports = {
             valType: 'color',
             editType: 'style',
             role: 'style',
-            dflt: null, // rgba(0,0,0,0),
+            dflt: 'rgba(0,0,0,0)',
             description: [
                 'sets the color of the root node for a sunburst or a treemap trace.'
             ].join(' ')
         },
-        editType: 'plot'
+        editType: 'calc'
     },
 
     domain: domainAttrs({name: 'sunburst', trace: true, editType: 'calc'})

--- a/src/traces/sunburst/attributes.js
+++ b/src/traces/sunburst/attributes.js
@@ -215,5 +215,18 @@ module.exports = {
     },
     sort: pieAttrs.sort,
 
+    root: {
+        color: {
+            valType: 'color',
+            editType: 'style',
+            role: 'style',
+            dflt: null, // rgba(0,0,0,0),
+            description: [
+                'sets the color of the root node for a sunburst or a treemap trace.'
+            ].join(' ')
+        },
+        editType: 'plot'
+    },
+
     domain: domainAttrs({name: 'sunburst', trace: true, editType: 'calc'})
 };

--- a/src/traces/sunburst/attributes.js
+++ b/src/traces/sunburst/attributes.js
@@ -218,11 +218,12 @@ module.exports = {
     root: {
         color: {
             valType: 'color',
-            editType: 'style',
+            editType: 'calc',
             role: 'style',
             dflt: 'rgba(0,0,0,0)',
             description: [
-                'sets the color of the root node for a sunburst or a treemap trace.'
+                'sets the color of the root node for a sunburst or a treemap trace.',
+                'this has no effect when a colorscale is used to set the markers.'
             ].join(' ')
         },
         editType: 'calc'

--- a/src/traces/sunburst/calc.js
+++ b/src/traces/sunburst/calc.js
@@ -278,6 +278,9 @@ exports._runCrossTraceCalc = function(desiredType, gd) {
             } else {
                 // root gets no coloring by default
                 cdi.color = 'rgba(0,0,0,0)';
+                if (cdi.trace.root) {
+                    cdi.color = cdi.trace.root.color;
+                }
             }
         }
     }

--- a/src/traces/sunburst/calc.js
+++ b/src/traces/sunburst/calc.js
@@ -276,11 +276,8 @@ exports._runCrossTraceCalc = function(desiredType, gd) {
                     dfltColorCount++;
                 }
             } else {
-                // root gets no coloring by default
-                cdi.color = 'rgba(0,0,0,0)';
-                if(cdi.trace.root) {
-                    cdi.color = cdi.trace.root.color;
-                }
+                // set root color. no coloring by default.
+                cdi.color = cdi.trace.root.color;
             }
         }
     }

--- a/src/traces/sunburst/calc.js
+++ b/src/traces/sunburst/calc.js
@@ -278,7 +278,7 @@ exports._runCrossTraceCalc = function(desiredType, gd) {
             } else {
                 // root gets no coloring by default
                 cdi.color = 'rgba(0,0,0,0)';
-                if (cdi.trace.root) {
+                if(cdi.trace.root) {
                     cdi.color = cdi.trace.root.color;
                 }
             }

--- a/src/traces/sunburst/defaults.js
+++ b/src/traces/sunburst/defaults.js
@@ -77,6 +77,8 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
 
     coerce('rotation');
 
+    coerce('root.color');
+
     handleDomainDefaults(traceOut, layout, coerce);
 
     // do not support transforms for now

--- a/src/traces/treemap/attributes.js
+++ b/src/traces/treemap/attributes.js
@@ -269,6 +269,7 @@ module.exports = {
         ].join(' ')
     },
     sort: pieAttrs.sort,
+    root: sunburstAttrs.root,
 
     domain: domainAttrs({name: 'treemap', trace: true, editType: 'calc'}),
 };

--- a/src/traces/treemap/defaults.js
+++ b/src/traces/treemap/defaults.js
@@ -116,6 +116,8 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
 
     coerce('sort');
 
+    coerce('root.color');
+
     handleDomainDefaults(traceOut, layout, coerce);
 
     // do not support transforms for now


### PR DESCRIPTION
new attribute for treemap & sunburst traces to set the color of the root node.

Setting the color of the root node of a treemap can also be used to fix the height of a treemap. By default the root node has no color, and when doing a drilldown, the surface of the root nood  is overwritten with descendent data. Having a root node color set makes the surface used more prominent visible.

See also #5199 