### PR TITLE
Correct wrong element targeting on hover in shadow DOM

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -333,8 +333,9 @@ function _hover(gd, evt, subplot, noHoverEvent) {
                 return;
             }
 
+            // Discover event target, traversing open shadow roots.
             var target = evt.composedPath && evt.composedPath()[0];
-            if (!target) {
+            if(!target) {
                 return;
             }
             var dbb = target.getBoundingClientRect();

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -333,7 +333,11 @@ function _hover(gd, evt, subplot, noHoverEvent) {
                 return;
             }
 
-            var dbb = evt.target.getBoundingClientRect();
+            var target = evt.composedPath && evt.composedPath()[0];
+            if (!target) {
+                return;
+            }
+            var dbb = target.getBoundingClientRect();
 
             xpx = evt.clientX - dbb.left;
             ypx = evt.clientY - dbb.top;

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -336,7 +336,8 @@ function _hover(gd, evt, subplot, noHoverEvent) {
             // Discover event target, traversing open shadow roots.
             var target = evt.composedPath && evt.composedPath()[0];
             if(!target) {
-                return;
+                // Fallback for browsers not supporting composedPath
+                target = evt.target;
             }
             var dbb = target.getBoundingClientRect();
 


### PR DESCRIPTION
When using plotly inside of a shadow DOM, the calculations used to determine if the pointer has moved off of the graph would use the wrong element to determine the bounding box. This was resulting in a flicker in the hover text as it would find that the mouse pointer had apparently moved off the graph when it actually hadn't and the next `mousemove` event would immediately redraw the hover text.

This PR uses the [`Event.composedPath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) method of the Event interface to determine the correct element from which to base bounding box calculations.

In my limited testing, I found that occasionally a `mousemove` event originating from a shadow DOM would get raised that did not have a properly formed `composedPath()` -- it would return an empty list. I haven't been able to nail down exactly why but for those rare cases, the early return ensures the hover text doesn't flicker.

I'm pretty new to Plotly but I tried to do my research so hopefully this solution isn't too naive. More than happy to work with maintainers to get this to a point where it can be accepted.

Thanks and excellent work on Plotly!