### PR TITLE
Set false locale

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -667,7 +667,7 @@ function emptySubplotLists() {
  */
 function getFormatObj(gd, formatKeys) {
     var locale = gd._context.locale;
-    if(!locale) locale === 'en-US';
+    if(!locale) locale = 'en-US';
 
     var formatDone = false;
     var formatObj = {};

--- a/src/traces/histogram/cross_trace_defaults.js
+++ b/src/traces/histogram/cross_trace_defaults.js
@@ -174,10 +174,9 @@ module.exports = function crossTraceDefaults(fullData, fullLayout) {
         }
 
         var binGroupFound = false;
-        for(i = 0; i < traces.length; i++) {
-            traceOut = traces[i];
+        if(traces.length) {
+            traceOut = traces[0];
             binGroupFound = coerce('bingroup');
-            break;
         }
 
         groupName = binGroupFound || groupName;


### PR DESCRIPTION
Addressing a bug and a warning mentioned in #5289.
Namely:

Bug: 
**-line 69736: Suspicious code. This code lacks side-effects. Is there a bug?**
`if(!locale) locale === 'en-US';`
**-line 69736: Suspicious code. The result of the 'sheq' operator is not being used.**
`if(!locale) locale === 'en-US';`
Shouldn't it be `if(!locale) locale = 'en-US';` instead?

Warning:
**-line 87184: unreachable code**
`for(i = 0; i < traces.length; i++) {`
Since this for loop contains a `break;` that cannot be avoided, is it relevant to use a for loop to only do things with i==0 while i < traces.length?

@plotly/plotly_js 
