### PR TITLE
Avoid autoscale error with false autorange

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1948,7 +1948,9 @@ function axRangeSupplyDefaultsByPass(gd, flags, specs) {
         var axIn = gd.layout[axName];
         var axOut = fullLayout[axName];
         axOut.autorange = axIn.autorange;
-        axOut.range = axIn.range.slice();
+        if(axIn.range) {
+            axOut.range = axIn.range.slice();
+        }
         axOut.cleanRange();
 
         if(axOut._matchGroup) {

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1468,7 +1468,7 @@ describe('Test axes', function() {
                 expect(gd._fullLayout.xaxis.range).toEqual([-1, 6]);
                 expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-0.07, 1.07]);
 
-                Plotly.relayout(gd, 'yaxis.autorange', false);
+                return Plotly.relayout(gd, 'yaxis.autorange', false);
             }).then(function() {
                 expect(gd._fullLayout.yaxis.autorange).toBe(false);
                 expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-0.07, 1.07]);

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1473,7 +1473,7 @@ describe('Test axes', function() {
                 expect(gd._fullLayout.yaxis.autorange).toBe(false);
                 expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-0.07, 1.07]);
 
-                Plotly.relayout(gd, 'xaxis.autorange', true);
+                return Plotly.relayout(gd, 'xaxis.autorange', true);
             }).then(function() {
                 expect(gd._fullLayout.xaxis.autorange).toBe(true);
                 expect(gd._fullLayout.xaxis.range).toBeCloseToArray([-0.07, 1.07]);

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1433,6 +1433,56 @@ describe('Test axes', function() {
         });
     });
 
+    describe('autorange relayout', function() {
+        var gd;
+
+        beforeEach(function() {
+            gd = createGraphDiv();
+        });
+
+        afterEach(destroyGraphDiv);
+
+        it('can relayout autorange', function(done) {
+            Plotly.newPlot(gd, {
+                data: [{
+                    x: [0, 1],
+                    y: [0, 1]
+                }],
+                layout: {
+                    width: 400,
+                    height: 400,
+                    margin: {
+                        t: 40,
+                        b: 40,
+                        l: 40,
+                        r: 40
+                    },
+                    xaxis: {
+                        autorange: false,
+                    },
+                    yaxis: {
+                        autorange: true,
+                    }
+                }
+            }).then(function() {
+                expect(gd._fullLayout.xaxis.range).toEqual([-1, 6]);
+                expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-0.07, 1.07]);
+
+                Plotly.relayout(gd, 'yaxis.autorange', false);
+            }).then(function() {
+                expect(gd._fullLayout.yaxis.autorange).toBe(false);
+                expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-0.07, 1.07]);
+
+                Plotly.relayout(gd, 'xaxis.autorange', true);
+            }).then(function() {
+                expect(gd._fullLayout.xaxis.autorange).toBe(true);
+                expect(gd._fullLayout.xaxis.range).toBeCloseToArray([-0.07, 1.07]);
+            })
+            .catch(failTest)
+            .then(done);
+        });
+    });
+
     describe('constraints relayout', function() {
         var gd;
 


### PR DESCRIPTION
Fixes #5290.

@plotly/plotly_js 