### PR TITLE
Avoid unnecessary styling of backgrounds during automargin redraws when subplot positions are incomplete

### DIFF
--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -178,7 +178,7 @@ function lsInner(gd) {
         xa = plotinfo.xaxis;
         ya = plotinfo.yaxis;
 
-        if(plotinfo.bg) {
+        if(plotinfo.bg && xa._offset !== undefined && ya._offset !== undefined) {
             plotinfo.bg
                 .call(Drawing.setRect,
                     xa._offset - pad, ya._offset - pad,


### PR DESCRIPTION
Fixes https://github.com/plotly/plotly.js/issues/5235.

@plotly/plotly_js 
