### PR TITLE
feat(CI): add a GitHub Action to check spelling

### DIFF
--- a/.github/workflows/spell-checker.yml
+++ b/.github/workflows/spell-checker.yml
@@ -1,0 +1,17 @@
+name: 🏀 Spellchecker
+
+on: [pull_request]
+
+jobs:
+  misspell:
+    name: 🧹 Check Spelling
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🥭 Check Out
+        uses: actions/checkout@v2
+      - name: 🏗️ Install
+        run: |
+          wget -O - -q https://git.io/misspell | sh -s -- -b .
+      - name: 🧹 Misspell
+        run: |
+          find . -not -path './build**'  -not -path './dist**' -not -path './node_modules**' -type f | xargs misspell -error -i 'transforme,verificato'


### PR DESCRIPTION
Found a better way to check spelling.  This Go tool does find mistakes in source code as well as Markdown. From my experience it does not work on all file types or find all the errors, but it does seem to work well on code comments
- refs #5349
- refs https://github.com/plotly/dash/pull/1081
Using -> https://github.com/client9/misspell