### PR TITLE
WIP: Typed array encoding in supplyDefaults with Caching

### DIFF
--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -86,12 +86,12 @@ exports.decodeTypedArraySpec = function(v) {
     v = coerceTypedArraySpec(v);
     var T = typedArrays[v.dtype];
     var buffer;
-    if(v.buffer.constructor === ArrayBuffer) {
+    if(v.bvals.constructor === ArrayBuffer) {
         // Already an ArrayBuffer
-        buffer = v.buffer;
+        buffer = v.bvals;
     } else {
         // Decode, assuming a string
-        buffer = b64.decode(v.buffer);
+        buffer = b64.decode(v.bvals);
     }
 
     // Check if 1d shape. If so, we're done
@@ -143,7 +143,7 @@ exports.decodeTypedArraySpec = function(v) {
 
 function isTypedArraySpec(v) {
     // Assume v has not passed through
-    return isPlainObject(v) && typedArrays[v.dtype] && v.buffer && (
+    return isPlainObject(v) && typedArrays[v.dtype] && v.bvals && (
         Number.isInteger(v.shape) ||
         (isArrayOrTypedArray(v.shape) &&
             v.shape.length > 0 &&
@@ -154,7 +154,7 @@ exports.isTypedArraySpec = isTypedArraySpec;
 
 function coerceTypedArraySpec(v) {
     // Assume isTypedArraySpec passed
-    var coerced = {dtype: v.dtype, buffer: v.buffer};
+    var coerced = {dtype: v.dtype, bvals: v.bvals};
 
     // Normalize shape to a list
     if(Number.isInteger(v.shape)) {

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -83,7 +83,7 @@ exports.typedArrays = typedArrays;
 
 exports.decodeTypedArraySpec = function(v) {
     // Assume processed by coerceTypedArraySpec
-    v = coerceTypedArraySpec(v)
+    v = coerceTypedArraySpec(v);
     var T = typedArrays[v.dtype];
     var buffer;
     if(v.bvals.constructor === ArrayBuffer) {

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -41,7 +41,7 @@ exports.isArrayOrTypedArray = isArrayOrTypedArray;
  * not consistent we won't figure that out here.
  */
 function isArray1D(a) {
-    return !(isArrayOrTypedArray(a[0]) || (isTypedArraySpec(a) && a.ndims === 1));
+    return !isArrayOrTypedArray(a[0]);
 }
 exports.isArray1D = isArray1D;
 
@@ -83,6 +83,7 @@ exports.typedArrays = typedArrays;
 
 exports.decodeTypedArraySpec = function(v) {
     // Assume processed by coerceTypedArraySpec
+    v = coerceTypedArraySpec(v)
     var T = typedArrays[v.dtype];
     var buffer;
     if(v.bvals.constructor === ArrayBuffer) {
@@ -259,8 +260,6 @@ function _rowLength(z, fn, len0) {
         } else {
             return z.length;
         }
-    } else if(isTypedArraySpec(z)) {
-        return z.shape[z.shape.length - 1];
     }
     return 0;
 }

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -75,8 +75,8 @@ var typedArrays = {
     uint32: typeof Uint32Array !== 'undefined' ? Uint32Array : null,
     float32: typeof Float32Array !== 'undefined' ? Float32Array : null,
     float64: typeof Float64Array !== 'undefined' ? Float64Array : null,
-    bigint64: typeof BigInt64Array !== 'undefined' ? BigInt64Array : null,
-    biguint64: typeof BigUint64Array !== 'undefined' ? BigUint64Array : null
+    int64: typeof BigInt64Array !== 'undefined' ? BigInt64Array : null,
+    uint64: typeof BigUint64Array !== 'undefined' ? BigUint64Array : null
 };
 exports.typedArrays = typedArrays;
 

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -86,12 +86,12 @@ exports.decodeTypedArraySpec = function(v) {
     v = coerceTypedArraySpec(v);
     var T = typedArrays[v.dtype];
     var buffer;
-    if(v.bvals.constructor === ArrayBuffer) {
+    if(v.buffer.constructor === ArrayBuffer) {
         // Already an ArrayBuffer
-        buffer = v.bvals;
+        buffer = v.buffer;
     } else {
         // Decode, assuming a string
-        buffer = b64.decode(v.bvals);
+        buffer = b64.decode(v.buffer);
     }
 
     // Check if 1d shape. If so, we're done
@@ -143,7 +143,7 @@ exports.decodeTypedArraySpec = function(v) {
 
 function isTypedArraySpec(v) {
     // Assume v has not passed through
-    return isPlainObject(v) && typedArrays[v.dtype] && v.bvals && (
+    return isPlainObject(v) && typedArrays[v.dtype] && v.buffer && (
         Number.isInteger(v.shape) ||
         (isArrayOrTypedArray(v.shape) &&
             v.shape.length > 0 &&
@@ -154,7 +154,7 @@ exports.isTypedArraySpec = isTypedArraySpec;
 
 function coerceTypedArraySpec(v) {
     // Assume isTypedArraySpec passed
-    var coerced = {dtype: v.dtype, bvals: v.bvals};
+    var coerced = {dtype: v.dtype, buffer: v.buffer};
 
     // Normalize shape to a list
     if(Number.isInteger(v.shape)) {

--- a/src/lib/array.js
+++ b/src/lib/array.js
@@ -75,8 +75,6 @@ var typedArrays = {
     uint32: typeof Uint32Array !== 'undefined' ? Uint32Array : null,
     float32: typeof Float32Array !== 'undefined' ? Float32Array : null,
     float64: typeof Float64Array !== 'undefined' ? Float64Array : null,
-    int64: typeof BigInt64Array !== 'undefined' ? BigInt64Array : null,
-    uint64: typeof BigUint64Array !== 'undefined' ? BigUint64Array : null
 };
 exports.typedArrays = typedArrays;
 

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -32,7 +32,7 @@ exports.valObjectMeta = {
             'The value could be an {array}',
             'noting that typed arrays (e.g. Float32Array) are also supported.',
             'It could also be an object in the form of',
-            'v: {, dtype: \'float32\', buffer: [/* ... */]}, shape: [dim0 (, dim1, (dim3))]',
+            'v: {, dtype: \'float32\', bvals: [/* ... */]}, shape: [dim0 (, dim1, (dim3))]',
             'otherwise, it would be ignored.'
         ].join(' '),
         requiredOpts: [],
@@ -50,7 +50,7 @@ exports.valObjectMeta = {
                 var uid = propOut.obj.uid;
                 var module = propOut.obj._module;
 
-                if(v.buffer.constructor === ArrayBuffer || !uid || !module) {
+                if(v.bvals.constructor === ArrayBuffer || !uid || !module) {
                     // Already an ArrayBuffer
                     // decoding is cheap
                     propOut.set(decodeTypedArraySpec(v));
@@ -59,11 +59,11 @@ exports.valObjectMeta = {
                     var cache = module._b64BufferCache || {};
 
                     // Check cache
-                    var cachedBuffer = ((cache[uid] || {})[prop] || {})[v.buffer];
+                    var cachedBuffer = ((cache[uid] || {})[prop] || {})[v.bvals];
                     if(cachedBuffer !== undefined) {
                         // Use cached array buffer instead of base64 encoded
                         // string
-                        v.buffer = cachedBuffer;
+                        v.bvals = cachedBuffer;
                         propOut.set(decodeTypedArraySpec(v));
                     } else {
                         // Not in so cache decode
@@ -76,7 +76,7 @@ exports.valObjectMeta = {
                         // Clear any prior cache value (only store one per
                         // trace property
                         cache[uid][prop] = {};
-                        cache[uid][prop][v.buffer] = decoded.buffer;
+                        cache[uid][prop][v.bvals] = decoded.buffer;
                         module._b64BufferCache = cache;
                     }
                 }

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -32,7 +32,7 @@ exports.valObjectMeta = {
             'The value could be an {array}',
             'noting that typed arrays (e.g. Float32Array) are also supported.',
             'It could also be an object in the form of',
-            'v: {, dtype: \'float32\', bvals: [/* ... */]}, shape: [dim0 (, dim1, (dim3))]',
+            'v: {, dtype: \'float32\', buffer: [/* ... */]}, shape: [dim0 (, dim1, (dim3))]',
             'otherwise, it would be ignored.'
         ].join(' '),
         requiredOpts: [],
@@ -50,7 +50,7 @@ exports.valObjectMeta = {
                 var uid = propOut.obj.uid;
                 var module = propOut.obj._module;
 
-                if(v.bvals.constructor === ArrayBuffer || !uid || !module) {
+                if(v.buffer.constructor === ArrayBuffer || !uid || !module) {
                     // Already an ArrayBuffer
                     // decoding is cheap
                     propOut.set(decodeTypedArraySpec(v));
@@ -59,11 +59,11 @@ exports.valObjectMeta = {
                     var cache = module._b64BufferCache || {};
 
                     // Check cache
-                    var cachedBuffer = ((cache[uid] || {})[prop] || {})[v.bvals];
+                    var cachedBuffer = ((cache[uid] || {})[prop] || {})[v.buffer];
                     if(cachedBuffer !== undefined) {
                         // Use cached array buffer instead of base64 encoded
                         // string
-                        v.bvals = cachedBuffer;
+                        v.buffer = cachedBuffer;
                         propOut.set(decodeTypedArraySpec(v));
                     } else {
                         // Not in so cache decode
@@ -76,7 +76,7 @@ exports.valObjectMeta = {
                         // Clear any prior cache value (only store one per
                         // trace property
                         cache[uid][prop] = {};
-                        cache[uid][prop][v.bvals] = decoded.buffer;
+                        cache[uid][prop][v.buffer] = decoded.buffer;
                         module._b64BufferCache = cache;
                     }
                 }

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -20,7 +20,7 @@ var counterRegex = require('./regex').counter;
 var modHalf = require('./mod').modHalf;
 var isArrayOrTypedArray = require('./array').isArrayOrTypedArray;
 var isTypedArraySpec = require('./array').isTypedArraySpec;
-var coerceTypedArraySpec = require('./array').coerceTypedArraySpec;
+var decodeTypedArraySpec = require('./array').decodeTypedArraySpec;
 
 
 exports.valObjectMeta = {
@@ -42,7 +42,7 @@ exports.valObjectMeta = {
                 propOut.set(v);
                 wasSet = true;
             } else if(isTypedArraySpec(v)) {
-                propOut.set(coerceTypedArraySpec(v));
+                propOut.set(decodeTypedArraySpec(v));
                 wasSet = true;
             }
             if(!wasSet && dflt !== undefined) propOut.set(dflt);

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -18,22 +18,10 @@ var DESELECTDIM = require('../constants/interactions').DESELECTDIM;
 var nestedProperty = require('./nested_property');
 var counterRegex = require('./regex').counter;
 var modHalf = require('./mod').modHalf;
-var isPlainObject = require('./is_plain_object');
 var isArrayOrTypedArray = require('./array').isArrayOrTypedArray;
+var isTypedArraySpec = require('./array').isTypedArraySpec;
+var coerceTypedArraySpec = require('./array').coerceTypedArraySpec;
 
-var typedArrays = {
-    int8: typeof Int8Array !== 'undefined' ? 1 : 0,
-    uint8: typeof Uint8Array !== 'undefined' ? 1 : 0,
-    uint8clamped: typeof Uint8ClampedArray !== 'undefined' ? 1 : 0,
-    int16: typeof Int16Array !== 'undefined' ? 1 : 0,
-    uint16: typeof Uint16Array !== 'undefined' ? 1 : 0,
-    int32: typeof Int32Array !== 'undefined' ? 1 : 0,
-    uint32: typeof Uint32Array !== 'undefined' ? 1 : 0,
-    float32: typeof Float32Array !== 'undefined' ? 1 : 0,
-    float64: typeof Float64Array !== 'undefined' ? 1 : 0,
-    bigint64: typeof BigInt64Array !== 'undefined' ? 1 : 0,
-    biguint64: typeof BigUint64Array !== 'undefined' ? 1 : 0
-};
 
 exports.valObjectMeta = {
     data_array: {
@@ -53,12 +41,9 @@ exports.valObjectMeta = {
             if(isArrayOrTypedArray(v)) {
                 propOut.set(v);
                 wasSet = true;
-            } else if(isPlainObject(v)) {
-                var T = typedArrays[v.dtype];
-                if(T) {
-                    propOut.set(v);
-                    wasSet = true;
-                }
+            } else if(isTypedArraySpec(v)) {
+                propOut.set(coerceTypedArraySpec(v));
+                wasSet = true;
             }
             if(!wasSet && dflt !== undefined) propOut.set(dflt);
         }

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -11,8 +11,6 @@
 var d3 = require('d3');
 var timeFormatLocale = require('d3-time-format').timeFormatLocale;
 var isNumeric = require('fast-isnumeric');
-var decodeTypedArraySpec = require('../lib/array').decodeTypedArraySpec;
-var isTypedArraySpec = require('../lib/array').isTypedArraySpec;
 
 var Registry = require('../registry');
 var PlotSchema = require('../plot_api/plot_schema');
@@ -2850,36 +2848,7 @@ function _transition(gd, transitionOpts, opts) {
     return transitionStarting.then(function() { return gd; });
 }
 
-function _decode(cont) {
-    if(isTypedArraySpec(cont)) {
-        return decodeTypedArraySpec(cont);
-    }
-    for(var prop in cont) {
-        if(prop[0] !== '_' && cont.hasOwnProperty(prop)) {
-            var item = cont[prop];
-            if(Lib.isPlainObject(item)) {
-                var r = _decode(item);
-                if(r !== undefined) cont[prop] = r;
-            } else if(Array.isArray(cont) && cont.length > 0 && Lib.isPlainObject(cont[0])) {
-                for(var i = 0; i < cont.length; i++) {
-                    _decode(cont[i]);
-                }
-            }
-        }
-    }
-}
-
-function decodeTypedArrays(gd) {
-    for(var i = 0; i < gd._fullData.length; i++) {
-        _decode(gd._fullData[i]);
-    }
-
-    _decode(gd._fullLayout);
-}
-
 plots.doCalcdata = function(gd, traces) {
-    decodeTypedArrays(gd);
-
     var axList = axisIDs.list(gd);
     var fullData = gd._fullData;
     var fullLayout = gd._fullLayout;

--- a/src/traces/heatmap/xyz_defaults.js
+++ b/src/traces/heatmap/xyz_defaults.js
@@ -19,25 +19,19 @@ module.exports = function handleXYZDefaults(traceIn, traceOut, coerce, layout, x
     yName = yName || 'y';
     var x, y;
 
-    var shapeX = x ? (x.shape ? x.shape[0] : x.length) || 0 : 0;
-    var shapeY = y ? (y.shape ? y.shape[0] : y.length) || 0 : 0;
-    var shapeZ = z ? (z.shape ? z.shape[0] : z.length) || 0 : 0;
+    if(z === undefined || !z.length) return 0;
 
-    var zlen = shapeZ || (z && z.length) || 0;
-
-    if(z === undefined || !zlen) return 0;
-
-    if(Lib.isArray1D(traceIn.z) || (z && z.shape && z.shape.length === 1)) {
+    if(Lib.isArray1D(traceIn.z)) {
         x = coerce(xName);
         y = coerce(yName);
 
-        var xlen = shapeX || Lib.minRowLength(x);
-        var ylen = shapeY || Lib.minRowLength(y);
+        var xlen = Lib.minRowLength(x);
+        var ylen = Lib.minRowLength(y);
 
         // column z must be accompanied by xName and yName arrays
         if(xlen === 0 || ylen === 0) return 0;
 
-        traceOut._length = Math.min(xlen, ylen, zlen);
+        traceOut._length = Math.min(xlen, ylen, z.length);
     } else {
         x = coordDefaults(xName, coerce);
         y = coordDefaults(yName, coerce);

--- a/src/traces/heatmap/xyz_defaults.js
+++ b/src/traces/heatmap/xyz_defaults.js
@@ -21,7 +21,7 @@ module.exports = function handleXYZDefaults(traceIn, traceOut, coerce, layout, x
 
     if(z === undefined || !z.length) return 0;
 
-    if(Lib.isArray1D(traceIn.z)) {
+    if(Lib.isArray1D(z)) {
         x = coerce(xName);
         y = coerce(yName);
 

--- a/src/traces/isosurface/defaults.js
+++ b/src/traces/isosurface/defaults.js
@@ -38,8 +38,6 @@ function supplyIsoDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
     var z = coerce('z');
     var value = coerce('value');
 
-    console.log(["x", x]);
-
     if(
         !x || !x.length ||
         !y || !y.length ||

--- a/src/traces/isosurface/defaults.js
+++ b/src/traces/isosurface/defaults.js
@@ -38,18 +38,12 @@ function supplyIsoDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
     var z = coerce('z');
     var value = coerce('value');
 
-    var len = 0;
-
-    if(x && y && z && value) {
-        len = Math.min(
-            (x.shape ? x.shape[0] : x.length) || 0,
-            (y.shape ? y.shape[0] : y.length) || 0,
-            (z.shape ? z.shape[0] : z.length) || 0,
-            (value.shape ? value.shape[0] : value.length) || 0
-        );
-    }
-
-    if(!len) {
+    if(
+        !x || !x.length ||
+        !y || !y.length ||
+        !z || !z.length ||
+        !value || !value.length
+    ) {
         traceOut.visible = false;
         return;
     }

--- a/src/traces/isosurface/defaults.js
+++ b/src/traces/isosurface/defaults.js
@@ -38,6 +38,8 @@ function supplyIsoDefaults(traceIn, traceOut, defaultColor, layout, coerce) {
     var z = coerce('z');
     var value = coerce('value');
 
+    console.log(["x", x]);
+
     if(
         !x || !x.length ||
         !y || !y.length ||

--- a/src/traces/scatter/xy_defaults.js
+++ b/src/traces/scatter/xy_defaults.js
@@ -19,22 +19,19 @@ module.exports = function handleXYDefaults(traceIn, traceOut, layout, coerce) {
     var handleCalendarDefaults = Registry.getComponentMethod('calendars', 'handleTraceDefaults');
     handleCalendarDefaults(traceIn, traceOut, ['x', 'y'], layout);
 
-    var shapeX = x && x.shape ? x.shape[0] : 0;
-    var shapeY = y && y.shape ? y.shape[0] : 0;
-
     if(x) {
-        var xlen = shapeX || Lib.minRowLength(x);
+        var xlen = Lib.minRowLength(x);
         if(y) {
-            len = shapeY || Math.min(xlen, Lib.minRowLength(y));
+            len = Math.min(xlen, Lib.minRowLength(y));
         } else {
-            len = shapeX || xlen;
+            len = xlen;
             coerce('y0');
             coerce('dy');
         }
     } else {
         if(!y) return 0;
 
-        len = shapeY || Lib.minRowLength(y);
+        len = Lib.minRowLength(y);
         coerce('x0');
         coerce('dx');
     }

--- a/src/traces/scatter3d/defaults.js
+++ b/src/traces/scatter3d/defaults.js
@@ -78,12 +78,8 @@ function handleXYZDefaults(traceIn, traceOut, coerce, layout) {
     handleCalendarDefaults(traceIn, traceOut, ['x', 'y', 'z'], layout);
 
     if(x && y && z) {
-        var shapeX = (x.shape ? x.shape[0] : x.length) || 0;
-        var shapeY = (y.shape ? y.shape[0] : y.length) || 0;
-        var shapeZ = (z.shape ? z.shape[0] : z.length) || 0;
-
         // TODO: what happens if one is missing?
-        len = Math.min(shapeX, shapeY, shapeZ);
+        len = Math.min(x.length, y.length, z.length);
         traceOut._length = traceOut._xlength = traceOut._ylength = traceOut._zlength = len;
     }
 


### PR DESCRIPTION
## Overview
This PR builds off of https://github.com/plotly/plotly.js/pull/5230, with a candidate solution to the problem outlined in https://github.com/plotly/plotly.js/pull/5230#issuecomment-735271393.

## Architecture Details
The approach is to perform the typed array decoding in coerce (before the supplyDefaults logic in the layout and traces). This has the advantage that none of the supply defaults or calc logic needs to be aware of the typed array specification objects.

For performance, the ArrayBuffer instances resulting from the decoding process are cached by trace uid and property name.  To keep cache bounded, only one ArrayBuffer is cached per trace per property.  Playing with the isosurface example in https://github.com/plotly/plotly.js/pull/5230, building the typed array with this caching approach is about 10x faster than when performing the base64 decoding.

## Implementation Details
This PR handles decoding N-dimensional arrays into a nested collection of `Arrays`.  The inner most layer contains TypedArrays that are backed by the original decoded ArrayBuffer, so no copying is performed.  So far, all the 2D traces I've played with have worked fine with this nesting arrangement.

More testing is needed, but hopefully nothing in supplyDefaults or calc or rendering will need to change in any of the traces (apart from potential bug fixes for TypedArray handling).

