### PR TITLE
Fix typo in Czech locale file

### DIFF
--- a/lib/locales/cs.js
+++ b/lib/locales/cs.js
@@ -25,7 +25,7 @@ module.exports = {
         'Compare data on hover': 'Porovnat hodnoty při najetí myší',                            // components/modebar/buttons.js:167
         'Double-click on legend to isolate one trace': 'Dvojklikem na legendu izolujete jedinou datovou sadu',  // components/legend/handle_click.js:90
         'Double-click to zoom back out': 'Dvojklikem vrátíte zvětšení',                                  // plots/cartesian/dragbox.js:299
-        'Download plot as a png': 'Uložit jsko PNG',                                                       // components/modebar/buttons.js:52
+        'Download plot as a png': 'Uložit jako PNG',                                                       // components/modebar/buttons.js:52
         'Download plot': 'Uložit',                                                                         // components/modebar/buttons.js:53
         'Edit in Chart Studio': 'Editovat v Chart Studio',                                               // components/modebar/buttons.js:76
         'IE only supports svg.  Changing format to svg.': 'IE podporuje pouze SVG formát. Změněno na SVG.', // components/modebar/buttons.js:60


### PR DESCRIPTION
Just a single letter typo fix – "j**a**ko" is a Czech word for "as", "j**s**ko" is… nothing.

https://en.wiktionary.org/wiki/jako#Czech