### PR TITLE
add optional dependency bindings due to npm warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -996,6 +996,16 @@
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
       "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
@@ -4345,6 +4355,13 @@
       "resolved": "https://registry.npmjs.org/file-exists-dazinatorfork/-/file-exists-dazinatorfork-1.0.2.tgz",
       "integrity": "sha512-r70c72ln2YHzQINNfxDp02hAhbGkt1HffZ+Du8oetWDLjDtFja/Lm10lUaSh9e+wD+7VDvPee0b0C9SAy8pWZg==",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filing-cabinet": {
       "version": "2.6.0",
@@ -13249,6 +13266,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },


### PR DESCRIPTION
Today if I run `npm install` on `master` branch it modifies `package-lock.json` with the following warning:

1. Unexpected warning for https://registry.npmjs.org/: Miscellaneous
Warning EAI_AGAIN: request to https://registry.npmjs.org/bindings failed,
reason: getaddrinfo EAI_AGAIN registry.npmjs.org
2. Using stale data from https://registry.npmjs.org/ due to a request error during revalidation.

The changes are committed in this PR 
@alexcjohnson @antoinerg do you get an identical diff?

@plotly/plotly_js 