### PR TITLE
In staticPlot, do not draw-zero length bars

### DIFF
--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -242,7 +242,7 @@ function plot(gd, plotinfo, cdModule, traceLayer, opts, makeOnCompleteCallback) 
             var sel = transition(Lib.ensureSingle(bar, 'path'), fullLayout, opts, makeOnCompleteCallback);
             sel
                 .style('vector-effect', 'non-scaling-stroke')
-                .attr('d', isNaN((x1 - x0) * (y1 - y0)) ? 'M0,0Z' : 'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z')
+                .attr('d', (isNaN((x1 - x0) * (y1 - y0)) || (isBlank && gd._context.staticPlot)) ? 'M0,0Z' : 'M' + x0 + ',' + y0 + 'V' + y1 + 'H' + x1 + 'V' + y0 + 'Z')
                 .call(Drawing.setClipUrl, plotinfo.layerClipId, gd);
 
             if(!fullLayout.uniformtext.mode && withTransition) {

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -2119,6 +2119,21 @@ describe('A bar plot', function() {
         .then(done);
     });
 
+    it('should display bar of zero-length as M0,0Z when staticPlot is true', function(done) {
+        // otherwise Chromium produces a PDF with visual artifacts in place of zero-length bar: https://github.com/plotly/orca/issues/345
+        var mock = {data: [{type: 'bar', x: ['a', 'b'], y: [0, 5]}], config: {staticPlot: true}};
+
+        Plotly.newPlot(gd, mock)
+        .then(function() {
+            var nodes = gd.querySelectorAll('g.point > path');
+            expect(nodes.length).toBe(2, '# of bars');
+            var d = nodes[0].getAttribute('d');
+            expect(d).toBe('M0,0Z');
+        })
+        .catch(failTest)
+        .then(done);
+    });
+
     describe('show narrow bars', function() {
         ['initial zoom', 'after zoom out'].forEach(function(zoomStr) {
             it(zoomStr, function(done) {


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/issues/5282

I'm not sure it's possible to know that transitions will not be used in a future API call except for when `staticPlot` is true. This PR ensures that when `staticPlot` is true, bars of zero-length are drawn with a SVG path `d=M0,0Z` which is rendered correctly in Chromium's PDF.

Note that there is still an issue for Chromium users "printing to PDF" webpages containing interactive plotly.js figure with bars of zero-length. This one is much more complicated to fix in my opinion.