### PR TITLE
Fix reordering of mapbox raster/image layers on update

### DIFF
--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -73,7 +73,7 @@ proto.needsNewSource = function(opts) {
     // stay safe and make new source on type changes
     return (
         this.sourceType !== opts.sourcetype ||
-        this.source !== opts.source ||
+        JSON.stringify(this.source) !== JSON.stringify(opts.source) ||
         this.layerType !== opts.type
     );
 };

--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -85,6 +85,10 @@ proto.needsNewLayer = function(opts) {
     );
 };
 
+proto.lookupBelow = function() {
+    return this.subplot.belowLookup['layout-' + this.index];
+};
+
 proto.updateImage = function(opts) {
     var map = this.subplot.map;
     map.getSource(this.idSource).updateImage({
@@ -107,15 +111,9 @@ proto.updateSource = function(opts) {
     map.addSource(this.idSource, sourceOpts);
 };
 
-proto.updateLayer = function(opts) {
-    var subplot = this.subplot;
-    var convertedOpts = convertOpts(opts);
-
-    var below = this.subplot.belowLookup['layout-' + this.index];
-    var _below;
-
+proto.findFollowingMapboxLayerId = function(below) {
     if(below === 'traces') {
-        var mapLayers = subplot.getMapLayers();
+        var mapLayers = this.subplot.getMapLayers();
 
         // find id of first plotly trace layer
         for(var i = 0; i < mapLayers.length; i++) {
@@ -123,13 +121,19 @@ proto.updateLayer = function(opts) {
             if(typeof layerId === 'string' &&
                 layerId.indexOf(constants.traceLayerPrefix) === 0
             ) {
-                _below = layerId;
+                below = layerId;
                 break;
             }
         }
-    } else {
-        _below = below;
     }
+    return below;
+};
+
+proto.updateLayer = function(opts) {
+    var subplot = this.subplot;
+    var convertedOpts = convertOpts(opts);
+    var below = this.lookupBelow();
+    var _below = this.findFollowingMapboxLayerId(below);
 
     this.removeLayer();
 

--- a/src/plots/mapbox/layers.js
+++ b/src/plots/mapbox/layers.js
@@ -94,6 +94,14 @@ proto.updateImage = function(opts) {
     map.getSource(this.idSource).updateImage({
         url: opts.source, coordinates: opts.coordinates
     });
+
+    // Since the `updateImage` control flow doesn't call updateLayer,
+    // We need to take care of moving the image layer to match the location
+    // where updateLayer would have placed it.
+    var _below = this.findFollowingMapboxLayerId(this.lookupBelow());
+    if(_below !== null) {
+        this.subplot.map.moveLayer(this.idLayer, _below);
+    }
 };
 
 proto.updateSource = function(opts) {


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/issues/5266

This PR contains contains a few fixes that take care of the reordering problem described in #5266. The commit log is pretty clean and atomic, so probably easiest to review that way for explanations of each change.

![mapbox_layer_order_fixed](https://user-images.githubusercontent.com/15064365/99005166-5160cb80-250e-11eb-8edb-153a85a024fc.gif)
