### PR TITLE
Make tests less dependant on Plotly.plot calls

### DIFF
--- a/test/jasmine/tests/animate_test.js
+++ b/test/jasmine/tests/animate_test.js
@@ -104,7 +104,7 @@ describe('Test animate API', function() {
             return Promise.resolve().then(delay(arguments[5].duration));
         });
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             return Plotly.addFrames(gd, mockCopy.frames);
         }).then(done);
     });
@@ -598,7 +598,7 @@ describe('Animate API details', function() {
     beforeEach(function(done) {
         gd = createGraphDiv();
         mockCopy = Lib.extendDeep({}, mock);
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
     });
 
     afterEach(function() {
@@ -720,7 +720,7 @@ describe('Animating multiple axes', function() {
     });
 
     it('updates ranges of secondary axes', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {y: [1, 2, 3]},
             {y: [1, 2, 3], yaxis: 'y2'}
         ], {
@@ -751,7 +751,7 @@ describe('Animating multiple axes', function() {
     });
 
     it('updates ranges of secondary axes (date + category case)', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {x: ['2018-01-01', '2019-01-01', '2020-01-01'], y: [1, 2, 3]},
             {x: ['a', 'b', 'c'], y: [1, 2, 3], xaxis: 'x2', yaxis: 'y2'}
         ], {
@@ -818,7 +818,7 @@ describe('Animating multiple axes', function() {
             };
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [0.1, 0.2, 0.3],
             y: [0.4, 0.5, 0.6],
         }, {
@@ -882,7 +882,7 @@ describe('non-animatable fallback', function() {
     });
 
     it('falls back to a simple update for bar graphs', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3],
             y: [4, 5, 6],
             type: 'bar'
@@ -913,7 +913,7 @@ describe('animating scatter traces', function() {
 
     it('animates trace opacity', function(done) {
         var trace;
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3],
             y: [4, 5, 6],
             opacity: 1
@@ -931,7 +931,7 @@ describe('animating scatter traces', function() {
     });
 
     it('computes calcdata correctly when transforms are present', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 x: [1, 2, 3],
                 y: [1, 2, 3],
@@ -971,7 +971,7 @@ describe('animating scatter traces', function() {
                 .map(Number);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 1]
         }, {
             type: 'bar',

--- a/test/jasmine/tests/annotations_test.js
+++ b/test/jasmine/tests/annotations_test.js
@@ -187,7 +187,7 @@ describe('annotations relayout', function() {
         expect(typeof MathJax).toBe('undefined');
         mockLayout.annotations[14].text = '$x+y+z$';
 
-        Plotly.plot(gd, mockData, mockLayout)
+        Plotly.newPlot(gd, mockData, mockLayout)
         .then(function() {
             spyOn(Loggers, 'warn');
 
@@ -512,7 +512,7 @@ describe('annotations log/linear axis changes', function() {
         var mockData = Lib.extendDeep([], mock.data);
         var mockLayout = Lib.extendDeep({}, mock.layout);
 
-        Plotly.plot(gd, mockData, mockLayout).then(done);
+        Plotly.newPlot(gd, mockData, mockLayout).then(done);
     });
 
     afterEach(destroyGraphDiv);
@@ -667,7 +667,7 @@ describe('annotations autorange', function() {
     }
 
     it('should adapt to relayout calls', function(done) {
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             assertRanges(
                 [0.91, 2.09], [0.91, 2.09],
                 ['2000-11-13', '2001-04-21'], [-0.069, 3.917],
@@ -756,7 +756,7 @@ describe('annotations autorange', function() {
     });
 
     it('catches bad xref/yref', function(done) {
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             return Plotly.relayout(gd, {'annotations[1]': {
                 text: 'LT',
                 x: -1,
@@ -787,7 +787,7 @@ describe('annotations autorange', function() {
             expect(fullLayout.yaxis.range).toBeCloseToArray(yrng, 1, msg + ' yrng');
         }
 
-        Plotly.plot(gd, [{y: [1, 2]}], {
+        Plotly.newPlot(gd, [{y: [1, 2]}], {
             xaxis: {range: [0, 2]},
             yaxis: {range: [0, 2]},
             annotations: [{
@@ -818,7 +818,7 @@ describe('annotations autorange', function() {
     });
 
     it('should not error out on subplots w/o visible traces', function(done) {
-        Plotly.plot(gd, [{}], {
+        Plotly.newPlot(gd, [{}], {
             annotations: [{
                 x: 0.1,
                 y: 0.1,
@@ -931,7 +931,7 @@ describe('annotation clicktoshow', function() {
 
     it('should select only clicktoshow annotations matching x, y, and axes of any point', function(done) {
         // first try to select without adding clicktoshow, both visible and invisible
-        Plotly.plot(gd, data, layout())
+        Plotly.newPlot(gd, data, layout())
         // clicktoshow is off initially, so it doesn't *expect* clicking will
         // do anything, and it doesn't *actually* do anything.
         .then(clickAndCheck({newPts: [[1, 2]], newCTS: false, on: allIndices, step: 1}))
@@ -968,7 +968,7 @@ describe('annotation clicktoshow', function() {
     });
 
     it('works on date and log axes', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: ['2016-01-01', '2016-01-02', '2016-01-03'],
             y: [1, 1, 3]
         }], {
@@ -992,7 +992,7 @@ describe('annotation clicktoshow', function() {
     });
 
     it('works on category axes', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: ['a', 'b', 'c'],
             y: [1, 2, 3]
         }], {
@@ -1039,7 +1039,7 @@ describe('annotation effects', function() {
         // we've already tested autorange with relayout, so fix the geometry
         // completely so we know exactly what we're dealing with
         // plot area is 300x300, and covers data range 100x100
-        return Plotly.plot(gd,
+        return Plotly.newPlot(gd,
             [{x: [0, 100], y: [0, 100], mode: 'markers'}],
             {
                 xaxis: {range: [0, 100]},
@@ -1635,7 +1635,7 @@ describe('annotation effects', function() {
             };
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [0, 1, 2, 3, 4, 5, 6, 7, 8],
             y: [0, 4, 5, 1, 2, 2, 3, 4, 2],
         }], {
@@ -1719,7 +1719,7 @@ describe('animating annotations', function() {
             });
         }
 
-        Plotly.plot(gd,
+        Plotly.newPlot(gd,
             [{y: [1, 2, 3]}],
             {
                 annotations: [{text: 'hello'}],

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1493,7 +1493,7 @@ describe('Test axes', function() {
         afterEach(destroyGraphDiv);
 
         it('updates ranges when adding, removing, or changing a constraint', function(done) {
-            Plotly.plot(gd,
+            Plotly.newPlot(gd,
                 [{z: [[0, 1], [2, 3]], type: 'heatmap'}],
                 // plot area is 200x100 px
                 {width: 400, height: 300, margin: {l: 100, r: 100, t: 100, b: 100}}
@@ -1549,7 +1549,7 @@ describe('Test axes', function() {
         }
 
         it('can change per-axis constrain:domain/range and constraintoward', function(done) {
-            Plotly.plot(gd,
+            Plotly.newPlot(gd,
                 // start with a heatmap as it has no padding so calculations are easy
                 [{z: [[0, 1], [2, 3]], type: 'heatmap'}],
                 // plot area is 200x100 px
@@ -1649,7 +1649,7 @@ describe('Test axes', function() {
             var xAutorange = [-xAutoPad, 1 + xAutoPad];
             var yAutoPad = 0.15476190476190477;
             var yAutorange = [-yAutoPad, 1 + yAutoPad];
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {y: [0, 1], mode: 'markers', marker: {size: 4}},
                 {y: [0, 1], mode: 'markers', marker: {size: 4}, xaxis: 'x2', yaxis: 'y2'}
             ], {
@@ -1691,7 +1691,7 @@ describe('Test axes', function() {
         });
 
         it('can constrain date axes', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['2001-01-01', '2002-01-01'],
                 y: ['2001-01-01', '2002-01-01'],
                 mode: 'markers',
@@ -1723,7 +1723,7 @@ describe('Test axes', function() {
         });
 
         it('can constrain category axes', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['a', 'b'],
                 y: ['c', 'd'],
                 mode: 'markers',
@@ -1752,7 +1752,7 @@ describe('Test axes', function() {
         });
 
         it('can constrain log axes', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [1, 10],
                 y: [1, 10],
                 mode: 'markers',
@@ -1820,7 +1820,7 @@ describe('Test axes', function() {
 
             var rng = [-1, 6];
 
-            Plotly.plot(gd, fig1())
+            Plotly.newPlot(gd, fig1())
             .then(function() {
                 var msg = 'fig1';
                 assertRangeDomain('xaxis', rng, [0, 0.230769], [0, 0.230769], msg);
@@ -1869,7 +1869,7 @@ describe('Test axes', function() {
         }
 
         it('should auto-range according to all matching trace data', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 { y: [1, 2, 1] },
                 { y: [2, 1, 2, 3], xaxis: 'x2' },
                 { y: [0, 1], xaxis: 'x3' }
@@ -1916,7 +1916,7 @@ describe('Test axes', function() {
 
         describe('setting, or not setting categoryorder if it is not explicitly declared', function() {
             it('should set categoryorder to default if categoryorder and categoryarray are not supplied', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {xaxis: {type: 'category'}})
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {xaxis: {type: 'category'}})
                 .then(function() {
                     expect(gd._fullLayout.xaxis.categoryorder).toBe('trace');
                     expect(gd._fullLayout.xaxis.categorarray).toBe(undefined);
@@ -1926,7 +1926,7 @@ describe('Test axes', function() {
             });
 
             it('should set categoryorder to default even if type is not set to category explicitly', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}])
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}])
                 .then(function() {
                     expect(gd._fullLayout.xaxis.categoryorder).toBe('trace');
                     expect(gd._fullLayout.xaxis.categorarray).toBe(undefined);
@@ -1936,7 +1936,7 @@ describe('Test axes', function() {
             });
 
             it('should NOT set categoryorder to default if type is not category', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}])
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}])
                 .then(function() {
                     expect(gd._fullLayout.yaxis.categoryorder).toBe(undefined);
                     expect(gd._fullLayout.xaxis.categorarray).toBe(undefined);
@@ -1946,7 +1946,7 @@ describe('Test axes', function() {
             });
 
             it('should set categoryorder to default if type is overridden to be category', function(done) {
-                Plotly.plot(gd, [{x: [1, 2, 3, 4, 5], y: [15, 11, 12, 13, 14]}], {yaxis: {type: 'category'}})
+                Plotly.newPlot(gd, [{x: [1, 2, 3, 4, 5], y: [15, 11, 12, 13, 14]}], {yaxis: {type: 'category'}})
                 .then(function() {
                     expect(gd._fullLayout.xaxis.categoryorder).toBe(undefined);
                     expect(gd._fullLayout.yaxis.categorarray).toBe(undefined);
@@ -1960,7 +1960,7 @@ describe('Test axes', function() {
 
         describe('setting categoryorder to "array"', function() {
             it('should leave categoryorder on "array" if it is supplied', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'array', categoryarray: ['b', 'a', 'd', 'e', 'c']}
                 })
                 .then(function() {
@@ -1972,7 +1972,7 @@ describe('Test axes', function() {
             });
 
             it('should switch categoryorder on "array" if it is not supplied but categoryarray is supplied', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryarray: ['b', 'a', 'd', 'e', 'c']}
                 })
                 .then(function() {
@@ -1984,7 +1984,7 @@ describe('Test axes', function() {
             });
 
             it('should revert categoryorder to "trace" if "array" is supplied but there is no list', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'array'}
                 })
                 .then(function() {
@@ -1998,7 +1998,7 @@ describe('Test axes', function() {
 
         describe('do not set categoryorder to "array" if list exists but empty', function() {
             it('should switch categoryorder to default if list is not supplied', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'array', categoryarray: []}
                 })
                 .then(function() {
@@ -2010,7 +2010,7 @@ describe('Test axes', function() {
             });
 
             it('should not switch categoryorder on "array" if categoryarray is supplied but empty', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryarray: []}
                 })
                 .then(function() {
@@ -2024,7 +2024,7 @@ describe('Test axes', function() {
 
         describe('do NOT set categoryorder to "array" if it has some other proper value', function() {
             it('should use specified categoryorder if it is supplied even if categoryarray exists', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'trace', categoryarray: ['b', 'a', 'd', 'e', 'c']}
                 })
                 .then(function() {
@@ -2036,7 +2036,7 @@ describe('Test axes', function() {
             });
 
             it('should use specified categoryorder if it is supplied even if categoryarray exists', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'category ascending', categoryarray: ['b', 'a', 'd', 'e', 'c']}
                 })
                 .then(function() {
@@ -2048,7 +2048,7 @@ describe('Test axes', function() {
             });
 
             it('should use specified categoryorder if it is supplied even if categoryarray exists', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'category descending', categoryarray: ['b', 'a', 'd', 'e', 'c']}
                 })
                 .then(function() {
@@ -2062,7 +2062,7 @@ describe('Test axes', function() {
 
         describe('setting categoryorder to the default if the value is unexpected', function() {
             it('should switch categoryorder to "trace" if mode is supplied but invalid', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'invalid value'}
                 })
                 .then(function() {
@@ -2074,7 +2074,7 @@ describe('Test axes', function() {
             });
 
             it('should switch categoryorder to "array" if mode is supplied but invalid and list is supplied', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], {
                     xaxis: {type: 'category', categoryorder: 'invalid value', categoryarray: ['b', 'a', 'd', 'e', 'c']}
                 })
                 .then(function() {
@@ -2098,7 +2098,7 @@ describe('Test axes', function() {
 
         describe('a category has the same value of one of the auto range computed extreme', function() {
             it('should compute the right range for X axis', function(done) {
-                Plotly.plot(gd, [{x: ['0', '-0.5', '3.5', 'Not Known'], y: [ '1.0', '1.0', '2.0', '1.0'], type: 'bar'}], {
+                Plotly.newPlot(gd, [{x: ['0', '-0.5', '3.5', 'Not Known'], y: [ '1.0', '1.0', '2.0', '1.0'], type: 'bar'}], {
                     xaxis: {type: 'category', autorange: true}
                 })
                 .then(function() {
@@ -2132,7 +2132,7 @@ describe('Test axes', function() {
                 }
             };
 
-            Plotly.plot(gd, data, layout)
+            Plotly.newPlot(gd, data, layout)
             .then(function() {
                 var yaxis = gd._fullLayout.yaxis;
                 expect(yaxis.ticklen).toBe(5);
@@ -2159,7 +2159,7 @@ describe('Test axes', function() {
                 }
             };
 
-            Plotly.plot(gd, data, layout)
+            Plotly.newPlot(gd, data, layout)
             .then(function() {
                 var yaxis = gd._fullLayout.yaxis;
                 expect(yaxis.ticklen).toBe(10);
@@ -2182,7 +2182,7 @@ describe('Test axes', function() {
                 }
             };
 
-            Plotly.plot(gd, data, layout)
+            Plotly.newPlot(gd, data, layout)
             .then(function() {
                 var yaxis = gd._fullLayout.yaxis;
                 expect(yaxis.tickangle).toBeUndefined();
@@ -4044,7 +4044,7 @@ describe('Test axes', function() {
                 };
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [
                     'short label 1', 'loooooong label 1',
                     'short label 2', 'loooooong label 2',
@@ -4158,7 +4158,7 @@ describe('Test axes', function() {
                 expect(gs.b + gs.h + gs.t).toBeWithin(exp.totalHeight, 1.5, msg + ' - total height');
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['loooooong label 1', 'loooooong label 2'],
                 y: [1, 2]
             }], {
@@ -4198,7 +4198,7 @@ describe('Test axes', function() {
                 expect(gs.l + gs.w + gs.r).toBeWithin(exp.totalWidth, 1.5, msg + ' - total width');
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 y: ['loooooong label 1', 'loooooong label 2'],
                 x: [1, 2]
             }], {
@@ -4231,7 +4231,7 @@ describe('Test axes', function() {
         });
 
         it('should handle cases with free+mirror axes', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 y: [1, 2, 1]
             }], {
                 xaxis: {
@@ -4442,7 +4442,7 @@ describe('Test axes', function() {
                 });
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['a', 'b', 'c'],
                 y: [1, 2, 1]
             }], {
@@ -4500,7 +4500,7 @@ describe('Test axes', function() {
                 });
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['A very long title', 'short', 'Another very long title'],
                 y: [1, 4, 2]
             }], {
@@ -4917,7 +4917,7 @@ describe('Test axes', function() {
             }
 
             it('should adapt padding about axis rangebreaks length', function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     mode: 'markers',
                     x: [
                         '1970-01-01 00:00:00.000',
@@ -5014,7 +5014,7 @@ describe('Test axes', function() {
             }
 
             it('should locate rangebreaks & compute l <-> p parameters - x-axis case', function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     x: [
                         '1970-01-01 00:00:00.000',
                         '1970-01-01 00:00:00.010',
@@ -5136,7 +5136,7 @@ describe('Test axes', function() {
             });
 
             it('should locate rangebreaks & compute l <-> p parameters - y-axis case', function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     y: [
                         '1970-01-01 00:00:00.000',
                         '1970-01-01 00:00:00.010',
@@ -5198,7 +5198,7 @@ describe('Test axes', function() {
             });
 
             it('should locate rangebreaks & compute l <-> p parameters - date axis case', function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     x: [
                         // Thursday
                         '2020-01-02 08:00', '2020-01-02 17:00',
@@ -5388,7 +5388,7 @@ describe('Test axes', function() {
             }
 
             it('should not include requested ticks that fall within rangebreaks', function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     x: [
                         '1970-01-01 00:00:00.000',
                         '1970-01-01 00:00:00.010',
@@ -5563,7 +5563,7 @@ describe('Test axes', function() {
 
             spyOn(Lib, 'warn');
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'scattergl',
                 x: [
                     '2020-01-02 08:00', '2020-01-02 17:00',
@@ -6683,7 +6683,7 @@ describe('Test tickformatstops:', function() {
     afterEach(destroyGraphDiv);
 
     it('handles zooming-in until milliseconds zoom level', function(done) {
-        var promise = Plotly.plot(gd, mockCopy.data, mockCopy.layout);
+        var promise = Plotly.newPlot(gd, mockCopy.data, mockCopy.layout);
 
         var testCount = 0;
 
@@ -6710,7 +6710,7 @@ describe('Test tickformatstops:', function() {
     });
 
     it('handles zooming-out until years zoom level', function(done) {
-        var promise = Plotly.plot(gd, mockCopy.data, mockCopy.layout);
+        var promise = Plotly.newPlot(gd, mockCopy.data, mockCopy.layout);
 
         var testCount = 0;
 
@@ -6740,7 +6740,7 @@ describe('Test tickformatstops:', function() {
     it('responds to hover', function(done) {
         var evt = { xpx: 270, ypx: 10 };
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             Fx.hover(gd, evt, 'xy');
 
             var hoverTrace = gd._hoverdata[0];
@@ -6761,7 +6761,7 @@ describe('Test tickformatstops:', function() {
     });
 
     it('doesn\'t fail on bad input', function(done) {
-        var promise = Plotly.plot(gd, mockCopy.data, mockCopy.layout);
+        var promise = Plotly.newPlot(gd, mockCopy.data, mockCopy.layout);
 
         [1, {a: 1, b: 2}, 'boo'].forEach(function(v) {
             promise = promise.then(function() {

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -1163,7 +1163,7 @@ describe('A bar plot', function() {
         }];
         var layout = {};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var barNodes = getAllBarNodes(traceNodes[0]);
             var foundTextNodes;
@@ -1199,7 +1199,7 @@ describe('A bar plot', function() {
         }];
         var layout = {barmode: 'relative'};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var barNodes = getAllBarNodes(traceNodes[0]);
             var foundTextNodes;
@@ -1236,7 +1236,7 @@ describe('A bar plot', function() {
         }];
         var layout = {barmode: 'relative'};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var barNodes = getAllBarNodes(traceNodes[0]);
             var foundTextNodes;
@@ -1268,7 +1268,7 @@ describe('A bar plot', function() {
             barmode: 'relative'
         };
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var barNodes = getAllBarNodes(traceNodes[0]);
             var foundTextNodes;
@@ -1299,7 +1299,7 @@ describe('A bar plot', function() {
         }];
         var layout = {};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var barNodes = getAllBarNodes(traceNodes[0]);
             var foundTextNodes;
@@ -1333,7 +1333,7 @@ describe('A bar plot', function() {
             barnorm: 'percent'
         };
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var barNodes = getAllBarNodes(traceNodes[0]);
             var foundTextNodes;
@@ -1370,7 +1370,7 @@ describe('A bar plot', function() {
         var noMarkerTrace = Lib.extendFlat({}, insideTextTestsTrace);
         delete noMarkerTrace.marker;
 
-        Plotly.plot(gd, [insideTextTestsTrace, noMarkerTrace])
+        Plotly.newPlot(gd, [insideTextTestsTrace, noMarkerTrace])
           .then(function() {
               var trace1Colors = [DARK, DARK, LIGHT, LIGHT, DARK, LIGHT];
               var trace2Colors = Lib.repeat(DARK, 6);
@@ -1393,7 +1393,7 @@ describe('A bar plot', function() {
             }
         };
 
-        Plotly.plot(gd, [trace])
+        Plotly.newPlot(gd, [trace])
           .then(assertTextFontColors([DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -1402,7 +1402,7 @@ describe('A bar plot', function() {
     it('should use defined textfont.color for inside text instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, { textfont: { color: '#09f' } });
 
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(assertTextFontColors(Lib.repeat('#09f', 6)))
           .catch(failTest)
           .then(done);
@@ -1411,7 +1411,7 @@ describe('A bar plot', function() {
     it('should use matching color from textfont.color array for inside text, contrasting otherwise', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, { textfont: { color: ['#09f', 'green'] } });
 
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(assertTextFontColors(['#09f', 'green', LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -1420,7 +1420,7 @@ describe('A bar plot', function() {
     it('should use defined insidetextfont.color for inside text instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, { insidetextfont: { color: '#09f' } });
 
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(assertTextFontColors(Lib.repeat('#09f', 6)))
           .catch(failTest)
           .then(done);
@@ -1429,7 +1429,7 @@ describe('A bar plot', function() {
     it('should use matching color from insidetextfont.color array instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, { insidetextfont: { color: ['yellow', 'green'] } });
 
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(assertTextFontColors(['yellow', 'green', LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -1447,7 +1447,7 @@ describe('A bar plot', function() {
         var trace2 = Lib.extendFlat({}, trace1);
         var layout = {barmode: 'stack'};
 
-        Plotly.plot(gd, [trace1, trace2], layout)
+        Plotly.newPlot(gd, [trace1, trace2], layout)
           .then(assertTextFontColors([LIGHT, DARK]))
           .catch(failTest)
           .then(done);
@@ -1465,7 +1465,7 @@ describe('A bar plot', function() {
         var trace2 = Lib.extendFlat({}, trace1);
         var layout = {barmode: 'stack', font: {family: 'Arial'}};
 
-        Plotly.plot(gd, [trace1, trace2], layout)
+        Plotly.newPlot(gd, [trace1, trace2], layout)
           .then(assertTextFontColors(['blue', DARK]))
           .then(assertTextFontFamilies(['serif', 'Arial']))
           .then(assertTextFontSizes([24, 12]))
@@ -1489,7 +1489,7 @@ describe('A bar plot', function() {
         });
         var layout = {font: {family: 'Roboto', size: 12}};
 
-        Plotly.plot(gd, [trace], layout)
+        Plotly.newPlot(gd, [trace], layout)
           .then(assertTextFontColors(['yellow', 'green', 'blue', LIGHT, DARK, LIGHT]))
           .then(assertTextFontFamilies(['Arial', 'serif', 'Roboto', 'Roboto', 'Roboto', 'Roboto']))
           .then(assertTextFontSizes([16, 24, 12, 12, 12, 12]))
@@ -1525,7 +1525,7 @@ describe('A bar plot', function() {
             clickmode: 'event+select'
         };
 
-        Plotly.plot(gd, [trace1, trace2], layout)
+        Plotly.newPlot(gd, [trace1, trace2], layout)
           .then(function() {
               assertNonSelectionModeStyle('before selection');
           })
@@ -1578,7 +1578,7 @@ describe('A bar plot', function() {
     it('should be able to restyle', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/bar_attrs_relative'));
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             var cd = gd.calcdata;
             assertPointField(cd, 'x', [
                 [1, 2, 3, 4], [1, 2, 3, 4],
@@ -1773,7 +1773,7 @@ describe('A bar plot', function() {
             }
         };
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var barNodes = getAllBarNodes(traceNodes[0]);
             var pathNodes = [
@@ -1882,7 +1882,7 @@ describe('A bar plot', function() {
             expect(sel.size()).toBe(cnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'bar',
             x: ['Product A', 'Product B', 'Product C'],
             y: [20, 14, 23],
@@ -1951,7 +1951,7 @@ describe('A bar plot', function() {
     });
 
     it('should not error out when *textfont* is set in traces w/o *text*', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'bar',
             x: ['A', 'K', 'M', 'O', 'Q', 'S', 'T', 'V', 'X', 'Z', 'D', 'F', 'H'],
             y: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25],
@@ -2086,7 +2086,7 @@ describe('A bar plot', function() {
     it('should not show up null and zero bars as thin bars', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/bar_hide_nulls.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             var nodes = gd.querySelectorAll('g.point > path');
             expect(nodes.length).toBe(16, '# of bars');
@@ -2151,7 +2151,7 @@ describe('A bar plot', function() {
                     mock.layout.yaxis4.range = [17.9, -14.9];
                 }
 
-                Plotly.plot(gd, mock)
+                Plotly.newPlot(gd, mock)
                 .then(function() {
                     var nodes = gd.querySelectorAll('g.point > path');
                     expect(nodes.length).toBe(16, '# of bars');
@@ -2188,7 +2188,7 @@ describe('bar visibility toggling:', function() {
     }
 
     it('should update axis range according to visible edits (group case)', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {type: 'bar', x: [1, 2, 3], y: [1, 2, 1]},
             {type: 'bar', x: [1, 2, 3], y: [-1, -2, -1]}
         ])
@@ -2224,7 +2224,7 @@ describe('bar visibility toggling:', function() {
     });
 
     it('should update axis range according to visible edits (stack case)', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {type: 'bar', x: [1, 2, 3], y: [1, 2, 1]},
             {type: 'bar', x: [1, 2, 3], y: [2, 3, 2]}
         ], {barmode: 'stack'})
@@ -2343,7 +2343,7 @@ describe('bar hover', function() {
 
             var mock = Lib.extendDeep({}, require('@mocks/11.json'));
 
-            Plotly.plot(gd, mock.data, mock.layout)
+            Plotly.newPlot(gd, mock.data, mock.layout)
             .catch(failTest)
             .then(done);
         });
@@ -2369,7 +2369,7 @@ describe('bar hover', function() {
 
             var mock = Lib.extendDeep({}, require('@mocks/bar_attrs_group_norm.json'));
 
-            Plotly.plot(gd, mock.data, mock.layout)
+            Plotly.newPlot(gd, mock.data, mock.layout)
             .catch(failTest)
             .then(done);
         });
@@ -2413,7 +2413,7 @@ describe('bar hover', function() {
             var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
             mock.data.forEach(function(t) { t.type = 'bar'; });
 
-            Plotly.plot(gd, mock).then(function() {
+            Plotly.newPlot(gd, mock).then(function() {
                 var out = _hover(gd, -0.25, 0.5, 'closest');
                 expect(out.text).toEqual('Hover text\nA', 'hover text');
 
@@ -2453,7 +2453,7 @@ describe('bar hover', function() {
                 Fx.hover('graph', evt, 'xy');
             }
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({
@@ -2477,7 +2477,7 @@ describe('bar hover', function() {
                 };
             }
 
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     type: 'bar',
                     x: ['a', 'b'],
@@ -2521,7 +2521,7 @@ describe('bar hover', function() {
                 };
             }
 
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     type: 'bar',
                     orientation: 'h',
@@ -2564,7 +2564,7 @@ describe('bar hover', function() {
         });
 
         it('should return correct hover data (single bar, trace width)', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'bar',
                 x: [1],
                 y: [2],
@@ -2607,7 +2607,7 @@ describe('bar hover', function() {
         });
 
         it('should return correct hover data (two bars, array width)', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'bar',
                 x: [1, 200],
                 y: [2, 1],
@@ -2682,7 +2682,7 @@ describe('bar hover', function() {
             it('- under barmode:' + m, function(done) {
                 gd = createGraphDiv();
 
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     type: 'bar',
                     y: [0, 1, 0]
                 }, {
@@ -3207,7 +3207,7 @@ describe('bar uniformtext', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextSizes('without uniformtext', {
             fontsizes: [12, 12, 12, 12, 12, 12, 12],
             scales: [0.48, 1, 1, 1, 1, 1, 1],

--- a/test/jasmine/tests/barpolar_test.js
+++ b/test/jasmine/tests/barpolar_test.js
@@ -58,7 +58,7 @@ describe('Test barpolar hover:', function() {
             margin: {t: 0, b: 0, l: 0, r: 0, pad: 0}
         }, specs.layout || {});
 
-        return Plotly.plot(gd, data, layout).then(function() {
+        return Plotly.newPlot(gd, data, layout).then(function() {
             var subplot = gd._fullLayout.polar._subplot;
 
             var results = gd.calcdata.map(function(cd) {

--- a/test/jasmine/tests/box_test.js
+++ b/test/jasmine/tests/box_test.js
@@ -731,7 +731,7 @@ describe('Test box hover:', function() {
 
         var pos = specs.pos || [200, 200];
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             mouseEvent('mousemove', pos[0], pos[1]);
             assertHoverLabelContent(specs, specs.desc);
         });
@@ -1094,7 +1094,7 @@ describe('Test box restyle:', function() {
             _assertOne(msg, exp, trace3, 'ptsCnt', 'path.point');
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             _assert('base', {boxCnt: 1});
         })
@@ -1125,7 +1125,7 @@ describe('Test box restyle:', function() {
             expect(fullLayout.yaxis.range).toBeCloseToArray(yrng, 2, msg + ' yrng');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'box',
             y: [0, 1, 1, 1, 1, 2, 2, 3, 5, 6, 10]
         }], {
@@ -1161,7 +1161,7 @@ describe('Test box restyle:', function() {
             expect(fullLayout.yaxis.range).toBeCloseToArray(yrng, 2, msg + ' yrng');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'box',
             width: 0.4,
             y: [0, 5, 7, 8],

--- a/test/jasmine/tests/calcdata_test.js
+++ b/test/jasmine/tests/calcdata_test.js
@@ -17,7 +17,7 @@ describe('calculated data and points', function() {
 
     describe('connectGaps', function() {
         it('should exclude null and undefined points when false', function(done) {
-            Plotly.plot(gd, [{ x: [1, 2, 3, undefined, 5], y: [1, null, 3, 4, 5]}], {})
+            Plotly.newPlot(gd, [{ x: [1, 2, 3, undefined, 5], y: [1, null, 3, 4, 5]}], {})
             .then(function() {
                 expect(gd.calcdata[0][1]).toEqual(jasmine.objectContaining({ x: BADNUM, y: BADNUM}));
                 expect(gd.calcdata[0][3]).toEqual(jasmine.objectContaining({ x: BADNUM, y: BADNUM}));
@@ -27,7 +27,7 @@ describe('calculated data and points', function() {
         });
 
         it('should exclude null and undefined points as categories when false', function(done) {
-            Plotly.plot(gd, [{ x: [1, 2, 3, undefined, 5], y: [1, null, 3, 4, 5] }], { xaxis: { type: 'category' }})
+            Plotly.newPlot(gd, [{ x: [1, 2, 3, undefined, 5], y: [1, null, 3, 4, 5] }], { xaxis: { type: 'category' }})
             .then(function() {
                 expect(gd.calcdata[0][1]).toEqual(jasmine.objectContaining({ x: BADNUM, y: BADNUM}));
                 expect(gd.calcdata[0][3]).toEqual(jasmine.objectContaining({ x: BADNUM, y: BADNUM}));
@@ -40,7 +40,7 @@ describe('calculated data and points', function() {
     describe('category ordering', function() {
         describe('default category ordering reified', function() {
             it('should output categories in the given order by default', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category'
                 }})
                 .then(function() {
@@ -55,7 +55,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in the given order if `trace` order is explicitly specified', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'trace'
                     // Also, if axis tick order is made configurable, shouldn't we make trace order configurable?
@@ -77,7 +77,7 @@ describe('calculated data and points', function() {
 
         describe('domain alphanumerical category ordering', function() {
             it('should output categories in ascending domain alphanumerical order', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'category ascending'
                 }})
@@ -93,7 +93,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in descending domain alphanumerical order', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'category descending'
                 }})
@@ -109,7 +109,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in ascending domain alphanumerical order even if categories are all numbers', function(done) {
-                Plotly.plot(gd, [{x: [3, 1, 5, 2, 4], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: [3, 1, 5, 2, 4], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'category ascending'
                 }})
@@ -125,7 +125,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in categoryorder order even if category array is defined', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'category ascending',
                     categoryarray: ['b', 'a', 'd', 'e', 'c'] // These must be ignored. Alternative: error?
@@ -142,7 +142,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in ascending domain alphanumerical order, excluding undefined', function(done) {
-                Plotly.plot(gd, [{x: ['c', undefined, 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', undefined, 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'category ascending'
                 }})
@@ -157,7 +157,7 @@ describe('calculated data and points', function() {
             });
 
             it('should combine duplicate categories', function(done) {
-                Plotly.plot(gd, [{x: [ '1', '1'], y: [10, 20]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: [ '1', '1'], y: [10, 20]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'category ascending'
                 }})
@@ -171,7 +171,7 @@ describe('calculated data and points', function() {
             });
 
             it('should skip over visible-false traces', function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     x: [1, 2, 3],
                     y: [7, 6, 5],
                     visible: false
@@ -197,7 +197,7 @@ describe('calculated data and points', function() {
 
         describe('explicit category ordering', function() {
             it('should output categories in explicitly supplied order, independent of trace order', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: ['b', 'a', 'd', 'e', 'c']
@@ -214,7 +214,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in explicitly supplied order even if category values are all numbers', function(done) {
-                Plotly.plot(gd, [{x: [3, 1, 5, 2, 4], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: [3, 1, 5, 2, 4], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: [2, 1, 4, 5, 3]
@@ -231,7 +231,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in explicitly supplied order, independent of trace order, pruned', function(done) {
-                Plotly.plot(gd, [{x: ['c', undefined, 'e', 'b', 'd'], y: [15, 11, 12, null, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', undefined, 'e', 'b', 'd'], y: [15, 11, 12, null, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: ['b', 'a', 'd', 'e', 'c']
@@ -248,7 +248,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in explicitly supplied order even if not all categories are present', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: ['b', 'x', 'a', 'd', 'z', 'e', 'c']
@@ -265,7 +265,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in explicitly supplied order even if some missing categories were at the beginning or end of categoryarray', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: ['y', 'b', 'x', 'a', 'd', 'z', 'e', 'c', 'q', 'k']
@@ -294,7 +294,7 @@ describe('calculated data and points', function() {
                 // BUT keeps it if a data point with null is added; test is almost identical to the one above
                 // except that it explicitly adds an axis tick for y
 
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd', 'y'], y: [15, 11, 12, 13, 14, null]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd', 'y'], y: [15, 11, 12, 13, 14, null]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: ['y', 'b', 'x', 'a', 'd', 'z', 'e', 'c', 'q', 'k']
@@ -316,7 +316,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in explicitly supplied order even if not all categories are present, and should interact with a null value orthogonally', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, null, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, null, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: ['b', 'x', 'a', 'd', 'z', 'e', 'c']
@@ -333,7 +333,7 @@ describe('calculated data and points', function() {
             });
 
             it('should output categories in explicitly supplied order first, if not all categories are covered', function(done) {
-                Plotly.plot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
+                Plotly.newPlot(gd, [{x: ['c', 'a', 'e', 'b', 'd'], y: [15, 11, 12, 13, 14]}], { xaxis: {
                     type: 'category',
                     categoryorder: 'array',
                     categoryarray: ['b', 'a', 'x', 'c']
@@ -361,7 +361,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -390,7 +390,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -423,7 +423,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -457,7 +457,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -491,7 +491,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -526,7 +526,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Bearing', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -556,7 +556,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Bearing', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -590,7 +590,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Bearing', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -625,7 +625,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Bearing', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -660,7 +660,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Bearing', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -696,7 +696,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Bearing', 'Gear', 'Motor'];
                 var x3 = ['Motor', 'Gear', 'Bearing'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -723,7 +723,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Bearing', 'Gear', 'Motor'];
                 var x3 = ['Motor', 'Gear', 'Bearing'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -754,7 +754,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Bearing', 'Gear', 'Motor'];
                 var x3 = ['Motor', 'Gear', 'Bearing'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -786,7 +786,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Bearing', 'Gear', 'Motor'];
                 var x3 = ['Motor', 'Gear', 'Bearing'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -818,7 +818,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Bearing', 'Gear', 'Motor'];
                 var x3 = ['Motor', 'Gear', 'Bearing'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -851,7 +851,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Bearing', 'Gear', 'Motor'];
                 var x3 = ['Motor', 'Gear', 'Bearing'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;})},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;})},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;})}
@@ -886,7 +886,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Switch', 'Plug', 'Cord', 'Fuse', 'Bulb'];
                 var x3 = ['Pump', 'Leak', 'Bearing', 'Seals'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;}), type: 'bar'},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;}), type: 'bar'},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;}), type: 'bar'}
@@ -923,7 +923,7 @@ describe('calculated data and points', function() {
                 var x2 = ['Bearing', 'Gear', 'Motor'];
                 var x3 = ['Motor', 'Gear', 'Bearing'];
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: x1, y: x1.map(function(d, i) {return i + 10;}), type: 'bar'},
                     {x: x2, y: x2.map(function(d, i) {return i + 20;}), type: 'bar'},
                     {x: x3, y: x3.map(function(d, i) {return i + 30;}), type: 'bar'}
@@ -954,7 +954,7 @@ describe('calculated data and points', function() {
         });
 
         it('should order categories per axis', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {x: ['a', 'c', 'g', 'e']},
                 {x: ['b', 'h', 'f', 'd'], xaxis: 'x2'}
             ], {
@@ -970,7 +970,7 @@ describe('calculated data and points', function() {
         });
 
         it('should consider number categories and their string representation to be the same', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['a', 'b', 1, '1'],
                 y: [1, 2, 3, 4]
             }], {
@@ -1236,7 +1236,7 @@ describe('calculated data and points', function() {
 
     describe('customdata', function() {
         it('should pass customdata to the calcdata points', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 3],
                 y: [4, 5, 7],
                 customdata: ['a', 'b', {foo: 'bar'}]

--- a/test/jasmine/tests/carpet_test.js
+++ b/test/jasmine/tests/carpet_test.js
@@ -510,7 +510,7 @@ describe('Test carpet interactions:', function() {
     it('should restyle visible attribute properly', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/cheater.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             expect(countCarpets()).toEqual(1);
             expect(countContourTraces()).toEqual(3);
@@ -541,7 +541,7 @@ describe('Test carpet interactions:', function() {
         var mock = Lib.extendDeep({}, require('@mocks/cheater.json'));
         var trace1 = Lib.extendDeep({}, mock.data[1]);
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             expect(countCarpets()).toEqual(1);
             expect(countContourTraces()).toEqual(3);
@@ -571,7 +571,7 @@ describe('Test carpet interactions:', function() {
     it('should respond to relayout properly', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/cheater.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             return Plotly.relayout(gd, 'xaxis.range', [0, 1]);
         })
@@ -670,7 +670,7 @@ describe('scattercarpet array attributes', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             for(var i = 0; i < 4; i++) {
                 var pt = gd.calcdata[5][i];
@@ -708,7 +708,7 @@ describe('scattercarpet hover labels', function() {
     function run(pos, fig, content) {
         gd = createGraphDiv();
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             mouseEvent('mousemove', pos[0], pos[1]);
             assertHoverLabelContent({
                 nums: content[0].join('\n'),

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -31,7 +31,7 @@ describe('zoom box element', function() {
         var mockCopy = Lib.extendDeep({}, mock);
         mockCopy.layout.dragmode = 'zoom';
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
         .then(done);
     });
 
@@ -120,7 +120,7 @@ describe('main plot pan', function() {
             _checkAxes(xr0, yr0);
         }
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             modeBar = gd._fullLayout._modeBar;
             relayoutCallback = jasmine.createSpy('relayoutCallback');
             gd.on('plotly_relayout', relayoutCallback);
@@ -194,7 +194,7 @@ describe('main plot pan', function() {
         var events = [];
         var relayoutCallback;
 
-        Plotly.plot(gd, mock.data, mock.layout)
+        Plotly.newPlot(gd, mock.data, mock.layout)
         .then(function() {
             relayoutCallback = jasmine.createSpy('relayoutCallback');
             gd.on('plotly_relayout', relayoutCallback);
@@ -568,7 +568,7 @@ describe('axis zoom/pan and main plot zoom', function() {
             expect(gd._fullLayout.yaxis4.range).toBeCloseToArray(y4rng, 2, 'y3 rng');
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             _assert([-0.36, 4.36], [-0.36, 4.36]);
         })
@@ -590,7 +590,7 @@ describe('axis zoom/pan and main plot zoom', function() {
             expect(xGrid.size()).toEqual(xGridCnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 1.5, 0, -1.5, -1, -1.5, 0, 1.5, 1],
             y: [0, 1.5, 1, 1.5, 0, -1.5, -1, -1.5, 0],
             line: {shape: 'spline'}
@@ -635,7 +635,7 @@ describe('axis zoom/pan and main plot zoom', function() {
             .then(drag.end);
         }
 
-        Plotly.plot(gd, [{ y: [1, 2, 1] }])
+        Plotly.newPlot(gd, [{ y: [1, 2, 1] }])
         .then(function() {
             return _run('full-x full-y', [30, 30], {cornerCnt: 4});
         })
@@ -665,7 +665,7 @@ describe('axis zoom/pan and main plot zoom', function() {
 
     it('should emit plotly_relayouting events when drawing zoom selection', function(done) {
         var nsteps = 10; var events = []; var relayoutCallback;
-        Plotly.plot(gd, [{ y: [1, 2, 1] }])
+        Plotly.newPlot(gd, [{ y: [1, 2, 1] }])
         .then(function() {
             relayoutCallback = jasmine.createSpy('relayoutCallback');
             gd.on('plotly_relayout', relayoutCallback);
@@ -684,7 +684,7 @@ describe('axis zoom/pan and main plot zoom', function() {
 
     it('should emit plotly_relayouting events when zooming via mouse wheel', function(done) {
         var nsteps = 10; var events = []; var relayoutCallback;
-        Plotly.plot(gd, [{ y: [1, 2, 1] }], {}, {scrollZoom: true})
+        Plotly.newPlot(gd, [{ y: [1, 2, 1] }], {}, {scrollZoom: true})
         .then(function() {
             relayoutCallback = jasmine.createSpy('relayoutCallback');
             gd.on('plotly_relayout', relayoutCallback);
@@ -707,7 +707,7 @@ describe('axis zoom/pan and main plot zoom', function() {
             expect(gd.layout.yaxis.range).toBeCloseToArray(yrng, 2, 'yrng - ' + msg);
         }
 
-        Plotly.plot(gd, [{ y: [1, 2, 1] }])
+        Plotly.newPlot(gd, [{ y: [1, 2, 1] }])
         .then(doDrag('xy', 'nsew', 50, 50))
         .then(function() { _assert('after xy drag', [1, 1.208], [1.287, 1.5]); })
         .then(doDblClick('xy', 'nsew'))
@@ -735,7 +735,7 @@ describe('axis zoom/pan and main plot zoom', function() {
         var yrng1 = [1.3581, 1.5];
         var blank = [undefined, undefined];
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 1]
         }], {
             margin: {l: 0, t: 0, r: 0, b: 0},
@@ -816,7 +816,7 @@ describe('axis zoom/pan and main plot zoom', function() {
                 .then(drag.end);
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             _assertLabels('base', {
                 angle: [0, 0, 0, 0, 0, 0, 0],
@@ -945,7 +945,7 @@ describe('axis zoom/pan and main plot zoom', function() {
             spyOn(Axes, 'drawOne').and.callThrough();
             eventData = null;
 
-            return Plotly.plot(gd, fig).then(function() {
+            return Plotly.newPlot(gd, fig).then(function() {
                 Axes.drawOne.calls.reset();
                 gd.on('plotly_relayout', function(d) { eventData = d; });
             });
@@ -1757,7 +1757,7 @@ describe('axis zoom/pan and main plot zoom', function() {
                 };
             }
 
-            Plotly.plot(gd, [{y: [1, 2, 1]}], {dragmode: 'zoom'})
+            Plotly.newPlot(gd, [{y: [1, 2, 1]}], {dragmode: 'zoom'})
             .then(_assert('base', {
                 nodeCnt: 3,
                 xrng: [-0.128, 2.128],
@@ -1903,7 +1903,7 @@ describe('axis zoom/pan and main plot zoom', function() {
                 };
             }
 
-            Plotly.plot(gd, [{ type: 'heatmap', z: z() }], {dragmode: 'pan'})
+            Plotly.newPlot(gd, [{ type: 'heatmap', z: z() }], {dragmode: 'pan'})
             .then(function() {
                 // inspired by https://github.com/plotly/plotly.js/issues/2687
                 gd.on('plotly_relayout', function(d) {
@@ -2034,7 +2034,7 @@ describe('axis zoom/pan and main plot zoom', function() {
                 margin: {l: 0, r: 0, t: 0, b: 0}
             };
 
-            Plotly.plot(gd, [trace0], layout)
+            Plotly.newPlot(gd, [trace0], layout)
             .then(function() {
                 // inspired by https://github.com/plotly/plotly.js-crossfilter.js
                 gd.on('plotly_selecting', function(d) {
@@ -2141,7 +2141,7 @@ describe('axis zoom/pan and main plot zoom', function() {
             };
         }
 
-        Plotly.plot(gd, [{y: [1, 2, 1]}], {width: 400, height: 400})
+        Plotly.newPlot(gd, [{y: [1, 2, 1]}], {width: 400, height: 400})
         .then(function() {
             gd.on('plotly_relayout', function(d) { eventData = d; });
         })
@@ -2161,7 +2161,7 @@ describe('axis zoom/pan and main plot zoom', function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(xrng, 2, 'xrng - ' + msg);
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 mode: 'lines',
                 x: [
                     '1970-01-01 00:00:00.000',
@@ -2227,7 +2227,7 @@ describe('axis zoom/pan and main plot zoom', function() {
                 expect(gd.layout.yaxis.range).toBeCloseToArray(yrng, 2, 'yrng - ' + msg);
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 mode: 'lines',
                 y: [
                     '1970-01-01 00:00:00.000',
@@ -2315,7 +2315,7 @@ describe('Event data:', function() {
     }
 
     it('should have correct content for *scatter* traces', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 1],
             marker: {
                 color: [20, 30, 10],
@@ -2342,7 +2342,7 @@ describe('Event data:', function() {
     });
 
     it('should have correct content for *heatmap* traces', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'heatmap',
             z: [[1, 2, 1], [2, 3, 1]],
             colorbar: {

--- a/test/jasmine/tests/cartesian_test.js
+++ b/test/jasmine/tests/cartesian_test.js
@@ -26,7 +26,7 @@ describe('restyle', function() {
                 return d3.selectAll('g.trace.scatter .fills>g');
             }
 
-            Plotly.plot(gd, mock.data, mock.layout).then(function() {
+            Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
                 fills = getFills();
 
                 // Assert there are two fills, first is tozero, second is tonext
@@ -70,7 +70,7 @@ describe('restyle', function() {
             var lines, firstLine1, secondLine1, firstLine2, secondLine2;
             var mock = Lib.extendDeep({}, require('@mocks/basic_line.json'));
 
-            Plotly.plot(gd, mock.data, mock.layout).then(function() {
+            Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
                 lines = d3.selectAll('g.scatter.trace .js-line');
 
                 firstLine1 = lines[0][0];
@@ -120,7 +120,7 @@ describe('restyle', function() {
                 expect(texts.size()).toEqual(textSize);
             }
 
-            Plotly.plot(gd, mock.data, mock.layout).then(function() {
+            Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
                 assertScatterModeSizes(2, 6, 9);
 
                 return Plotly.restyle(gd, 'mode', 'lines');
@@ -153,7 +153,7 @@ describe('restyle', function() {
         });
 
         it('can legend-hide the second and only scatter trace', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {y: [1, 2, 3], type: 'bar'},
                 {y: [1, 2, 3], xaxis: 'x2', yaxis: 'y2', type: 'scatter'}
             ], {
@@ -179,7 +179,7 @@ describe('restyle', function() {
         });
 
         it('@gl can legend-hide the second and only scattergl trace', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {y: [1, 2, 3], type: 'bar'},
                 {y: [1, 2, 3], xaxis: 'x2', yaxis: 'y2', type: 'scattergl'}
             ], {
@@ -227,7 +227,7 @@ describe('relayout', function() {
                 });
             }
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 assertCategories(['giraffes', 'orangutans', 'monkeys']);
 
                 return Plotly.relayout(gd, 'xaxis.categoryorder', 'category descending');
@@ -296,7 +296,7 @@ describe('relayout', function() {
                 expect(Math.abs(texts.attr('y') - textT[1])).toBeLessThan(TOLERANCE);
             }
 
-            Plotly.plot(gd, mockData).then(function() {
+            Plotly.newPlot(gd, mockData).then(function() {
                 assertPointTranslate([270, 135], [270, 135]);
 
                 return Plotly.relayout(gd, 'xaxis.range', [2, 3]);
@@ -399,7 +399,7 @@ describe('subplot creation / deletion:', function() {
             expect(d3.select('.x2title').size()).toEqual(0);
         }
 
-        Plotly.plot(gd, [], {
+        Plotly.newPlot(gd, [], {
             xaxis: { title: 'X' },
             yaxis: { title: 'Y' },
             xaxis2: { title: 'X2', anchor: 'y2' },
@@ -505,7 +505,7 @@ describe('subplot creation / deletion:', function() {
     });
 
     it('puts plot backgrounds behind everything except if they overlap', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {y: [1, 2, 3]},
             {y: [2, 3, 1], xaxis: 'x2', yaxis: 'y2'},
             {y: [3, 1, 2], yaxis: 'y3'}
@@ -551,7 +551,7 @@ describe('subplot creation / deletion:', function() {
     });
 
     it('puts not have backgrounds nodes when plot and paper color match', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {y: [1, 2, 3]},
             {y: [2, 3, 1], xaxis: 'x2', yaxis: 'y2'},
             {y: [3, 1, 2], yaxis: 'y3'}
@@ -628,7 +628,7 @@ describe('subplot creation / deletion:', function() {
                 .toBe(x2y2Cnt, 'has correct x2y2 oveylaid subplot trace count');
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert(1, 1);
             return Plotly.restyle(gd, 'visible', false, [1]);
         })
@@ -674,7 +674,7 @@ describe('subplot creation / deletion:', function() {
             assertChildrenCnt(g.select('.yaxislayer-above'), yAbove[1], 'yaxislayer above');
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert(
                 [false, 0],
                 [false, 0],
@@ -818,7 +818,7 @@ describe('subplot creation / deletion:', function() {
             expect(info.selectAll('.g-ytitle').size()).toBe(yaxis[2], 'y title cnt');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 1]
         }], {
             xaxis: {title: 'X'},

--- a/test/jasmine/tests/choropleth_test.js
+++ b/test/jasmine/tests/choropleth_test.js
@@ -176,7 +176,7 @@ describe('Test choropleth hover:', function() {
             fontFamily: 'Arial'
         };
 
-        return Plotly.plot(gd, fig)
+        return Plotly.newPlot(gd, fig)
         .then(function() {
             if(hasCssTransform) {
                 scale = 0.5;

--- a/test/jasmine/tests/choroplethmapbox_test.js
+++ b/test/jasmine/tests/choroplethmapbox_test.js
@@ -554,7 +554,7 @@ describe('Test choroplethmapbox hover:', function() {
 
         var pos = s.pos || [270, 220];
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             if(hasCssTransform) transformPlot(gd, 'translate(-25%, -25%) scale(0.5)');
 
             var to = setTimeout(function() {
@@ -708,7 +708,7 @@ describe('Test choroplethmapbox interactions:', function() {
             marker: {opacity: 0.3}
         };
 
-        Plotly.plot(gd,
+        Plotly.newPlot(gd,
             [trace0, trace1],
             {mapbox: {style: 'basic'}},
             {mapboxAccessToken: MAPBOX_ACCESS_TOKEN}
@@ -736,7 +736,7 @@ describe('Test choroplethmapbox interactions:', function() {
             return layerIds;
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'choroplethmapbox',
             locations: ['AL'],
             z: [10],

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -57,7 +57,7 @@ describe('Test click interactions:', function() {
         var futureData, clickPassthroughs, contextPassthroughs;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
                 clickPassthroughs = 0;
@@ -245,7 +245,7 @@ describe('Test click interactions:', function() {
         beforeEach(function(done) {
             var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
             modifiedMockCopy.data[0].hoverinfo = 'skip';
-            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+            Plotly.newPlot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -268,7 +268,7 @@ describe('Test click interactions:', function() {
         beforeEach(function(done) {
             var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
             modifiedMockCopy.data[0].hoverinfo = 'skip';
-            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+            Plotly.newPlot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -291,7 +291,7 @@ describe('Test click interactions:', function() {
         beforeEach(function(done) {
             var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
             modifiedMockCopy.data[0].hoverinfo = 'none';
-            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+            Plotly.newPlot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -324,7 +324,7 @@ describe('Test click interactions:', function() {
         beforeEach(function(done) {
             var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
             modifiedMockCopy.data[0].hoverinfo = 'none';
-            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+            Plotly.newPlot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -361,7 +361,7 @@ describe('Test click interactions:', function() {
         beforeEach(function(done) {
             var modifiedMockCopy = Lib.extendDeep({}, mockCopy);
             modifiedMockCopy.data[0].hoverinfo = 'none';
-            Plotly.plot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
+            Plotly.newPlot(gd, modifiedMockCopy.data, modifiedMockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -399,7 +399,7 @@ describe('Test click interactions:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -422,7 +422,7 @@ describe('Test click interactions:', function() {
 
     describe('drag interactions', function() {
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 // Do not let the notifier hide the drag elements
                 var tooltip = document.querySelector('.notifier-note');
                 if(tooltip) tooltip.style.display = 'None';
@@ -702,7 +702,7 @@ describe('Test click interactions:', function() {
         }
 
         it('when set to \'reset+autorange\' (the default) should work when \'autorange\' is on', function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
@@ -724,7 +724,7 @@ describe('Test click interactions:', function() {
         it('when set to \'reset+autorange\' (the default) should reset to set range on double click', function(done) {
             mockCopy = setRanges(mockCopy);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
@@ -745,7 +745,7 @@ describe('Test click interactions:', function() {
         it('when set to \'reset+autorange\' (the default) should autosize on 1st double click and reset on 2nd', function(done) {
             mockCopy = setRanges(mockCopy);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
@@ -766,7 +766,7 @@ describe('Test click interactions:', function() {
         it('when set to \'reset+autorange\' (the default) should autosize on 1st double click and zoom when immediately dragged', function(done) {
             mockCopy = setRanges(mockCopy);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
@@ -795,7 +795,7 @@ describe('Test click interactions:', function() {
             var newAutoRangeX = [-4.482371794871794, 3.4823717948717943];
             var newAutoRangeY = [-0.8892256657741471, 1.6689872212461876];
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
@@ -824,7 +824,7 @@ describe('Test click interactions:', function() {
         });
 
         it('when set to \'reset\' should work when \'autorange\' is on', function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'reset' }).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'reset' }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
@@ -845,7 +845,7 @@ describe('Test click interactions:', function() {
         it('when set to \'reset\' should reset to set range on double click', function(done) {
             mockCopy = setRanges(mockCopy);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'reset' }).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'reset' }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
@@ -866,7 +866,7 @@ describe('Test click interactions:', function() {
         it('when set to \'reset\' should reset on all double clicks', function(done) {
             mockCopy = setRanges(mockCopy);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'reset' }).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'reset' }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
@@ -880,7 +880,7 @@ describe('Test click interactions:', function() {
         });
 
         it('when set to \'autosize\' should work when \'autorange\' is on', function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'autosize' }).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'autosize' }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(autoRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(autoRangeY);
 
@@ -901,7 +901,7 @@ describe('Test click interactions:', function() {
         it('when set to \'autosize\' should set to autorange on double click', function(done) {
             mockCopy = setRanges(mockCopy);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'autosize' }).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'autosize' }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
@@ -922,7 +922,7 @@ describe('Test click interactions:', function() {
         it('when set to \'autosize\' should reset on all double clicks', function(done) {
             mockCopy = setRanges(mockCopy);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'autosize' }).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, { doubleClick: 'autosize' }).then(function() {
                 expect(gd.layout.xaxis.range).toBeCloseToArray(setRangeX);
                 expect(gd.layout.yaxis.range).toBeCloseToArray(setRangeY);
 
@@ -1029,7 +1029,7 @@ describe('Test click interactions:', function() {
 
     describe('zoom interactions', function() {
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('on main dragbox should update the axis ranges', function(done) {
@@ -1052,7 +1052,7 @@ describe('Test click interactions:', function() {
 
     describe('scroll zoom interactions', function() {
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, { scrollZoom: true }).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, { scrollZoom: true }).then(done);
         });
 
         it('zooms in on scroll up', function() {
@@ -1081,7 +1081,7 @@ describe('Test click interactions:', function() {
         beforeEach(function(done) {
             mockCopy.layout.dragmode = 'pan';
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('on main dragbox should update the axis ranges', function(done) {
@@ -1132,7 +1132,7 @@ describe('dragbox', function() {
             expect(scale.y).toBeCloseTo(y, 1);
         }
 
-        Plotly.plot(createGraphDiv(), mock).then(function() {
+        Plotly.newPlot(createGraphDiv(), mock).then(function() {
             var node = d3.select('rect.nedrag').node();
             var pos = getRectCenter(node);
             var fns = drag.makeFns({pos0: pos, dpos: [50, 0]});

--- a/test/jasmine/tests/colorscale_test.js
+++ b/test/jasmine/tests/colorscale_test.js
@@ -783,7 +783,7 @@ describe('Test colorscale restyle calls:', function() {
         var reds = ['rgb(220, 220, 220)', 'rgb(234, 135, 92)', 'rgb(178, 10, 28)'];
         var grns = ['rgb(0, 68, 27)', 'rgb(116, 196, 118)', 'rgb(247, 252, 245)'];
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'contour',
             z: [
                 [1, 20, 30],
@@ -891,7 +891,7 @@ describe('Test colorscale restyle calls:', function() {
         var rdbu = ['rgb(5, 10, 172)', 'rgb(77, 101, 226)', 'rgb(178, 10, 28)'];
         var grns = ['rgb(0, 68, 27)', 'rgb(35, 139, 69)', 'rgb(247, 252, 245)'];
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             y: [1, 2, 3],
             marker: {color: [-1, 0, 3]}
@@ -970,7 +970,7 @@ describe('Test colorscale restyle calls:', function() {
         var blues = ['rgb(220, 220, 220)', 'rgb(70, 100, 245)', 'rgb(5, 10, 172)'];
         var grns = ['rgb(247, 252, 245)', 'rgb(116, 196, 118)', 'rgb(0, 68, 27)'];
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             y: [1, 2, 3],
             marker: {
@@ -1052,7 +1052,7 @@ describe('Test colorscale restyle calls:', function() {
         var grns = ['rgb(0, 68, 27)', 'rgb(12, 119, 52)', 'rgb(174, 222, 167)',
             'rgb(12, 119, 52)', 'rgb(12, 119, 52)', 'rgb(247, 252, 245)'];
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             y: [1, 2, 3],
             marker: {color: [-1, 0, 3], coloraxis: 'coloraxis'}
@@ -1155,7 +1155,7 @@ describe('Test colorscale restyle calls:', function() {
             }
         };
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 3],
             marker: {color: [1, 2, 3]}
         }])
@@ -1177,7 +1177,7 @@ describe('Test colorscale restyle calls:', function() {
     });
 
     it('@gl should work with scatter3d', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [1, 2, 3],

--- a/test/jasmine/tests/command_test.js
+++ b/test/jasmine/tests/command_test.js
@@ -75,7 +75,7 @@ describe('Plots.hasSimpleAPICommandBindings', function() {
     beforeEach(function() {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {x: [1, 2, 3], y: [1, 2, 3]},
             {x: [1, 2, 3], y: [4, 5, 6]},
         ]);
@@ -194,7 +194,7 @@ describe('Plots.computeAPICommandBindings', function() {
     beforeEach(function() {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {x: [1, 2, 3], y: [1, 2, 3]},
             {x: [1, 2, 3], y: [4, 5, 6]},
         ]);
@@ -518,7 +518,7 @@ describe('component bindings', function() {
         var mockCopy = Lib.extendDeep({}, mock);
         gd = createGraphDiv();
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
     });
 
     afterEach(function() {
@@ -604,7 +604,7 @@ describe('attaching component bindings', function() {
 
     beforeEach(function(done) {
         gd = createGraphDiv();
-        Plotly.plot(gd, [{x: [1, 2, 3], y: [1, 2, 3]}]).then(done);
+        Plotly.newPlot(gd, [{x: [1, 2, 3], y: [1, 2, 3]}]).then(done);
     });
 
     afterEach(function() {

--- a/test/jasmine/tests/compute_frame_test.js
+++ b/test/jasmine/tests/compute_frame_test.js
@@ -17,7 +17,7 @@ describe('Test mergeFrames', function() {
     beforeEach(function(done) {
         mock = [{x: [1, 2, 3], y: [2, 1, 3]}, {x: [1, 2, 3], y: [6, 4, 5]}];
         gd = createGraphDiv();
-        Plotly.plot(gd, mock).then(done);
+        Plotly.newPlot(gd, mock).then(done);
     });
 
     afterEach(destroyGraphDiv);

--- a/test/jasmine/tests/cone_test.js
+++ b/test/jasmine/tests/cone_test.js
@@ -87,7 +87,7 @@ describe('Test cone autorange:', function() {
             return function(v) { return v * s; };
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assertAxisRanges('base', rng0, rng0, rng0);
 
             // the resulting image should be independent of what I multiply by here
@@ -190,7 +190,7 @@ describe('Test cone autorange:', function() {
     });
 
     it('@gl should skip identical positions in calculating cone vectorScale', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [
                 {
                     type: 'cone',
@@ -227,7 +227,7 @@ describe('Test cone interactions', function() {
         // put traces on same subplot
         delete fig.data[1].scene;
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             var scene = gd._fullLayout.scene._scene;
             var objs = scene.glplot.objects;
 
@@ -301,7 +301,7 @@ describe('Test cone interactions', function() {
             mouseEvent('mouseover', 200, 200);
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(delay(20))
         .then(_hover)
         .then(delay(20))
@@ -368,7 +368,7 @@ describe('Test cone interactions', function() {
             mouseEvent('mouseover', 282, 240);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'cone',
             name: 'blue cone',
             x: [1], y: [1], z: [1],

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -76,7 +76,7 @@ describe('config argument', function() {
                 if(!autosize) compareLayoutAndFullLayout(gd);
             }
 
-            Plotly.plot(gd, data, layout, config).then(function() {
+            Plotly.newPlot(gd, data, layout, config).then(function() {
                 beforeResize();
 
                 return Plotly.relayout(gd, relayout);
@@ -174,7 +174,7 @@ describe('config argument', function() {
         it('should fill the container when autosize: true up its max-width and max-height', function(done) {
             gd.style.maxWidth = '400px';
             gd.style.maxHeight = '300px';
-            Plotly.plot(gd, data, {autosize: true})
+            Plotly.newPlot(gd, data, {autosize: true})
             .then(function() {
                 checkLayoutSize(400, 300);
             })
@@ -206,7 +206,7 @@ describe('config argument', function() {
                 var dfltWidth = Plots.layoutAttributes.width.dflt;
                 var dfltHeight = Plots.layoutAttributes.height.dflt;
 
-                Plotly.plot(gd, data, {autosize: true})
+                Plotly.newPlot(gd, data, {autosize: true})
                 .then(function() {
                     if(spec.dflt) {
                         expect(gd._fullLayout.width).toBe(dfltWidth);
@@ -232,7 +232,7 @@ describe('config argument', function() {
         afterEach(destroyGraphDiv);
 
         it('should not display the edit link by default', function(done) {
-            Plotly.plot(gd, [], {})
+            Plotly.newPlot(gd, [], {})
             .then(function() {
                 var link = document.getElementsByClassName('js-plot-link-container')[0];
 
@@ -243,7 +243,7 @@ describe('config argument', function() {
         });
 
         it('should display a link when true', function(done) {
-            Plotly.plot(gd, [], {}, { showLink: true })
+            Plotly.newPlot(gd, [], {}, { showLink: true })
             .then(function() {
                 var link = document.getElementsByClassName('js-plot-link-container')[0];
 
@@ -272,7 +272,7 @@ describe('config argument', function() {
             var edits = {};
             edits[editFlag] = true;
 
-            return Plotly.plot(gd, [
+            return Plotly.newPlot(gd, [
                 { x: [1, 2, 3], y: [1, 2, 3] },
                 { x: [1, 2, 3], y: [3, 2, 1] }
             ], {
@@ -465,7 +465,7 @@ describe('config argument', function() {
         }
 
         it('should have drag rectangles cursors by default', function(done) {
-            Plotly.plot(gd, mockCopy.data, {})
+            Plotly.newPlot(gd, mockCopy.data, {})
             .then(function() {
                 testDraggers(1);
             })
@@ -474,7 +474,7 @@ describe('config argument', function() {
         });
 
         it('should not have drag rectangles when disabled', function(done) {
-            Plotly.plot(gd, mockCopy.data, {}, { showAxisDragHandles: false })
+            Plotly.newPlot(gd, mockCopy.data, {}, { showAxisDragHandles: false })
             .then(function() {
                 testDraggers(0);
             })
@@ -496,7 +496,7 @@ describe('config argument', function() {
         afterEach(destroyGraphDiv);
 
         it('allows axis range entry by default', function(done) {
-            Plotly.plot(gd, mockCopy.data, {})
+            Plotly.newPlot(gd, mockCopy.data, {})
             .then(function() {
                 var corner = document.getElementsByClassName('edrag')[0];
                 var cornerBox = corner.getBoundingClientRect();
@@ -514,7 +514,7 @@ describe('config argument', function() {
         });
 
         it('disallows axis range entry when disabled', function(done) {
-            Plotly.plot(gd, mockCopy.data, {}, { showAxisRangeEntryBoxes: false })
+            Plotly.newPlot(gd, mockCopy.data, {}, { showAxisRangeEntryBoxes: false })
             .then(function() {
                 var corner = document.getElementsByClassName('edrag')[0];
                 var cornerBox = corner.getBoundingClientRect();
@@ -545,7 +545,7 @@ describe('config argument', function() {
         afterEach(destroyGraphDiv);
 
         it('should not default to an external plotly cloud', function(done) {
-            Plotly.plot(gd, [], {})
+            Plotly.newPlot(gd, [], {})
             .then(function() {
                 expect(gd._context.plotlyServerURL).not.toBe('https://plot.ly');
                 expect(gd._context.plotlyServerURL).not.toBe('https://chart-studio.plotly.com');
@@ -559,7 +559,7 @@ describe('config argument', function() {
         });
 
         it('should be able to connect to Chart Studio Cloud when set to https://chart-studio.plotly.com', function(done) {
-            Plotly.plot(gd, [], {}, {
+            Plotly.newPlot(gd, [], {}, {
                 plotlyServerURL: 'https://chart-studio.plotly.com'
             })
             .then(function() {
@@ -574,7 +574,7 @@ describe('config argument', function() {
         });
 
         it('can be set to other base urls', function(done) {
-            Plotly.plot(gd, [], {}, {plotlyServerURL: 'dummy'})
+            Plotly.newPlot(gd, [], {}, {plotlyServerURL: 'dummy'})
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('dummy');
 
@@ -589,7 +589,7 @@ describe('config argument', function() {
         it('has lesser priotiy then window env', function(done) {
             window.PLOTLYENV = {BASE_URL: 'yo'};
 
-            Plotly.plot(gd, [], {}, {plotlyServerURL: 'dummy'})
+            Plotly.newPlot(gd, [], {}, {plotlyServerURL: 'dummy'})
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('dummy');
 
@@ -683,7 +683,7 @@ describe('config argument', function() {
 
             it('should resize when the viewport width/height changes', function(done) {
                 fillParent(1, 1);
-                Plotly.plot(gd, data, {}, {responsive: true})
+                Plotly.newPlot(gd, data, {}, {responsive: true})
                 .then(testResponsive)
                 .catch(failTest)
                 .then(done);
@@ -691,7 +691,7 @@ describe('config argument', function() {
 
             it('should still be responsive if the plot is edited', function(done) {
                 fillParent(1, 1);
-                Plotly.plot(gd, data, {}, {responsive: true})
+                Plotly.newPlot(gd, data, {}, {responsive: true})
                 .then(function() {return Plotly.restyle(gd, 'y[0]', data[0].y[0] + 2);})
                 .then(testResponsive)
                 .catch(failTest)
@@ -700,7 +700,7 @@ describe('config argument', function() {
 
             it('should still be responsive if the plot is purged and replotted', function(done) {
                 fillParent(1, 1);
-                Plotly.plot(gd, data, {}, {responsive: true})
+                Plotly.newPlot(gd, data, {}, {responsive: true})
                 .then(function() {return Plotly.newPlot(gd, data, {}, {responsive: true});})
                 .then(testResponsive)
                 .catch(failTest)
@@ -713,7 +713,7 @@ describe('config argument', function() {
                 window.addEventListener('resize', function() {cntWindowResize++;});
                 spyOn(Plotly.Plots, 'resize').and.callThrough();
 
-                Plotly.plot(gd, data, {}, {responsive: true})
+                Plotly.newPlot(gd, data, {}, {responsive: true})
                 .then(function() {return Plotly.restyle(gd, 'y[0]', data[0].y[0] + 2);})
                 .then(function() {viewport.set(width / 2, width / 2);})
                 .then(delay(RESIZE_DELAY))
@@ -728,7 +728,7 @@ describe('config argument', function() {
 
             it('should become responsive if configured as such via Plotly.react', function(done) {
                 fillParent(1, 1);
-                Plotly.plot(gd, data, {}, {responsive: false})
+                Plotly.newPlot(gd, data, {}, {responsive: false})
                 .then(function() {return Plotly.react(gd, data, {}, {responsive: true});})
                 .then(testResponsive)
                 .catch(failTest)
@@ -737,7 +737,7 @@ describe('config argument', function() {
 
             it('should stop being responsive if configured as such via Plotly.react', function(done) {
                 fillParent(1, 1);
-                Plotly.plot(gd, data, {}, {responsive: true})
+                Plotly.newPlot(gd, data, {}, {responsive: true})
                 // Check initial size
                 .then(function() {checkLayoutSize(width, height);})
                 // Turn off responsiveness
@@ -760,7 +760,7 @@ describe('config argument', function() {
                     this.style.flexGrow = '1';
                 });
 
-                Plotly.plot(gd, data, {}, { responsive: true })
+                Plotly.newPlot(gd, data, {}, { responsive: true })
                 .then(testResponsive)
                 .catch(failTest)
                 .then(done);
@@ -773,7 +773,7 @@ describe('config argument', function() {
                     this.style.flexGrow = '1';
                 });
 
-                Plotly.plot(gd, data, {}, { responsive: true })
+                Plotly.newPlot(gd, data, {}, { responsive: true })
                 .then(testResponsive)
                 .catch(failTest)
                 .then(done);
@@ -787,7 +787,7 @@ describe('config argument', function() {
                 parent.style.gridTemplateRows = 'repeat(' + numRows + ', 1fr)';
                 fillParent(numRows, numCols);
 
-                Plotly.plot(gd, data, {}, { responsive: true })
+                Plotly.newPlot(gd, data, {}, { responsive: true })
                 .then(testResponsive)
                 .catch(failTest)
                 .then(done);
@@ -799,7 +799,7 @@ describe('config argument', function() {
                     this.style.width = null;
                     this.style.height = null;
                 });
-                Plotly.plot(gd, data, {autosize: true}, {responsive: true})
+                Plotly.newPlot(gd, data, {autosize: true}, {responsive: true})
                 .then(function() {
                     checkLayoutSize(700, 450);
                     expect(gd.clientWidth).toBe(700);
@@ -827,7 +827,7 @@ describe('config argument', function() {
                     this.style.height = '500px';
                 });
 
-                Plotly.plot(gd, data, {autosize: true, width: 1200, height: 700}, {responsive: true})
+                Plotly.newPlot(gd, data, {autosize: true, width: 1200, height: 700}, {responsive: true})
                 .then(function() {
                     expect(gd.clientWidth).toBe(1000);
                     expect(gd.clientHeight).toBe(500);
@@ -842,7 +842,7 @@ describe('config argument', function() {
                 spyOn(Plotly.Plots, 'resize').and.callThrough();
 
                 fillParent(1, 1);
-                Plotly.plot(gd, data, {}, {responsive: true})
+                Plotly.newPlot(gd, data, {}, {responsive: true})
                 .then(function() {
                     gd.style.display = 'none';
                     viewport.set(width / 2, height / 2);
@@ -865,7 +865,7 @@ describe('config argument', function() {
         afterEach(destroyGraphDiv);
 
         function plot(config) {
-            return Plotly.plot(gd, [], {}, config);
+            return Plotly.newPlot(gd, [], {}, config);
         }
 
         it('should fill in scrollZoom default', function(done) {

--- a/test/jasmine/tests/contour_test.js
+++ b/test/jasmine/tests/contour_test.js
@@ -630,7 +630,7 @@ describe('contour hover', function() {
         beforeAll(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     type: 'contour',
                     x: [10, 11, 10, 11],
@@ -660,7 +660,7 @@ describe('contour hover', function() {
         beforeAll(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'contour',
                 x: [1, 2, 3],
                 y: [2, 3, 4],

--- a/test/jasmine/tests/contourgl_test.js
+++ b/test/jasmine/tests/contourgl_test.js
@@ -169,7 +169,7 @@ var plotDataElliptical = function(maxJitter) {
 
 
 function makePlot(gd, mock, done) {
-    return Plotly.plot(gd, mock.data, mock.layout)
+    return Plotly.newPlot(gd, mock.data, mock.layout)
         .then(null, failTest)
         .then(done);
 }
@@ -224,7 +224,7 @@ describe('contourgl plots', function() {
         var mock = plotDataElliptical(0);
         var scene2d;
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             scene2d = gd._fullLayout._plots.xy._scene2d;
 
             expect(scene2d.traces[mock.data[0].uid].type).toEqual('contourgl');

--- a/test/jasmine/tests/densitymapbox_test.js
+++ b/test/jasmine/tests/densitymapbox_test.js
@@ -296,7 +296,7 @@ describe('Test densitymapbox hover:', function() {
 
         var pos = s.pos || [353, 143];
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             var to = setTimeout(function() {
                 failTest('no event data received');
                 done();
@@ -410,7 +410,7 @@ describe('Test densitymapbox interactions:', function() {
             z: [1, 20, 5],
         };
 
-        Plotly.plot(gd,
+        Plotly.newPlot(gd,
             [trace0, trace1],
             {mapbox: {style: 'basic'}},
             {mapboxAccessToken: MAPBOX_ACCESS_TOKEN}
@@ -438,7 +438,7 @@ describe('Test densitymapbox interactions:', function() {
             return layerIds;
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'densitymapbox',
             lon: [10, 20, 30],
             lat: [15, 25, 35],
@@ -507,7 +507,7 @@ describe('Test densitymapbox interactions:', function() {
             }
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'densitymapbox',
             lon: [10, 20, 30],
             lat: [15, 25, 35],

--- a/test/jasmine/tests/download_test.js
+++ b/test/jasmine/tests/download_test.js
@@ -111,7 +111,7 @@ describe('Plotly.downloadImage', function() {
         var plotClip = /clip-path='url\("#clip[0-9a-f]{6}xyplot"\)/;
         var legendClip = /clip-path=\'url\("#legend[0-9a-f]{6}"\)/;
 
-        Plotly.plot(gd, textchartMock.data, textchartMock.layout)
+        Plotly.newPlot(gd, textchartMock.data, textchartMock.layout)
         .then(function(gd) {
             savedBlob = undefined;
             return Plotly.downloadImage(gd, {
@@ -150,7 +150,7 @@ describe('Plotly.downloadImage', function() {
         spyOn(Lib, 'isSafari').and.callFake(function() { return true; });
         spyOn(helpers, 'octetStream');
 
-        Plotly.plot(gd, textchartMock.data, textchartMock.layout)
+        Plotly.newPlot(gd, textchartMock.data, textchartMock.layout)
         .then(function() { return Plotly.downloadImage(gd, {format: 'svg'}); })
         .then(function() { return Plotly.downloadImage(gd, {format: 'png'}); })
         .then(function() { return Plotly.downloadImage(gd, {format: 'jpeg'}); })
@@ -177,7 +177,7 @@ describe('Plotly.downloadImage', function() {
         gd.style.width = '500px';
         gd.style.height = '300px';
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() { return Plotly.downloadImage(gd, {format: 'png'}); })
         .then(function() {
             var args = helpers.octetStream.calls.allArgs();
@@ -210,7 +210,7 @@ function downloadTest(gd, format) {
         });
     });
 
-    return Plotly.plot(gd, textchartMock.data, textchartMock.layout).then(function(_gd) {
+    return Plotly.newPlot(gd, textchartMock.data, textchartMock.layout).then(function(_gd) {
         // start observing dom
         // configuration of the observer:
         var config = { childList: true };

--- a/test/jasmine/tests/drawing_test.js
+++ b/test/jasmine/tests/drawing_test.js
@@ -368,7 +368,7 @@ describe('Drawing', function() {
             // allow page to scroll
             gd.style.position = 'static';
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 y: [1, 2, 1]
             }], {
                 annotations: [{
@@ -482,7 +482,7 @@ describe('gradients', function() {
     }
 
     it('clears unused gradients after a replot', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [0, 1, 2],
             mode: 'markers',
             marker: {
@@ -549,7 +549,7 @@ describe('gradients', function() {
             .append('base')
             .attr('href', 'https://chart-studio.plotly.com');
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'heatmap',
             x: [1, 2],
             y: [2, 3],

--- a/test/jasmine/tests/finance_test.js
+++ b/test/jasmine/tests/finance_test.js
@@ -664,7 +664,7 @@ describe('finance charts auto-range', function() {
         it('- ohlc case', function(done) {
             var trace = Lib.extendDeep({}, base, {type: 'ohlc'});
 
-            Plotly.plot(gd, [trace]).then(function() {
+            Plotly.newPlot(gd, [trace]).then(function() {
                 expect(gd._fullLayout.xaxis.range).toBeCloseToArray([-0.5, 2.5], 1);
             })
             .catch(failTest)
@@ -674,7 +674,7 @@ describe('finance charts auto-range', function() {
         it('- candlestick case', function(done) {
             var trace = Lib.extendDeep({}, base, {type: 'candlestick'});
 
-            Plotly.plot(gd, [trace]).then(function() {
+            Plotly.newPlot(gd, [trace]).then(function() {
                 expect(gd._fullLayout.xaxis.range).toBeCloseToArray([-0.5, 2.5], 1);
             })
             .catch(failTest)
@@ -714,7 +714,7 @@ describe('finance charts updates:', function() {
 
         var path0;
 
-        Plotly.plot(gd, [trace0]).then(function() {
+        Plotly.newPlot(gd, [trace0]).then(function() {
             expect(gd.calcdata[0][0].t.tickLen).toBeCloseTo(0.3, 5);
             expect(gd.calcdata[0][0].o).toEqual(33.01);
 
@@ -752,7 +752,7 @@ describe('finance charts updates:', function() {
             Lib.extendDeep({}, mock0, { type: 'candlestick' }),
         ];
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(countOHLCTraces()).toEqual(1);
             expect(countBoxTraces()).toEqual(1);
 
@@ -799,7 +799,7 @@ describe('finance charts updates:', function() {
     it('Plotly.relayout should work', function(done) {
         var trace0 = Lib.extendDeep({}, mock0, { type: 'ohlc' });
 
-        Plotly.plot(gd, [trace0]).then(function() {
+        Plotly.newPlot(gd, [trace0]).then(function() {
             expect(countRangeSliders()).toEqual(1);
 
             return Plotly.relayout(gd, 'xaxis.rangeslider.visible', false);
@@ -817,7 +817,7 @@ describe('finance charts updates:', function() {
             Lib.extendDeep({}, mock0, { type: 'candlestick' }),
         ];
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.calcdata[0].length).toEqual(8);
             expect(gd.calcdata[1].length).toEqual(8);
 
@@ -853,7 +853,7 @@ describe('finance charts updates:', function() {
             Lib.extendDeep({}, mock0, { type: 'candlestick' }),
         ];
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(countOHLCTraces()).toEqual(1);
             expect(countBoxTraces()).toEqual(1);
 
@@ -907,7 +907,7 @@ describe('finance charts updates:', function() {
             close: [2, 3]
         };
 
-        Plotly.plot(gd, [trace0], {boxmode: 'group'})
+        Plotly.newPlot(gd, [trace0], {boxmode: 'group'})
         .then(function() {
             assertBoxPosFields([0]);
 
@@ -934,14 +934,14 @@ describe('finance charts updates:', function() {
         .then(done);
     });
 
-    it('Plotly.plot with data-less trace and adding with Plotly.restyle', function(done) {
+    it('Plotly.newPlot with data-less trace and adding with Plotly.restyle', function(done) {
         var data = [
             { type: 'candlestick' },
             { type: 'ohlc' },
             { type: 'bar', y: [2, 1, 2] }
         ];
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(countOHLCTraces()).toEqual(0);
             expect(countBoxTraces()).toEqual(0);
             expect(countRangeSliders()).toEqual(0);
@@ -986,7 +986,7 @@ describe('finance charts updates:', function() {
                 .toBe(exp.pathd, 'path d attr - ' + msg);
         }
 
-        Plotly.plot(gd, [trace0], {
+        Plotly.newPlot(gd, [trace0], {
             xaxis: { rangeslider: {visible: false} }
         })
         .then(function() {
@@ -1044,7 +1044,7 @@ describe('finance charts updates:', function() {
             Lib.extendDeep({}, mock0, {type: 'candlestick'}),
         ];
 
-        Plotly.plot(gd, dataTA)
+        Plotly.newPlot(gd, dataTA)
         .then(function() {
             expect(countOHLCTraces()).toBe(1, '# of ohlc traces');
             expect(countBoxTraces()).toBe(1, '# of candlestick traces');
@@ -1088,7 +1088,7 @@ describe('finance charts *special* handlers:', function() {
             setTimeout(function() { return resolve(gd); }, 0);
         }
 
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             Lib.extendDeep({}, mock0, { type: 'ohlc' }),
             Lib.extendDeep({}, mock0, { type: 'candlestick' })
         ], {}, {
@@ -1150,7 +1150,7 @@ describe('finance trace hover:', function() {
         var yval = 'yval' in specs ? specs.yval : 1;
         var hovermode = layout.hovermode || 'x';
 
-        return Plotly.plot(gd, data, layout).then(function() {
+        return Plotly.newPlot(gd, data, layout).then(function() {
             var results = gd.calcdata.map(function(cd) {
                 var trace = cd[0].trace;
                 var pointData = {

--- a/test/jasmine/tests/frame_api_test.js
+++ b/test/jasmine/tests/frame_api_test.js
@@ -13,7 +13,7 @@ describe('Test frame api', function() {
     beforeEach(function(done) {
         mock = [{x: [1, 2, 3], y: [2, 1, 3]}, {x: [1, 2, 3], y: [6, 4, 5]}];
         gd = createGraphDiv();
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             f = gd._transitionData._frames;
             h = gd._transitionData._frameHash;
         }).then(function() {

--- a/test/jasmine/tests/funnel_test.js
+++ b/test/jasmine/tests/funnel_test.js
@@ -645,7 +645,7 @@ describe('A funnel plot', function() {
         }];
         var layout = {};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var funnelNodes = getAllFunnelNodes(traceNodes[0]);
             var foundTextNodes;
@@ -675,7 +675,7 @@ describe('A funnel plot', function() {
         }];
         var layout = {};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var funnelNodes = getAllFunnelNodes(traceNodes[0]);
             var foundTextNodes;
@@ -706,7 +706,7 @@ describe('A funnel plot', function() {
         }];
         var layout = {};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var funnelNodes = getAllFunnelNodes(traceNodes[0]);
             var foundTextNodes;
@@ -750,7 +750,7 @@ describe('A funnel plot', function() {
             }
         };
 
-        Plotly.plot(gd, [trace])
+        Plotly.newPlot(gd, [trace])
           .then(assertTextFontColors([DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -759,7 +759,7 @@ describe('A funnel plot', function() {
     it('should use defined textfont.color for inside text instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, { textfont: { color: '#09f' }, orientation: 'v' });
 
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(assertTextFontColors(Lib.repeat('#09f', 6)))
           .catch(failTest)
           .then(done);
@@ -812,7 +812,7 @@ describe('A funnel plot', function() {
             }
         };
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             var cd = gd.calcdata;
             assertPointField(cd, 'x', [
                 [1, 2, 3, 4], [1, 2, 3, 4],
@@ -966,7 +966,7 @@ describe('A funnel plot', function() {
             expect(sel.size()).toBe(cnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'funnel',
             x: ['Initial', 'A', 'B', 'C', 'Total'],
             y: [10, 2, 3, 5],
@@ -1009,7 +1009,7 @@ describe('A funnel plot', function() {
             expect(sel.size()).toBe(cnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'funnel',
             x: ['Initial', 'A', 'B', 'C', 'Total'],
             y: [10, 2, 3, 5],
@@ -1083,7 +1083,7 @@ describe('A funnel plot', function() {
     });
 
     it('should be able to deal with transform that empty out the data coordinate arrays', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'funnel',
                 x: [1, 2, 3],
@@ -1160,7 +1160,7 @@ describe('A funnel plot', function() {
             }
         };
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var funnelNodes = getAllFunnelNodes(traceNodes[0]);
             var pathNodes = [
@@ -1203,7 +1203,7 @@ describe('A funnel plot', function() {
             expect(sel.size()).toBe(cnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'funnel',
             orientation: 'v',
             x: ['Product A', 'Product B', 'Product C'],
@@ -1347,7 +1347,7 @@ describe('funnel hover', function() {
 
             var mock = Lib.extendDeep({}, require('@mocks/funnel_11.json'));
 
-            Plotly.plot(gd, mock.data, mock.layout)
+            Plotly.newPlot(gd, mock.data, mock.layout)
             .catch(failTest)
             .then(done);
         });
@@ -1375,7 +1375,7 @@ describe('funnel hover', function() {
             mock.data.forEach(function(t) { t.type = 'funnel'; t.orientation = 'v'; });
             mock.layout.funnelmode = 'group';
 
-            Plotly.plot(gd, mock).then(function() {
+            Plotly.newPlot(gd, mock).then(function() {
                 var out = _hover(gd, -0.25, 0.25, 'closest');
                 expect(out.text).toEqual('Hover text\nA', 'hover text');
 
@@ -1420,7 +1420,7 @@ describe('funnel hover', function() {
                 Fx.hover('graph', evt, 'xy');
             }
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(_hover)
             .then(function() {
                 expect(d3.selectAll('g.hovertext').size()).toBe(0);
@@ -1444,7 +1444,7 @@ describe('funnel hover', function() {
                 Fx.hover('graph', evt, 'xy');
             }
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({
@@ -1476,7 +1476,7 @@ describe('funnel hover', function() {
                 Fx.hover('graph', evt, 'xy');
             }
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({
@@ -1497,7 +1497,7 @@ describe('funnel hover', function() {
             it('should format numbers and add tick prefix & suffix even if axis is not visible', function(done) {
                 gd = createGraphDiv();
 
-                Plotly.plot(gd, {
+                Plotly.newPlot(gd, {
                     data: [{
                         x: ['A', 'B', 'C', 'D', 'E'],
                         y: [5.5, 4.4, 3.3, 2.2, 1.1],
@@ -1536,7 +1536,7 @@ describe('funnel hover', function() {
         });
 
         it('should return correct hover data (single funnel, trace width)', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'funnel',
                 orientation: 'v',
                 x: [1],
@@ -1729,7 +1729,7 @@ describe('funnel uniformtext', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextSizes('without uniformtext', {
             fontsizes: [12, 12, 12, 12, 12, 12, 12],
             scales: [0.44, 1, 1, 1, 1, 1, 1],

--- a/test/jasmine/tests/funnelarea_test.js
+++ b/test/jasmine/tests/funnelarea_test.js
@@ -398,7 +398,7 @@ describe('Funnelarea traces', function() {
             showlegend: true
         };
 
-        Plotly.plot(gd, data, layout)
+        Plotly.newPlot(gd, data, layout)
           .then(function() {
               var expWidths = ['3', '0', '0'];
 
@@ -431,7 +431,7 @@ describe('Funnelarea traces', function() {
                 size: [12, 20, 16]
             };
 
-            Plotly.plot(gd, [data])
+            Plotly.newPlot(gd, [data])
               .then(_checkFontColors(['red', 'green', 'blue']))
               .then(_checkFontFamilies(['Arial', 'Gravitas', 'Roboto']))
               .then(_checkFontSizes([12, 20, 16]))
@@ -449,7 +449,7 @@ describe('Funnelarea traces', function() {
     };
 
     it('should use inside text colors contrasting to explicitly set slice colors by default', function(done) {
-        Plotly.plot(gd, [insideTextTestsTrace])
+        Plotly.newPlot(gd, [insideTextTestsTrace])
           .then(_checkFontColors([DARK, DARK, LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -459,7 +459,7 @@ describe('Funnelarea traces', function() {
         var noMarkerTrace = Lib.extendFlat({}, insideTextTestsTrace);
         delete noMarkerTrace.marker;
 
-        Plotly.plot(gd, [noMarkerTrace])
+        Plotly.newPlot(gd, [noMarkerTrace])
           .then(_checkFontColors([LIGHT, DARK, LIGHT, LIGHT, LIGHT, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -467,7 +467,7 @@ describe('Funnelarea traces', function() {
 
     it('should use textfont.color for inside text instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, {textfont: {color: 'red'}});
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(_checkFontColors(Lib.repeat('red', 6)))
           .catch(failTest)
           .then(done);
@@ -475,14 +475,14 @@ describe('Funnelarea traces', function() {
 
     it('should use matching color from textfont.color array for inside text, contrasting otherwise', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, {textfont: {color: ['red', 'blue']}});
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(_checkFontColors(['red', 'blue', LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
     });
 
     it('should not use layout.font.color for inside text, but a contrasting color instead', function(done) {
-        Plotly.plot(gd, [insideTextTestsTrace], {font: {color: 'green'}})
+        Plotly.newPlot(gd, [insideTextTestsTrace], {font: {color: 'green'}})
           .then(_checkFontColors([DARK, DARK, LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -490,7 +490,7 @@ describe('Funnelarea traces', function() {
 
     it('should use matching color from insidetextfont.color array instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, {textfont: {color: ['orange', 'purple']}});
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(_checkFontColors(['orange', 'purple', LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -507,7 +507,7 @@ describe('Funnelarea traces', function() {
             });
             data[spec.fontAttr] = {color: ['blue', 'yellow'], family: ['Arial', 'Arial'], size: [24, 34]};
 
-            Plotly.plot(gd, [data])
+            Plotly.newPlot(gd, [data])
               .then(_checkFontColors(['blue', 'yellow', 'orange', 'orange', 'orange', 'orange']))
               .then(_checkFontFamilies(['Arial', 'Arial', 'Gravitas', 'Gravitas', 'Gravitas', 'Gravitas']))
               .then(_checkFontSizes([24, 34, 12, 12, 12, 12]))
@@ -528,7 +528,7 @@ describe('Funnelarea traces', function() {
             }
         });
 
-        Plotly.plot(gd, [data], layout)
+        Plotly.newPlot(gd, [data], layout)
           .then(_checkFontColors(['purple', 'blue', LIGHT, LIGHT, DARK, LIGHT]))
           .then(_checkFontFamilies(['Roboto', 'Arial', 'serif', 'serif', 'serif', 'serif']))
           .then(_checkFontSizes([24, 18, 16, 16, 16, 16]))
@@ -547,7 +547,7 @@ describe('Funnelarea traces', function() {
             data.textposition = 'inside';
             data[spec.fontAttr] = {color: ['blue', 'yellow'], family: ['Arial', 'Arial'], size: [24, 34]};
 
-            Plotly.plot(gd, [data], layout)
+            Plotly.newPlot(gd, [data], layout)
               .then(_checkFontColors(['blue', 'yellow', LIGHT, LIGHT, DARK, LIGHT]))
               .then(_checkFontFamilies(['Arial', 'Arial', 'serif', 'serif', 'serif', 'serif']))
               .then(_checkFontSizes([24, 34, 16, 16, 16, 16]))
@@ -563,7 +563,7 @@ describe('Funnelarea traces', function() {
     }
 
     it('show a user-defined title with a custom position and font', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'funnelarea',
             values: [1, 2, 3],
             title: {
@@ -581,7 +581,7 @@ describe('Funnelarea traces', function() {
     });
 
     it('should be able to restyle title', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'funnelarea',
             values: [1, 2, 3],
             title: {
@@ -609,7 +609,7 @@ describe('Funnelarea traces', function() {
     });
 
     it('should be able to restyle title despite using the deprecated attributes', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'funnelarea',
             values: [1, 2, 3],
             title: 'yo',
@@ -635,7 +635,7 @@ describe('Funnelarea traces', function() {
     });
 
     it('should be able to react with new text colors', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'funnelarea',
             values: [1, 2, 3],
             text: ['A', 'B', 'C'],
@@ -672,7 +672,7 @@ describe('Funnelarea traces', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', 4))
         .then(function() { return Plotly.restyle(gd, 'visible', false); })
         .then(_assert('both visible:false', 0))
@@ -707,7 +707,7 @@ describe('funnelarea hovering', function() {
         beforeEach(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                 .then(done);
         });
 
@@ -761,7 +761,7 @@ describe('funnelarea hovering', function() {
         beforeEach(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                 .then(done);
         });
 
@@ -873,7 +873,7 @@ describe('funnelarea hovering', function() {
         }
 
         it('should show the default selected values', function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertLabel(
@@ -955,7 +955,7 @@ describe('funnelarea hovering', function() {
             mockCopy.data[0].values[0] = 12345678.912;
             mockCopy.data[0].values[1] = 10000;
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertLabel('0\n12|345|678@91\n99@9%');
@@ -965,7 +965,7 @@ describe('funnelarea hovering', function() {
         });
 
         it('should show falsy zero text', function(done) {
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     type: 'funnelarea',
                     labels: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
@@ -988,7 +988,7 @@ describe('funnelarea hovering', function() {
 
         it('should use hovertemplate if specified', function(done) {
             mockCopy.data[0].name = '';
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertLabel(
@@ -1057,7 +1057,7 @@ describe('funnelarea hovering', function() {
             mockCopy.data[0].name = 'loooooooooooooooooooooooong';
             mockCopy.data[0].hoverinfo = 'all';
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({nums: '0\n5\n33.3%', name: 'looooooooooo...'}, 'base');
@@ -1085,7 +1085,7 @@ describe('Test event data of interactions on a funnelarea plot:', function() {
     beforeAll(function(done) {
         gd = createGraphDiv();
         mockCopy = Lib.extendDeep({}, mock);
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             pointPos = getClientPosition('g.slicetext');
             destroyGraphDiv();
             done();
@@ -1130,7 +1130,7 @@ describe('Test event data of interactions on a funnelarea plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1184,7 +1184,7 @@ describe('Test event data of interactions on a funnelarea plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1368,7 +1368,7 @@ describe('Test funnelarea interactions edge cases:', function() {
             unhoverCnt = 0;
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_hover', function() {
                 hoverCnt++;
@@ -1478,7 +1478,7 @@ describe('Test funnelarea calculated areas', function() {
                 baseratio: spec.baseratio
             }];
 
-            Plotly.plot(gd, data)
+            Plotly.newPlot(gd, data)
               .then(_checkCalculatedAreaRatios([0.4, 0.3, 0.2, 0.1]))
               .catch(failTest)
               .then(done);
@@ -1578,7 +1578,7 @@ describe('Test funnelarea calculated areas with scalegroup', function() {
                 baseratio: spec.baseratio
             }];
 
-            Plotly.plot(gd, data)
+            Plotly.newPlot(gd, data)
               .then(_checkCalculatedAreaRatios([0.4, 0.3, 0.2, 0.1]))
               .catch(failTest)
               .then(done);
@@ -1771,7 +1771,7 @@ describe('Test funnelarea calculated areas with scalegroup on various domain rat
                 baseratio: spec.baseratio
             }];
 
-            Plotly.plot(gd, data)
+            Plotly.newPlot(gd, data)
               .then(_checkCalculatedAreaRatios([0.4, 0.3, 0.2, 0.1]))
               .catch(failTest)
               .then(done);
@@ -1850,7 +1850,7 @@ describe('funnelarea uniformtext', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextSizes('without uniformtext', {
             fontsizes: [12, 12, 12, 12, 12, 12, 12, 12],
             scales: [1, 1, 1, 1, 1, 1, 1, 0.69],

--- a/test/jasmine/tests/fx_test.js
+++ b/test/jasmine/tests/fx_test.js
@@ -232,7 +232,7 @@ describe('relayout', function() {
             expect(!!node.onmousedown).toBe(isActive, 'mousedown handler');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [2, 1, 2]
         }]).then(function() {
             assertMainDrag('crosshair', true);

--- a/test/jasmine/tests/geo_test.js
+++ b/test/jasmine/tests/geo_test.js
@@ -833,7 +833,7 @@ describe('Test geo interactions', function() {
 
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         describe('scattergeo hover events', function() {
@@ -1347,7 +1347,7 @@ describe('Test geo interactions', function() {
         fig.layout.width = 700;
         fig.layout.height = 500;
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             mouseEvent('mousemove', 350, 250);
             expect(d3.selectAll('g.hovertext').size()).toEqual(1);
         })
@@ -1368,7 +1368,7 @@ describe('Test geo interactions', function() {
         var py = 290;
         var cnt = 0;
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             gd.on('plotly_unhover', function() { cnt++; });
 
             mouseEvent('mousemove', px, py);
@@ -1415,7 +1415,7 @@ describe('Test geo interactions', function() {
             Lib.clearThrottle();
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             var px = 255;
 
             check([px, 163], 0);
@@ -1430,7 +1430,7 @@ describe('Test geo interactions', function() {
 
         spyOn(Lib, 'warn');
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergeo',
             lon: [0],
             lat: [0]
@@ -1729,7 +1729,7 @@ describe('Test geo interactions', function() {
         it('- no base layers + lon/lat traces', function(done) {
             var fig = Lib.extendDeep({}, require('@mocks/geo_skymap.json'));
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(_assert(0))
             .then(function() { return Plotly.relayout(gd, 'geo.showcoastlines', true); })
             .then(_assert(1))
@@ -1738,7 +1738,7 @@ describe('Test geo interactions', function() {
         });
 
         it('- no base layers + choropleth', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'choropleth',
                 locations: ['CAN'],
                 z: [10]
@@ -1751,7 +1751,7 @@ describe('Test geo interactions', function() {
         });
 
         it('- no base layers + location scattergeo', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'scattergeo',
                 locations: ['CAN'],
             }], {
@@ -1763,7 +1763,7 @@ describe('Test geo interactions', function() {
         });
 
         it('- geo.visible:false', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'scattergeo',
                 lon: [0],
                 lat: [0]
@@ -1791,7 +1791,7 @@ describe('Test event property of interactions on a geo plot:', function() {
     beforeAll(function(done) {
         gd = createGraphDiv();
         mockCopy = Lib.extendDeep({}, mock);
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             pointPos = getClientPosition('path.point');
             nearPos = [pointPos[0] - 30, pointPos[1] - 30];
             destroyGraphDiv();
@@ -1810,7 +1810,7 @@ describe('Test event property of interactions on a geo plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1863,7 +1863,7 @@ describe('Test event property of interactions on a geo plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1918,7 +1918,7 @@ describe('Test event property of interactions on a geo plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1961,7 +1961,7 @@ describe('Test event property of interactions on a geo plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -2022,7 +2022,7 @@ describe('Test geo base layers', function() {
             });
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'choropleth',
             locations: ['CAN', 'FRA'],
             z: [10, 20]
@@ -2083,7 +2083,7 @@ describe('Test geo base layers', function() {
             expect(first(latParts)).toBeCloseToArray(exp.lat0, 1, msg + ' - first lataxis grid pt');
         }
 
-        Plotly.plot(gd, [{type: 'scattergeo'}], {
+        Plotly.newPlot(gd, [{type: 'scattergeo'}], {
             geo: {
                 lonaxis: {showgrid: true},
                 lataxis: {showgrid: true}
@@ -2131,7 +2131,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
     function plot(fig) {
         gd = createGraphDiv();
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             gd.on('plotly_relayout', function(d) { eventData = d; });
             gd.on('plotly_doubleclick', function() { dblClickCnt++; });
         });
@@ -2790,7 +2790,7 @@ describe('Test geo zoom/pan/drag interactions:', function() {
                     fig.layout.height = 500;
 
                     gd = createGraphDiv();
-                    Plotly.plot(gd, fig)
+                    Plotly.newPlot(gd, fig)
                     .then(function() {
                         gd.on('plotly_relayout', function(e) {
                             relayoutCnt++;

--- a/test/jasmine/tests/gl2d_click_test.js
+++ b/test/jasmine/tests/gl2d_click_test.js
@@ -216,7 +216,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -255,7 +255,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -294,7 +294,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -314,7 +314,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl with hoverinfo'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -341,7 +341,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl with hovertext'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -361,7 +361,7 @@ describe('Test hover and click interactions', function() {
             }
         };
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(function() {
             gd.on('plotly_hover', function() {
                 fail('should not trigger plotly_hover event');
@@ -398,7 +398,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl with hovertext'
         });
 
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 text: ['', 'FALSE', '', 'TRUE'],
                 x: [1, 2, 3, 2],
@@ -440,7 +440,7 @@ describe('Test hover and click interactions', function() {
             msg: 'pointcloud'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -498,7 +498,7 @@ describe('Test hover and click interactions', function() {
             msg: 'heatmapgl'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -531,7 +531,7 @@ describe('Test hover and click interactions', function() {
             msg: 'heatmapgl'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);
@@ -569,7 +569,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl after visibility restyle'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .then(function() {
             return Plotly.restyle(gd, 'visible', false, [1]);
@@ -617,7 +617,7 @@ describe('Test hover and click interactions', function() {
             msg: 'scattergl fancy after visibility restyle'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .then(function() {
             return Plotly.restyle(gd, 'visible', false, [1]);
@@ -649,7 +649,7 @@ describe('Test hover and click interactions', function() {
             msg: 'contourgl'
         });
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(run)
         .catch(failTest)
         .then(done);

--- a/test/jasmine/tests/gl2d_plot_interact_test.js
+++ b/test/jasmine/tests/gl2d_plot_interact_test.js
@@ -31,7 +31,7 @@ describe('Test removal of gl contexts', function() {
     });
 
     it('@gl Plots.cleanPlot should remove gl context from the graph div of a gl2d plot', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             x: [1, 2, 3],
             y: [2, 1, 3]
@@ -49,7 +49,7 @@ describe('Test removal of gl contexts', function() {
     it('@gl Plotly.newPlot should remove gl context from the graph div of a gl2d plot', function(done) {
         var firstGlplotObject, firstGlContext, firstCanvas;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             x: [1, 2, 3],
             y: [2, 1, 3]
@@ -119,7 +119,7 @@ describe('Test gl plot side effects', function() {
             xaxis: { rangeslider: { visible: true } }
         };
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var rangeSlider = document.getElementsByClassName('range-slider')[0];
             expect(rangeSlider).not.toBeDefined();
         })
@@ -139,11 +139,11 @@ describe('Test gl plot side effects', function() {
             y: [2, 1, 2]
         }];
 
-        Plotly.plot(gd, [])
+        Plotly.newPlot(gd, [])
         .then(function() {
             countCanvases(0);
 
-            return Plotly.plot(gd, data);
+            return Plotly.newPlot(gd, data);
         })
         .then(function() {
             countCanvases(3);
@@ -153,7 +153,7 @@ describe('Test gl plot side effects', function() {
         .then(function() {
             countCanvases(0);
 
-            return Plotly.plot(gd, data);
+            return Plotly.newPlot(gd, data);
         })
         .then(function() {
             countCanvases(3);
@@ -170,7 +170,7 @@ describe('Test gl plot side effects', function() {
     });
 
     it('@gl should be able to switch trace type', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'parcoords',
             x: [1, 2, 3],
             y: [2, 1, 2],
@@ -200,7 +200,7 @@ describe('Test gl plot side effects', function() {
 
         _mock.layout.width = 600;
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(function() {
             expect(gd.querySelector('.gl-canvas-context').width).toBe(600);
 
@@ -222,7 +222,7 @@ describe('Test gl plot side effects', function() {
             canvas.dispatchEvent(ev);
         }
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             return new Promise(function(resolve, reject) {
                 gd.once('plotly_webglcontextlost', resolve);
                 setTimeout(reject, 10);
@@ -312,7 +312,7 @@ describe('Test gl plot side effects', function() {
     });
 
     it('@gl should be able to toggle from svg to gl', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 1],
         }])
         .then(function() {
@@ -338,7 +338,7 @@ describe('Test gl plot side effects', function() {
     it('@gl should create two WebGL contexts per graph', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl2d_stacked_subplots.json'));
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             var cnt = 0;
             d3.select(gd).selectAll('canvas').each(function(d) {
                 if(d.regl) cnt++;
@@ -350,7 +350,7 @@ describe('Test gl plot side effects', function() {
     });
 
     it('@gl should clear canvases on *replot* edits', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             y: [1, 2, 1]
         }, {
@@ -713,7 +713,7 @@ describe('Test gl2d plot interactions:', function() {
         gd.addEventListener('touchstart', assertEvent);
         gd.addEventListener('wheel', assertEvent);
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             sceneTarget = gd.querySelector('.nsewdrag');
 

--- a/test/jasmine/tests/gl3d_hover_click_test.js
+++ b/test/jasmine/tests/gl3d_hover_click_test.js
@@ -79,7 +79,7 @@ describe('Test gl3d trace click/hover:', function() {
             mouseEvent('mouseover', 300, 200);
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             gd.on('plotly_hover', function(eventData) {
@@ -108,7 +108,7 @@ describe('Test gl3d trace click/hover:', function() {
             mouseEvent('mouseover', 300, 200);
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() { return Plotly.restyle(gd, 'hoverlabel.namelength', 3); })
         .then(_hover)
@@ -133,7 +133,7 @@ describe('Test gl3d trace click/hover:', function() {
             mouseEvent('mouseover', 655, 221);
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             gd.on('plotly_hover', function(eventData) {
@@ -306,7 +306,7 @@ describe('Test gl3d trace click/hover:', function() {
             mouseEvent('mouseover', 300, 200);
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             gd.on('plotly_hover', function(eventData) {
@@ -338,7 +338,7 @@ describe('Test gl3d trace click/hover:', function() {
             mouseEvent('mouseover', 605, 271);
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             gd.on('plotly_hover', function(eventData) {
@@ -460,7 +460,7 @@ describe('Test gl3d trace click/hover:', function() {
             mouseEvent('mouseover', 605, 271, {buttons: 1});
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             gd.on('plotly_click', function(eventData) {
@@ -916,7 +916,7 @@ describe('Test gl3d trace click/hover:', function() {
             mouseEvent('mouseover', 200, 200);
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             gd.on('plotly_hover', function(eventData) {

--- a/test/jasmine/tests/gl3d_plot_interact_test.js
+++ b/test/jasmine/tests/gl3d_plot_interact_test.js
@@ -76,7 +76,7 @@ describe('Test gl3d before/after plot', function() {
         _stayThere()
         .then(function() {
             gd = createGraphDiv();
-            return Plotly.plot(gd, _mock);
+            return Plotly.newPlot(gd, _mock);
         })
         .then(delay(100))
         .then(function() {
@@ -154,7 +154,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should set the camera dragmode to orbit if the camera.up.z vector is set to be tilted', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -182,7 +182,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should set the camera dragmode to turntable if the camera.up.z vector is set to be upwards', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -210,7 +210,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should set the camera dragmode to turntable if the camera.up is not set', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -233,7 +233,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should set the camera dragmode to turntable if any of camera.up.[x|y|z] is missing', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -261,7 +261,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should not set the camera dragmode to turntable if camera.up.z is zero.', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -289,7 +289,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should set the camera projection type to perspective if the camera.projection.type is not set', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -313,7 +313,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should set the camera projection type to orthographic if the camera.projection.type is set to orthographic', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -340,7 +340,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should enable orthographic & perspective projections using relayout', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'scatter3d',
                 x: [1, 2, 3],
@@ -391,7 +391,7 @@ describe('Test gl3d plots', function() {
     });
 
     it('@gl should not set _length to NaN and dtick should be defined.', function(done) {
-        Plotly.plot(gd,
+        Plotly.newPlot(gd,
             {
                 data: [{
                     type: 'scatter3d',
@@ -467,7 +467,7 @@ describe('Test gl3d modebar handlers - perspective case', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
 
         .then(function() {
             modeBar = gd._fullLayout._modeBar;
@@ -769,7 +769,7 @@ describe('Test gl3d modebar handlers - orthographic case', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
 
         .then(function() {
             modeBar = gd._fullLayout._modeBar;
@@ -986,7 +986,7 @@ describe('Test gl3d drag and wheel interactions', function() {
         gd.addEventListener('touchmove', function(e) { assertEvent(e, false); });
         gd.addEventListener('wheel', function(e) { assertEvent(e, false); });
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             sceneTarget = gd.querySelector('.svg-container .gl-container #scene');
 
@@ -1334,7 +1334,7 @@ describe('Test gl3d drag and wheel interactions', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_relayout', function(e) {
                 relayoutCnt++;
@@ -1386,7 +1386,7 @@ describe('Test gl3d drag and wheel interactions', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_relayout', function(e) {
                 relayoutCnt++;
@@ -1438,7 +1438,7 @@ describe('Test gl3d drag and wheel interactions', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_relayout', function(e) {
                 relayoutCnt++;
@@ -1516,7 +1516,7 @@ describe('Test gl3d drag and wheel interactions', function() {
         var relayoutEvent;
         var relayoutCnt = 0;
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_relayout', function(e) {
                 relayoutCnt++;
@@ -1632,7 +1632,7 @@ describe('Test gl3d relayout calls', function() {
     });
 
     it('@gl should maintain projection type when resetCamera buttons clicked after switching projection type from perspective to orthographic', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'surface',
                 x: [0, 1],
@@ -1672,7 +1672,7 @@ describe('Test gl3d relayout calls', function() {
     });
 
     it('@gl should maintain projection type when resetCamera buttons clicked after switching projection type from orthographic to perspective', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'surface',
                 x: [0, 1],
@@ -1769,7 +1769,7 @@ describe('Test gl3d annotations', function() {
     }
 
     it('@gl should move with camera', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [1, 2, 3],
@@ -1812,7 +1812,7 @@ describe('Test gl3d annotations', function() {
         // replace text with something easier to identify
         mock.layout.scene.annotations.forEach(function(ann, i) { ann.text = String(i); });
 
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             assertAnnotationText(['0', '1', '2', '3', '4', '5', '6'], 'base');
 
             return Plotly.relayout(gd, 'scene.yaxis.range', [0.5, 1.5]);
@@ -1852,7 +1852,7 @@ describe('Test gl3d annotations', function() {
             text: 'new!'
         };
 
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             assertAnnotationText(['0', '1', '2', '3', '4', '5', '6'], 'base');
 
             return Plotly.relayout(gd, 'scene.annotations[1].visible', false);
@@ -1894,7 +1894,7 @@ describe('Test gl3d annotations', function() {
             expect(d3.selectAll('g.annotation-' + id).size()).toEqual(cnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [1, 2, 3],
@@ -1951,7 +1951,7 @@ describe('Test gl3d annotations', function() {
             expect(sceneLayout.zaxis.range).toBeCloseToArray(zRange, 1, 'zaxis range');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [1, 2, 3],
@@ -2010,7 +2010,7 @@ describe('Test gl3d annotations', function() {
             });
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [1, 2, 3],
@@ -2048,7 +2048,7 @@ describe('Test gl3d annotations', function() {
             target.dispatchEvent(new MouseEvent(eventType));
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [1, 2, 3],
@@ -2103,7 +2103,7 @@ describe('Test removal of gl contexts', function() {
     afterEach(destroyGraphDiv);
 
     it('@gl Plots.cleanPlot should remove gl context from the graph div of a gl3d plot', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [2, 1, 3],
@@ -2122,7 +2122,7 @@ describe('Test removal of gl contexts', function() {
     it('@gl Plotly.newPlot should remove gl context from the graph div of a gl3d plot', function(done) {
         var firstGlplotObject, firstGlContext, firstCanvas;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             x: [1, 2, 3],
             y: [2, 1, 3],
@@ -2167,7 +2167,7 @@ describe('Test removal of gl contexts', function() {
     it('@gl should fire *plotly_webglcontextlost* when on webgl context lost', function(done) {
         var _mock = Lib.extendDeep({}, require('@mocks/gl3d_marker-arrays.json'));
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             return new Promise(function(resolve, reject) {
                 gd.on('plotly_webglcontextlost', resolve);
                 setTimeout(reject, 10);
@@ -2207,7 +2207,7 @@ describe('Test gl3d drag events', function() {
     };
 
     function makePlot(gd, mock) {
-        return Plotly.plot(gd, mock.data, mock.layout);
+        return Plotly.newPlot(gd, mock.data, mock.layout);
     }
 
     function addEventCallback(graphDiv) {

--- a/test/jasmine/tests/gl3dlayout_test.js
+++ b/test/jasmine/tests/gl3dlayout_test.js
@@ -544,7 +544,7 @@ describe('Gl3d layout edge cases', function() {
     afterEach(destroyGraphDiv);
 
     it('@gl should handle auto aspect ratio correctly on data changes', function(done) {
-        Plotly.plot(gd, [{x: [1, 2], y: [1, 3], z: [1, 4], type: 'scatter3d'}])
+        Plotly.newPlot(gd, [{x: [1, 2], y: [1, 3], z: [1, 4], type: 'scatter3d'}])
         .then(function() {
             var aspect = gd.layout.scene.aspectratio;
             expect(aspect.x).toBeCloseTo(0.5503);

--- a/test/jasmine/tests/heatmap_test.js
+++ b/test/jasmine/tests/heatmap_test.js
@@ -677,7 +677,7 @@ describe('heatmap plot', function() {
             expect(images.size()).toEqual(cnt);
         }
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             assertImageCnt(5);
 
             return Plotly.relayout(gd, 'xaxis.range', [2, 3]);
@@ -732,7 +732,7 @@ describe('heatmap plot', function() {
 
         var imageURLs = [];
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             imageURLs.push(getImageURL());
 
             return Plotly.restyle(gd, 'colorscale', 'Greens');
@@ -778,9 +778,9 @@ describe('heatmap plot', function() {
 
         var argumentsWithoutPadding = [];
         var argumentsWithPadding = [];
-        Plotly.plot(gd, mockWithoutPadding.data, mockWithoutPadding.layout).then(function() {
+        Plotly.newPlot(gd, mockWithoutPadding.data, mockWithoutPadding.layout).then(function() {
             argumentsWithoutPadding = getContextStub.fillRect.calls.allArgs().slice(0);
-            return Plotly.plot(gd, mockWithPadding.data, mockWithPadding.layout);
+            return Plotly.newPlot(gd, mockWithPadding.data, mockWithPadding.layout);
         }).then(function() {
             var xGap = mockWithPadding.data[0].xgap;
             var yGap = mockWithPadding.data[0].ygap;
@@ -873,7 +873,7 @@ describe('heatmap hover', function() {
             var mock = require('@mocks/heatmap_multi-trace.json');
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         afterAll(destroyGraphDiv);
@@ -900,7 +900,7 @@ describe('heatmap hover', function() {
             var mock = require('@mocks/heatmap_categoryorder.json');
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
         afterAll(destroyGraphDiv);
 
@@ -915,7 +915,7 @@ describe('heatmap hover', function() {
         beforeAll(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'heatmap',
                 x: [1, 2, 3],
                 y: [1, 1, 1],
@@ -951,7 +951,7 @@ describe('heatmap hover', function() {
             var mock = require('@mocks/heatmap_contour_irregular_bricks.json');
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         afterAll(destroyGraphDiv);
@@ -981,7 +981,7 @@ describe('heatmap hover', function() {
         beforeAll(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     type: 'heatmap',
                     x: [10, 11, 10, 11],

--- a/test/jasmine/tests/histogram2d_test.js
+++ b/test/jasmine/tests/histogram2d_test.js
@@ -368,7 +368,7 @@ describe('Test histogram2d hover:', function() {
     }
 
     it('should display correct label content with specified format', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'histogram2d',
             x: [0, 1, 2, 0, 1, 2, 1],
             y: [0, 0, 0, 1, 1, 1, 1],
@@ -439,7 +439,7 @@ describe('Test histogram2d hover:', function() {
 
     describe('hover info', function() {
         it('shows the data range when bins have multiple values', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 2, 3, 4, 5, 6, 7],
                 y: [1, 3, 4, 5, 6, 7, 8],
                 xbins: {start: -0.5, end: 8.5, size: 3},
@@ -461,7 +461,7 @@ describe('Test histogram2d hover:', function() {
         });
 
         it('shows the data range when bins have multiple values (case 2)', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'histogram2d',
                 x: ['a', 'b', 'c', 'a'],
                 y: [7, 2, 3, 7],
@@ -479,7 +479,7 @@ describe('Test histogram2d hover:', function() {
         });
 
         it('shows the exact data when bins have single values', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 0, 3.3, 3.3, 3.3, 7, 7],
                 y: [2, 2, 4.2, 4.2, 4.2, 8.8, 8.8],
                 xbins: {start: -0.5, end: 8.5, size: 3},

--- a/test/jasmine/tests/histogram_test.js
+++ b/test/jasmine/tests/histogram_test.js
@@ -1113,7 +1113,7 @@ describe('Test histogram', function() {
             // note: I'm *not* testing what this does to gd.data, as that's
             // really a matter of convenience and will perhaps change later (v2?)
             var data1 = [1.5, 2, 2, 3, 3, 3, 4, 4, 5];
-            Plotly.plot(gd, [{x: data1, type: 'histogram' }])
+            Plotly.newPlot(gd, [{x: data1, type: 'histogram' }])
             .then(function() {
                 expect(gd._fullData[0].xbins).toEqual({start: 1, end: 6, size: 1});
                 expect(gd._fullData[0].nbinsx).toBe(0);
@@ -1175,7 +1175,7 @@ describe('Test histogram', function() {
 
         it('respects explicit autobin: false as a one-time autobin', function(done) {
             var data1 = [1.5, 2, 2, 3, 3, 3, 4, 4, 5];
-            Plotly.plot(gd, [{x: data1, type: 'histogram', autobinx: false }])
+            Plotly.newPlot(gd, [{x: data1, type: 'histogram', autobinx: false }])
             .then(function() {
                 // we have no bins, so even though autobin is false we have to autobin once
                 // but for backward compat. calc pushes these bins back into gd.data

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -63,7 +63,7 @@ describe('Fx.hover:', function() {
             showlegend: false
         };
 
-        Plotly.plot(gd, data, layout)
+        Plotly.newPlot(gd, data, layout)
         .then(function() {
             Fx.hover(gd, {xpx: 300, ypx: 100}, 'x2y2');
             expect(gd._hoverdata).toBe(undefined, 'did not generate hoverdata');
@@ -86,7 +86,7 @@ describe('hover info', function() {
         var mockCopy = Lib.extendDeep({}, mock);
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover', function() {
@@ -113,7 +113,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'x';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover x', function() {
@@ -137,7 +137,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'y';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover y', function() {
@@ -165,7 +165,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'text';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover text', function() {
@@ -196,7 +196,7 @@ describe('hover info', function() {
         mockCopy.data[0].mode = 'lines+markers+text';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover text', function() {
@@ -233,7 +233,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'all';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover all', function() {
@@ -270,7 +270,7 @@ describe('hover info', function() {
         });
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('cleans the name', function() {
@@ -305,7 +305,7 @@ describe('hover info', function() {
                 mockCopy.data[0].y[i] *= 1e9;
             }
 
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover y', function() {
@@ -323,7 +323,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'y+text';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover y+text', function() {
@@ -351,7 +351,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'x+text';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover x+text', function() {
@@ -379,7 +379,7 @@ describe('hover info', function() {
         mockCopy.data[0].error_x.array[17] = 1;
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover x+text', function() {
@@ -399,7 +399,7 @@ describe('hover info', function() {
         mockCopy.data[0].error_x.array[17] = 0;
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover x+text', function() {
@@ -419,7 +419,7 @@ describe('hover info', function() {
         mockCopy.data[0].error_x.array[17] = -1;
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover x+text', function() {
@@ -440,7 +440,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'text';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('responds to hover text with html', function() {
@@ -466,7 +466,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'skip';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('does not hover if hover info is set to skip', function() {
@@ -484,7 +484,7 @@ describe('hover info', function() {
         mockCopy.data[0].hoverinfo = 'none';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('does not render if hover is set to none', function() {
@@ -513,7 +513,7 @@ describe('hover info', function() {
 
         beforeEach(function(done) {
             gd = createGraphDiv();
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('render hover labels of the above trace', function() {
@@ -580,7 +580,7 @@ describe('hover info', function() {
         });
 
         it('puts the top trace on top', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {y: [1, 2, 3], type: 'bar', name: 'a'},
                 {y: [2, 0, 1], type: 'bar', name: 'b'},
                 {y: [1, 0, 1], type: 'bar', name: 'c'},
@@ -619,7 +619,7 @@ describe('hover info', function() {
         });
 
         it('puts the right trace on the right', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {x: [1, 2, 3], type: 'bar', name: 'a', orientation: 'h'},
                 {x: [2, 0, 1], type: 'bar', name: 'b', orientation: 'h'},
                 {x: [1, 0, 1], type: 'bar', name: 'c', orientation: 'h'},
@@ -665,7 +665,7 @@ describe('hover info', function() {
         });
 
         it('should display correct label content', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'heatmap',
                 y: [0, 1],
                 z: [[1, 2, 3], [2, 2, 1]],
@@ -710,7 +710,7 @@ describe('hover info', function() {
         });
 
         it('should display correct label content with specified format - heatmap', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'heatmap',
                 y: [0, 1],
                 z: [[1.11111, 2.2222, 3.33333], [4.44444, 5.55555, 6.66666]],
@@ -751,7 +751,7 @@ describe('hover info', function() {
                     (exp < 0 ? MINUS_SIGN + -exp : exp) +
                     '</tspan><tspan dy="0.42em">\u200b</tspan>';
             }
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'heatmap',
                 y: [0, 1, 2, 3],
                 z: [
@@ -785,7 +785,7 @@ describe('hover info', function() {
         });
 
         it('should display correct label content with specified format - contour', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'contour',
                 y: [0, 1],
                 z: [[1.11111, 2.2222, 3.33333], [4.44444, 5.55555, 6.66666]],
@@ -900,7 +900,7 @@ describe('hover info', function() {
         it('should get the right content and color for contour constraints', function(done) {
             var contourConstraints = require('@mocks/contour_constraints.json');
 
-            Plotly.plot(gd, contourConstraints)
+            Plotly.newPlot(gd, contourConstraints)
             .then(function() {
                 _hover(gd, 250, 250);
                 assertHoverLabelContent({
@@ -968,7 +968,7 @@ describe('hover info', function() {
         });
 
         it('should display correct label content with specified format - histogram2dcontour', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'histogram2dcontour',
                 x: [0, 1, 2, 0, 1, 2, 1],
                 y: [0, 0, 0, 1, 1, 1, 1],
@@ -1028,7 +1028,7 @@ describe('hover info', function() {
         });
 
         it('should display correct label - x/y/z heatmap|contour', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'heatmap',
                 x: [1, 1, 2, 2],
                 y: [1, 2, 1, 2],
@@ -1077,7 +1077,7 @@ describe('hover info', function() {
         it('shows negative data even though it is infinitely off-screen', function(done) {
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, [{x: [1, 2, 3], y: [1, -5, 10]}], {
+            Plotly.newPlot(gd, [{x: [1, 2, 3], y: [1, -5, 10]}], {
                 yaxis: {type: 'log'},
                 width: 500,
                 height: 400,
@@ -1099,7 +1099,7 @@ describe('hover info', function() {
         it('shows the data range when bins have multiple values', function(done) {
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 2, 3, 4, 5, 6, 7],
                 xbins: {start: -0.5, end: 8.5, size: 3},
                 type: 'histogram'
@@ -1161,7 +1161,7 @@ describe('hover info', function() {
         it('shows the exact data when bins have single values', function(done) {
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 // even though the data aren't regularly spaced, each bin only has
                 // one data value in it so we see exactly that value
                 x: [0, 0, 3.3, 3.3, 3.3, 7, 7],
@@ -1194,7 +1194,7 @@ describe('hover info', function() {
         it('will show a category range if you ask nicely', function(done) {
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 // even though the data aren't regularly spaced, each bin only has
                 // one data value in it so we see exactly that value
                 x: [
@@ -1248,7 +1248,7 @@ describe('hover info', function() {
 
             it('has the right basic and event behavior', function(done) {
                 var pts;
-                Plotly.plot(gd, financeMock({
+                Plotly.newPlot(gd, financeMock({
                     customdata: [11, 22, 33]
                 }))
                 .then(function() {
@@ -1292,7 +1292,7 @@ describe('hover info', function() {
 
             it('shows correct labels in split mode', function(done) {
                 var pts;
-                Plotly.plot(gd, financeMock({
+                Plotly.newPlot(gd, financeMock({
                     customdata: [11, 22, 33],
                     hoverlabel: {
                         split: true
@@ -1345,7 +1345,7 @@ describe('hover info', function() {
             });
 
             it('shows text iff text is in hoverinfo', function(done) {
-                Plotly.plot(gd, financeMock({text: ['A', 'B', 'C']}))
+                Plotly.newPlot(gd, financeMock({text: ['A', 'B', 'C']}))
                 .then(function() {
                     _hover(gd, 150, 150);
                     assertHoverLabelContent({
@@ -1393,7 +1393,7 @@ describe('hover info', function() {
         });
 
         it('should display the correct format when ticklabels true', function(done) {
-            Plotly.plot(this.gd, data, layout)
+            Plotly.newPlot(this.gd, data, layout)
             .then(function() {
                 mouseEvent('mousemove', 303, 213);
 
@@ -1408,7 +1408,7 @@ describe('hover info', function() {
 
         it('should display the correct format when ticklabels false', function(done) {
             layout.yaxis.showticklabels = false;
-            Plotly.plot(this.gd, data, layout)
+            Plotly.newPlot(this.gd, data, layout)
             .then(function() {
                 mouseEvent('mousemove', 303, 213);
 
@@ -1436,7 +1436,7 @@ describe('hover info', function() {
         };
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), data, layout).then(done);
+            Plotly.newPlot(createGraphDiv(), data, layout).then(done);
         });
 
         it('should show text labels', function() {
@@ -1471,7 +1471,7 @@ describe('hover info', function() {
 
         beforeEach(function(done) {
             gd = createGraphDiv();
-            Plotly.plot(gd, data, layout).then(done);
+            Plotly.newPlot(gd, data, layout).then(done);
         });
 
         it('should skip the hover event if explicitly instructed', function(done) {
@@ -1532,7 +1532,7 @@ describe('hover info', function() {
 
         beforeEach(function(done) {
             gd = createGraphDiv();
-            Plotly.plot(gd, data, layout).then(done);
+            Plotly.newPlot(gd, data, layout).then(done);
         });
 
         function labelCount() {
@@ -1624,7 +1624,7 @@ describe('hover info', function() {
             var data = [trace1, trace2];
             var layout = {width: 600, height: 300, barmode: 'stack'};
 
-            Plotly.plot(gd, data, layout)
+            Plotly.newPlot(gd, data, layout)
             .then(function() { _hover(gd, 300, 150); })
             .then(function() {
                 var nodes = ensureCentered(hoverInfoNodes('LA Zoo'));
@@ -1660,7 +1660,7 @@ describe('hover info', function() {
             var data = [trace1, trace2, trace3];
             var layout = {width: 600, height: 300};
 
-            Plotly.plot(gd, data, layout)
+            Plotly.newPlot(gd, data, layout)
             .then(function() { _hover(gd, 300, 150); })
             .then(function() {
                 var nodesLA = ensureCentered(hoverInfoNodes('LA Zoo'));
@@ -1688,7 +1688,7 @@ describe('hover info', function() {
             var name = 'Multi<br>line<br>trace<br>name';
             var name2 = 'Multi<br>line<br>trace<br>name2';
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 y: [1, 2, 1],
                 name: name,
                 hoverlabel: {namelength: -1},
@@ -1729,7 +1729,7 @@ describe('hover info', function() {
         });
 
         it('should avoid overlaps on *too close* pts are filtered out', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {name: 'A', x: [9, 10], y: [9, 10]},
                 {name: 'B', x: [8, 9], y: [9, 10]},
                 {name: 'C', x: [9, 10], y: [10, 11]}
@@ -1789,7 +1789,7 @@ describe('hover info', function() {
 
             function _hoverRight() { return _hover(gd, 370, 300); }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'bar',
                 x: ['2019-01-01', '2019-06-01', '2020-01-01'],
                 y: [2, 5, 10]
@@ -1849,7 +1849,7 @@ describe('hover info', function() {
 
             function _hoverA() { return _hover(gd, 135, 20); }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'bar',
                 orientation: 'h',
                 y: ['Looong label', 'Loooooger label', 'Waay loooong label', 'a'],
@@ -1884,7 +1884,7 @@ describe('hover info', function() {
 
         beforeEach(function(done) {
             mockCopy = Lib.extendDeep({}, mock);
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         afterEach(function() {
@@ -2094,7 +2094,7 @@ describe('hover info', function() {
     it('should work with trace.name linked to layout.meta', function(done) {
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 1, 1],
             name: '%{meta[0]}',
             marker: {size: 40}
@@ -2130,7 +2130,7 @@ describe('hover info', function() {
         fig.layout.showlegend = false;
         fig.layout.margin = {t: 0, b: 0, l: 0, r: 0};
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() { _hoverNatural(gd, 180, 200); })
         .then(function() {
             assertHoverLabelContent({
@@ -2158,7 +2158,7 @@ describe('hover info', function() {
             expect(Number(tx.attr('x'))).toBeWithin(exp.posX, 3, 'x position|' + msg);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 1],
             text: 'LONG TEXT'
         }], {
@@ -2207,7 +2207,7 @@ describe('hover info', function() {
             delete gd._hoverdata;
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: ['giraffes'],
             y: [5],
             name: 'LA Zoo',
@@ -2256,7 +2256,7 @@ describe('hover info on stacked subplots', function() {
 
         beforeEach(function(done) {
             gd = createGraphDiv();
-            Plotly.plot(gd, mock.data, mock.layout).then(done);
+            Plotly.newPlot(gd, mock.data, mock.layout).then(done);
         });
 
         function _check(xval, ptSpec1, ptSpec2) {
@@ -2318,7 +2318,7 @@ describe('hover info on stacked subplots', function() {
         mock.layout.hoverlabel = {namelength: 10};
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mock.data, mock.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mock.data, mock.layout).then(done);
         });
 
         it('responds to hover', function() {
@@ -2408,7 +2408,7 @@ describe('hover info on overlaid subplots', function() {
     it('should respond to hover', function(done) {
         var mock = require('@mocks/autorange-tozero-rangemode.json');
 
-        Plotly.plot(createGraphDiv(), mock.data, mock.layout).then(function() {
+        Plotly.newPlot(createGraphDiv(), mock.data, mock.layout).then(function() {
             mouseEvent('mousemove', 768, 345);
 
             assertHoverLabelContent({
@@ -2455,7 +2455,7 @@ describe('hover after resizing', function() {
         var pos0 = [305, 403];
         var pos1 = [401, 122];
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             // to test https://github.com/plotly/plotly.js/issues/1044
             return _click(pos0);
         })
@@ -2512,7 +2512,7 @@ describe('hover on fill', function() {
         var mock = Lib.extendDeep({}, require('@mocks/scatter_fill_self_next.json'));
         mock.data.forEach(function(trace) { trace.hoveron = 'fills'; });
 
-        Plotly.plot(createGraphDiv(), mock.data, mock.layout).then(function() {
+        Plotly.newPlot(createGraphDiv(), mock.data, mock.layout).then(function() {
             assertLabelsCorrect([242, 142], [252, 133.8], 'trace 2');
             assertLabelsCorrect([242, 292], [233, 210], 'trace 1');
             assertLabelsCorrect([147, 252], [158.925, 248.1], 'trace 0');
@@ -2524,7 +2524,7 @@ describe('hover on fill', function() {
     it('should always show one label in the right place (symmetric fill edge case)', function(done) {
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [6, 7, 8, 7, 6],
             y: [5, 4, 5, 6, 5],
             fill: 'tonext',
@@ -2554,7 +2554,7 @@ describe('hover on fill', function() {
         var mock = Lib.extendDeep({}, require('@mocks/ternary_fill.json'));
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             expect(gd._fullLayout.hovermode).toBe('closest');
 
             // hover over a point when that's closest, even if you're over
@@ -2595,7 +2595,7 @@ describe('hover on fill', function() {
         mock.layout.xaxis = {domain: [0.8, 1], visible: false};
         mock.layout.yaxis = {domain: [0.8, 1], visible: false};
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             expect(gd._fullLayout.hovermode).toBe('x');
 
             // hover over a point when that's closest, even if you're over
@@ -2631,7 +2631,7 @@ describe('Hover on multicategory axes', function() {
     }
 
     it('should work for bar traces', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'bar',
             x: [['2018', '2018', '2019', '2019'], ['a', 'b', 'a', 'b']],
             y: [1, 2, -1, 3]
@@ -2671,7 +2671,7 @@ describe('Hover on multicategory axes', function() {
         fig.layout.width = 500;
         fig.layout.height = 500;
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             gd.on('plotly_hover', function(d) {
                 eventData = d.points[0];
@@ -3165,7 +3165,7 @@ describe('Hover on axes with rangebreaks', function() {
     }
 
     it('should work when rangebreaks are present on x-axis', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'lines',  // i.e. no autorange padding
             x: [
                 '1970-01-01 00:00:00.000',
@@ -3233,7 +3233,7 @@ describe('Hover on axes with rangebreaks', function() {
     });
 
     it('should work when rangebreaks are present on x-axis (reversed range)', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'lines',  // i.e. no autorange padding
             x: [
                 '1970-01-01 00:00:00.000',
@@ -3302,7 +3302,7 @@ describe('Hover on axes with rangebreaks', function() {
     });
 
     it('should work when rangebreaks are present on y-axis using hovermode x (case of bar and autorange reversed)', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'bar',
             orientation: 'h',
             y: [
@@ -3381,7 +3381,7 @@ describe('Hover on axes with rangebreaks', function() {
     });
 
     it('should work when rangebreaks are present on y-axis', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'lines',  // i.e. no autorange padding
             y: [
                 '1970-01-01 00:00:00.000',
@@ -3449,7 +3449,7 @@ describe('Hover on axes with rangebreaks', function() {
     });
 
     it('should work when rangebreaks are present on y-axis (reversed range)', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'lines',  // i.e. no autorange padding
             y: [
                 '1970-01-01 00:00:00.000',
@@ -3561,7 +3561,7 @@ describe('hover updates', function() {
         };
 
         var gd = createGraphDiv();
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             // The label text gets concatenated together when queried. Such is life.
             assertLabelsCorrect([100, 100], [103, 100], 'trace 00.5', 'animation/update 0');
         }).then(function() {
@@ -3604,7 +3604,7 @@ describe('hover updates', function() {
         var hoverCnt = 0;
         var unHoverCnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             x: [1, 2, 3, 4, 5, 6, 7],
             y: [1, 2, 3, 2, 3, 4, 3],
@@ -3730,7 +3730,7 @@ describe('Test hover label custom styling:', function() {
     it('should work for x/y cartesian traces', function(done) {
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3],
             y: [1, 2, 1],
             marker: {
@@ -3912,7 +3912,7 @@ describe('Test hover label custom styling:', function() {
             }
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3],
             y: [1, 2, 1],
         }, {
@@ -3965,7 +3965,7 @@ describe('Test hover label custom styling:', function() {
     it('should work for 2d z cartesian traces', function(done) {
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'heatmap',
             x: [1, 2],
             y: [1, 2],
@@ -4031,7 +4031,7 @@ describe('hover distance', function() {
         mockCopy.layout.hovermode = 'closest';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('does not render if distance to the point is larger than default (>20)', function() {
@@ -4113,7 +4113,7 @@ describe('hover distance', function() {
         mockCopy.layout.hovermode = 'x';
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('does not render if distance to the point is larger than default (>20)', function() {
@@ -4339,7 +4339,7 @@ describe('hover label rotation:', function() {
         beforeAll(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'bar',
                 orientation: 'h',
                 y: [0, 1, 2],
@@ -4389,7 +4389,7 @@ describe('hover label rotation:', function() {
         beforeAll(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'bar',
                 orientation: 'h',
                 y: [0, 1, 2],
@@ -4444,7 +4444,7 @@ describe('hovermode defaults to', function() {
     afterEach(destroyGraphDiv);
 
     it('\'closest\' for cartesian plots if clickmode includes \'select\'', function(done) {
-        Plotly.plot(gd, [{ x: [1, 2, 3], y: [4, 5, 6] }], { clickmode: 'event+select' })
+        Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [4, 5, 6] }], { clickmode: 'event+select' })
           .then(function() {
               expect(gd._fullLayout.hovermode).toBe('closest');
           })
@@ -4453,7 +4453,7 @@ describe('hovermode defaults to', function() {
     });
 
     it('\'x\' for horizontal cartesian plots if clickmode lacks \'select\'', function(done) {
-        Plotly.plot(gd, [{ x: [1, 2, 3], y: [4, 5, 6], type: 'bar', orientation: 'h' }], { clickmode: 'event' })
+        Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [4, 5, 6], type: 'bar', orientation: 'h' }], { clickmode: 'event' })
           .then(function() {
               expect(gd._fullLayout.hovermode).toBe('y');
           })
@@ -4462,7 +4462,7 @@ describe('hovermode defaults to', function() {
     });
 
     it('\'y\' for vertical cartesian plots if clickmode lacks \'select\'', function(done) {
-        Plotly.plot(gd, [{ x: [1, 2, 3], y: [4, 5, 6], type: 'bar', orientation: 'v' }], { clickmode: 'event' })
+        Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [4, 5, 6], type: 'bar', orientation: 'v' }], { clickmode: 'event' })
           .then(function() {
               expect(gd._fullLayout.hovermode).toBe('x');
           })
@@ -4474,7 +4474,7 @@ describe('hovermode defaults to', function() {
         var mock = require('@mocks/polar_scatter.json');
         expect(mock.layout.hovermode).toBeUndefined();
 
-        Plotly.plot(gd, mock.data, mock.layout)
+        Plotly.newPlot(gd, mock.data, mock.layout)
           .then(function() {
               expect(gd._fullLayout.hovermode).toBe('closest');
           })
@@ -4494,7 +4494,7 @@ describe('hover labels z-position', function() {
     var mock = require('@mocks/14.json');
 
     it('is above the modebar', function(done) {
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             var infolayer = document.getElementsByClassName('infolayer');
             var modebar = document.getElementsByClassName('modebar-container');
             var hoverlayer = document.getElementsByClassName('hoverlayer');
@@ -4525,7 +4525,7 @@ describe('touch devices', function() {
 
             beforeEach(function(done) {
                 gd = createGraphDiv();
-                Plotly.plot(gd, data, layout).then(done);
+                Plotly.newPlot(gd, data, layout).then(done);
             });
 
             it('emits click events', function(done) {
@@ -4560,7 +4560,7 @@ describe('dragmode: false', function() {
 
     beforeEach(function(done) {
         gd = createGraphDiv();
-        Plotly.plot(gd, data, layout).then(done);
+        Plotly.newPlot(gd, data, layout).then(done);
     });
     afterEach(destroyGraphDiv);
 

--- a/test/jasmine/tests/hover_spikeline_test.js
+++ b/test/jasmine/tests/hover_spikeline_test.js
@@ -74,7 +74,7 @@ describe('spikeline hover', function() {
     it('draws lines and markers on enabled axes in the closest hovermode', function(done) {
         var _mock = makeMock('toaxis', 'closest');
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 2, yval: 3});
             _assert(
                 [[557, 401, 557, 250], [80, 250, 557, 250]],
@@ -96,7 +96,7 @@ describe('spikeline hover', function() {
         _mock.data[0].type = 'scattergl';
         _mock.data[1].type = 'scattergl';
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 2, yval: 3});
             _assert(
                 [[557, 401, 557, 250], [80, 250, 557, 250]],
@@ -119,7 +119,7 @@ describe('spikeline hover', function() {
         _mock.layout.xaxis.showticklabels = false;
         _mock.layout.yaxis.showticklabels = false;
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 2, yval: 3});
             _assert(
                 [[557, 401, 557, 250], [80, 250, 557, 250]],
@@ -139,7 +139,7 @@ describe('spikeline hover', function() {
     it('draws lines and markers on enabled axes in the x hovermode', function(done) {
         var _mock = makeMock('across', 'x');
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 2, yval: 3});
             _assert(
                 [[557, 100, 557, 401], [80, 250, 1036, 250]],
@@ -157,7 +157,7 @@ describe('spikeline hover', function() {
     });
 
     it('draws lines up to x-axis position', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             { y: [1, 2, 1] },
             { y: [2, 1, 2], yaxis: 'y2' }
         ], {
@@ -184,7 +184,7 @@ describe('spikeline hover', function() {
     });
 
     it('draws lines up to y-axis position - anchor free case', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             { y: [1, 2, 1] },
             { y: [2, 1, 2], xaxis: 'x2' }
         ], {
@@ -213,7 +213,7 @@ describe('spikeline hover', function() {
     });
 
     it('draws lines up to y-axis position', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             { y: [1, 2, 1] },
             { y: [2, 1, 2], xaxis: 'x2' }
         ], {
@@ -242,7 +242,7 @@ describe('spikeline hover', function() {
     });
 
     it('draws lines up to y-axis position - anchor free case', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             { y: [1, 2, 1] },
             { y: [2, 1, 2], yaxis: 'y2' }
         ], {
@@ -277,7 +277,7 @@ describe('spikeline hover', function() {
         _mock.layout.yaxis.spikesnap = 'cursor';
         _mock.layout.xaxis2.spikesnap = 'cursor';
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(function() {
             _setSpikedistance(200);
         })
@@ -328,7 +328,7 @@ describe('spikeline hover', function() {
     it('doesn\'t switch between toaxis and across spikemodes on switching the hovermodes', function(done) {
         var _mock = makeMock('toaxis', 'closest');
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 2, yval: 3});
             _assert(
                 [[557, 401, 557, 250], [80, 250, 557, 250]],
@@ -363,7 +363,7 @@ describe('spikeline hover', function() {
     it('increase the range of search for points to draw the spikelines on spikedistance change', function(done) {
         var _mock = makeMock('toaxis', 'closest');
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 1.6, yval: 2.6});
             _assert(
                 [],
@@ -399,7 +399,7 @@ describe('spikeline hover', function() {
         'the range of search for points to draw the spikelines to Infinity', function(done) {
         var _mock = makeMock('toaxis', 'closest');
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 1.6, yval: 2.6});
             _assert(
                 [],
@@ -458,7 +458,7 @@ describe('spikeline hover', function() {
         'the search for points to draw the spikelines', function(done) {
         var _mock = makeMock('toaxis', 'closest');
 
-        Plotly.plot(gd, _mock).then(function() {
+        Plotly.newPlot(gd, _mock).then(function() {
             _hover({xval: 2, yval: 3});
             _assert(
                 [[557, 401, 557, 250], [80, 250, 557, 250]],

--- a/test/jasmine/tests/image_test.js
+++ b/test/jasmine/tests/image_test.js
@@ -262,7 +262,7 @@ describe('image plot', function() {
             expect(images.size()).toEqual(cnt);
         }
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             assertImageCnt(1);
 
             return Plotly.relayout(gd, 'xaxis.range', [-100, -50]);
@@ -454,7 +454,7 @@ describe('image hover:', function() {
             var mock = require('@mocks/image_cat.json');
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         afterAll(destroyGraphDiv);

--- a/test/jasmine/tests/indicator_test.js
+++ b/test/jasmine/tests/indicator_test.js
@@ -496,7 +496,7 @@ describe('Indicator plot', function() {
             return d3.selectAll('g.value-bullet > rect').attr('width');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'indicator',
             mode: 'number+delta+gauge',
             value: null
@@ -541,7 +541,7 @@ describe('Indicator animations', function() {
 
             spyOn(Plots, 'transitionFromReact').and.callThrough();
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(function() {
                 gd.data[0].value = 400;
                 return Plotly.react(gd, gd.data, gd.layout);

--- a/test/jasmine/tests/isosurface_test.js
+++ b/test/jasmine/tests/isosurface_test.js
@@ -219,7 +219,7 @@ describe('Test isosurface', function() {
             data.isomin = -Infinity;
             data.isomax = Infinity;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 assertCells(0, 'to be OK cells');
             })
@@ -240,7 +240,7 @@ describe('Test isosurface', function() {
             data.isomin = Infinity;
             data.isomax = Infinity;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 assertCells(0, 'to be OK cells');
             })
@@ -281,7 +281,7 @@ describe('Test isosurface', function() {
             fig.data[0].isomin = 0;
             fig.data[0].isomax = 3;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 _assert([undefined, undefined, undefined], [true, 0, 3]);
 
@@ -342,7 +342,7 @@ describe('Test isosurface', function() {
                 return delay(20)();
             }
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(delay(20))
             .then(_hover1)
             .then(function() {
@@ -503,7 +503,7 @@ describe('Test isosurface grid', function() {
                     expect(exp.cellsLength).toBe(objs[0].cells.length, 'cells length - ' + msg);
                 }
 
-                Plotly.plot(gd, fig).then(function() {
+                Plotly.newPlot(gd, fig).then(function() {
                     _assert('lengths', {
                         positionsLength: 372,
                         cellsLength: 104
@@ -550,7 +550,7 @@ describe('Test isosurface grid', function() {
 
         spyOn(Lib, 'warn');
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('arbitrary coordinates', {
                 positionsLength: 0,
                 cellsLength: 0

--- a/test/jasmine/tests/layout_images_test.js
+++ b/test/jasmine/tests/layout_images_test.js
@@ -176,7 +176,7 @@ describe('Layout images', function() {
             }
 
             it('should work for center middle', function(done) {
-                Plotly.plot(gd, data, { images: [{
+                Plotly.newPlot(gd, data, { images: [{
                     source: jsLogo,
                     xanchor: 'center',
                     yanchor: 'middle'
@@ -189,7 +189,7 @@ describe('Layout images', function() {
             });
 
             it('should work for left top', function(done) {
-                Plotly.plot(gd, data, { images: [{
+                Plotly.newPlot(gd, data, { images: [{
                     source: jsLogo,
                     xanchor: 'left',
                     yanchor: 'top'
@@ -202,7 +202,7 @@ describe('Layout images', function() {
             });
 
             it('should work for right bottom', function(done) {
-                Plotly.plot(gd, data, { images: [{
+                Plotly.newPlot(gd, data, { images: [{
                     source: jsLogo,
                     xanchor: 'right',
                     yanchor: 'bottom'
@@ -215,7 +215,7 @@ describe('Layout images', function() {
             });
 
             it('should work for stretch sizing', function(done) {
-                Plotly.plot(gd, data, { images: [{
+                Plotly.newPlot(gd, data, { images: [{
                     source: jsLogo,
                     xanchor: 'middle',
                     yanchor: 'center',
@@ -229,7 +229,7 @@ describe('Layout images', function() {
             });
 
             it('should work for fill sizing', function(done) {
-                Plotly.plot(gd, data, { images: [{
+                Plotly.newPlot(gd, data, { images: [{
                     source: jsLogo,
                     xanchor: 'invalid',
                     yanchor: 'invalid',
@@ -265,7 +265,7 @@ describe('Layout images', function() {
                 sizey: 0.1
             };
 
-            Plotly.plot(gd, data, {
+            Plotly.newPlot(gd, data, {
                 images: [image],
                 dragmode: 'pan',
                 width: 600,
@@ -299,7 +299,7 @@ describe('Layout images', function() {
                 sizey: 1
             };
 
-            Plotly.plot(gd, data, {
+            Plotly.newPlot(gd, data, {
                 images: [image],
                 dragmode: 'pan',
                 width: 600,
@@ -329,7 +329,7 @@ describe('Layout images', function() {
 
         beforeEach(function(done) {
             gd = createGraphDiv();
-            Plotly.plot(gd, data, {
+            Plotly.newPlot(gd, data, {
                 images: [{
                     source: jsLogo,
                     x: 2,
@@ -439,7 +439,7 @@ describe('Layout images', function() {
                 expect(d3.selectAll('image').size()).toEqual(cnt);
             }
 
-            Plotly.plot(gd, data, layout).then(function() {
+            Plotly.newPlot(gd, data, layout).then(function() {
                 assertImages(0);
                 expect(gd.layout.images).toBeUndefined();
 
@@ -527,7 +527,7 @@ describe('images log/linear axis changes', function() {
         var mockData = Lib.extendDeep([], mock.data);
         var mockLayout = Lib.extendDeep({}, mock.layout);
 
-        Plotly.plot(gd, mockData, mockLayout).then(done);
+        Plotly.newPlot(gd, mockData, mockLayout).then(done);
     });
 
     afterEach(destroyGraphDiv);

--- a/test/jasmine/tests/legend_scroll_test.js
+++ b/test/jasmine/tests/legend_scroll_test.js
@@ -70,7 +70,7 @@ describe('The legend', function() {
 
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(done);
         });
 
@@ -420,7 +420,7 @@ describe('The legend', function() {
             var data = [{ x: [1, 2, 3], y: [2, 3, 4], name: 'Test' }];
             var layout = { showlegend: true };
 
-            Plotly.plot(gd, data, layout);
+            Plotly.newPlot(gd, data, layout);
         });
 
         afterEach(destroyGraph);

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -680,7 +680,7 @@ describe('legend relayout update', function() {
             expect(node.style.strokeWidth).toEqual(borderWidth + 'px');
         }
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             assertLegendStyle('rgb(255, 255, 255)', 'rgb(0, 0, 0)', 1);
 
             return Plotly.relayout(gd, {
@@ -716,7 +716,7 @@ describe('legend relayout update', function() {
             var mockCopy = Lib.extendDeep({}, require('@mocks/legend_valign_top.json'));
 
             var top, middle, bottom;
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 top = markerOffsetY();
                 return Plotly.relayout(gd, 'legend.valign', 'middle');
@@ -775,7 +775,7 @@ describe('legend relayout update', function() {
             };
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(_assert('base', [5, 4.4], [512, 29]))
         .then(function() { return Plotly.relayout(gd, 'legend.x', 0.8); })
         .then(_assert('after relayout almost to right edge', [188, 4.4], [512, 29]))
@@ -809,7 +809,7 @@ describe('legend relayout update', function() {
             };
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(_assert('base', [667.72, 60], [120, 83]))
         .then(function() { return Plotly.relayout(gd, 'legend.title.side', 'left'); })
         .then(_assert('after relayout to *left*', [607.54, 60], [180, 67]))
@@ -866,7 +866,7 @@ describe('legend orientation change:', function() {
         var gd = createGraphDiv();
         var initialLegendBGColor;
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             initialLegendBGColor = gd._fullLayout.legend.bgcolor;
             return Plotly.relayout(gd, 'legend.bgcolor', '#000000');
         }).then(function() {
@@ -914,7 +914,7 @@ describe('legend restyle update', function() {
             });
         }
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             expect(countLegendItems()).toEqual(1);
             assertTraceToggleRect();
 
@@ -944,7 +944,7 @@ describe('legend interaction', function() {
             mockCopy = Lib.extendDeep({}, mock);
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 legendItems = d3.selectAll('rect.legendtoggle')[0];
                 legendLabels = d3.selectAll('text.legendtext')[0];
                 legendItem = legendItems[testEntry];
@@ -1039,7 +1039,7 @@ describe('legend interaction', function() {
             mockCopy = Lib.extendDeep({}, mock);
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 legendItems = d3.selectAll('rect.legendtoggle')[0];
                 legendItem = legendItems[testEntry];
                 done();
@@ -1165,7 +1165,7 @@ describe('legend interaction', function() {
             var _mock = Lib.extendDeep({}, require('@mocks/cheater.json'));
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, _mock).then(function() {
+            Plotly.newPlot(gd, _mock).then(function() {
                 assertVisible(gd, [true, true, true, true]);
             })
             .then(_click(0))
@@ -1209,7 +1209,7 @@ describe('legend interaction', function() {
 
         beforeEach(function(done) {
             gd = createGraphDiv();
-            Plotly.plot(gd, Lib.extendDeep({}, mock)).then(done);
+            Plotly.newPlot(gd, Lib.extendDeep({}, mock)).then(done);
         });
 
         afterEach(destroyGraphDiv);
@@ -1388,7 +1388,7 @@ describe('legend interaction', function() {
             var msg = s.orientation + ' - ' + JSON.stringify(s.edits);
 
             it('should find correct bounding box (case ' + msg + ')', function(done) {
-                Plotly.plot(gd,
+                Plotly.newPlot(gd,
                     Lib.extendDeep([], data),
                     {legend: {orientation: s.orientation}, width: 500, height: 500},
                     {edits: s.edits}
@@ -1441,7 +1441,7 @@ describe('legend interaction', function() {
 
         describe('for regular traces', function() {
             beforeEach(function(done) {
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {x: [1, 2], y: [0, 1], visible: false},
                     {x: [1, 2], y: [1, 2], visible: 'legendonly'},
                     {x: [1, 2], y: [2, 3]}
@@ -1483,7 +1483,7 @@ describe('legend interaction', function() {
 
         describe('legendgroup visibility', function() {
             beforeEach(function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     x: [1, 2],
                     y: [3, 4],
                     visible: false
@@ -1522,7 +1522,7 @@ describe('legend interaction', function() {
 
         describe('legend visibility toggles with groupby', function() {
             beforeEach(function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     x: [1, 2],
                     y: [3, 4],
                     visible: false
@@ -1600,7 +1600,7 @@ describe('legend interaction', function() {
 
         describe('legend visibility with *showlegend:false* traces', function() {
             beforeEach(function(done) {
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {y: [1, 2, 3]},
                     {y: [2, 3, 1]},
                     {type: 'heatmap', z: [[1, 2], [3, 4]], showscale: false}
@@ -1911,7 +1911,7 @@ describe('legend interaction', function() {
             it('- regular trace case', function(done) {
                 _assert = assertVisible;
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     { y: [1, 2, 1] },
                     { y: [2, 1, 2] },
                     { y: [3, 5, 0] }
@@ -1932,7 +1932,7 @@ describe('legend interaction', function() {
                     };
                 };
 
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     type: 'pie',
                     labels: ['A', 'B', 'C'],
                     values: [1, 2, 3]
@@ -2003,7 +2003,7 @@ describe('legend with custom doubleClickDelay', function() {
             };
         }
 
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {y: [1, 2, 1]},
             {y: [2, 1, 2]}
         ], {}, {

--- a/test/jasmine/tests/lib_test.js
+++ b/test/jasmine/tests/lib_test.js
@@ -2738,7 +2738,7 @@ describe('Queue', function() {
     });
 
     it('should not fill in undoQueue by default', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [2, 1, 2]
         }]).then(function() {
             expect(gd.undoQueue).toBeUndefined();
@@ -2760,7 +2760,7 @@ describe('Queue', function() {
     it('should fill in undoQueue up to value found in *queueLength* config', function(done) {
         Plotly.setPlotConfig({ queueLength: 2 });
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [2, 1, 2]
         }])
         .then(function() {

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -288,7 +288,7 @@ describe('mapbox credentials', function() {
         spyOn(Lib, 'error');
 
         expect(function() {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'scattermapbox',
                 lon: [10, 20, 30],
                 lat: [10, 20, 30]
@@ -302,7 +302,7 @@ describe('mapbox credentials', function() {
         spyOn(Lib, 'error');
 
         expect(function() {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'scattermapbox',
                 lon: [10, 20, 30],
                 lat: [10, 20, 30]
@@ -317,7 +317,7 @@ describe('mapbox credentials', function() {
     it('@gl should throw error if token is invalid', function(done) {
         var cnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [10, 20, 30]
@@ -337,7 +337,7 @@ describe('mapbox credentials', function() {
     it('@gl should use access token in mapbox layout options if present', function(done) {
         var cnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [10, 20, 30]
@@ -360,7 +360,7 @@ describe('mapbox credentials', function() {
         spyOn(Lib, 'warn');
         var cnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [10, 20, 30]
@@ -385,7 +385,7 @@ describe('mapbox credentials', function() {
     it('@gl should not throw when using a custom non-mapbox style', function(done) {
         var cnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [10, 20, 30]
@@ -403,7 +403,7 @@ describe('mapbox credentials', function() {
     it('@gl should not throw when using a custom mapbox style URL with an access token in the layout', function(done) {
         var cnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [10, 20, 30]
@@ -425,7 +425,7 @@ describe('mapbox credentials', function() {
         spyOn(Lib, 'log');
         var cnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [10, 20, 30]
@@ -459,7 +459,7 @@ describe('mapbox credentials', function() {
         //
         // https://www.mapbox.com/atlas/#developing-with-atlas
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [10, 20, 30]
@@ -498,7 +498,7 @@ describe('mapbox plots', function() {
 
         var mockCopy = Lib.extendDeep({}, mock);
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
     });
 
     afterEach(function() {
@@ -1785,7 +1785,7 @@ describe('test mapbox trace/layout *below* interactions', function() {
             expect(layersIds.indexOf(layoutLayerId)).toBe(exp.layout, msg + '| layout layer');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [15, 25, 35],
@@ -1893,7 +1893,7 @@ describe('test mapbox trace/layout *below* interactions', function() {
             expect(layersIds.indexOf(choroplethPrefix + '-line')).toBe(exp.choropleth[1], msg + '| choropleth line');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [15, 25, 35],
@@ -1968,7 +1968,7 @@ describe('test mapbox trace/layout *below* interactions', function() {
             });
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattermapbox',
             lon: [10, 20, 30],
             lat: [15, 25, 35]
@@ -2033,7 +2033,7 @@ describe('Test mapbox GeoJSON fetching:', function() {
         var url2 = 'https://raw.githubusercontent.com/plotly/datasets/master/florida-blue-data.json';
         var cnt = 0;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'choroplethmapbox',
             locations: ['a'],
             z: [1],
@@ -2059,7 +2059,7 @@ describe('Test mapbox GeoJSON fetching:', function() {
     it('@gl should fetch GeoJSON using URLs found in the traces', function(done) {
         var actual = '';
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'choroplethmapbox',
             locations: ['a'],
             z: [1],

--- a/test/jasmine/tests/mesh3d_test.js
+++ b/test/jasmine/tests/mesh3d_test.js
@@ -238,7 +238,7 @@ describe('Test mesh3d', function() {
                 expect(fullTrace.cmax).toBe(full[2], 'full cmax');
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'mesh3d',
                 x: [0, 1, 2, 0],
                 y: [0, 0, 1, 2],
@@ -299,7 +299,7 @@ describe('Test mesh3d', function() {
         }
 
         it('@gl mesh3d should be visible when the indices are not integer', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -322,7 +322,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the indices could be rounded to be in vertex range', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -345,7 +345,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the indices are equal or greater than the number of vertices', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -368,7 +368,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the indices are negative', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -391,7 +391,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the indices have different sizes', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -414,7 +414,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the indices are provided and OK', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -437,7 +437,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when values are passed in string format', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['0', '1', '0.5', '0.5'],
                 y: ['0', '0.5', '1', '0.5'],
                 z: ['0', '0.5', '0.5', '1'],
@@ -459,7 +459,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the index arrays are empty', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -482,7 +482,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the index arrays are not provided', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -502,7 +502,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be visible when the vertex arrays are empty', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [],
                 y: [],
                 z: [],
@@ -522,7 +522,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the vertex arrays missing', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'mesh3d'
             }])
             .then(function() {
@@ -533,7 +533,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the vertex arrays are not arrays - number case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: 1,
@@ -550,7 +550,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the vertex arrays are not arrays - boolean case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: true,
@@ -567,7 +567,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the vertex arrays are not arrays - object case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: {},
@@ -584,7 +584,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the vertex arrays are not arrays - string case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: '[0, 0.5, 0.5, 1]',
@@ -601,7 +601,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the index arrays are not arrays - string case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -618,7 +618,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the index arrays are not arrays - object case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -635,7 +635,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the index arrays are not arrays - boolean case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],
@@ -652,7 +652,7 @@ describe('Test mesh3d', function() {
         });
 
         it('@gl mesh3d should be invisible when the index arrays are not arrays - number case', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [0, 1, 0.5, 0.5],
                 y: [0, 0.5, 1, 0.5],
                 z: [0, 0.5, 0.5, 1],

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -1042,7 +1042,7 @@ describe('ModeBar', function() {
             });
 
             it('should use defaults', function(done) {
-                Plotly.plot(gd, {data: [], layout: {}})
+                Plotly.newPlot(gd, {data: [], layout: {}})
                 .then(function() {
                     selectButton(gd._fullLayout._modeBar, 'toImage').click();
                     expect(Registry.call)
@@ -1053,7 +1053,7 @@ describe('ModeBar', function() {
             });
 
             it('should accept overriding defaults', function(done) {
-                Plotly.plot(gd, {data: [], layout: {}, config: {
+                Plotly.newPlot(gd, {data: [], layout: {}, config: {
                     toImageButtonOptions: {
                         format: 'svg',
                         filename: 'x',
@@ -1070,7 +1070,7 @@ describe('ModeBar', function() {
             });
 
             it('should accept overriding defaults with null values', function(done) {
-                Plotly.plot(gd, {data: [], layout: {}, config: {
+                Plotly.newPlot(gd, {data: [], layout: {}, config: {
                     toImageButtonOptions: {width: null, height: null}
                 }})
                 .then(function() {
@@ -1122,7 +1122,7 @@ describe('ModeBar', function() {
                 };
 
                 gd = createGraphDiv();
-                Plotly.plot(gd, mockData, mockLayout).then(function() {
+                Plotly.newPlot(gd, mockData, mockLayout).then(function() {
                     modeBar = gd._fullLayout._modeBar;
                     buttonToggle = selectButton(modeBar, 'toggleSpikelines');
                     buttonCompare = selectButton(modeBar, 'hoverCompareCartesian');
@@ -1296,7 +1296,7 @@ describe('ModeBar', function() {
                 }];
 
                 gd = createGraphDiv();
-                Plotly.plot(gd, mockData).then(function() {
+                Plotly.newPlot(gd, mockData).then(function() {
                     modeBar = gd._fullLayout._modeBar;
                     done();
                 });
@@ -1329,7 +1329,7 @@ describe('ModeBar', function() {
                 }];
 
                 gd = createGraphDiv();
-                Plotly.plot(gd, mockData).then(function() {
+                Plotly.newPlot(gd, mockData).then(function() {
                     modeBar = gd._fullLayout._modeBar;
                     done();
                 });
@@ -1365,7 +1365,7 @@ describe('ModeBar', function() {
                     expect(mapboxLayout.zoom).toBe(zoom, 'zoom');
                 }
 
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     type: 'scattermapbox',
                     lon: [10, 20, 30],
                     lat: [10, 20, 30]
@@ -1412,7 +1412,7 @@ describe('ModeBar', function() {
                     expect(gd._fullLayout.hovermode).toBe('closest', msg + '| after 2nd click');
                 }
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {type: 'scatterternary', a: [1], b: [2], c: [3]}
                 ])
                 .then(function() {
@@ -1432,7 +1432,7 @@ describe('ModeBar', function() {
             it('ternary + geo case ', function(done) {
                 var gd = createGraphDiv();
 
-                Plotly.plot(gd, [
+                Plotly.newPlot(gd, [
                     {type: 'scatterternary', a: [1], b: [2], c: [3]},
                     {type: 'scattergeo', lon: [10], lat: [20]}
                 ])
@@ -1484,7 +1484,7 @@ describe('ModeBar', function() {
 
         it('create an associated style element and destroy it on purge', function(done) {
             var styleSelector, style;
-            Plotly.plot(gd, [], {})
+            Plotly.newPlot(gd, [], {})
             .then(function() {
                 styleSelector = 'style[id*="modebar-' + gd._fullLayout._uid + '"]';
 
@@ -1501,7 +1501,7 @@ describe('ModeBar', function() {
         });
 
         it('changes icon colors', function(done) {
-            Plotly.plot(gd, [], {modebar: { color: colors[0]}})
+            Plotly.newPlot(gd, [], {modebar: { color: colors[0]}})
             .then(function() {
                 button = selectButton(gd._fullLayout._modeBar, targetBtn);
                 checkButtonColor(button, colors[0]);
@@ -1515,7 +1515,7 @@ describe('ModeBar', function() {
         });
 
         it('changes active icon colors', function(done) {
-            Plotly.plot(gd, [], {modebar: { activecolor: colors[0]}})
+            Plotly.newPlot(gd, [], {modebar: { activecolor: colors[0]}})
             .then(function() {
                 button = selectButton(gd._fullLayout._modeBar, targetBtn);
                 button.click();
@@ -1530,7 +1530,7 @@ describe('ModeBar', function() {
         });
 
         it('changes background color (displayModeBar: hover)', function(done) {
-            Plotly.plot(gd, [], {modebar: { bgcolor: colors[0]}})
+            Plotly.newPlot(gd, [], {modebar: { bgcolor: colors[0]}})
             .then(function() {
                 style = window.getComputedStyle(gd._fullLayout._modeBar.element.querySelector('.modebar-group'));
                 expect(style.backgroundColor).toBe('rgba(0, 0, 0, 0)');
@@ -1547,7 +1547,7 @@ describe('ModeBar', function() {
         });
 
         it('changes background color (displayModeBar: true)', function(done) {
-            Plotly.plot(gd, [], {modebar: {bgcolor: colors[0]}}, {displayModeBar: true})
+            Plotly.newPlot(gd, [], {modebar: {bgcolor: colors[0]}}, {displayModeBar: true})
             .then(function() {
                 style = window.getComputedStyle(gd._fullLayout._modeBar.element.querySelector('.modebar-group'));
                 expect(style.backgroundColor).toBe(colors[0]);
@@ -1566,7 +1566,7 @@ describe('ModeBar', function() {
         it('changes orientation', function(done) {
             var modeBarEl, size;
 
-            Plotly.plot(gd, [], {modebar: { orientation: 'v' }})
+            Plotly.newPlot(gd, [], {modebar: { orientation: 'v' }})
             .then(function() {
                 modeBarEl = gd._fullLayout._modeBar.element;
                 size = modeBarEl.getBoundingClientRect();
@@ -1608,7 +1608,7 @@ describe('ModeBar', function() {
         traces.forEach(function(fromTrace) {
             traces.forEach(function(toTrace) {
                 it('is still present when switching from ' + fromTrace.type + ' to ' + toTrace.type, function(done) {
-                    Plotly.plot(gd, [fromTrace], {})
+                    Plotly.newPlot(gd, [fromTrace], {})
                     .then(function() {
                         expect(getModebarDiv()).toBeTruthy();
                         expect(getModebarDiv().innerHTML).toBeTruthy();

--- a/test/jasmine/tests/parcats_test.js
+++ b/test/jasmine/tests/parcats_test.js
@@ -1721,7 +1721,7 @@ describe('Parcats hover:', function() {
         );
         if(s.patch) fig = s.patch(fig);
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             mouseEvent('mousemove', s.pos[0], s.pos[1]);
             mouseEvent('mouseover', s.pos[0], s.pos[1]);
 

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -372,7 +372,7 @@ describe('parcoords edge cases', function() {
 
     it('@gl Works fine with one panel only', function(done) {
         var mockCopy = Lib.extendDeep({}, mock2);
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(2);
             expect(document.querySelectorAll('.axis').length).toEqual(2);
@@ -390,7 +390,7 @@ describe('parcoords edge cases', function() {
 
     it('@gl Do something sensible if there is no panel i.e. dimension count is less than 2', function(done) {
         var mockCopy = Lib.extendDeep({}, mock1);
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(1);
             expect(document.querySelectorAll('.axis').length).toEqual(1); // sole axis still shows up
@@ -407,7 +407,7 @@ describe('parcoords edge cases', function() {
     it('@gl Does not error with zero dimensions', function(done) {
         var mockCopy = Lib.extendDeep({}, mock0);
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(0);
             expect(document.querySelectorAll('.axis').length).toEqual(0);
@@ -417,7 +417,7 @@ describe('parcoords edge cases', function() {
     });
 
     it('@gl Does not error with dimensions including only 0', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'parcoords',
                 dimensions: [{
@@ -441,7 +441,7 @@ describe('parcoords edge cases', function() {
         mockCopy.layout.width = 320;
         mockCopy.data[0].dimensions[1].label = mockCopy.data[0].dimensions[0].label;
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(2);
             expect(document.querySelectorAll('.axis').length).toEqual(2);
@@ -467,7 +467,7 @@ describe('parcoords edge cases', function() {
             }
         }
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(2);
             expect(document.querySelectorAll('.axis').length).toEqual(2);
@@ -489,7 +489,7 @@ describe('parcoords edge cases', function() {
             dim.values = [];
         }
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(2);
             expect(document.querySelectorAll('.axis').length).toEqual(0);
@@ -515,7 +515,7 @@ describe('parcoords edge cases', function() {
             }
         }
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(2);
             expect(document.querySelectorAll('.axis').length).toEqual(2);
@@ -603,7 +603,7 @@ describe('parcoords edge cases', function() {
             mockCopy.data[0].dimensions[i] = newDimension;
         }
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(60);
             expect(document.querySelectorAll('.axis').length).toEqual(60);
@@ -636,7 +636,7 @@ describe('parcoords edge cases', function() {
         mockCopy.data[0].dimensions[0] = 'This is not a plain object';
         mockCopy.data[0].dimensions[1].values = 'This is not an array';
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].dimensions.length).toEqual(5); // it's still five, but ...
             expect(document.querySelectorAll('.axis').length).toEqual(3); // only 3 axes shown
@@ -656,7 +656,7 @@ describe('parcoords Lifecycle methods', function() {
 
         mockCopy.data[0].line.showscale = false;
 
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(gd.data.length).toEqual(1);
 
             return Plotly.deleteTraces(gd, 0).then(function() {
@@ -674,7 +674,7 @@ describe('parcoords Lifecycle methods', function() {
         mockCopy2.data[0].dimensions.splice(3, 4);
         mockCopy.data[0].line.showscale = false;
 
-        Plotly.plot(gd, mockCopy)
+        Plotly.newPlot(gd, mockCopy)
             .then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(document.querySelectorAll('.y-axis').length).toEqual(10);
@@ -728,7 +728,7 @@ describe('parcoords Lifecycle methods', function() {
             };
         }
 
-        Plotly.plot(gd, mockCopy)
+        Plotly.newPlot(gd, mockCopy)
         .then(_assertVisibleData(true, 'initial'))
         .then(restyleDimension('values', 1, [[]]))
         .then(_assertVisibleData(false, 'no panels'))
@@ -739,7 +739,7 @@ describe('parcoords Lifecycle methods', function() {
     it('@gl displays focused and context data after relayout', function(done) {
         var mockCopy = Lib.extendDeep({}, mock2);
 
-        Plotly.plot(gd, mockCopy)
+        Plotly.newPlot(gd, mockCopy)
         .then(_assertVisibleData(true, 'initial'))
         .then(function() {
             return Plotly.relayout(gd, 'paper_bgcolor', '#eef');
@@ -759,7 +759,7 @@ describe('parcoords Lifecycle methods', function() {
 
             expect(document.querySelectorAll('.gl-container').length).toEqual(0);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
                 .then(function() {
                     expect(1).toEqual(1);
                     expect(document.querySelectorAll('.gl-container').length).toEqual(1);
@@ -785,7 +785,7 @@ describe('parcoords Lifecycle methods', function() {
 
             expect(document.querySelectorAll('.gl-container').length).toEqual(0);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
                 .then(function() {
                     expect(document.querySelectorAll('.gl-container').length).toEqual(1);
                     expect(gd.data.length).toEqual(1);
@@ -826,7 +826,7 @@ describe('parcoords Lifecycle methods', function() {
 
             expect(document.querySelectorAll('.gl-container').length).toEqual(0);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
                 .then(function() {
                     expect(document.querySelectorAll('.gl-container').length).toEqual(1);
                     expect(gd.data.length).toEqual(1);
@@ -847,7 +847,7 @@ describe('parcoords Lifecycle methods', function() {
 
     it('@gl line.color `Plotly.restyle` should change focus layer', function(done) {
         var testLayer = '.gl-canvas-focus';
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'parcoords',
             dimensions: [{
                 values: [1, 2]
@@ -879,7 +879,7 @@ describe('parcoords Lifecycle methods', function() {
         var testLayer = '.gl-canvas-context';
         var oldRGB, newRGB;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'parcoords',
             dimensions: [{
                 values: [1, 2]
@@ -943,7 +943,7 @@ describe('parcoords basic use', function() {
         .then(done);
     });
 
-    it('@gl `Plotly.plot` should have proper fields on `gd.data` on initial rendering', function(done) {
+    it('@gl `Plotly.newPlot` should have proper fields on `gd.data` on initial rendering', function(done) {
         Plotly.react(gd, mockCopy)
         .then(function() {
             expect(gd.data.length).toEqual(1);

--- a/test/jasmine/tests/pie_test.js
+++ b/test/jasmine/tests/pie_test.js
@@ -595,7 +595,7 @@ describe('Pie traces', function() {
             showlegend: true
         };
 
-        Plotly.plot(gd, data, layout)
+        Plotly.newPlot(gd, data, layout)
           .then(function() {
               var expWidths = ['3', '0', '0'];
 
@@ -630,7 +630,7 @@ describe('Pie traces', function() {
                 size: [12, 20, 16]
             };
 
-            Plotly.plot(gd, [data])
+            Plotly.newPlot(gd, [data])
               .then(_checkFontColors(['red', 'green', 'blue']))
               .then(_checkFontFamilies(['Arial', 'Gravitas', 'Roboto']))
               .then(_checkFontSizes([12, 20, 16]))
@@ -648,7 +648,7 @@ describe('Pie traces', function() {
     };
 
     it('should use inside text colors contrasting to explicitly set slice colors by default', function(done) {
-        Plotly.plot(gd, [insideTextTestsTrace])
+        Plotly.newPlot(gd, [insideTextTestsTrace])
           .then(_checkFontColors([DARK, DARK, LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -658,7 +658,7 @@ describe('Pie traces', function() {
         var noMarkerTrace = Lib.extendFlat({}, insideTextTestsTrace);
         delete noMarkerTrace.marker;
 
-        Plotly.plot(gd, [noMarkerTrace])
+        Plotly.newPlot(gd, [noMarkerTrace])
           .then(_checkFontColors([LIGHT, DARK, LIGHT, LIGHT, LIGHT, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -666,7 +666,7 @@ describe('Pie traces', function() {
 
     it('should use textfont.color for inside text instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, {textfont: {color: 'red'}});
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(_checkFontColors(Lib.repeat('red', 6)))
           .catch(failTest)
           .then(done);
@@ -674,14 +674,14 @@ describe('Pie traces', function() {
 
     it('should use matching color from textfont.color array for inside text, contrasting otherwise', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, {textfont: {color: ['red', 'blue']}});
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(_checkFontColors(['red', 'blue', LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
     });
 
     it('should not use layout.font.color for inside text, but a contrasting color instead', function(done) {
-        Plotly.plot(gd, [insideTextTestsTrace], {font: {color: 'green'}})
+        Plotly.newPlot(gd, [insideTextTestsTrace], {font: {color: 'green'}})
           .then(_checkFontColors([DARK, DARK, LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -689,7 +689,7 @@ describe('Pie traces', function() {
 
     it('should use matching color from insidetextfont.color array instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, {textfont: {color: ['orange', 'purple']}});
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(_checkFontColors(['orange', 'purple', LIGHT, LIGHT, DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -707,7 +707,7 @@ describe('Pie traces', function() {
             });
             data[spec.fontAttr] = {color: ['blue', 'yellow'], family: ['Arial', 'Arial'], size: [24, 34]};
 
-            Plotly.plot(gd, [data])
+            Plotly.newPlot(gd, [data])
               .then(_checkFontColors(['blue', 'yellow', 'orange', 'orange', 'orange', 'orange']))
               .then(_checkFontFamilies(['Arial', 'Arial', 'Gravitas', 'Gravitas', 'Gravitas', 'Gravitas']))
               .then(_checkFontSizes([24, 34, 12, 12, 12, 12]))
@@ -728,7 +728,7 @@ describe('Pie traces', function() {
             }
         });
 
-        Plotly.plot(gd, [data], layout)
+        Plotly.newPlot(gd, [data], layout)
           .then(_checkFontColors(['purple', 'blue', LIGHT, LIGHT, DARK, LIGHT]))
           .then(_checkFontFamilies(['Roboto', 'Arial', 'serif', 'serif', 'serif', 'serif']))
           .then(_checkFontSizes([24, 18, 16, 16, 16, 16]))
@@ -749,7 +749,7 @@ describe('Pie traces', function() {
             }
         });
 
-        Plotly.plot(gd, [data], layout)
+        Plotly.newPlot(gd, [data], layout)
           .then(_checkFontColors(['purple', 'blue', 'orange', 'orange', 'orange', 'orange']))
           .then(_checkFontFamilies(['Roboto', 'Arial', 'serif', 'serif', 'serif', 'serif']))
           .then(_checkFontSizes([24, 18, 16, 16, 16, 16]))
@@ -768,7 +768,7 @@ describe('Pie traces', function() {
             data.textposition = 'inside';
             data[spec.fontAttr] = {color: ['blue', 'yellow'], family: ['Arial', 'Arial'], size: [24, 34]};
 
-            Plotly.plot(gd, [data], layout)
+            Plotly.newPlot(gd, [data], layout)
               .then(_checkFontColors(['blue', 'yellow', LIGHT, LIGHT, DARK, LIGHT]))
               .then(_checkFontFamilies(['Arial', 'Arial', 'serif', 'serif', 'serif', 'serif']))
               .then(_checkFontSizes([24, 34, 16, 16, 16, 16]))
@@ -788,7 +788,7 @@ describe('Pie traces', function() {
             data.textposition = 'outside';
             data[spec.fontAttr] = {color: ['blue', 'yellow'], family: ['Arial', 'Arial'], size: [24, 34]};
 
-            Plotly.plot(gd, [data], layout)
+            Plotly.newPlot(gd, [data], layout)
               .then(_checkFontColors(['blue', 'yellow', 'orange', 'orange', 'orange', 'orange']))
               .then(_checkFontFamilies(['Arial', 'Arial', 'serif', 'serif', 'serif', 'serif']))
               .then(_checkFontSizes([24, 34, 16, 16, 16, 16]))
@@ -804,7 +804,7 @@ describe('Pie traces', function() {
     }
 
     it('show a user-defined title with a custom position and font', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'pie',
             values: [1, 2, 3],
             title: {
@@ -822,7 +822,7 @@ describe('Pie traces', function() {
     });
 
     it('still support the deprecated `title` structure (backwards-compatibility)', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'pie',
             values: [1, 2, 3],
             title: 'yo',
@@ -838,7 +838,7 @@ describe('Pie traces', function() {
     });
 
     it('should be able to restyle title', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'pie',
             values: [1, 2, 3],
             title: {
@@ -866,7 +866,7 @@ describe('Pie traces', function() {
     });
 
     it('should be able to restyle title despite using the deprecated attributes', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'pie',
             values: [1, 2, 3],
             title: 'yo',
@@ -892,7 +892,7 @@ describe('Pie traces', function() {
     });
 
     it('should be able to react with new text colors', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'pie',
             values: [1, 2, 3],
             text: ['A', 'B', 'C'],
@@ -934,7 +934,7 @@ describe('Pie traces', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', 4))
         .then(function() { return Plotly.restyle(gd, 'visible', false); })
         .then(_assert('both visible:false', 0))
@@ -990,7 +990,7 @@ describe('Pie traces', function() {
             };
         }
 
-        Plotly.plot(gd, data, layout)
+        Plotly.newPlot(gd, data, layout)
         .then(function() {
             var gs = gd._fullLayout._size;
             previousSize = Lib.extendDeep({}, gs);
@@ -1057,7 +1057,7 @@ describe('pie hovering', function() {
         beforeEach(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                 .then(done);
         });
 
@@ -1111,7 +1111,7 @@ describe('pie hovering', function() {
         beforeEach(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                 .then(done);
         });
 
@@ -1223,7 +1223,7 @@ describe('pie hovering', function() {
         }
 
         it('should show the default selected values', function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertLabel(
@@ -1305,7 +1305,7 @@ describe('pie hovering', function() {
             mockCopy.data[0].values[0] = 12345678.912;
             mockCopy.data[0].values[1] = 10000;
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertLabel('0\n12|345|678@91\n99@9%');
@@ -1315,7 +1315,7 @@ describe('pie hovering', function() {
         });
 
         it('should show falsy zero text', function(done) {
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     type: 'pie',
                     labels: ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
@@ -1338,7 +1338,7 @@ describe('pie hovering', function() {
 
         it('should use hovertemplate if specified', function(done) {
             mockCopy.data[0].name = '';
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertLabel(
@@ -1407,7 +1407,7 @@ describe('pie hovering', function() {
             mockCopy.data[0].name = 'loooooooooooooooooooooooong';
             mockCopy.data[0].hoverinfo = 'all';
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({nums: '4\n5\n33.3%', name: 'looooooooooo...'}, 'base');
@@ -1438,7 +1438,7 @@ describe('pie hovering', function() {
                 Lib.clearThrottle();
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'pie',
                 labels: ['a', 'b']
             }], {
@@ -1485,7 +1485,7 @@ describe('pie hovering', function() {
         afterEach(destroyGraphDiv);
 
         it('- when labels overflow left and right', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 hole: 0.33,
                 hoverinfo: 'label+text+percent',
                 values: ['22238.58', '3145.82', '2865.21', '1664.58'],
@@ -1540,7 +1540,7 @@ describe('Test event data of interactions on a pie plot:', function() {
     beforeAll(function(done) {
         gd = createGraphDiv();
         mockCopy = Lib.extendDeep({}, mock);
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             pointPos = getClientPosition('g.slicetext');
             destroyGraphDiv();
             done();
@@ -1585,7 +1585,7 @@ describe('Test event data of interactions on a pie plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1639,7 +1639,7 @@ describe('Test event data of interactions on a pie plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1823,7 +1823,7 @@ describe('Test pie interactions edge cases:', function() {
             unhoverCnt = 0;
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_hover', function() {
                 hoverCnt++;
@@ -1924,7 +1924,7 @@ describe('pie inside text orientation', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextRotations('using default "auto"', {
             rotations: [-84, 0, -30, 0]
         }))
@@ -2031,7 +2031,7 @@ describe('pie uniformtext', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextSizes('without uniformtext', {
             fontsizes: [12, 12, 12, 12, 12, 12, 12, 12],
             scales: [1, 1, 1, 1, 1, 1, 1, 0.52],

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -72,12 +72,12 @@ describe('@noCIdep Plotly.react', function() {
             subroutines[m].calls.reset();
         });
 
-        // calls to Plotly.plot via plot_api.js or Registry.call('plot')
+        // calls to Plotly.newPlot via plot_api.js or Registry.call('plot')
         var plotCalls = plotApi.plot.calls.count() +
             Registry.call.calls.all()
                 .filter(function(d) { return d.args[0] === 'plot'; })
                 .length;
-        expect(plotCalls).toBe(counts.plot || 0, 'Plotly.plot calls');
+        expect(plotCalls).toBe(counts.plot || 0, 'Plotly.newPlot calls');
         plotApi.plot.calls.reset();
         Registry.call.calls.reset();
 

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -30,7 +30,7 @@ describe('Test plot api', function() {
         });
     });
 
-    describe('Plotly.plot', function() {
+    describe('Plotly.newPlot', function() {
         var gd;
 
         beforeEach(function() {
@@ -40,7 +40,7 @@ describe('Test plot api', function() {
         afterEach(destroyGraphDiv);
 
         it('accepts gd, data, layout, and config as args', function(done) {
-            Plotly.plot(gd,
+            Plotly.newPlot(gd,
                 [{x: [1, 2, 3], y: [1, 2, 3]}],
                 {width: 500, height: 500},
                 {editable: true}
@@ -55,7 +55,7 @@ describe('Test plot api', function() {
         });
 
         it('accepts gd and an object as args', function(done) {
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{x: [1, 2, 3], y: [1, 2, 3]}],
                 layout: {width: 500, height: 500},
                 config: {editable: true},
@@ -72,7 +72,7 @@ describe('Test plot api', function() {
         });
 
         it('allows adding more frames to the initial set', function(done) {
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{x: [1, 2, 3], y: [1, 2, 3]}],
                 layout: {width: 500, height: 500},
                 config: {editable: true},
@@ -101,7 +101,7 @@ describe('Test plot api', function() {
         it('should emit afterplot event after plotting is done', function(done) {
             var afterPlot = false;
 
-            var promise = Plotly.plot(gd, [{ y: [2, 1, 2]}]);
+            var promise = Plotly.newPlot(gd, [{ y: [2, 1, 2]}]);
 
             gd.on('plotly_afterplot', function() {
                 afterPlot = true;
@@ -134,7 +134,7 @@ describe('Test plot api', function() {
         });
 
         it('should update the plot clipPath if the plot is resized', function(done) {
-            Plotly.plot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }], { width: 500, height: 500 })
+            Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }], { width: 500, height: 500 })
             .then(function() {
                 return Plotly.relayout(gd, { width: 400, height: 400 });
             })
@@ -155,7 +155,7 @@ describe('Test plot api', function() {
 
         it('sets null values to their default', function(done) {
             var defaultWidth;
-            Plotly.plot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
+            Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
             .then(function() {
                 defaultWidth = gd._fullLayout.width;
                 return Plotly.relayout(gd, { width: defaultWidth - 25});
@@ -173,7 +173,7 @@ describe('Test plot api', function() {
 
         it('ignores undefined values', function(done) {
             var defaultWidth;
-            Plotly.plot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
+            Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
             .then(function() {
                 defaultWidth = gd._fullLayout.width;
                 return Plotly.relayout(gd, { width: defaultWidth - 25});
@@ -190,7 +190,7 @@ describe('Test plot api', function() {
         });
 
         it('can set items in array objects', function(done) {
-            Plotly.plot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
+            Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
             .then(function() {
                 return Plotly.relayout(gd, {rando: [1, 2, 3]});
             })
@@ -210,7 +210,7 @@ describe('Test plot api', function() {
             var edit2 = {'rando[1]': {c: 3}};
             var edit3 = {'rando[1].d': 4};
 
-            Plotly.plot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
+            Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [1, 2, 3] }])
             .then(function() {
                 return Plotly.relayout(gd, edit1);
             })
@@ -250,7 +250,7 @@ describe('Test plot api', function() {
             }];
             var scatter = null;
             var oldHeight = 0;
-            Plotly.plot(gd, data)
+            Plotly.newPlot(gd, data)
             .then(function() {
                 scatter = document.getElementsByClassName('scatter')[0];
                 oldHeight = scatter.getBoundingClientRect().height;
@@ -265,7 +265,7 @@ describe('Test plot api', function() {
         });
 
         it('should skip empty axis objects', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [1, 2, 3],
                 y: [1, 2, 1]
             }], {
@@ -299,7 +299,7 @@ describe('Test plot api', function() {
                 return getPos(d3.select('.layer-above').select('.imagelayer').select('image'));
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: ['a', 'b', 'c'],
                 y: [1, 2, 1]
             }], {
@@ -356,7 +356,7 @@ describe('Test plot api', function() {
             var initialXRange;
             var initialYRange;
 
-            Plotly.plot(gd, [{x: [1, 2], y: [1, 2]}])
+            Plotly.newPlot(gd, [{x: [1, 2], y: [1, 2]}])
             .then(function() {
                 expect(gd.layout.xaxis.autorange).toBe(true);
                 expect(gd.layout.yaxis.autorange).toBe(true);
@@ -392,7 +392,7 @@ describe('Test plot api', function() {
         });
 
         it('sets aspectmode to manual when you provide any aspectratio', function(done) {
-            Plotly.plot(gd, [{x: [1, 2], y: [1, 2], z: [1, 2], type: 'scatter3d'}])
+            Plotly.newPlot(gd, [{x: [1, 2], y: [1, 2], z: [1, 2], type: 'scatter3d'}])
             .then(function() {
                 expect(gd.layout.scene.aspectmode).toBe('auto');
 
@@ -411,7 +411,7 @@ describe('Test plot api', function() {
         });
 
         it('sets tickmode to linear when you edit tick0 or dtick', function(done) {
-            Plotly.plot(gd, [{x: [1, 2], y: [1, 2]}])
+            Plotly.newPlot(gd, [{x: [1, 2], y: [1, 2]}])
             .then(function() {
                 expect(gd.layout.xaxis.tickmode).toBeUndefined();
                 expect(gd.layout.yaxis.tickmode).toBeUndefined();
@@ -436,7 +436,7 @@ describe('Test plot api', function() {
         });
 
         it('updates non-auto ranges for linear/log changes', function(done) {
-            Plotly.plot(gd, [{x: [3, 5], y: [3, 5]}], {
+            Plotly.newPlot(gd, [{x: [3, 5], y: [3, 5]}], {
                 xaxis: {range: [1, 10]},
                 yaxis: {type: 'log', range: [0, 1]}
             })
@@ -458,7 +458,7 @@ describe('Test plot api', function() {
         });
 
         it('respects reversed autorange when switching linear to log', function(done) {
-            Plotly.plot(gd, [{x: [1, 2], y: [1, 2]}])
+            Plotly.newPlot(gd, [{x: [1, 2], y: [1, 2]}])
             .then(function() {
                 // Ideally we should change this to xaxis.autorange: 'reversed'
                 // but that's a weird disappearing setting used just to force
@@ -484,7 +484,7 @@ describe('Test plot api', function() {
         });
 
         it('autoranges automatically when switching to/from any other axis type than linear <-> log', function(done) {
-            Plotly.plot(gd, [{x: ['1.5', '0.8'], y: [1, 2]}], {xaxis: {range: [0.6, 1.7]}})
+            Plotly.newPlot(gd, [{x: ['1.5', '0.8'], y: [1, 2]}], {xaxis: {range: [0.6, 1.7]}})
             .then(function() {
                 expect(gd.layout.xaxis.autorange).toBeUndefined();
                 expect(gd._fullLayout.xaxis.type).toBe('linear');
@@ -1143,7 +1143,7 @@ describe('Test plot api', function() {
         });
 
         it('should redo auto z/contour when editing z array', function(done) {
-            Plotly.plot(gd, [{type: 'contour', z: [[1, 2], [3, 4]]}]).then(function() {
+            Plotly.newPlot(gd, [{type: 'contour', z: [[1, 2], [3, 4]]}]).then(function() {
                 expect(gd._fullData[0].zauto).toBe(true);
                 expect(gd._fullData[0].zmin).toBe(1);
                 expect(gd._fullData[0].zmax).toBe(4);
@@ -1166,7 +1166,7 @@ describe('Test plot api', function() {
             var edit2 = {'rando[1]': {c: 3}};
             var edit3 = {'rando[1].d': 4};
 
-            Plotly.plot(gd, [{x: [1, 2, 3], y: [1, 2, 3], type: 'scatter'}])
+            Plotly.newPlot(gd, [{x: [1, 2, 3], y: [1, 2, 3], type: 'scatter'}])
             .then(function() {
                 return Plotly.restyle(gd, edit1);
             })
@@ -1208,7 +1208,7 @@ describe('Test plot api', function() {
                 expect(gd._fullData[1].zauto).toBe(auto, msg);
             }
 
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {z: [[1, 2], [3, 4]], type: 'heatmap'},
                 {x: [2, 3], z: [[5, 6], [7, 8]], type: 'contour'}
             ])
@@ -1255,7 +1255,7 @@ describe('Test plot api', function() {
                 expect(gd._fullData[1].marker.line.colorscale).toEqual(auto ? autocscale : scales[mlcscl1]);
             }
 
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {y: [1, 2], mode: 'markers', marker: {color: [1, 10]}},
                 {y: [2, 1], mode: 'markers', marker: {line: {width: 2, color: [3, 4]}}}
             ])
@@ -1301,7 +1301,7 @@ describe('Test plot api', function() {
                 return function() { return Plotly.restyle(gd, arg); };
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 mode: 'markers',
                 y: [1, 2, 1],
                 marker: { color: [1, -1, 4] }
@@ -1384,7 +1384,7 @@ describe('Test plot api', function() {
                 }
             }
 
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {x: [1, 1, 1, 1, 2, 2, 2, 3, 3, 4], type: 'histogram'},
                 {x: [1, 1, 2, 2, 3, 3, 4, 4], y: [1, 1, 2, 2, 3, 3, 4, 4], type: 'histogram2d'}
             ])
@@ -1419,7 +1419,7 @@ describe('Test plot api', function() {
                 negateIf(auto, expect(gd.data[1].contours.size)).toBe(size1, msg);
             }
 
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {z: [[1, 2], [3, 4]], type: 'contour'},
                 {x: [1, 2, 3, 4], y: [3, 4, 5, 6], type: 'histogram2dcontour'}
             ])
@@ -1453,7 +1453,7 @@ describe('Test plot api', function() {
         }
 
         it('sets heatmap xtype/ytype when you edit x/y data or scaling params', function(done) {
-            Plotly.plot(gd, [{type: 'heatmap', z: [[0, 1], [2, 3]]}])
+            Plotly.newPlot(gd, [{type: 'heatmap', z: [[0, 1], [2, 3]]}])
             .then(function() {
                 // TODO would probably be better to actively default to 'array' here...
                 checkScaling(undefined, undefined, 0, 0);
@@ -1471,7 +1471,7 @@ describe('Test plot api', function() {
         });
 
         it('sets heatmap xtype/ytype even when data/fullData indices mismatch', function(done) {
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {
                     // importantly, this is NOT a heatmap trace, so _fullData[1]
                     // will not have the same attributes as data[1]
@@ -1509,7 +1509,7 @@ describe('Test plot api', function() {
                 expect(gd._fullData[1].colorbar.tickmode).toBe(auto ? 'auto' : 'linear', msg);
             }
 
-            Plotly.plot(gd, [
+            Plotly.newPlot(gd, [
                 {z: [[1, 2], [3, 4]], type: 'heatmap'},
                 {x: [2, 3], z: [[1, 2], [3, 4]], type: 'heatmap'}
             ])
@@ -2323,7 +2323,7 @@ describe('Test plot api', function() {
             var intialHTML = gd.innerHTML;
             var mockData = [{ x: [1, 2, 3], y: [2, 3, 4] }];
 
-            Plotly.plot(gd, mockData).then(function() {
+            Plotly.newPlot(gd, mockData).then(function() {
                 Plotly.purge(gd);
 
                 expect(Object.keys(gd)).toEqual(initialKeys);
@@ -2388,7 +2388,7 @@ describe('Test plot api', function() {
                 scl: 'Blues'
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].colorscale).toBe('Blues');
             expect(gd.data[0].scl).toBe(undefined);
         });
@@ -2400,7 +2400,7 @@ describe('Test plot api', function() {
                 scl: 'Reds'
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].colorscale).toBe('Greens');
             expect(gd.data[0].scl).not.toBe(undefined);
         });
@@ -2411,7 +2411,7 @@ describe('Test plot api', function() {
                 reversescl: true
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].reversescale).toBe(true);
             expect(gd.data[0].reversescl).toBe(undefined);
         });
@@ -2423,7 +2423,7 @@ describe('Test plot api', function() {
                 reversescl: false
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].reversescale).toBe(true);
             expect(gd.data[0].reversescl).not.toBe(undefined);
         });
@@ -2434,7 +2434,7 @@ describe('Test plot api', function() {
                 colorscale: 'YIGnBu'
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].colorscale).toBe('YlGnBu');
         });
 
@@ -2444,7 +2444,7 @@ describe('Test plot api', function() {
                 marker: { colorscale: 'YIGnBu' }
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].marker.colorscale).toBe('YlGnBu');
         });
 
@@ -2454,7 +2454,7 @@ describe('Test plot api', function() {
                 colorscale: 'YIOrRd'
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].colorscale).toBe('YlOrRd');
         });
 
@@ -2464,7 +2464,7 @@ describe('Test plot api', function() {
                 marker: { colorscale: 'YIOrRd' }
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
             expect(gd.data[0].marker.colorscale).toBe('YlOrRd');
         });
 
@@ -2491,7 +2491,7 @@ describe('Test plot api', function() {
 
             spyOn(Plots.subplotsRegistry.gl3d, 'plot');
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
 
             expect(Plots.subplotsRegistry.gl3d.plot).toHaveBeenCalled();
 
@@ -2520,7 +2520,7 @@ describe('Test plot api', function() {
 
             spyOn(Plots.subplotsRegistry.gl3d, 'plot');
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
 
             expect(Plots.subplotsRegistry.gl3d.plot).toHaveBeenCalled();
 
@@ -2550,7 +2550,7 @@ describe('Test plot api', function() {
                 }]
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
 
             var trace0 = gd.data[0];
             var trace1 = gd.data[1];
@@ -2580,7 +2580,7 @@ describe('Test plot api', function() {
                 }]
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
 
             var trace0 = gd.data[0];
             var trace1 = gd.data[1];
@@ -2609,7 +2609,7 @@ describe('Test plot api', function() {
                 ]
             };
 
-            Plotly.plot(gd, data, layout);
+            Plotly.newPlot(gd, data, layout);
 
             expect(gd.layout.annotations[0]).toEqual({ xref: 'paper', yref: 'paper' });
             expect(gd.layout.annotations[1]).toEqual(null);
@@ -2674,7 +2674,7 @@ describe('Test plot api', function() {
                 name: 'Emmenthaler'
             }];
 
-            Plotly.plot(gd, data);
+            Plotly.newPlot(gd, data);
 
             // Even if both showlegends are false, leave trace.showlegend out
             // My rationale for this is that legends are sufficiently different
@@ -2724,7 +2724,7 @@ describe('Test plot api', function() {
             }];
             var height = 50;
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 return Plotly.newPlot(gd, data, { height: height });
             })
             .then(function() {
@@ -2750,7 +2750,7 @@ describe('Test plot api', function() {
                 };
             }
 
-            Plotly.plot(gd, data)
+            Plotly.newPlot(gd, data)
             .then(_assert('base'))
             .then(function() { return Plotly.newPlot(gd, data); })
             .then(_assert('after newPlot()'))
@@ -2784,7 +2784,7 @@ describe('Test plot api', function() {
             });
 
             gd = createGraphDiv();
-            Plotly.plot(gd, [{ y: [2, 1, 2] }]).then(function() {
+            Plotly.newPlot(gd, [{ y: [2, 1, 2] }]).then(function() {
                 data = gd.data;
                 layout = gd.layout;
                 calcdata = gd.calcdata;

--- a/test/jasmine/tests/plot_interact_test.js
+++ b/test/jasmine/tests/plot_interact_test.js
@@ -54,7 +54,7 @@ describe('Test plot structure', function() {
                 var mockData = Lib.extendDeep([], mock.data);
                 var mockLayout = Lib.extendDeep({}, mock.layout);
 
-                Plotly.plot(gd, mockData, mockLayout).then(done);
+                Plotly.newPlot(gd, mockData, mockLayout).then(done);
             });
 
             it('has one *subplot xy* node', function() {
@@ -199,7 +199,7 @@ describe('Test plot structure', function() {
                     var mockCopy = extendMock();
                     var gd = createGraphDiv();
 
-                    Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+                    Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                         .then(done);
                 });
 
@@ -228,7 +228,7 @@ describe('Test plot structure', function() {
                     var mockCopy = extendMock();
                     var gd = createGraphDiv();
 
-                    Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+                    Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                     .then(function() {
                         return Plotly.restyle(gd, {
                             type: 'scatter',
@@ -274,7 +274,7 @@ describe('Test plot structure', function() {
                     gd = createGraphDiv();
 
                     var mockCopy = extendMock();
-                    Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+                    Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                         .then(done);
                 });
 
@@ -408,7 +408,7 @@ describe('Test plot structure', function() {
                 var mockData = Lib.extendDeep([], mock.data);
                 var mockLayout = Lib.extendDeep({}, mock.layout);
 
-                Plotly.plot(gd, mockData, mockLayout).then(done);
+                Plotly.newPlot(gd, mockData, mockLayout).then(done);
             });
 
             it('has as many *slice* nodes as there are pie items', function() {
@@ -472,7 +472,7 @@ describe('Test plot structure', function() {
         var mock = require('@mocks/geo_first.json');
 
         beforeEach(function(done) {
-            Plotly.plot(createGraphDiv(), mock.data, mock.layout).then(done);
+            Plotly.newPlot(createGraphDiv(), mock.data, mock.layout).then(done);
         });
 
         it('has as many *choroplethlocation* nodes as there are choropleth locations', function() {
@@ -520,7 +520,7 @@ describe('Test plot structure', function() {
 describe('plot svg clip paths', function() {
     // plot with all features that rely on clip paths
     function plot() {
-        return Plotly.plot(createGraphDiv(), [{
+        return Plotly.newPlot(createGraphDiv(), [{
             type: 'contour',
             z: [[1, 2, 3], [2, 3, 1]]
         }, {

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -330,7 +330,7 @@ describe('Test Plots', function() {
             beforeAll(function(done) {
                 gd = createGraphDiv();
 
-                Plotly.plot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }])
+                Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }])
                     .then(function() {
                         gd.style.width = '400px';
                         gd.style.height = '400px';
@@ -410,7 +410,7 @@ describe('Test Plots', function() {
                     }
                 }
 
-                Plotly.plot(gd, [], {})
+                Plotly.newPlot(gd, [], {})
                     .then(function() { _assert({l: 74, r: 74, t: 82, b: 66}); })
                     .then(function() { return Plotly.Plots.resize(gd); })
                     .then(function() { _assert({l: 74, r: 74, t: 82, b: 66}); })
@@ -450,7 +450,7 @@ describe('Test Plots', function() {
 
         beforeEach(function(done) {
             gd = createGraphDiv();
-            Plotly.plot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], {}).then(done);
+            Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], {}).then(done);
 
             // hacky: simulate getting stuck with these flags due to an error
             // see #2055 and commit 6a44a9a - before fixing that error, we would
@@ -599,7 +599,7 @@ describe('Test Plots', function() {
                 }]
             };
 
-            Plotly.plot(gd, mock).then(function() {
+            Plotly.newPlot(gd, mock).then(function() {
                 var str = Plots.graphJson(gd, false, 'keepdata');
                 var obj = JSON.parse(str);
 
@@ -634,7 +634,7 @@ describe('Test Plots', function() {
                 }
             };
 
-            Plotly.plot(gd, [trace]).then(function() {
+            Plotly.newPlot(gd, [trace]).then(function() {
                 var str = Plots.graphJson(gd, false, 'keepdata');
                 var obj = JSON.parse(str);
 
@@ -773,7 +773,7 @@ describe('Test Plots', function() {
         });
 
         it('should handle cases when module plot is not set (geo case)', function(done) {
-            Plotly.plot(createGraphDiv(), [{
+            Plotly.newPlot(createGraphDiv(), [{
                 type: 'scattergeo',
                 visible: false,
                 lon: [10, 20],
@@ -793,7 +793,7 @@ describe('Test Plots', function() {
         });
 
         it('should handle cases when module plot is not set (ternary case)', function(done) {
-            Plotly.plot(createGraphDiv(), [{
+            Plotly.newPlot(createGraphDiv(), [{
                 type: 'scatterternary',
                 visible: false,
                 a: [0.1, 0.2],
@@ -825,7 +825,7 @@ describe('Test Plots', function() {
         it('should call reused style modules only once per graph', function(done) {
             var Drawing = require('@src/components/drawing');
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 mode: 'markers',
                 y: [1, 2, 1]
             }, {
@@ -973,7 +973,7 @@ describe('Test Plots', function() {
         });
 
         it('ignores unused axis and subplot objects', function(done) {
-            Plotly.plot('graph', [{
+            Plotly.newPlot('graph', [{
                 type: 'pie',
                 values: [1]
             }], {

--- a/test/jasmine/tests/pointcloud_test.js
+++ b/test/jasmine/tests/pointcloud_test.js
@@ -158,7 +158,7 @@ describe('pointcloud traces', function() {
     });
 
     it('@gl renders without raising an error', function(done) {
-        Plotly.plot(gd, Lib.extendDeep({}, plotData))
+        Plotly.newPlot(gd, Lib.extendDeep({}, plotData))
         .catch(failTest)
         .then(done);
     });
@@ -166,7 +166,7 @@ describe('pointcloud traces', function() {
     it('@gl should update properly', function(done) {
         var scene2d;
 
-        Plotly.plot(gd, Lib.extendDeep({}, plotData))
+        Plotly.newPlot(gd, Lib.extendDeep({}, plotData))
         .then(function() {
             scene2d = gd._fullLayout._plots.xy._scene2d;
             expect(scene2d.traces[gd._fullData[0].uid].type).toBe('pointcloud');
@@ -194,7 +194,7 @@ describe('pointcloud traces', function() {
 
     it('@gl should not change other traces colors', function(done) {
         var _mock = Lib.extendDeep({}, multipleScatter2dMock);
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             var canvas = d3.select('.gl-canvas-context').node();
@@ -224,7 +224,7 @@ describe('pointcloud traces', function() {
             expect(gd._fullLayout.yaxis.range).toBeCloseToArray(yrng, 2, msg);
         }
 
-        Plotly.plot(gd, Lib.extendDeep({}, plotData))
+        Plotly.newPlot(gd, Lib.extendDeep({}, plotData))
         .then(delay(20))
         .then(function() {
             _assertRange('base', [-0.548, 9.548], [-1.415, 10.415]);

--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -51,7 +51,7 @@ describe('Test legacy polar plots logs:', function() {
 
     specs.forEach(function(s) {
         it('should log deprecation warning on ' + s.name, function(done) {
-            Plotly.plot(gd, s.data)
+            Plotly.newPlot(gd, s.data)
             .then(function() {
                 expect(Lib.log).toHaveBeenCalledTimes(1);
                 expect(Lib.log).toHaveBeenCalledWith('Legacy polar charts are deprecated!');
@@ -284,7 +284,7 @@ describe('Test relayout on polar subplots:', function() {
             });
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert(dflt);
             return Plotly.relayout(gd, 'polar.radialaxis.layer', 'below traces');
         })
@@ -328,7 +328,7 @@ describe('Test relayout on polar subplots:', function() {
         var gd = createGraphDiv();
         var fig = Lib.extendDeep({}, require('@mocks/polar_scatter.json'));
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             expect(gd._fullLayout.polar._subplot.viewInitial['radialaxis.range'])
                 .toBeCloseToArray([0, 11.225]);
             expect(gd._fullLayout.polar.radialaxis.range)
@@ -360,7 +360,7 @@ describe('Test relayout on polar subplots:', function() {
         var pos0 = [];
         var pos1 = [];
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             d3.selectAll('.angularaxistick > text').each(function() {
                 var tx = d3.select(this);
                 pos0.push([tx.attr('x'), tx.attr('y')]);
@@ -393,7 +393,7 @@ describe('Test relayout on polar subplots:', function() {
             });
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             check(8, 'M1.5,0h5');
             return Plotly.relayout(gd, 'polar.angularaxis.ticks', 'inside');
         })
@@ -451,7 +451,7 @@ describe('Test relayout on polar subplots:', function() {
             };
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(toggle(
             'polar.radialaxis.showline',
             [true, false], [null, 'none'],
@@ -516,7 +516,7 @@ describe('Test relayout on polar subplots:', function() {
             lastBBox = newBBox;
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             r: [1, 2, 3],
             theta: [10, 20, 30]
@@ -569,7 +569,7 @@ describe('Test relayout on polar subplots:', function() {
             expect(clipCnt).toBe(exp.clip, '# clip paths');
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert({subplot: 1, clip: 1, rtitle: 1});
 
             return Plotly.deleteTraces(gd, inds);
@@ -607,7 +607,7 @@ describe('Test relayout on polar subplots:', function() {
                 .toBeCloseToArray(exp.sampleXY, -1, 'sample (x,y) px coords in calcdata - ' + msg);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             r: [39, 28, 8, 7, 28, 39, 40, 30, 30, 30, 30],
             theta: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'A']
@@ -664,7 +664,7 @@ describe('Test relayout on polar subplots:', function() {
             assertLetterCount('.angular-line > path');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             r: [1, 2, 3, 2, 3, 1],
             theta: ['a', 'b', 'c', 'd', 'e', 'a']
@@ -700,7 +700,7 @@ describe('Test relayout on polar subplots:', function() {
             });
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             r: ['a', 'b', 'c']
         }])
@@ -1322,7 +1322,7 @@ describe('Test polar interactions:', function() {
             }
 
             var gd = createGraphDiv();
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 gd.on('plotly_relayout', function(e) {
                     relayoutEvents.push(e);
@@ -1356,7 +1356,7 @@ describe('Test polar interactions:', function() {
             }
 
             var gd = createGraphDiv();
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 gd.on('plotly_relayout', function(e) {
                     relayoutEvents.push(e);
@@ -1390,7 +1390,7 @@ describe('Test polar interactions:', function() {
             var dragPos0 = [360, 180];
 
             var gd = createGraphDiv();
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 gd.on('plotly_relayout', function(e) {
                     relayoutEvents.push(e);
@@ -1441,7 +1441,7 @@ describe('Test polar *gridshape linear* interactions', function() {
                 .toBeCloseTo(angle, 1, msg + ' - angle');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             // octogons have nice angles
             r: [1, 2, 3, 2, 3, 1, 2, 1, 2],
@@ -1506,7 +1506,7 @@ describe('Test polar *gridshape linear* interactions', function() {
             .then(dragFns.end);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             r: [1, 2, 3, 2, 3],
             theta: ['a', 'b', 'c', 'd', 'e']
@@ -1582,7 +1582,7 @@ describe('Test polar *gridshape linear* interactions', function() {
             .then(dragFns.end);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             r: [1, 2, 3, 2, 3],
             theta: ['a', 'b', 'c', 'd', 'e']

--- a/test/jasmine/tests/range_selector_test.js
+++ b/test/jasmine/tests/range_selector_test.js
@@ -466,7 +466,7 @@ describe('range selector interactions:', function() {
         gd = createGraphDiv();
         mockCopy = Lib.extendDeep({}, mock);
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
         .then(done);
     });
 
@@ -634,7 +634,7 @@ describe('range selector automargin', function() {
             margin: {l: 50, r: 50, t: 100, b: 100}
         }});
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
         .then(done);
     });
 

--- a/test/jasmine/tests/range_slider_test.js
+++ b/test/jasmine/tests/range_slider_test.js
@@ -50,7 +50,7 @@ describe('Visible rangesliders', function() {
     function plotMock() {
         var mockCopy = Lib.extendDeep({}, mock);
 
-        return Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        return Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             var bb = getRangeSlider().getBoundingClientRect();
             sliderY = bb.top + bb.height / 2;
             expect(sliderY).toBeCloseTo(387, -1);
@@ -239,7 +239,7 @@ describe('Visible rangesliders', function() {
         var start = 250;
         var end = 300;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'lines',
             x: [
                 '1970-01-01 00:00:00.000',
@@ -454,7 +454,7 @@ describe('Visible rangesliders', function() {
             expect(gd._fullLayout._size.b).toBeWithin(val, 10);
         }
 
-        Plotly.plot(gd, topMock)
+        Plotly.newPlot(gd, topMock)
         .then(function() {
             assertTop(true);
             return Plotly.relayout(gd, 'xaxis.range', [-0.5, 1.5]);
@@ -503,7 +503,7 @@ describe('Rangeslider visibility property', function() {
     }
 
     it('should not add the slider to the DOM by default', function(done) {
-        Plotly.plot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], defaultLayout())
+        Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], defaultLayout())
         .then(function() {
             var rangeSlider = getRangeSlider();
             expect(rangeSlider).not.toBeDefined();
@@ -514,7 +514,7 @@ describe('Rangeslider visibility property', function() {
     });
 
     it('should add the slider if rangeslider is set to anything', function(done) {
-        Plotly.plot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], defaultLayout())
+        Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], defaultLayout())
         .then(function() {
             return Plotly.relayout(gd, 'xaxis.rangeslider', 'exists');
         })
@@ -528,7 +528,7 @@ describe('Rangeslider visibility property', function() {
     });
 
     it('should add the slider if visible changed to `true`', function(done) {
-        Plotly.plot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], defaultLayout())
+        Plotly.newPlot(gd, [{ x: [1, 2, 3], y: [2, 3, 4] }], defaultLayout())
         .then(function() {
             return Plotly.relayout(gd, 'xaxis.rangeslider.visible', true);
         })
@@ -543,7 +543,7 @@ describe('Rangeslider visibility property', function() {
     });
 
     it('should remove the slider if changed to `false` or `undefined`', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3],
             y: [2, 3, 4]
         }], defaultLayout({
@@ -569,7 +569,7 @@ describe('Rangeslider visibility property', function() {
             return d3.select(getRangeSlider()).selectAll(query).size();
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter',
             x: [1, 2, 3],
             y: [2, 1, 2]
@@ -922,7 +922,7 @@ describe('rangesliders in general', function() {
     }
 
     it('should plot when only x data is provided', function(done) {
-        Plotly.plot(gd, [{ x: [1, 2, 3] }], { xaxis: { rangeslider: {} }})
+        Plotly.newPlot(gd, [{ x: [1, 2, 3] }], { xaxis: { rangeslider: {} }})
         .then(function() {
             var rangeSlider = getRangeSlider();
 
@@ -933,7 +933,7 @@ describe('rangesliders in general', function() {
     });
 
     it('should plot when only y data is provided', function(done) {
-        Plotly.plot(gd, [{ y: [1, 2, 3] }], { xaxis: { rangeslider: {} }})
+        Plotly.newPlot(gd, [{ y: [1, 2, 3] }], { xaxis: { rangeslider: {} }})
         .then(function() {
             var rangeSlider = getRangeSlider();
 
@@ -944,7 +944,7 @@ describe('rangesliders in general', function() {
     });
 
     it('should expand its range in accordance with new data arrays', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [2, 1, 2]
         }], {
             xaxis: { rangeslider: {} }
@@ -977,7 +977,7 @@ describe('rangesliders in general', function() {
     });
 
     it('should not expand its range when range slider range is set', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [2, 1, 2]
         }], {
             xaxis: { rangeslider: { range: [-1, 11] } }
@@ -1031,7 +1031,7 @@ describe('rangesliders in general', function() {
     });
 
     it('should configure yaxis opts on relayout', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [2, 1, 2]
         }], {
             xaxis: { rangeslider: { yaxis: { range: [-10, 20] } } }
@@ -1058,7 +1058,7 @@ describe('rangesliders in general', function() {
     });
 
     it('should update rangeslider x/y ranges when data changes even if main axes are not autoranged', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             // use a heatmap because it doesn't add any padding
             x0: 0, dx: 1,
             y0: 1, dy: 1,
@@ -1086,7 +1086,7 @@ describe('rangesliders in general', function() {
     });
 
     it('should be able to turn on rangeslider x/y autorange if initially specified', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             // use a heatmap because it doesn't add any padding
             x0: 0, dx: 1,
             y0: 1, dy: 1,
@@ -1121,7 +1121,7 @@ describe('rangesliders in general', function() {
 
     it('should be able to turn on rangeslider x/y autorange implicitly by deleting x range', function(done) {
         // this does not apply to y ranges, because the default there is 'match'
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             // use a heatmap because it doesn't add any padding
             x0: 0, dx: 1,
             y0: 1, dy: 1,
@@ -1158,7 +1158,7 @@ describe('rangesliders in general', function() {
                 .toBeCloseToArray(exp.rangesliderRng, 1, 'rangeslider input rng ' + msg);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 1]
         }], {
             xaxis: { rangeslider: {visible: true} }

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -359,7 +359,7 @@ describe('sankey tests', function() {
             var mockCopy = Lib.extendDeep({}, mock);
             var mockCopy2 = Lib.extendDeep({}, mockDark);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
                 .then(function() {
                     expect(gd.data.length).toEqual(1);
                     expect(d3.selectAll('.sankey').size()).toEqual(1);
@@ -385,7 +385,7 @@ describe('sankey tests', function() {
 
         it('Plotly.deleteTraces removes draggers', function(done) {
             var mockCopy = Lib.extendDeep({}, mock);
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
                 .then(function() {
                     expect(document.getElementsByClassName('bgsankey').length).toBe(1);
                     return Plotly.deleteTraces(gd, [0]);
@@ -397,10 +397,10 @@ describe('sankey tests', function() {
                 .then(done);
         });
 
-        it('Plotly.plot does not show Sankey if \'visible\' is false', function(done) {
+        it('Plotly.newPlot does not show Sankey if \'visible\' is false', function(done) {
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
                 .then(function() {
                     expect(gd.data.length).toEqual(1);
                     expect(d3.selectAll('.sankey').size()).toEqual(1);
@@ -431,7 +431,7 @@ describe('sankey tests', function() {
                     value: [1000000, 0.001]
                 }
             }];
-            Plotly.plot(gd, minimock)
+            Plotly.newPlot(gd, minimock)
                 .then(function() {
                     expect(d3.selectAll('.sankey .node-rect')[0].reduce(function(prevMin, rect) {
                         return Math.min(prevMin, d3.select(rect).attr('height'));
@@ -445,7 +445,7 @@ describe('sankey tests', function() {
             var mockCopy = Lib.extendDeep({}, mock);
             var mockCircularCopy = Lib.extendDeep({}, mockCircular);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
               .then(function() {
                   expect(gd.calcdata[0][0].circular).toBe(false);
                   return Plotly.react(gd, mockCircularCopy);
@@ -460,7 +460,7 @@ describe('sankey tests', function() {
         it('switch from circular to normal Sankey on react', function(done) {
             var mockCircularCopy = Lib.extendDeep({}, mockCircular);
 
-            Plotly.plot(gd, mockCircularCopy)
+            Plotly.newPlot(gd, mockCircularCopy)
               .then(function() {
                   expect(gd.calcdata[0][0].circular).toBe(true);
 
@@ -488,7 +488,7 @@ describe('sankey tests', function() {
             var newGroup = [[2, 3]];
             mockCircularCopy.data[0].node.groups = firstGroup;
 
-            Plotly.plot(gd, mockCircularCopy)
+            Plotly.newPlot(gd, mockCircularCopy)
               .then(function() {
                   expect(gd._fullData[0].node.groups).toEqual(firstGroup);
                   return Plotly.restyle(gd, {'node.groups': [newGroup]});
@@ -524,7 +524,7 @@ describe('sankey tests', function() {
         it('switches from normal to circular Sankey on grouping', function(done) {
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
               .then(function() {
                   expect(gd.calcdata[0][0].circular).toBe(false);
 
@@ -554,7 +554,7 @@ describe('sankey tests', function() {
 
             var mockCopy = Lib.extendDeep({}, mockXY);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
             .then(function() {
                 // Nodes overlap
                 expect(checkElementOverlap(3, 6)).toBeTruthy('nodes do not overlap');
@@ -580,7 +580,7 @@ describe('sankey tests', function() {
             mockCopy.data[0].node.groups = [];
             mockCopy.data[1].node.groups = [[2, 3]];
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
             .then(function() {
                 expect(gd._fullData[0].node.groups).toEqual([]);
                 expect(gd._fullData[1].node.groups).toEqual([[2, 3]]);
@@ -623,7 +623,7 @@ describe('sankey tests', function() {
                 y: [5, 1, 4, 3, 2]
             };
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
             .catch(failTest)
             .then(done);
         });
@@ -635,7 +635,7 @@ describe('sankey tests', function() {
                 var mockCopy = Lib.extendDeep({}, mockCircular);
                 mockCopy.layout.uirevision = uirevisions[0];
 
-                Plotly.plot(gd, mockCopy)
+                Plotly.newPlot(gd, mockCopy)
                       .then(function() {
                           // Create a group via guiRestyle
                           return Registry.call('_guiRestyle', gd, 'node.groups', [[[0, 1]]]);
@@ -687,7 +687,7 @@ describe('sankey tests', function() {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy).then(function() {
+            Plotly.newPlot(gd, mockCopy).then(function() {
                 _hover(404, 302);
 
                 assertLabel(
@@ -787,7 +787,7 @@ describe('sankey tests', function() {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
             .then(function() {
                 _hover(900, 230);
 
@@ -827,7 +827,7 @@ describe('sankey tests', function() {
             mockCopy.data[0].link.customdata = [];
             mockCopy.data[0].link.customdata[61] = ['linkCustomdata0', 'linkCustomdata1'];
 
-            Plotly.plot(gd, mockCopy).then(function() {
+            Plotly.newPlot(gd, mockCopy).then(function() {
                 _hover(404, 302);
 
                 assertLabel(
@@ -902,7 +902,7 @@ describe('sankey tests', function() {
                 }
             };
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
             .then(function() {
                 _hover(404, 302);
 
@@ -928,7 +928,7 @@ describe('sankey tests', function() {
             var mockCopy = Lib.extendDeep({}, mock);
             delete mockCopy.data[0].link.label;
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
                 .then(function() {
                     _hover(450, 300);
 
@@ -944,7 +944,7 @@ describe('sankey tests', function() {
         it('should show the multiple hover labels in a flow in hovermode `x`', function(done) {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
-            Plotly.plot(gd, mockCopy).then(function() {
+            Plotly.newPlot(gd, mockCopy).then(function() {
                 _hover(351, 202);
 
                 assertLabel(
@@ -986,7 +986,7 @@ describe('sankey tests', function() {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy).then(function() {
+            Plotly.newPlot(gd, mockCopy).then(function() {
                 return Plotly.relayout(gd, 'hovermode', false);
             })
             .then(function() {
@@ -1006,7 +1006,7 @@ describe('sankey tests', function() {
                 var gd = createGraphDiv();
                 var mockCopy = Lib.extendDeep({}, mock);
 
-                Plotly.plot(gd, mockCopy).then(function() {
+                Plotly.newPlot(gd, mockCopy).then(function() {
                     return Plotly.restyle(gd, 'node.hoverinfo', hoverinfoFlag);
                 })
                 .then(function() {
@@ -1023,7 +1023,7 @@ describe('sankey tests', function() {
                 var gd = createGraphDiv();
                 var mockCopy = Lib.extendDeep({}, mock);
 
-                Plotly.plot(gd, mockCopy).then(function() {
+                Plotly.newPlot(gd, mockCopy).then(function() {
                     return Plotly.restyle(gd, 'link.hoverinfo', hoverinfoFlag);
                 })
                 .then(function() {
@@ -1040,7 +1040,7 @@ describe('sankey tests', function() {
                 var gd = createGraphDiv();
                 var mockCopy = Lib.extendDeep({}, mock);
 
-                Plotly.plot(gd, mockCopy).then(function() {
+                Plotly.newPlot(gd, mockCopy).then(function() {
                     return Plotly.restyle(gd, 'hoverinfo', hoverinfoFlag);
                 })
                 .then(function() {
@@ -1060,7 +1060,7 @@ describe('sankey tests', function() {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy).then(function() {
+            Plotly.newPlot(gd, mockCopy).then(function() {
                 return Plotly.restyle(gd, 'link.hoverinfo', 'skip');
             })
             .then(function() {
@@ -1075,7 +1075,7 @@ describe('sankey tests', function() {
             var gd = createGraphDiv();
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy)
+            Plotly.newPlot(gd, mockCopy)
             .then(function() { _hover(404, 302); })
             .then(function() {
                 assertHoverLabelContent({
@@ -1153,7 +1153,7 @@ describe('sankey tests', function() {
         it('should output correct click event data', function(done) {
             var fig = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() { return _click('node'); })
             .then(function(d) {
                 _assert(d, {
@@ -1177,7 +1177,7 @@ describe('sankey tests', function() {
         it('should output correct hover/unhover event data', function(done) {
             var fig = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() { return Plotly.restyle(gd, 'hoverinfo', 'none'); })
             .then(function() { return _hover('node'); })
             .then(function(d) {
@@ -1245,7 +1245,7 @@ describe('sankey tests', function() {
         it('should not output hover/unhover event data when hovermode is false', function(done) {
             var fig = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() { return Plotly.relayout(gd, 'hovermode', false); })
             .then(assertNoHoverEvents('node'))
             .then(assertNoHoverEvents('link'))
@@ -1256,7 +1256,7 @@ describe('sankey tests', function() {
         it('should not output hover/unhover event data when trace hoverinfo is skip', function(done) {
             var fig = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() { return Plotly.restyle(gd, 'hoverinfo', 'skip'); })
             .then(assertNoHoverEvents('link'))
             .then(assertNoHoverEvents('node'))
@@ -1267,7 +1267,7 @@ describe('sankey tests', function() {
         it('should not output hover/unhover event data when link.hoverinfo is skip', function(done) {
             var fig = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
                   .then(function() { return Plotly.restyle(gd, 'link.hoverinfo', 'skip'); })
                   .then(assertNoHoverEvents('link'))
                   .catch(failTest)
@@ -1277,7 +1277,7 @@ describe('sankey tests', function() {
         it('@noCI should not output hover/unhover event data when node.hoverinfo is skip', function(done) {
             var fig = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
                   .then(function() { return Plotly.restyle(gd, 'node.hoverinfo', 'skip'); })
                   .then(assertNoHoverEvents('node'))
                   .catch(failTest)
@@ -1424,7 +1424,7 @@ describe('sankey tests', function() {
                     var mockCopy = Lib.extendDeep({}, mockCircularFreeform);
                     mockCopy.layout.uirevision = uirevisions[0];
 
-                    Plotly.plot(gd, mockCopy)
+                    Plotly.newPlot(gd, mockCopy)
                       .then(function() {
                           // move a node around
                           nodes = document.getElementsByClassName('sankey-node');
@@ -1482,7 +1482,7 @@ describe('sankey tests', function() {
         spyOn(Lib, 'warn').and.callFake(function(msg) {
             warnings.push(msg);
         });
-        Plotly.plot(gd, mockCopy).then(function() {
+        Plotly.newPlot(gd, mockCopy).then(function() {
             expect(warnings.length).toEqual(0);
 
             return Plotly.restyle(gd, 'node.pad', 50);

--- a/test/jasmine/tests/scatter3d_test.js
+++ b/test/jasmine/tests/scatter3d_test.js
@@ -127,7 +127,7 @@ describe('Test scatter3d interactions:', function() {
         var _mock = Lib.extendDeep({}, mock2);
         var sceneLayout = { aspectratio: { x: 1, y: 1, z: 1 } };
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             expect(countCanvases()).toEqual(1);
@@ -165,7 +165,7 @@ describe('Test scatter3d interactions:', function() {
     it('@gl should be able to delete the last trace', function(done) {
         var _mock = Lib.extendDeep({}, mock2);
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             return Plotly.deleteTraces(gd, [0]);
@@ -205,7 +205,7 @@ describe('Test scatter3d interactions:', function() {
             expect(actual).toEqual(expected);
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             assertObjects(order0);
@@ -249,7 +249,7 @@ describe('Test scatter3d interactions:', function() {
             var fullLayout = gd._fullLayout;
             expect(fullLayout.scene._scene.glplot.objects[0].glyphBuffer.length).not.toBe(0, msg);
         }
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             mode: 'text',
             x: [1, 2, 3],
@@ -266,7 +266,7 @@ describe('Test scatter3d interactions:', function() {
     it('@gl should avoid passing empty lines to webgl', function(done) {
         var obj;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             mode: 'lines',
             x: [1],
@@ -292,7 +292,7 @@ describe('Test scatter3d interactions:', function() {
     });
 
     it('@gl should only accept texts for textposition otherwise textposition is set to middle center before passing to webgl', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatter3d',
             mode: 'markers+text+lines',
             x: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -658,7 +658,7 @@ describe('end-to-end scatter tests', function() {
     afterEach(destroyGraphDiv);
 
     it('should add a plotly-customdata class to points with custom data', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3, 4, 5, 6, 7],
             y: [2, 3, 4, 5, 6, 7, 8],
             customdata: [null, undefined, 0, false, {foo: 'bar'}, 'a']
@@ -687,7 +687,7 @@ describe('end-to-end scatter tests', function() {
     });
 
     it('adds "textpoint" class to scatter text points', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'text',
             x: [1, 2, 3],
             y: [2, 3, 4],
@@ -710,7 +710,7 @@ describe('end-to-end scatter tests', function() {
             });
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [150, 350, 650],
             y: [100, 300, 600],
             text: ['A', 'B', 'C'],
@@ -778,7 +778,7 @@ describe('end-to-end scatter tests', function() {
         // from any case to any other case.
         var indices = transitions(cases.length);
 
-        var p = Plotly.plot(gd, [
+        var p = Plotly.newPlot(gd, [
             {y: [1, 2], text: 'a'},
             {y: [2, 3], text: 'b'},
             {y: [3, 4], text: 'c'}
@@ -856,7 +856,7 @@ describe('end-to-end scatter tests', function() {
     }
 
     it('should reorder point and text nodes even when linked to ids (shuffle case)', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [150, 350, 650],
             y: [100, 300, 600],
             text: ['apple', 'banana', 'clementine'],
@@ -898,7 +898,7 @@ describe('end-to-end scatter tests', function() {
     });
 
     it('should reorder point and text nodes even when linked to ids (add/remove case)', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [150, 350, null, 600],
             y: [100, 300, null, 700],
             text: ['apple', 'banana', null, 'clementine'],
@@ -942,7 +942,7 @@ describe('end-to-end scatter tests', function() {
     });
 
     it('should smoothly add/remove nodes tags with *ids* during animations', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 mode: 'markers+text',
                 y: [1, 2, 1],
@@ -982,7 +982,7 @@ describe('end-to-end scatter tests', function() {
             return d3.selectAll('.js-fill').node().style.fill;
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3, 4, 5, 6, 7],
             y: [2, 3, 4, 5, 6, 7, 8],
             fill: 'tozeroy',
@@ -1143,7 +1143,7 @@ describe('end-to-end scatter tests', function() {
         expect(schema.layout.layoutAttributes.xaxis.autorange.editType)
             .toBe('axrange', 'ax autorange editType');
 
-        Plotly.plot(gd, [{ y: [1, 2, 1] }])
+        Plotly.newPlot(gd, [{ y: [1, 2, 1] }])
         .then(function() {
             assertAxisRanges('auto rng / base marker.size', [-0.13, 2.13], [0.93, 2.07]);
             return Plotly.relayout(gd, {
@@ -1174,7 +1174,7 @@ describe('end-to-end scatter tests', function() {
     });
 
     it('should update axis range according to visible edits', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {x: [1, 2, 3], y: [1, 2, 1]},
             {x: [4, 5, 6], y: [-1, -2, -1]}
         ])
@@ -1207,7 +1207,7 @@ describe('end-to-end scatter tests', function() {
             expect(layer.selectAll('.point').size()).toBe(cnt, msg + '- scatter pts cnt');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             visible: false,
             y: [1, 2, 1]
         }])
@@ -1227,7 +1227,7 @@ describe('end-to-end scatter tests', function() {
     });
 
     it('should not error out when segment-less marker-less fill traces', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3, 4],
             y: [null, null, null, null],
             fill: 'tonexty'
@@ -1453,7 +1453,7 @@ describe('scatter hoverPoints', function() {
         var gd = createGraphDiv();
         var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
 
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             var pts = _hover(gd, 0, 1, 'x');
 
             // as in 'hovertext' arrays
@@ -1548,7 +1548,7 @@ describe('Test Scatter.style', function() {
     it('should style selected point marker opacity correctly', function(done) {
         var check = makeCheckFn('marker.opacity', getOpacity);
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             y: [1, 2, 1],
             marker: {opacity: 0.6}
@@ -1628,7 +1628,7 @@ describe('Test Scatter.style', function() {
         var check = makeCheckFn('marker.color', getColor);
         var checkOpacity = makeCheckFn('marker.opacity', getOpacity);
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             y: [1, 2, 1],
             marker: {color: b}
@@ -1714,7 +1714,7 @@ describe('Test Scatter.style', function() {
     it('should style selected point marker size correctly', function(done) {
         var check = makeCheckFn('marker.size', getMarkerSize);
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             y: [1, 2, 1],
             marker: {size: 20}
@@ -1760,7 +1760,7 @@ describe('Test Scatter.style', function() {
         var checkFontOpacity = makeCheckFn('textfont.color (alpha channel)', getFillOpacity);
         var checkPtOpacity = makeCheckFn('marker.opacity', getOpacity);
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers+text',
             y: [1, 2, 1],
             text: 'TEXT',
@@ -1899,7 +1899,7 @@ describe('Test scatter *clipnaxis*:', function() {
             );
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             _assert(
                 [false, true, false],

--- a/test/jasmine/tests/scattergeo_test.js
+++ b/test/jasmine/tests/scattergeo_test.js
@@ -308,7 +308,7 @@ describe('Test scattergeo hover', function() {
     beforeEach(function(done) {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergeo',
             lon: [10, 20, 30],
             lat: [10, 20, 30],

--- a/test/jasmine/tests/scattergl_select_test.js
+++ b/test/jasmine/tests/scattergl_select_test.js
@@ -87,7 +87,7 @@ describe('Test gl2d lasso/select:', function() {
         _mock.layout.dragmode = 'select';
         gd = createGraphDiv();
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             expect(gd._fullLayout._plots.xy._scene.select2d).not.toBe(undefined, 'scatter2d renderer');
@@ -113,7 +113,7 @@ describe('Test gl2d lasso/select:', function() {
         _mock.layout.dragmode = 'lasso';
         gd = createGraphDiv();
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             return select(gd, lassoPath2);
@@ -137,7 +137,7 @@ describe('Test gl2d lasso/select:', function() {
         _mock.layout.dragmode = 'select';
         gd = createGraphDiv();
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             return select(gd, selectPath2);
@@ -157,7 +157,7 @@ describe('Test gl2d lasso/select:', function() {
         _mock.layout.dragmode = 'lasso';
         gd = createGraphDiv();
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(20))
         .then(function() {
             return select(gd, lassoPath);
@@ -179,7 +179,7 @@ describe('Test gl2d lasso/select:', function() {
         fig.layout.width = 500;
         gd = createGraphDiv();
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(delay(20))
         .then(function() { return select(gd, [[100, 100], [250, 250]]); })
         .then(function(eventData) {
@@ -210,7 +210,7 @@ describe('Test gl2d lasso/select:', function() {
             });
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(delay(20))
         .then(function() {
             _assertGlTextOpts('base', {
@@ -293,7 +293,7 @@ describe('Test gl2d lasso/select:', function() {
             });
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(delay(20))
         .then(function() {
             _assertGlTextOpts('base', {
@@ -388,7 +388,7 @@ describe('Test displayed selections:', function() {
 
         function readFocus() { return _read('.gl-canvas-focus'); }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             mode: 'markers',
             y: [2, 1, 2]
@@ -448,7 +448,7 @@ describe('Test displayed selections:', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(select(gd, [[160, 100], [180, 100]]))
         .then(function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 168, 100)[3]).toBe(0);
@@ -493,7 +493,7 @@ describe('Test displayed selections:', function() {
             }
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(select(gd, [[160, 100], [180, 100]]))
         .then(function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 168, 100)[3]).toBe(0);
@@ -855,7 +855,7 @@ describe('Test selections during funky scenarios', function() {
 
         var scene, scene2;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3],
             y: [40, 50, 60],
             type: 'scattergl',

--- a/test/jasmine/tests/scattergl_test.js
+++ b/test/jasmine/tests/scattergl_test.js
@@ -118,7 +118,7 @@ describe('end-to-end scattergl tests', function() {
                     'textposition': 'top center'
                 };
                 mock[attr] = ['1', '2', '3'];
-                Plotly.plot(gd, [mock])
+                Plotly.newPlot(gd, [mock])
                 .then(function() {
                     expect(mock[attr].length).toBe(3);
                 })
@@ -139,7 +139,7 @@ describe('end-to-end scattergl tests', function() {
             draw.calls.reset();
         }
 
-        Plotly.plot(gd, _mock)
+        Plotly.newPlot(gd, _mock)
         .then(delay(30))
         .then(function() {
             spyOn(gd._fullLayout._plots.xy._scene.scatter2d, 'draw');
@@ -219,7 +219,7 @@ describe('end-to-end scattergl tests', function() {
     });
 
     it('@gl should change plot type with incomplete data', function(done) {
-        Plotly.plot(gd, [{}])
+        Plotly.newPlot(gd, [{}])
         .then(function() {
             expect(function() {
                 return Plotly.restyle(gd, {type: 'scattergl', x: [[1]]}, 0);
@@ -245,7 +245,7 @@ describe('end-to-end scattergl tests', function() {
             'mode': 'markers'
         }];
 
-        Plotly.plot(gd, dat, {width: 500, height: 500})
+        Plotly.newPlot(gd, dat, {width: 500, height: 500})
         .then(function() {
             expect(ScatterGl.calc).toHaveBeenCalledTimes(1);
 
@@ -268,7 +268,7 @@ describe('end-to-end scattergl tests', function() {
             'selectedpoints': [0]
         }];
 
-        Plotly.plot(gd, dat, {
+        Plotly.newPlot(gd, dat, {
             width: 500,
             height: 500,
             dragmode: 'select'
@@ -348,7 +348,7 @@ describe('end-to-end scattergl tests', function() {
     it('@gl should remove fill2d', function(done) {
         var mock = require('@mocks/gl2d_axes_labels2.json');
 
-        Plotly.plot(gd, mock.data, mock.layout)
+        Plotly.newPlot(gd, mock.data, mock.layout)
         .then(delay(1000))
         .then(function() {
             expect(readPixel(gd.querySelector('.gl-canvas-context'), 100, 80)[0]).not.toBe(0);
@@ -408,7 +408,7 @@ describe('end-to-end scattergl tests', function() {
     });
 
     it('@gl should work with typed array', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             mode: 'markers',
             x: new Float32Array([1, 2, 3]),
@@ -441,7 +441,7 @@ describe('end-to-end scattergl tests', function() {
     it('@gl should handle transform traces properly (calcTransform case)', function(done) {
         spyOn(ScatterGl, 'calc').and.callThrough();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             x: [1, 2, 3],
             y: [1, 2, 1],
@@ -473,7 +473,7 @@ describe('end-to-end scattergl tests', function() {
     it('@gl should handle transform traces properly (default transform case)', function(done) {
         spyOn(ScatterGl, 'calc').and.callThrough();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             x: [1, 2, 3],
             y: [1, 2, 1],
@@ -511,7 +511,7 @@ describe('end-to-end scattergl tests', function() {
             expect(pos).toBeCloseTo2DArray(exp, 2, msg);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             mode: 'lines',
             x: [1, 2, 3],

--- a/test/jasmine/tests/scattermapbox_test.js
+++ b/test/jasmine/tests/scattermapbox_test.js
@@ -676,7 +676,7 @@ describe('scattermapbox hover', function() {
             text: ['A', 'B', 'C', 'D']
         }];
 
-        Plotly.plot(gd, data, { autosize: true }).then(done);
+        Plotly.newPlot(gd, data, { autosize: true }).then(done);
     });
 
     afterAll(function() {
@@ -936,7 +936,7 @@ describe('Test plotly events on a scattermapbox plot:', function() {
         mockCopy = Lib.extendDeep({}, mock);
         mockCopy.layout.width = 800;
         mockCopy.layout.height = 500;
-        Plotly.plot(gd, mockCopy).then(done);
+        Plotly.newPlot(gd, mockCopy).then(done);
     });
 
     afterEach(destroyGraphDiv);
@@ -1116,7 +1116,7 @@ describe('Test plotly events on a scattermapbox plot when css transform is prese
         mockCopy.layout.width = 800;
         mockCopy.layout.height = 500;
 
-        Plotly.plot(gd, mockCopy)
+        Plotly.newPlot(gd, mockCopy)
             .then(function() { transformPlot(gd, 'translate(-25%, -25%) scale(0.5)'); })
             .then(done);
     });

--- a/test/jasmine/tests/scatterpolar_test.js
+++ b/test/jasmine/tests/scatterpolar_test.js
@@ -100,7 +100,7 @@ describe('Test scatterpolar hover:', function() {
 
         var pos = specs.pos || [200, 200];
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             mouseEvent('mousemove', pos[0], pos[1]);
             assertHoverLabelContent(specs);
         });

--- a/test/jasmine/tests/scatterpolargl_test.js
+++ b/test/jasmine/tests/scatterpolargl_test.js
@@ -137,7 +137,7 @@ describe('Test scatterpolargl interactions:', function() {
 
         var scene;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterpolar',
             r: [1, 2, 1],
         }], {
@@ -185,7 +185,7 @@ describe('Test scatterpolargl interactions:', function() {
 
         var sceneXY, scenePolar;
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scattergl',
             y: [1, 2, 1]
         }, {

--- a/test/jasmine/tests/scatterternary_test.js
+++ b/test/jasmine/tests/scatterternary_test.js
@@ -310,7 +310,7 @@ describe('scatterternary plot and hover', function() {
         var gd = createGraphDiv();
         var mockCopy = Lib.extendDeep({}, mock);
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
     });
 
     it('should put scatterternary trace in \'frontplot\' node', function() {
@@ -355,7 +355,7 @@ describe('scatterternary hover', function() {
             c: [0.1, 0.4, 0.5],
             text: ['A', 'B', 'C']
         }];
-        Plotly.plot(gd, data).then(done);
+        Plotly.newPlot(gd, data).then(done);
     });
 
     afterAll(destroyGraphDiv);
@@ -483,7 +483,7 @@ describe('Test scatterternary *cliponaxis*', function() {
             );
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             _assert(
                 [false, false],

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -158,7 +158,7 @@ describe('Click-to-select', function() {
           defaultLayoutOpts,
           { layout: layoutOpts });
 
-        return Plotly.plot(gd, mockCopy.data, mockCopy.layout);
+        return Plotly.newPlot(gd, mockCopy.data, mockCopy.layout);
     }
 
     /**
@@ -381,7 +381,7 @@ describe('Click-to-select', function() {
     });
 
     it('@gl works in a multi-trace plot', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {
                 x: [1, 3, 5, 4, 10, 12, 12, 7],
                 y: [2, 7, 6, 1, 0, 13, 6, 12],
@@ -488,7 +488,7 @@ describe('Click-to-select', function() {
     });
 
     it('@gl is supported by scattergl in pan/zoom mode', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {
                 x: [7, 8, 9, 10],
                 y: [7, 9, 13, 21],
@@ -520,7 +520,7 @@ describe('Click-to-select', function() {
         var thirdBinPts = [3, 4, 5];
 
         mock.layout.clickmode = 'event+select';
-        Plotly.plot(gd, mock.data, mock.layout)
+        Plotly.newPlot(gd, mock.data, mock.layout)
           .then(function() {
               return clickFirstBinImmediately();
           })
@@ -560,7 +560,7 @@ describe('Click-to-select', function() {
         mock.layout.width = 1100;
         mock.layout.height = 450;
 
-        Plotly.plot(gd, mock.data, mock.layout)
+        Plotly.newPlot(gd, mock.data, mock.layout)
           .then(function() {
               return clickPtImmediately();
           })
@@ -682,7 +682,7 @@ describe('Click-to-select', function() {
           });
 
         function _run(testCase, doneFn) {
-            Plotly.plot(gd, testCase.mock.data, testCase.mock.layout, testCase.mock.config)
+            Plotly.newPlot(gd, testCase.mock.data, testCase.mock.layout, testCase.mock.config)
               .then(function() {
                   return _immediateClickPt(testCase);
               })
@@ -770,7 +770,7 @@ describe('Click-to-select', function() {
         });
 
         function _run(testCase, doneFn) {
-            Plotly.plot(gd, testCase.mock.data, testCase.mock.layout, testCase.mock.config)
+            Plotly.newPlot(gd, testCase.mock.data, testCase.mock.layout, testCase.mock.config)
               .then(function() {
                   var clickHandlerCalled = false;
                   var selectedHandlerCalled = false;
@@ -870,7 +870,7 @@ describe('Test select box and lasso in general:', function() {
         beforeEach(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                 .then(done);
         });
 
@@ -1016,7 +1016,7 @@ describe('Test select box and lasso in general:', function() {
         beforeEach(function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
                 .then(done);
         });
 
@@ -1157,7 +1157,7 @@ describe('Test select box and lasso in general:', function() {
             expect((selectedData.points || []).length).toBe(cnt, msg);
         }
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
         .then(resetAndSelect)
         .then(function() {
             checkPointCount(2, '(case 0)');
@@ -1224,7 +1224,7 @@ describe('Test select box and lasso in general:', function() {
         };
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             resetEvents(gd);
             drag([[100, 100], [300, 300]]);
             return selectedPromise;
@@ -1267,7 +1267,7 @@ describe('Test select box and lasso in general:', function() {
             mouseEvent('scroll', selectPath[0][0], selectPath[0][1], {deltaX: 0, deltaY: -20});
         }
 
-        Plotly.plot(gd, mockCopy)
+        Plotly.newPlot(gd, mockCopy)
         .then(_drag)
         .then(_scroll)
         .then(function() {
@@ -1305,7 +1305,7 @@ describe('Test select box and lasso in general:', function() {
             it('- on ' + s.axType + ' axes', function(done) {
                 var gd = createGraphDiv();
 
-                Plotly.plot(gd, [], {
+                Plotly.newPlot(gd, [], {
                     xaxis: {type: s.axType},
                     dragmode: 'select',
                     width: 400,
@@ -1347,7 +1347,7 @@ describe('Test select box and lasso in general:', function() {
             it('- on ' + s.axType + ' axes', function(done) {
                 var gd = createGraphDiv();
 
-                Plotly.plot(gd, [], {
+                Plotly.newPlot(gd, [], {
                     xaxis: {type: s.axType},
                     dragmode: 'lasso',
                     width: 400,
@@ -1378,7 +1378,7 @@ describe('Test select box and lasso in general:', function() {
             return selectedPromise;
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(_drag)
         .then(function() { assertSelectionNodes(0, 2, 'after drag 1'); })
         .then(function() { return Plotly.relayout(gd, 'xaxis.range', [-5, 5]); })
@@ -1454,7 +1454,7 @@ describe('Test select box and lasso in general:', function() {
         var fig = Lib.extendDeep({}, require('@mocks/0.json'));
 
         fig.layout.dragmode = 'select';
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
           .then(function() {
               return drag([[350, 100], [400, 400]]);
           })
@@ -1511,7 +1511,7 @@ describe('Test select box and lasso in general:', function() {
             }
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('base', {
                 xrng: [2, 8],
                 yrng: [0, 3],
@@ -1640,7 +1640,7 @@ describe('Test select box and lasso in general:', function() {
             };
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() { _assert('base', {outline: false}); })
         .then(_drag(path1))
         .then(function() {
@@ -1893,7 +1893,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.dragmode = 'select';
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -1951,7 +1951,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.dragmode = 'select';
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2000,7 +2000,7 @@ describe('Test select box and lasso per trace:', function() {
             };
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2061,7 +2061,7 @@ describe('Test select box and lasso per trace:', function() {
             };
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2135,7 +2135,7 @@ describe('Test select box and lasso per trace:', function() {
             };
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2210,7 +2210,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.dragmode = 'select';
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2255,7 +2255,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.dragmode = 'select';
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2325,7 +2325,7 @@ describe('Test select box and lasso per trace:', function() {
             emptyChoroplethTrace.z = [];
             fig.data.push(emptyChoroplethTrace);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2382,7 +2382,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.dragmode = 'lasso';
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2444,7 +2444,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.dragmode = 'lasso';
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2508,7 +2508,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.dragmode = 'lasso';
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2616,7 +2616,7 @@ describe('Test select box and lasso per trace:', function() {
             var x1 = 250;
             var y1 = 250;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2666,7 +2666,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.height = 500;
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2723,7 +2723,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.xaxis = {range: [-0.565, 1.5]};
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2797,7 +2797,7 @@ describe('Test select box and lasso per trace:', function() {
                 }
             };
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2841,7 +2841,7 @@ describe('Test select box and lasso per trace:', function() {
             fig.layout.height = 500;
             addInvisible(fig);
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -2980,7 +2980,7 @@ describe('Test select box and lasso per trace:', function() {
         it('should work on traces with enabled transforms, hasCssTransform: ' + hasCssTransform, function(done) {
             var assertSelectedPoints = makeAssertSelectedPoints();
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 x: [1, 2, 3, 4, 5],
                 y: [2, 3, 1, 7, 9],
                 marker: {size: [10, 20, 20, 20, 10]},
@@ -3038,7 +3038,7 @@ describe('Test select box and lasso per trace:', function() {
                 });
             }
 
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 mode: 'markers+text',
                 x: [1, 2, 3],
                 y: [1, 2, 1],
@@ -3086,7 +3086,7 @@ describe('Test select box and lasso per trace:', function() {
                 fig.layout.dragmode = 'select';
                 var dblClickPos = [250, 400];
 
-                Plotly.plot(gd, fig)
+                Plotly.newPlot(gd, fig)
                 .then(function() {
                     if(hasCssTransform) transformPlot(gd, cssTransform);
 
@@ -3121,7 +3121,7 @@ describe('Test select box and lasso per trace:', function() {
             var fig = Lib.extendDeep({}, require('@mocks/sankey_circular.json'));
             fig.layout.dragmode = undefined;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 // No groups initially
                 expect(gd._fullData[0].node.groups).toEqual([]);
@@ -3163,7 +3163,7 @@ describe('Test that selections persist:', function() {
             assertPtOpacity('.point', expected);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [1, 2, 3],
             y: [1, 2, 1]
         }], {
@@ -3204,7 +3204,7 @@ describe('Test that selections persist:', function() {
             assertPtOpacity('.point', expected);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'box',
             x0: 0,
             y: [5, 4, 4, 1, 2, 2, 2, 2, 2, 3, 3, 3],
@@ -3249,7 +3249,7 @@ describe('Test that selections persist:', function() {
             assertPtOpacity('.point > path', expected);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'histogram',
             x: [1, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 5],
             boxpoints: 'all'
@@ -3311,7 +3311,7 @@ describe('Test that selection styles propagate to range-slider plot:', function(
     it('- svg points case', function(done) {
         var _assert = makeAssertFn('path.point,.point>path');
 
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             { mode: 'markers', x: [1], y: [1] },
             { type: 'bar', x: [2], y: [2], },
             { type: 'histogram', x: [3, 3, 3] },
@@ -3349,7 +3349,7 @@ describe('Test that selection styles propagate to range-slider plot:', function(
     it('- svg finance case', function(done) {
         var _assert = makeAssertFn('path.box,.ohlc>path');
 
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             { type: 'ohlc', x: [6], open: [6], high: [6], low: [6], close: [6] },
             { type: 'candlestick', x: [7], open: [7], high: [7], low: [7], close: [7] },
         ], {

--- a/test/jasmine/tests/shapes_test.js
+++ b/test/jasmine/tests/shapes_test.js
@@ -224,7 +224,7 @@ describe('Test shapes:', function() {
         var mockData = Lib.extendDeep([], mock.data);
         var mockLayout = Lib.extendDeep({}, mock.layout);
 
-        Plotly.plot(gd, mockData, mockLayout).then(done);
+        Plotly.newPlot(gd, mockData, mockLayout).then(done);
     });
 
     afterEach(destroyGraphDiv);
@@ -479,7 +479,7 @@ describe('shapes axis reference changes', function() {
     beforeEach(function(done) {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {y: [1, 2, 3]},
             {y: [1, 2, 3], yaxis: 'y2'}
         ], {
@@ -608,7 +608,7 @@ describe('shapes autosize', function() {
             }
         };
 
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             assertRanges('base', [0, 2], [0, 2]);
             return Plotly.relayout(gd, { 'shapes[1].visible': false });
         })
@@ -632,7 +632,7 @@ describe('shapes autosize', function() {
     it('should propagate axis autorange changes when axis ranges are set', function(done) {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [{y: [1, 2]}], {
+        Plotly.newPlot(gd, [{y: [1, 2]}], {
             xaxis: {range: [0, 2]},
             yaxis: {range: [0, 2]},
             shapes: [{
@@ -727,7 +727,7 @@ describe('Test shapes: a plot with shapes and an overlaid axis', function() {
     afterEach(destroyGraphDiv);
 
     it('should not throw an exception', function(done) {
-        Plotly.plot(gd, data, layout)
+        Plotly.newPlot(gd, data, layout)
         .catch(failTest)
         .then(done);
     });
@@ -786,7 +786,7 @@ describe('A path shape sized relative to data', function() {
     afterEach(destroyGraphDiv);
 
     it('is expanding an auto-ranging axes', function() {
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         assertShapeFullyVisible(getFirstShapeNode());
     });
@@ -830,7 +830,7 @@ describe('A fixed size path shape', function() {
     afterEach(destroyGraphDiv);
 
     it('is defined in pixel', function() {
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         assertShapeSize(getFirstShapeNode(), 30, 20);
     });
@@ -839,7 +839,7 @@ describe('A fixed size path shape', function() {
         layout.shapes[0].xanchor = 10;
         layout.shapes[0].yanchor = 10;
 
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         assertShapeFullyVisible(getFirstShapeNode());
     });
@@ -856,7 +856,7 @@ describe('A fixed size path shape', function() {
         layout.shapes[0].xanchor = '2018-07-01 00:00:00';
         layout.shapes[0].yanchor = 10;
 
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         var shapeNode = getFirstShapeNode();
         assertShapeFullyVisible(shapeNode);
@@ -864,7 +864,7 @@ describe('A fixed size path shape', function() {
     });
 
     it('keeps its dimensions when plot is being resized', function(done) {
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         assertShapeSize(getFirstShapeNode(), 30, 20);
 
@@ -877,7 +877,7 @@ describe('A fixed size path shape', function() {
     });
 
     it('is draggable', function(done) {
-        Plotly.plot(gd, data, layout, {editable: true})
+        Plotly.newPlot(gd, data, layout, {editable: true})
           .then(function() {
               drag({node: getFirstShapeNode(), dpos: [50, 50]}).then(function() {
                   assertShapeSize(getFirstShapeNode(), 30, 20);
@@ -893,7 +893,7 @@ describe('A fixed size path shape', function() {
           layout.shapes[0].xsizemode = 'data';
           layout.shapes[0].path = 'M0,0 L2,0 L1,20 Z';
 
-          Plotly.plot(gd, data, layout, {editable: true})
+          Plotly.newPlot(gd, data, layout, {editable: true})
             .then(function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var widthBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().width;
@@ -916,7 +916,7 @@ describe('A fixed size path shape', function() {
           layout.shapes[0].ysizemode = 'data';
           layout.shapes[0].path = 'M0,0 L30,0 L15,2 Z';
 
-          Plotly.plot(gd, data, layout, {editable: true})
+          Plotly.newPlot(gd, data, layout, {editable: true})
             .then(function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var heightBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().height;
@@ -969,7 +969,7 @@ describe('A fixed size shape', function() {
     afterEach(destroyGraphDiv);
 
     it('can be positioned relative to data', function() {
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         var shapeNode = getFirstShapeNode();
         assertShapeSize(shapeNode, 25, 25);
@@ -986,7 +986,7 @@ describe('A fixed size shape', function() {
         layout.shapes[0].yref = 'paper';
         layout.shapes[0].xanchor = '1';
         layout.shapes[0].yanchor = '1';
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         var shapeNode = getFirstShapeNode();
         assertShapeSize(shapeNode, 25, 25);
@@ -997,7 +997,7 @@ describe('A fixed size shape', function() {
         layout.shapes[0].ysizemode = 'data';
         layout.shapes[0].y0 = 1;
         layout.shapes[0].y1 = 5;
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         var shapeNode = getFirstShapeNode();
         var bBox = shapeNode.getBoundingClientRect();
@@ -1009,7 +1009,7 @@ describe('A fixed size shape', function() {
         layout.shapes[0].xsizemode = 'data';
         layout.shapes[0].x0 = 1;
         layout.shapes[0].x1 = 5;
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         var shapeNode = getFirstShapeNode();
         var bBox = shapeNode.getBoundingClientRect();
@@ -1029,7 +1029,7 @@ describe('A fixed size shape', function() {
         layout.shapes[0].xanchor = '2018-07-01 00:00:00';
         layout.shapes[0].yanchor = 10;
 
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         var shapeNode = getFirstShapeNode();
         assertShapeFullyVisible(shapeNode);
@@ -1038,7 +1038,7 @@ describe('A fixed size shape', function() {
 
     it('keeps its dimensions when plot is being resized', function(done) {
         layout.shapes[0].yanchor = 3; // Ensure visible for debugging
-        Plotly.plot(gd, data, layout);
+        Plotly.newPlot(gd, data, layout);
 
         var shapeNode = getFirstShapeNode();
         assertShapeSize(shapeNode, 25, 25);
@@ -1053,7 +1053,7 @@ describe('A fixed size shape', function() {
     });
 
     it('is draggable', function(done) {
-        Plotly.plot(gd, data, layout, {editable: true})
+        Plotly.newPlot(gd, data, layout, {editable: true})
           .then(function() {
               drag({node: getFirstShapeNode(), dpos: [50, 50]}).then(function() {
                   assertShapeSize(getFirstShapeNode(), 25, 25);
@@ -1070,7 +1070,7 @@ describe('A fixed size shape', function() {
           layout.shapes[0].x0 = 1;
           layout.shapes[0].x1 = 2;
 
-          Plotly.plot(gd, data, layout, {editable: true})
+          Plotly.newPlot(gd, data, layout, {editable: true})
             .then(function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var widthBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().width;
@@ -1094,7 +1094,7 @@ describe('A fixed size shape', function() {
           layout.shapes[0].y0 = 1;
           layout.shapes[0].y1 = 2;
 
-          Plotly.plot(gd, data, layout, {editable: true})
+          Plotly.newPlot(gd, data, layout, {editable: true})
             .then(function() {
                 var shapeNodeBeforeDrag = getFirstShapeNode();
                 var heightBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect().height;
@@ -1131,7 +1131,7 @@ describe('A fixed size shape', function() {
                 it('over direction ' + direction, function(done) {
                     layout.shapes[0].type = testCase.type;
 
-                    Plotly.plot(gd, data, layout, {editable: true})
+                    Plotly.newPlot(gd, data, layout, {editable: true})
                       .then(function() {
                           var shapeNodeBeforeDrag = getFirstShapeNode();
                           var bBoxBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect();
@@ -1164,7 +1164,7 @@ describe('A fixed size shape', function() {
         });
 
         it('can be moved by dragging the middle', function(done) {
-            Plotly.plot(gd, data, layout, {editable: true})
+            Plotly.newPlot(gd, data, layout, {editable: true})
               .then(function() {
                   var shapeNodeBeforeDrag = getFirstShapeNode();
                   var bBoxBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect();
@@ -1185,7 +1185,7 @@ describe('A fixed size shape', function() {
         });
 
         it('can be resized by dragging the start point', function(done) {
-            Plotly.plot(gd, data, layout, {editable: true})
+            Plotly.newPlot(gd, data, layout, {editable: true})
               .then(function() {
                   var shapeNodeBeforeDrag = getFirstShapeNode();
                   var bBoxBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect();
@@ -1208,7 +1208,7 @@ describe('A fixed size shape', function() {
         });
 
         it('can be resized by dragging the end point', function(done) {
-            Plotly.plot(gd, data, layout, {editable: true})
+            Plotly.newPlot(gd, data, layout, {editable: true})
               .then(function() {
                   var shapeNodeBeforeDrag = getFirstShapeNode();
                   var bBoxBeforeDrag = shapeNodeBeforeDrag.getBoundingClientRect();
@@ -1249,7 +1249,7 @@ describe('A fixed size shape', function() {
                       layout.shapes[0].xanchor = -1;
                       layout.shapes[0].x0 = testCase.x0;
                       layout.shapes[0].x1 = testCase.x1;
-                      Plotly.plot(gd, data, layout);
+                      Plotly.newPlot(gd, data, layout);
 
                       expect(gd.layout.xaxis.range[0]).toBeLessThanOrEqual(-1);
                       assertShapeFullyVisible(getFirstShapeNode());
@@ -1266,7 +1266,7 @@ describe('A fixed size shape', function() {
                       layout.shapes[0].xanchor = 10;
                       layout.shapes[0].x0 = testCase.x0;
                       layout.shapes[0].x1 = testCase.x1;
-                      Plotly.plot(gd, data, layout);
+                      Plotly.newPlot(gd, data, layout);
 
                       expect(gd.layout.xaxis.range[1]).toBeGreaterThanOrEqual(10);
                       assertShapeFullyVisible(getFirstShapeNode());
@@ -1293,7 +1293,7 @@ describe('A fixed size shape', function() {
                       layout.shapes[0].yanchor = -1;
                       layout.shapes[0].y0 = testCase.y0;
                       layout.shapes[0].y1 = testCase.y1;
-                      Plotly.plot(gd, data, layout);
+                      Plotly.newPlot(gd, data, layout);
 
                       expect(gd.layout.yaxis.range[0]).toBeLessThanOrEqual(-1);
                       assertShapeFullyVisible(getFirstShapeNode());
@@ -1310,7 +1310,7 @@ describe('A fixed size shape', function() {
                       layout.shapes[0].yanchor = 10;
                       layout.shapes[0].y0 = testCase.y0;
                       layout.shapes[0].y1 = testCase.y1;
-                      Plotly.plot(gd, data, layout);
+                      Plotly.newPlot(gd, data, layout);
 
                       expect(gd.layout.yaxis.range[1]).toBeGreaterThanOrEqual(10);
                       assertShapeFullyVisible(getFirstShapeNode());
@@ -1446,7 +1446,7 @@ describe('Test shapes', function() {
     }
 
     function testDragEachShape(done) {
-        var promise = Plotly.plot(gd, data, layout, config);
+        var promise = Plotly.newPlot(gd, data, layout, config);
 
         var layoutShapes = gd.layout.shapes;
 
@@ -1471,7 +1471,7 @@ describe('Test shapes', function() {
     }
 
     function testResizeEachShape(direction, done) {
-        var promise = Plotly.plot(gd, data, layout, config);
+        var promise = Plotly.newPlot(gd, data, layout, config);
 
         var layoutShapes = gd.layout.shapes;
 
@@ -1610,7 +1610,7 @@ describe('Test shapes', function() {
     }
 
     function testLineResize(pointToMove, done) {
-        var promise = Plotly.plot(gd, data, layout, config);
+        var promise = Plotly.newPlot(gd, data, layout, config);
         var layoutShape = gd.layout.shapes[0];
 
         var xa = Axes.getFromId(gd, layoutShape.xref);

--- a/test/jasmine/tests/sliders_test.js
+++ b/test/jasmine/tests/sliders_test.js
@@ -234,7 +234,7 @@ describe('sliders initialization', function() {
     beforeEach(function(done) {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [{x: [1, 2, 3]}], {
+        Plotly.newPlot(gd, [{x: [1, 2, 3]}], {
             sliders: [{
                 transition: {duration: 0},
                 steps: [
@@ -262,7 +262,7 @@ describe('ugly internal manipulation of steps', function() {
     beforeEach(function(done) {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [{x: [1, 2, 3]}], {
+        Plotly.newPlot(gd, [{x: [1, 2, 3]}], {
             sliders: [{
                 transition: {duration: 0},
                 steps: [
@@ -322,7 +322,7 @@ describe('sliders interactions', function() {
 
         mockCopy = Lib.extendDeep({}, mock, {layout: {sliders: [{x: 0.25}, {}]}});
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
     });
 
     afterEach(function() {

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -202,7 +202,7 @@ describe('Plotly.Snapshot', function() {
         afterEach(destroyGraphDiv);
 
         it('should not return any nested svg tags of plots', function(done) {
-            Plotly.plot(gd, subplotMock.data, subplotMock.layout).then(function() {
+            Plotly.newPlot(gd, subplotMock.data, subplotMock.layout).then(function() {
                 return Plotly.Snapshot.toSVG(gd);
             }).then(function(svg) {
                 var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
@@ -213,7 +213,7 @@ describe('Plotly.Snapshot', function() {
         });
 
         it('should not return any nested svg tags of annotations', function(done) {
-            Plotly.plot(gd, annotationMock.data, annotationMock.layout).then(function() {
+            Plotly.newPlot(gd, annotationMock.data, annotationMock.layout).then(function() {
                 return Plotly.Snapshot.toSVG(gd);
             }).then(function(svg) {
                 var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
@@ -227,7 +227,7 @@ describe('Plotly.Snapshot', function() {
             // we've gotten rid of visibility almost entirely, using display instead
             d3.select(gd).style('visibility', 'inherit');
 
-            Plotly.plot(gd, subplotMock.data, subplotMock.layout).then(function() {
+            Plotly.newPlot(gd, subplotMock.data, subplotMock.layout).then(function() {
                 d3.select(gd).selectAll('text').each(function() {
                     var thisStyle = window.getComputedStyle(this);
                     expect(thisStyle.visibility).toEqual('visible');
@@ -256,7 +256,7 @@ describe('Plotly.Snapshot', function() {
             }
 
             it('- marker-gradient case', function(done) {
-                Plotly.plot(gd, [{
+                Plotly.newPlot(gd, [{
                     y: [1, 2, 1],
                     marker: {
                         gradient: {
@@ -310,7 +310,7 @@ describe('Plotly.Snapshot', function() {
                 var fig = Lib.extendDeep({}, require('@mocks/contour_legend.json'));
                 var fillItemIndices = [0, 4, 5];
 
-                Plotly.plot(gd, fig)
+                Plotly.newPlot(gd, fig)
                 .then(function() { return Plotly.Snapshot.toSVG(gd); })
                 .then(function(svg) {
                     var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
@@ -330,7 +330,7 @@ describe('Plotly.Snapshot', function() {
             it('- colorbar case', function(done) {
                 var fig = Lib.extendDeep({}, require('@mocks/16.json'));
 
-                Plotly.plot(gd, fig)
+                Plotly.newPlot(gd, fig)
                 .then(function() { return Plotly.Snapshot.toSVG(gd); })
                 .then(function(svg) {
                     var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
@@ -348,7 +348,7 @@ describe('Plotly.Snapshot', function() {
             it('- legend3dandfriends case', function(done) {
                 var fig = Lib.extendDeep({}, require('@mocks/geo_choropleth-legend.json'));
 
-                Plotly.plot(gd, fig)
+                Plotly.newPlot(gd, fig)
                 .then(function() { return Plotly.Snapshot.toSVG(gd); })
                 .then(function(svg) {
                     var svgDOM = parser.parseFromString(svg, 'image/svg+xml');
@@ -365,7 +365,7 @@ describe('Plotly.Snapshot', function() {
         });
 
         it('should adapt *viewBox* attribute under *scale* option', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 y: [1, 2, 1]
             }], {
                 width: 300,

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -670,7 +670,7 @@ describe('Test splom interactions:', function() {
     it('@gl should destroy gl objects on Plots.cleanPlot', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/splom_large.json'));
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             expect(gd._fullLayout._splomGrid).toBeDefined();
             expect(gd._fullLayout._splomScenes).toBeDefined();
             expect(Object.keys(gd._fullLayout._splomScenes).length).toBe(1);
@@ -702,7 +702,7 @@ describe('Test splom interactions:', function() {
             cnt++;
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert([1198, 16558, 3358, 118]);
             return Plotly.restyle(gd, 'showupperhalf', false);
         })
@@ -775,7 +775,7 @@ describe('Test splom interactions:', function() {
             cnt++;
         }
 
-        Plotly.plot(gd, figLarge).then(function() {
+        Plotly.newPlot(gd, figLarge).then(function() {
             _assert({
                 subplotCnt: 400,
                 innerSubplotNodeCnt: 4,
@@ -865,7 +865,7 @@ describe('Test splom interactions:', function() {
             }
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             expect(gd._fullLayout.grid.xside).toBe('bottom', 'sanity check dflt grid.xside');
             expect(gd._fullLayout.grid.yside).toBe('left', 'sanity check dflt grid.yside');
 
@@ -893,7 +893,7 @@ describe('Test splom interactions:', function() {
     });
 
     it('@gl should work with typed arrays', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'splom',
             dimensions: [{
                 label: 'A',
@@ -921,7 +921,7 @@ describe('Test splom interactions:', function() {
             }
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             var splomScenes = gd._fullLayout._splomScenes;
             for(var k in splomScenes) {
                 spyOn(splomScenes[k], 'draw').and.callThrough();
@@ -977,7 +977,7 @@ describe('Test splom interactions:', function() {
 
         spyOn(Lib, 'log');
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             assertFnCall('base', {
                 cleanPlot: 1,       // called once from inside Plots.supplyDefaults
                 supplyDefaults: 1,
@@ -1045,7 +1045,7 @@ describe('Test splom interactions:', function() {
             }]
         }];
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             _assertAxisTypes('no upper half / no diagonal', {
                 xaxes: ['linear', 'category', undefined, null],
                 fullXaxes: ['linear', 'category', 'category', null],
@@ -1084,7 +1084,7 @@ describe('Test splom interactions:', function() {
     });
 
     it('@gl should not fail when editing graph with visible:false traces', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'splom',
             dimensions: [{values: []}, {values: []}]
         }, {
@@ -1168,7 +1168,7 @@ describe('Test splom update switchboard:', function() {
         var fig = Lib.extendDeep({}, require('@mocks/splom_large.json'));
         var matrix, regl, splomGrid;
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             var fullLayout = gd._fullLayout;
             var trace = gd._fullData[0];
             var scene = fullLayout._splomScenes[trace.uid];
@@ -1212,7 +1212,7 @@ describe('Test splom update switchboard:', function() {
         var fig = Lib.extendDeep({}, require('@mocks/splom_0.json'));
         var scene, matrix, regl;
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             var fullLayout = gd._fullLayout;
             var trace = gd._fullData[0];
             scene = fullLayout._splomScenes[trace.uid];
@@ -1375,7 +1375,7 @@ describe('Test splom hover:', function() {
 
         var pos = s.pos || [200, 100];
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             var to = setTimeout(function() {
                 failTest('no event data received');
                 done();
@@ -1530,7 +1530,7 @@ describe('Test splom drag:', function() {
             });
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             var uid = gd._fullData[0].uid;
             var scene = gd._fullLayout._splomScenes[uid];
@@ -1760,7 +1760,7 @@ describe('Test splom select:', function() {
             scene.matrix.draw.calls.reset();
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             uid = gd._fullData[0].uid;
             scene = gd._fullLayout._splomScenes[uid];
             spyOn(scene.matrix, 'update').and.callThrough();
@@ -1849,7 +1849,7 @@ describe('Test splom select:', function() {
             };
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'splom',
             dimensions: [{
                 values: [1, 2, 3]

--- a/test/jasmine/tests/streamtube_test.js
+++ b/test/jasmine/tests/streamtube_test.js
@@ -83,7 +83,7 @@ describe('Test streamtube autorange', function() {
     it('@gl should add pad around tubes to make sure they fit on the scene', function(done) {
         var fig = Lib.extendDeep({}, require('@mocks/gl3d_streamtube-first'));
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assertAxisRanges('base',
                 [-5.36, 5.55], [-6.36, 3.90], [-3.58, 3.95]
             );
@@ -155,7 +155,7 @@ describe('Test streamtube starting positions defaults:', function() {
             z: [0, 1, 2, 3]
         };
 
-        Plotly.plot(gd, mock).then(function() {
+        Plotly.newPlot(gd, mock).then(function() {
             _assert({
                 positionsLength: 6288,
                 cellsLength: 2096
@@ -166,7 +166,7 @@ describe('Test streamtube starting positions defaults:', function() {
     });
 
     it('@gl should cut xz at min-y and take all x/y/z pts on that plane except those on the edges', function(done) {
-        Plotly.plot(gd, makeFigure(3, 3, 3)).then(function() {
+        Plotly.newPlot(gd, makeFigure(3, 3, 3)).then(function() {
             _assert({
                 positionsLength: 1536,
                 cellsLength: 512
@@ -177,7 +177,7 @@ describe('Test streamtube starting positions defaults:', function() {
     });
 
     it('@gl should take middle pt if mesh vector has length 2', function(done) {
-        Plotly.plot(gd, makeFigure(3, 3, 2)).then(function() {
+        Plotly.newPlot(gd, makeFigure(3, 3, 2)).then(function() {
             _assert({
                 positionsLength: 1296,
                 cellsLength: 432
@@ -188,7 +188,7 @@ describe('Test streamtube starting positions defaults:', function() {
     });
 
     it('@gl should take pt if mesh vector has length 1', function(done) {
-        Plotly.plot(gd, makeFigure(1, 3, 2)).then(function() {
+        Plotly.newPlot(gd, makeFigure(1, 3, 2)).then(function() {
             _assert({
                 positionsLength: 720,
                 cellsLength: 240
@@ -229,7 +229,7 @@ describe('Test streamtube interactions', function() {
             expect(exp.cellsLength).toBe(objs[0].cells.length, 'cells length - ' + msg);
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('base', {
                 positionsLength: 0,
                 cellsLength: 0
@@ -327,7 +327,7 @@ describe('Test streamtube interactions', function() {
                     expect(exp.cellsLength).toBe(objs[0].cells.length, 'cells length - ' + msg);
                 }
 
-                Plotly.plot(gd, fig).then(function() {
+                Plotly.newPlot(gd, fig).then(function() {
                     _assert('lengths', {
                         positionsLength: 6336,
                         cellsLength: 2112
@@ -380,7 +380,7 @@ describe('Test streamtube interactions', function() {
 
         spyOn(Lib, 'warn');
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('arbitrary coordinates', {
                 positionsLength: 0,
                 cellsLength: 0
@@ -406,7 +406,7 @@ describe('Test streamtube interactions', function() {
             }
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('base', {glObjCnt: 1});
             return Plotly.addTraces(gd, [trace]);
         })
@@ -437,7 +437,7 @@ describe('Test streamtube interactions', function() {
             expect(objTypes).toEqual(exp.objTypes);
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('base cone', {objTypes: ['cone']});
             return Plotly.restyle(gd, 'type', 'streamtube');
         })
@@ -482,7 +482,7 @@ describe('Test streamtube hover', function() {
             mouseEvent('mouseover', 188, 199);
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(delay(20))
         .then(_hover)
         .then(delay(20))
@@ -555,7 +555,7 @@ describe('Test streamtube hover', function() {
             mouseEvent('mouseover', 193, 177);
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(delay(20))
         .then(_hover)
         .then(delay(20))
@@ -596,7 +596,7 @@ describe('Test streamtube hover', function() {
             mouseEvent('mouseover', 188, 199);
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(delay(20))
         .then(function() {
             gd.on('plotly_hover', function(d) { ptData = d.points[0]; });

--- a/test/jasmine/tests/sunburst_test.js
+++ b/test/jasmine/tests/sunburst_test.js
@@ -525,7 +525,7 @@ describe('Test sunburst hover:', function() {
         var exp = spec.exp || {};
         var ptData = null;
 
-        return Plotly.plot(gd, data, layout)
+        return Plotly.newPlot(gd, data, layout)
             .then(function() {
                 gd.once('plotly_hover', function(d) { ptData = d.points[0]; });
             })
@@ -728,7 +728,7 @@ describe('Test sunburst hover lifecycle:', function() {
     it('should fire the correct events', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/sunburst_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(hover(gd, 1))
         .then(function() {
@@ -804,7 +804,7 @@ describe('Test sunburst clicks:', function() {
     it('should trigger animation when clicking on branches', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/sunburst_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(click(gd, 2))
         .then(function() {
@@ -835,7 +835,7 @@ describe('Test sunburst clicks:', function() {
     it('should trigger plotly_click event when clicking on root node', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/sunburst_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(click(gd, 1))
         .then(function() {
@@ -864,7 +864,7 @@ describe('Test sunburst clicks:', function() {
     it('should trigger plotly_click event when clicking on leaf node', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/sunburst_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(click(gd, 8))
         .then(function() {
@@ -893,7 +893,7 @@ describe('Test sunburst clicks:', function() {
     it('should not trigger animation when graph is transitioning', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/sunburst_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(click(gd, 2))
         .then(function() {
@@ -953,7 +953,7 @@ describe('Test sunburst clicks:', function() {
     it('should be able to override default click behavior using plotly_sunburstclick handler ()', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/sunburst_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners({turnOffAnimation: true}))
         .then(click(gd, 2))
         .then(function() {
@@ -998,7 +998,7 @@ describe('Test sunburst restyle:', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', 2))
         .then(_restyle({'visible': false}))
         .then(_assert('both visible:false', 0))
@@ -1024,7 +1024,7 @@ describe('Test sunburst restyle:', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', 96))
         .then(function() {
             spyOn(Plots, 'doCalcdata').and.callThrough();
@@ -1067,7 +1067,7 @@ describe('Test sunburst restyle:', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', ['', '0.7', '', '0.7']))
         .then(function() {
             spyOn(Plots, 'doCalcdata').and.callThrough();
@@ -1122,7 +1122,7 @@ describe('Test sunburst restyle:', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', ['Root\nnode0', 'B\nnode2', 'A\nnode1', 'b\nnode3']))
         .then(function() {
             spyOn(Plots, 'doCalcdata').and.callThrough();
@@ -1231,7 +1231,7 @@ describe('Test sunburst tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 3))
         .then(function() {
             _assert('exit entry radially inward', 'd', 'Root',
@@ -1266,7 +1266,7 @@ describe('Test sunburst tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 1))
         .then(function() {
             _assert('enter new entry radially outward', 'd', 'Root',
@@ -1301,7 +1301,7 @@ describe('Test sunburst tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 3))
         .then(function() {
             _assert('exit entry radially inward', 'd', 'Root',
@@ -1336,7 +1336,7 @@ describe('Test sunburst tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 1))
         .then(function() {
             _assert('exit b radially outward and to parent sector angle', 'd', 'b',
@@ -1361,7 +1361,7 @@ describe('Test sunburst tweening:', function() {
 
     /*
     it('should tween in sectors from new traces', function(done) {
-        Plotly.plot(gd, [{type: 'sunburst'}])
+        Plotly.newPlot(gd, [{type: 'sunburst'}])
         .then(_reset)
         .then(function() {
             return Plotly.animate(gd, [{
@@ -1390,7 +1390,7 @@ describe('Test sunburst tweening:', function() {
     */
 
     it('should update text position during transition using *auto* insidetextorientation', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 textinfo: 'label',
@@ -1415,7 +1415,7 @@ describe('Test sunburst tweening:', function() {
     });
 
     it('should update text position during transition using *horizontal* insidetextorientation', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 textinfo: 'label',
@@ -1440,7 +1440,7 @@ describe('Test sunburst tweening:', function() {
     });
 
     it('should update text position during transition using *tangential* insidetextorientation', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 textinfo: 'label',
@@ -1465,7 +1465,7 @@ describe('Test sunburst tweening:', function() {
     });
 
     it('should update text position during transition using *radial* insidetextorientation', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 textinfo: 'label',
@@ -1490,7 +1490,7 @@ describe('Test sunburst tweening:', function() {
     });
 
     it('should update text position during transition using *radial* insidetextorientation with level', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 textinfo: 'label',
@@ -1514,7 +1514,7 @@ describe('Test sunburst tweening:', function() {
     });
 
     it('should update text position during transition using *tangential* insidetextorientation with level', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 textinfo: 'label',
@@ -1538,7 +1538,7 @@ describe('Test sunburst tweening:', function() {
     });
 
     it('should update text position during transition using *horizontal* insidetextorientation with level', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 textinfo: 'label',
@@ -1587,7 +1587,7 @@ describe('Test sunburst interactions edge cases', function() {
             unhoverCnt = 0;
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_hover', function() {
                 hoverCnt++;
@@ -1629,7 +1629,7 @@ describe('Test sunburst interactions edge cases', function() {
     });
 
     it('should show falsy zero text', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 parents: ['', 'A', 'B', 'C', 'D', 'E', 'F'],
@@ -1665,7 +1665,7 @@ describe('Test sunburst interactions edge cases', function() {
                 .toBe(exp.sunburstTraceCnt, '# of sunburst traces');
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             _assert('base', {
                 cartesianTraceCnt: 2,
@@ -1692,7 +1692,7 @@ describe('Test sunburst interactions edge cases', function() {
 
         spyOn(Plots, 'transitionFromReact').and.callThrough();
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.data[1].level = 'B';
             return Plotly.react(gd, gd.data, gd.layout);
@@ -1953,7 +1953,7 @@ describe('sunburst inside text orientation', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextRotations('using default "auto"', {
             rotations: [-0.6, 0, 48, 0]
         }))
@@ -2058,7 +2058,7 @@ describe('sunburst uniformtext', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextSizes('without uniformtext', {
             fontsizes: [12, 12, 12, 12, 12, 12, 12, 12, 12, 12],
             scales: [1, 1, 1, 1, 1, 1, 1, 1, 1, 0.52],
@@ -2116,7 +2116,7 @@ describe('sunburst uniformtext', function() {
     });
 
     it('should uniform text scales after transition', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'sunburst',
                 parents: [

--- a/test/jasmine/tests/surface_test.js
+++ b/test/jasmine/tests/surface_test.js
@@ -197,7 +197,7 @@ describe('Test surface', function() {
         }
 
         it('@gl surface should be invisible when the z array is empty', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 'type': 'surface',
                 'z': []
             }])
@@ -209,7 +209,7 @@ describe('Test surface', function() {
         });
 
         it('@gl surface should be invisible when the x array is defined but is empty', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 'type': 'surface',
                 'x': [],
                 'y': [0, 1],
@@ -223,7 +223,7 @@ describe('Test surface', function() {
         });
 
         it('@gl surface should be invisible when the y array is defined but is empty', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 'type': 'surface',
                 'x': [0, 1],
                 'y': [],
@@ -237,7 +237,7 @@ describe('Test surface', function() {
         });
 
         it('@gl surface should be invisible when the x array is defined and has at least one item', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 'type': 'surface',
                 'x': [0],
                 'y': [0, 1],
@@ -251,7 +251,7 @@ describe('Test surface', function() {
         });
 
         it('@gl surface should be invisible when the y array is defined and has at least one item', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 'type': 'surface',
                 'x': [0, 1],
                 'y': [0],
@@ -265,7 +265,7 @@ describe('Test surface', function() {
         });
 
         it('@gl surface should be visible when the x and y are not provided; but z array is provided', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 'type': 'surface',
                 'z': [[1, 2], [3, 4]]
             }])
@@ -277,7 +277,7 @@ describe('Test surface', function() {
         });
 
         it('@gl surface should be invisible when the x and y are provided; but z array is not provided', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 'type': 'surface',
                 'x': [0, 1],
                 'y': [0, 1]

--- a/test/jasmine/tests/table_test.js
+++ b/test/jasmine/tests/table_test.js
@@ -147,7 +147,7 @@ describe('table', function() {
         it('Works with more than one column', function(done) {
             var mockCopy = Lib.extendDeep({}, mock2);
             var gd = createGraphDiv();
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].header.values.length).toEqual(2);
                 expect(gd.data[0].cells.values.length).toEqual(2);
@@ -160,7 +160,7 @@ describe('table', function() {
         it('Works with one column', function(done) {
             var mockCopy = Lib.extendDeep({}, mock1);
             var gd = createGraphDiv();
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].header.values.length).toEqual(1);
                 expect(gd.data[0].cells.values.length).toEqual(1);
@@ -174,7 +174,7 @@ describe('table', function() {
             var mockCopy = Lib.extendDeep({}, mock0);
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].header.values.length).toEqual(0);
                 expect(gd.data[0].cells.values.length).toEqual(0);
@@ -192,7 +192,7 @@ describe('table', function() {
             mockCopy.data[0].cells.values = [[], []];
 
             var gd = createGraphDiv();
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].header.values.length).toEqual(2);
                 expect(gd.data[0].cells.values.length).toEqual(2);
@@ -213,14 +213,14 @@ describe('table', function() {
 
             // more info in: https://github.com/plotly/streambed/issues/11618
 
-            Plotly.plot(gd, mockCopy).then(function() {
+            Plotly.newPlot(gd, mockCopy).then(function() {
                 _assert('staticPlot:false (base)', {
                     captureZone: 1,
                     glyph: 1
                 });
             })
             .then(function() { return Plotly.purge(gd); })
-            .then(function() { return Plotly.plot(gd, mockCopy.data, mockCopy.layout, {staticPlot: true}); })
+            .then(function() { return Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, {staticPlot: true}); })
             .then(function() {
                 _assert('staticPlot:true', {
                     captureZone: 0,
@@ -238,11 +238,11 @@ describe('table', function() {
 
         afterEach(destroyGraphDiv);
 
-        it('`Plotly.plot` should render all the columns even if no cell contents were supplied yet', function(done) {
+        it('`Plotly.newPlot` should render all the columns even if no cell contents were supplied yet', function(done) {
             gd = createGraphDiv();
             mockCopy = Lib.extendDeep({}, mock);
             delete mockCopy.data[0].cells;
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].header.values.length).toEqual(7);
                 expect(document.querySelectorAll('.' + cn.yColumn).length).toEqual(7);
@@ -252,11 +252,11 @@ describe('table', function() {
             .then(done);
         });
 
-        it('`Plotly.plot` should render all columns even if no header contents were supplied yet', function(done) {
+        it('`Plotly.newPlot` should render all columns even if no header contents were supplied yet', function(done) {
             gd = createGraphDiv();
             mockCopy = Lib.extendDeep({}, mock);
             delete mockCopy.data[0].header;
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].cells.values.length).toEqual(7);
                 expect(document.querySelectorAll('.' + cn.yColumn).length).toEqual(7);
@@ -269,11 +269,11 @@ describe('table', function() {
             .then(done);
         });
 
-        it('`Plotly.plot` should render all the column headers even if not all header values were supplied', function(done) {
+        it('`Plotly.newPlot` should render all the column headers even if not all header values were supplied', function(done) {
             gd = createGraphDiv();
             mockCopy = Lib.extendDeep({}, mock);
             mockCopy.data[0].header.values = ['A', 'S', 'D']; // doesn't cover all 7 columns
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].cells.values.length).toEqual(7);
                 expect(document.querySelectorAll('.' + cn.yColumn).length).toEqual(7);
@@ -297,10 +297,10 @@ describe('table', function() {
                 y: [0.05, 0.85]
             };
             gd = createGraphDiv();
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
-        it('`Plotly.plot` should have proper fields on `gd.data` on initial rendering', function() {
+        it('`Plotly.newPlot` should have proper fields on `gd.data` on initial rendering', function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].header.values.length).toEqual(7);
             expect(gd.data[0].cells.values.length).toEqual(7);
@@ -386,7 +386,7 @@ describe('table', function() {
         beforeEach(function(done) {
             mockCopy = Lib.extendDeep({}, mock2);
             gd = createGraphDiv();
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('Calling `Plotly.restyle` for a `header.values` change should amend the preexisting one', function(done) {
@@ -426,7 +426,7 @@ describe('table', function() {
             mockCopy = Lib.extendDeep({}, mockMulti);
             gd = createGraphDiv();
             gdWheelEventCount = 0;
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 gd.addEventListener('wheel', function(evt) {
                     gdWheelEventCount++;

--- a/test/jasmine/tests/ternary_test.js
+++ b/test/jasmine/tests/ternary_test.js
@@ -35,7 +35,7 @@ describe('ternary plots', function() {
 
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         it('should be able to toggle trace visibility', function(done) {
@@ -260,7 +260,7 @@ describe('ternary plots', function() {
             var mockCopy = Lib.extendDeep({}, mock);
             var config = { staticPlot: true };
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout, config).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout, config).then(done);
         });
 
         it('should not respond to drag', function(done) {
@@ -300,7 +300,7 @@ describe('ternary plots', function() {
             });
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert(dflt);
             return Plotly.relayout(gd, 'ternary.aaxis.layer', 'below traces');
         })
@@ -361,7 +361,7 @@ describe('ternary plots', function() {
             expect(tick.style.fill).toBe(color, 'font color');
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('"Open Sans", verdana, arial, sans-serif', 'rgb(204, 204, 204)', 12);
 
             return Plotly.relayout(gd, 'ternary.aaxis.tickfont.size', 5);
@@ -397,7 +397,7 @@ describe('ternary plots', function() {
             expect(titleNode.style.fill).toBe(color, 'font color ' + msg);
         }
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('a', 'Component A', '"Open Sans", verdana, arial, sans-serif', rgb('#ccc'), 14);
             _assert('b', 'chocolate', '"Open Sans", verdana, arial, sans-serif', rgb('#0f0'), 14);
             _assert('c', 'Component C', '"Open Sans", verdana, arial, sans-serif', rgb('#444'), 14);
@@ -456,7 +456,7 @@ describe('ternary plots', function() {
             };
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(toggle(
             '.aaxis > .ytick > text', 'ternary.aaxis.showticklabels',
             [true, false], [4, 0]
@@ -488,7 +488,7 @@ describe('ternary plots', function() {
     it('should render a-axis and c-axis with negative offsets', function(done) {
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'scatterternary',
             a: [2, 1, 1],
             b: [1, 2, 1],
@@ -523,7 +523,7 @@ describe('ternary plots', function() {
                 fig.layout.dragmode = dragmode;
 
                 var gd = createGraphDiv();
-                Plotly.plot(gd, fig)
+                Plotly.newPlot(gd, fig)
                 .then(function() {
                     relayoutCallback = jasmine.createSpy('relayoutCallback');
                     gd.on('plotly_relayout', relayoutCallback);
@@ -587,7 +587,7 @@ describe('ternary plots when css transform is present', function() {
 
         var mockCopy = Lib.extendDeep({}, mock);
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() { transformPlot(gd, cssTransform); })
             .then(done);
     });
@@ -816,7 +816,7 @@ describe('Test event property of interactions on a ternary plot:', function() {
     beforeAll(function(done) {
         gd = createGraphDiv();
         mockCopy = Lib.extendDeep({}, mock);
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             pointPos = getClientPosition('path.point');
             destroyGraphDiv();
             done();
@@ -834,7 +834,7 @@ describe('Test event property of interactions on a ternary plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -880,7 +880,7 @@ describe('Test event property of interactions on a ternary plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -955,7 +955,7 @@ describe('Test event property of interactions on a ternary plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 
@@ -1006,7 +1006,7 @@ describe('Test event property of interactions on a ternary plot:', function() {
         var futureData;
 
         beforeEach(function(done) {
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
             .then(function() {
                 futureData = null;
 

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -44,7 +44,7 @@ describe('Plot title', function() {
     };
 
     it('is centered horizontally and vertically above the plot by default', function(done) {
-        Plotly.plot(gd, data, {title: {text: 'Plotly line chart'}})
+        Plotly.newPlot(gd, data, {title: {text: 'Plotly line chart'}})
         .then(function() {
             expectDefaultCenteredPosition(gd);
         })
@@ -53,7 +53,7 @@ describe('Plot title', function() {
     });
 
     it('can still be defined as `layout.title` to ensure backwards-compatibility', function(done) {
-        Plotly.plot(gd, data, {title: 'Plotly line chart'})
+        Plotly.newPlot(gd, data, {title: 'Plotly line chart'})
         .then(function() {
             expectTitle('Plotly line chart');
             expectDefaultCenteredPosition(gd);
@@ -63,7 +63,7 @@ describe('Plot title', function() {
     });
 
     it('can be updated via `relayout`', function(done) {
-        Plotly.plot(gd, data, {title: 'Plotly line chart'})
+        Plotly.newPlot(gd, data, {title: 'Plotly line chart'})
           .then(expectTitleFn('Plotly line chart'))
           .then(function() {
               return Plotly.relayout(gd, {title: {text: 'Some other title'}});
@@ -85,7 +85,7 @@ describe('Plot title', function() {
         }
     ].forEach(function(testCase) {
         it('can be placed at the left edge of the ' + testCase.selector.desc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: testCase.xref,
                 x: 0,
                 xanchor: 'left'
@@ -98,7 +98,7 @@ describe('Plot title', function() {
         });
 
         it('can be placed at the right edge of the ' + testCase.selector.desc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: testCase.xref,
                 x: 1,
                 xanchor: 'right'
@@ -111,7 +111,7 @@ describe('Plot title', function() {
         });
 
         it('can be placed at the center of the ' + testCase.selector.desc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: testCase.xref,
                 x: 0.5,
                 xanchor: 'center'
@@ -136,7 +136,7 @@ describe('Plot title', function() {
         }
     ].forEach(function(testCase) {
         it('can be placed at the top edge of the ' + testCase.selector.desc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: testCase.yref,
                 y: 1,
                 yanchor: 'top'
@@ -149,7 +149,7 @@ describe('Plot title', function() {
         });
 
         it('can be placed at the bottom edge of the ' + testCase.selector.desc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: testCase.yref,
                 y: 0,
                 yanchor: 'bottom'
@@ -162,7 +162,7 @@ describe('Plot title', function() {
         });
 
         it('can be placed in the vertical center of the ' + testCase.selector.desc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: testCase.yref,
                 y: 0.5,
                 yanchor: 'middle'
@@ -179,7 +179,7 @@ describe('Plot title', function() {
     it('provides a y \'auto\' value putting title baseline in middle ' +
       'of top margin irrespective of `yref`', function(done) {
         // yref: 'container'
-        Plotly.plot(gd, data, extendLayout({
+        Plotly.newPlot(gd, data, extendLayout({
             yref: 'container',
             y: 'auto'
         }))
@@ -214,7 +214,7 @@ describe('Plot title', function() {
         var testDesc = 'with {xanchor: \'auto\', x: ' + testCase.x + ', xref: \'' + xref +
           '\'} expected to be aligned ' + testCase.expAlignment;
         it(testDesc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: xref,
                 x: testCase.x,
                 xanchor: 'auto'
@@ -248,7 +248,7 @@ describe('Plot title', function() {
         var testDesc = 'with {yanchor: \'auto\', y: ' + testCase.y + ', yref: \'' + yref +
           '\'} expected to be aligned ' + testCase.expAlignment;
         it(testDesc, function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: yref,
                 y: testCase.y,
                 yanchor: 'auto'
@@ -263,7 +263,7 @@ describe('Plot title', function() {
 
     it('{y: \'auto\'} overrules {yanchor: \'auto\'} to support behavior ' +
       'before chart title alignment was introduced', function(done) {
-        Plotly.plot(gd, data, extendLayout({
+        Plotly.newPlot(gd, data, extendLayout({
             y: 'auto',
             yanchor: 'auto'
         }))
@@ -277,7 +277,7 @@ describe('Plot title', function() {
     // Horizontal padding
     [containerElemSelector, paperElemSelector].forEach(function(refSelector) {
         it('can be placed x pixels away from left ' + refSelector.desc + ' edge', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: refSelector.ref,
                 xanchor: 'left',
                 x: 0,
@@ -294,7 +294,7 @@ describe('Plot title', function() {
 
     [containerElemSelector, paperElemSelector].forEach(function(refSelector) {
         it('can be placed x pixels away from right ' + refSelector.desc + ' edge', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: refSelector.ref,
                 xanchor: 'right',
                 x: 1,
@@ -312,7 +312,7 @@ describe('Plot title', function() {
     [containerElemSelector, paperElemSelector].forEach(function(refSelector) {
         it('figures out for itself which horizontal padding applies when {xanchor: \'auto\'}' +
           refSelector.desc + ' edge', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: refSelector.ref,
                 xanchor: 'auto',
                 x: 1,
@@ -345,7 +345,7 @@ describe('Plot title', function() {
         {pad: {r: 20}, dir: 'right'}
     ].forEach(function(testCase) {
         it('mutes ' + testCase.dir + ' padding for {xanchor: \'center\'}', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 xref: 'paper',
                 xanchor: 'middle',
                 x: 0.5,
@@ -360,7 +360,7 @@ describe('Plot title', function() {
     });
 
     it('mutes left padding when xanchor is right', function(done) {
-        Plotly.plot(gd, data, extendLayout({
+        Plotly.newPlot(gd, data, extendLayout({
             xref: 'paper',
             x: 1,
             xanchor: 'right',
@@ -376,7 +376,7 @@ describe('Plot title', function() {
     });
 
     it('mutes right padding when xanchor is left', function(done) {
-        Plotly.plot(gd, data, extendLayout({
+        Plotly.newPlot(gd, data, extendLayout({
             xref: 'paper',
             x: 0,
             xanchor: 'left',
@@ -394,7 +394,7 @@ describe('Plot title', function() {
     // Vertical padding
     [containerElemSelector, paperElemSelector].forEach(function(refSelector) {
         it('can be placed x pixels below top ' + refSelector.desc + ' edge', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: refSelector.ref,
                 yanchor: 'top',
                 y: 1,
@@ -411,7 +411,7 @@ describe('Plot title', function() {
 
     [containerElemSelector, paperElemSelector].forEach(function(refSelector) {
         it('can be placed x pixels above bottom ' + refSelector.desc + ' edge', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: refSelector.ref,
                 yanchor: 'bottom',
                 y: 0,
@@ -429,7 +429,7 @@ describe('Plot title', function() {
     [containerElemSelector, paperElemSelector].forEach(function(refSelector) {
         it('figures out for itself which vertical padding applies when {yanchor: \'auto\'}' +
           refSelector.desc + ' edge', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: refSelector.ref,
                 yanchor: 'auto',
                 y: 1,
@@ -462,7 +462,7 @@ describe('Plot title', function() {
         {pad: {b: 20}, dir: 'bottom'}
     ].forEach(function(testCase) {
         it('mutes ' + testCase.dir + ' padding for {yanchor: \'middle\'}', function(done) {
-            Plotly.plot(gd, data, extendLayout({
+            Plotly.newPlot(gd, data, extendLayout({
                 yref: 'paper',
                 yanchor: 'middle',
                 y: 0.5,
@@ -477,7 +477,7 @@ describe('Plot title', function() {
     });
 
     it('mutes top padding when yanchor is bottom', function(done) {
-        Plotly.plot(gd, data, extendLayout({
+        Plotly.newPlot(gd, data, extendLayout({
             yref: 'paper',
             y: 0,
             yanchor: 'bottom',
@@ -493,7 +493,7 @@ describe('Plot title', function() {
     });
 
     it('mutes bottom padding when yanchor is top', function(done) {
-        Plotly.plot(gd, data, extendLayout({
+        Plotly.newPlot(gd, data, extendLayout({
             yref: 'paper',
             y: 1,
             yanchor: 'top',
@@ -629,7 +629,7 @@ describe('Titles can be updated', function() {
             yaxis: {title: {text: 'Weight'}}
         };
         gd = createGraphDiv();
-        Plotly.plot(gd, data, Lib.extendDeep({}, layout));
+        Plotly.newPlot(gd, data, Lib.extendDeep({}, layout));
 
         expectTitles('Plotly line chart', 'Age', 'Weight');
     });
@@ -808,7 +808,7 @@ describe('Titles support setting custom font properties', function() {
             }
         };
 
-        Plotly.plot(gd, data, layout)
+        Plotly.newPlot(gd, data, layout)
         .then(function() {
             expectTitleFont('blue', 'serif', 24);
             expectXAxisTitleFont('#333', 'sans-serif', 20);
@@ -850,7 +850,7 @@ describe('Titles support setting custom font properties', function() {
             }
         };
 
-        Plotly.plot(gd, data, layout)
+        Plotly.newPlot(gd, data, layout)
         .then(function() {
             expectTitleFont('blue', 'serif', 24);
             expectXAxisTitleFont('#333', 'sans-serif', 20);
@@ -893,7 +893,7 @@ describe('Title fonts can be updated', function() {
             }
         };
         gd = createGraphDiv();
-        Plotly.plot(gd, data, Lib.extendDeep({}, layout))
+        Plotly.newPlot(gd, data, Lib.extendDeep({}, layout))
         .then(function() {
             expectTitleFont('black', 'sans-serif', 24);
             expectXAxisTitleFont('red', 'serif', 20);
@@ -1049,7 +1049,7 @@ describe('Titles for multiple axes', function() {
     afterEach(destroyGraphDiv);
 
     it('still support deprecated `title` and `titlefont` syntax (backwards-compatibility)', function(done) {
-        Plotly.plot(gd, data, multiAxesLayout)
+        Plotly.newPlot(gd, data, multiAxesLayout)
         .then(function() {
             expect(xTitleSel(1).text()).toBe('X-Axis 1');
             expect(xTitleSel(1).node().style.fontSize).toBe('30px');
@@ -1068,7 +1068,7 @@ describe('Titles for multiple axes', function() {
     });
 
     it('can be updated using deprecated `title` and `titlefont` syntax (backwards-compatibility)', function(done) {
-        Plotly.plot(gd, data, multiAxesLayout)
+        Plotly.newPlot(gd, data, multiAxesLayout)
         .then(function() {
             return Plotly.relayout(gd, {
                 'xaxis2.title': '2nd X-Axis',
@@ -1276,7 +1276,7 @@ describe('Editable titles', function() {
     }
 
     it('shows default titles semi-opaque with no hover effects', function(done) {
-        Plotly.plot(gd, data, {}, {editable: true})
+        Plotly.newPlot(gd, data, {}, {editable: true})
         .then(function() {
             return Promise.all([
                 // Check all three titles in parallel. This only works because
@@ -1293,7 +1293,7 @@ describe('Editable titles', function() {
     });
 
     it('has hover effects for blank titles', function(done) {
-        Plotly.plot(gd, data, {
+        Plotly.newPlot(gd, data, {
             xaxis: {title: {text: ''}},
             yaxis: {title: {text: ''}},
             title: {text: ''}
@@ -1310,7 +1310,7 @@ describe('Editable titles', function() {
     });
 
     it('has no hover effects for titles that used to be blank', function(done) {
-        Plotly.plot(gd, data, {
+        Plotly.newPlot(gd, data, {
             xaxis: {title: {text: ''}},
             yaxis: {title: {text: ''}},
             title: {text: ''}

--- a/test/jasmine/tests/toimage_test.js
+++ b/test/jasmine/tests/toimage_test.js
@@ -52,7 +52,7 @@ describe('Plotly.toImage', function() {
             return !!x.then && typeof x.then === 'function';
         }
 
-        var returnValue = Plotly.plot(gd, subplotMock.data, subplotMock.layout)
+        var returnValue = Plotly.newPlot(gd, subplotMock.data, subplotMock.layout)
                .then(Plotly.toImage);
 
         expect(isPromise(returnValue)).toBe(true);
@@ -63,7 +63,7 @@ describe('Plotly.toImage', function() {
     it('should throw error with unsupported file type', function(done) {
         var fig = Lib.extendDeep({}, subplotMock);
 
-        Plotly.plot(gd, fig.data, fig.layout)
+        Plotly.newPlot(gd, fig.data, fig.layout)
         .then(function(gd) {
             expect(function() { Plotly.toImage(gd, {format: 'x'}); })
                 .toThrow(new Error('Export format is not png, jpeg, webp, svg or full-json.'));
@@ -75,7 +75,7 @@ describe('Plotly.toImage', function() {
     it('should throw error with height and/or width < 1', function(done) {
         var fig = Lib.extendDeep({}, subplotMock);
 
-        Plotly.plot(gd, fig.data, fig.layout)
+        Plotly.newPlot(gd, fig.data, fig.layout)
         .then(function() {
             expect(function() { Plotly.toImage(gd, {height: 0.5}); })
                 .toThrow(new Error('Height and width should be pixel values.'));
@@ -95,7 +95,7 @@ describe('Plotly.toImage', function() {
         fig.layout.height = 600;
         fig.layout.width = 700;
 
-        Plotly.plot(gd, fig.data, fig.layout).then(function(gd) {
+        Plotly.newPlot(gd, fig.data, fig.layout).then(function(gd) {
             expect(gd.layout.height).toBe(600);
             expect(gd.layout.width).toBe(700);
             return Plotly.toImage(gd);
@@ -122,7 +122,7 @@ describe('Plotly.toImage', function() {
         gd.style.width = '832px';
         gd.style.height = '502px';
 
-        Plotly.plot(gd, fig.data, fig.layout).then(function() {
+        Plotly.newPlot(gd, fig.data, fig.layout).then(function() {
             expect(gd.layout.width).toBe(undefined, 'user layout width');
             expect(gd.layout.height).toBe(undefined, 'user layout height');
             expect(gd._fullLayout.width).toBe(832, 'full layout width');
@@ -137,7 +137,7 @@ describe('Plotly.toImage', function() {
     it('should create proper file type', function(done) {
         var fig = Lib.extendDeep({}, subplotMock);
 
-        Plotly.plot(gd, fig.data, fig.layout)
+        Plotly.newPlot(gd, fig.data, fig.layout)
         .then(function() { return Plotly.toImage(gd, {format: 'png'}); })
         .then(function(url) { return assertSize(url, 700, 450); })
         .then(function(url) {
@@ -165,7 +165,7 @@ describe('Plotly.toImage', function() {
     it('should strip *data:image* prefix when *imageDataOnly* is turned on', function(done) {
         var fig = Lib.extendDeep({}, subplotMock);
 
-        Plotly.plot(gd, fig.data, fig.layout)
+        Plotly.newPlot(gd, fig.data, fig.layout)
         .then(function() { return Plotly.toImage(gd, {format: 'png', imageDataOnly: true}); })
         .then(function(d) {
             expect(d.indexOf('data:image/')).toBe(-1);
@@ -194,7 +194,7 @@ describe('Plotly.toImage', function() {
         it('should respond to *scale* option ( format ' + f + ')', function(done) {
             var fig = Lib.extendDeep({}, subplotMock);
 
-            Plotly.plot(gd, fig.data, fig.layout)
+            Plotly.newPlot(gd, fig.data, fig.layout)
             .then(function() { return Plotly.toImage(gd, {format: f, scale: 2}); })
             .then(function(url) { return assertSize(url, 1400, 900); })
             .then(function() { return Plotly.toImage(gd, {format: f, scale: 0.5}); })
@@ -220,7 +220,7 @@ describe('Plotly.toImage', function() {
     it('should accept graph div id as input', function(done) {
         var fig = Lib.extendDeep({}, subplotMock);
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() { return Plotly.toImage('graph'); })
         .then(createImage)
         .then(function(img) {
@@ -238,7 +238,7 @@ describe('Plotly.toImage', function() {
             .append('base')
             .attr('href', 'https://chart-studio.plotly.com');
 
-        Plotly.plot(gd, [{ y: [1, 2, 1] }])
+        Plotly.newPlot(gd, [{ y: [1, 2, 1] }])
         .then(function() {
             return Plotly.toImage(gd, {format: 'svg', imageDataOnly: true});
         })
@@ -275,7 +275,7 @@ describe('Plotly.toImage', function() {
         afterEach(destroyGraphDiv);
 
         it('export a graph div', function(done) {
-            Plotly.plot(gd, [{y: [1, 2, 3]}])
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
             .then(function(gd) { return Plotly.toImage(gd, imgOpts);})
             .then(function(fig) {
                 fig = JSON.parse(fig);

--- a/test/jasmine/tests/transform_filter_test.js
+++ b/test/jasmine/tests/transform_filter_test.js
@@ -1096,10 +1096,10 @@ describe('filter transforms interactions', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('Plotly.plot should plot the transform trace', function(done) {
+    it('Plotly.newPlot should plot the transform trace', function(done) {
         var data = Lib.extendDeep([], mockData0);
 
-        Plotly.plot(createGraphDiv(), data).then(function(gd) {
+        Plotly.newPlot(createGraphDiv(), data).then(function(gd) {
             assertDims([3]);
 
             var uid = gd._fullData[0]._fullInput.uid;
@@ -1122,7 +1122,7 @@ describe('filter transforms interactions', function() {
                 .toBe(uid + '0', 'should preserve uid on restyle');
         }
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             uid = gd._fullData[0]._fullInput.uid;
 
             expect(gd._fullData[0].marker.color).toEqual('red');
@@ -1161,7 +1161,7 @@ describe('filter transforms interactions', function() {
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.data[0].x.length).toEqual(7);
             expect(gd._fullData[0].x.length).toEqual(3);
 
@@ -1186,7 +1186,7 @@ describe('filter transforms interactions', function() {
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertDims([3, 4]);
 
             return Plotly.deleteTraces(gd, [1]);
@@ -1206,7 +1206,7 @@ describe('filter transforms interactions', function() {
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertDims([3, 4]);
 
             return Plotly.restyle(gd, 'visible', 'legendonly', [1]);
@@ -1232,7 +1232,7 @@ describe('filter transforms interactions', function() {
 
         function getTx(p) { return p.tx; }
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.calcdata[0].map(getTx)).toEqual(['e', 'f', 'g']);
             expect(gd.calcdata[1].map(getTx)).toEqual(['D', 'E', 'F', 'G']);
 
@@ -1267,7 +1267,7 @@ describe('filter transforms interactions', function() {
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd._fullLayout.xaxis._categories).toEqual(['a', 'f']);
             expect(gd._fullLayout.yaxis._categories).toEqual([]);
 

--- a/test/jasmine/tests/transform_groupby_test.js
+++ b/test/jasmine/tests/transform_groupby_test.js
@@ -69,12 +69,12 @@ describe('groupby', function() {
 
         afterEach(destroyGraphDiv);
 
-        it('Plotly.plot should plot the transform traces', function(done) {
+        it('Plotly.newPlot should plot the transform traces', function(done) {
             var data = Lib.extendDeep([], mockData0);
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
                 expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -113,7 +113,7 @@ describe('groupby', function() {
             var gd = createGraphDiv();
             var dims = [4, 3];
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 assertStyle(dims,
                     ['rgb(255, 0, 0)', 'rgb(0, 0, 255)'],
                     [1, 1]
@@ -154,7 +154,7 @@ describe('groupby', function() {
             var gd = createGraphDiv();
             var dims = [4, 3];
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 assertStyle(dims,
                     ['rgb(255, 0, 0)', 'rgb(0, 0, 255)'],
                     [1, 1]
@@ -204,7 +204,7 @@ describe('groupby', function() {
             var gd = createGraphDiv();
             var dims = [4, 3];
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 assertStyle(dims,
                     ['rgb(255, 0, 0)', 'rgb(0, 0, 255)'],
                     [1, 1]
@@ -266,7 +266,7 @@ describe('groupby', function() {
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd.data[0].x.length).toEqual(7);
                 expect(gd._fullData[0].x.length).toEqual(4);
                 expect(gd._fullData[1].x.length).toEqual(3);
@@ -294,7 +294,7 @@ describe('groupby', function() {
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 assertDims([4, 3, 4, 3]);
 
                 return Plotly.deleteTraces(gd, [1]);
@@ -314,7 +314,7 @@ describe('groupby', function() {
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 assertDims([4, 3, 4, 3]);
 
                 return Plotly.restyle(gd, 'visible', 'legendonly', [1]);
@@ -333,12 +333,12 @@ describe('groupby', function() {
             .then(done);
         });
 
-        it('Plotly.plot should group points properly using typed array', function(done) {
+        it('Plotly.newPlot should group points properly using typed array', function(done) {
             var data = Lib.extendDeep([], mockDataWithTypedArrayGroups);
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd._fullData.length).toEqual(2);
                 expect(gd._fullData[0].x).toEqual([20, 12, 0, 1]);
                 expect(gd._fullData[0].y).toEqual([1, 3, 2, 5]);
@@ -440,12 +440,12 @@ describe('groupby', function() {
 
         afterEach(destroyGraphDiv);
 
-        it('Plotly.plot should plot the transform traces', function(done) {
+        it('Plotly.newPlot should plot the transform traces', function(done) {
             var data = Lib.extendDeep([], mockData);
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
                 expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -462,12 +462,12 @@ describe('groupby', function() {
             .then(done);
         });
 
-        it('Plotly.plot should plot the transform traces', function(done) {
+        it('Plotly.newPlot should plot the transform traces', function(done) {
             var data = Lib.extendDeep([], mockData0);
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
                 expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -479,12 +479,12 @@ describe('groupby', function() {
             .then(done);
         });
 
-        it('Plotly.plot should plot the transform traces', function(done) {
+        it('Plotly.newPlot should plot the transform traces', function(done) {
             var data = Lib.extendDeep([], mockData1);
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
                 expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -499,12 +499,12 @@ describe('groupby', function() {
             .then(done);
         });
 
-        it('Plotly.plot should plot the transform traces', function(done) {
+        it('Plotly.newPlot should plot the transform traces', function(done) {
             var data = Lib.extendDeep([], mockData2);
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
                 expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -520,12 +520,12 @@ describe('groupby', function() {
             .then(done);
         });
 
-        it('Plotly.plot should plot the transform traces', function(done) {
+        it('Plotly.newPlot should plot the transform traces', function(done) {
             var data = Lib.extendDeep([], mockData3);
 
             var gd = createGraphDiv();
 
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd.data.length).toEqual(1);
                 expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
                 expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -553,7 +553,7 @@ describe('groupby', function() {
 
                 var gd = createGraphDiv();
 
-                Plotly.plot(gd, data).then(function() {
+                Plotly.newPlot(gd, data).then(function() {
                     expect(gd.data.length).toEqual(1);
                     expect(gd.data[0].ids).toEqual(['q', 'w', 'r', 't', 'y', 'u', 'i']);
                     expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
@@ -704,7 +704,7 @@ describe('groupby', function() {
         it('passes extended tests with group styles partially overriding top level aesthetics', function(done) {
             var data = Lib.extendDeep([], mockData3);
             var gd = createGraphDiv();
-            Plotly.plot(gd, data).then(function() {
+            Plotly.newPlot(gd, data).then(function() {
                 expect(gd._fullData[0].marker.line.color).toEqual(['orange', 'red', 'cyan', 'pink']);
                 expect(gd._fullData[1].marker.line.color).toEqual('yellow');
             })
@@ -728,7 +728,7 @@ describe('groupby', function() {
 
                 var gd = createGraphDiv();
 
-                Plotly.plot(gd, data).then(function() {
+                Plotly.newPlot(gd, data).then(function() {
                     expect(gd.data.length).toEqual(1);
                     expect(gd.data[0].ids).toEqual(['q', 'w', 'r', 't', 'y', 'u', 'i']);
                     expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);

--- a/test/jasmine/tests/transform_multi_test.js
+++ b/test/jasmine/tests/transform_multi_test.js
@@ -443,10 +443,10 @@ describe('multiple transforms:', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('Plotly.plot should plot the transform traces - filter|aggregate|filter', function(done) {
+    it('Plotly.newPlot should plot the transform traces - filter|aggregate|filter', function(done) {
         var data = Lib.extendDeep([], mockData2);
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.data.length).toEqual(1);
 
             // this would be the result if we didn't have a second filter - kept for test case overview
@@ -467,10 +467,10 @@ describe('multiple transforms:', function() {
     });
 
 
-    it('Plotly.plot should plot the transform traces', function(done) {
+    it('Plotly.newPlot should plot the transform traces', function(done) {
         var data = Lib.extendDeep([], mockData0);
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
             expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -487,12 +487,12 @@ describe('multiple transforms:', function() {
         .then(done);
     });
 
-    it('Plotly.plot should plot the transform traces (reverse case)', function(done) {
+    it('Plotly.newPlot should plot the transform traces (reverse case)', function(done) {
         var data = Lib.extendDeep([], mockData0);
 
         data[0].transforms.slice().reverse();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.data.length).toEqual(1);
             expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
             expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -515,7 +515,7 @@ describe('multiple transforms:', function() {
 
         var dims = [2, 2];
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertStyle(dims,
                 ['rgb(255, 0, 0)', 'rgb(0, 0, 255)'],
                 [1, 1]
@@ -564,7 +564,7 @@ describe('multiple transforms:', function() {
     it('Plotly.extendTraces should work', function(done) {
         var data = Lib.extendDeep([], mockData0);
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.data[0].x.length).toEqual(7);
             expect(gd._fullData[0].x.length).toEqual(2);
             expect(gd._fullData[1].x.length).toEqual(2);
@@ -590,7 +590,7 @@ describe('multiple transforms:', function() {
     it('Plotly.deleteTraces should work', function(done) {
         var data = Lib.extendDeep([], mockData1);
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertDims([2, 2, 2, 2]);
 
             return Plotly.deleteTraces(gd, [1]);
@@ -608,7 +608,7 @@ describe('multiple transforms:', function() {
     it('toggling trace visibility should work', function(done) {
         var data = Lib.extendDeep([], mockData1);
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertDims([2, 2, 2, 2]);
 
             return Plotly.restyle(gd, 'visible', 'legendonly', [1]);
@@ -725,7 +725,7 @@ describe('invalid transforms', function() {
     afterEach(destroyGraphDiv);
 
     it('ignores them', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             y: [1, 2, 3],
             transforms: [{}]
         }]).then(function() {
@@ -772,12 +772,12 @@ describe('multiple traces with transforms:', function() {
 
     afterEach(destroyGraphDiv);
 
-    it('Plotly.plot should plot the transform traces', function(done) {
+    it('Plotly.newPlot should plot the transform traces', function(done) {
         var data = Lib.extendDeep([], mockData0);
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.data.length).toEqual(2);
             expect(gd.data[0].x).toEqual([1, -1, -2, 0, 1, 2, 3]);
             expect(gd.data[0].y).toEqual([1, 2, 3, 1, 2, 3, 1]);
@@ -805,7 +805,7 @@ describe('multiple traces with transforms:', function() {
         var gd = createGraphDiv();
         var dims = [2, 3, 3];
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertStyle(dims,
                 ['rgb(0, 128, 0)', 'rgb(255, 0, 0)', 'rgb(0, 0, 255)'],
                 [1, 1, 1]
@@ -858,7 +858,7 @@ describe('multiple traces with transforms:', function() {
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertDims([2, 3, 3]);
 
             return Plotly.extendTraces(gd, {
@@ -885,7 +885,7 @@ describe('multiple traces with transforms:', function() {
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertDims([2, 3, 3]);
 
             return Plotly.deleteTraces(gd, [1]);
@@ -905,7 +905,7 @@ describe('multiple traces with transforms:', function() {
 
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             assertDims([2, 3, 3]);
 
             return Plotly.restyle(gd, 'visible', 'legendonly', [1]);
@@ -951,7 +951,7 @@ describe('restyle applied on transforms:', function() {
             groups: ['a', 'b', 'b']
         };
 
-        Plotly.plot(gd, data).then(function() {
+        Plotly.newPlot(gd, data).then(function() {
             expect(gd.data.transforms).toBeUndefined();
 
             return Plotly.restyle(gd, 'transforms[0]', transform0);

--- a/test/jasmine/tests/transform_sort_test.js
+++ b/test/jasmine/tests/transform_sort_test.js
@@ -269,7 +269,7 @@ describe('Test sort transform interactions:', function() {
     }
 
     it('should respond to restyle calls', function(done) {
-        Plotly.plot(createGraphDiv(), [{
+        Plotly.newPlot(createGraphDiv(), [{
             x: [-2, -1, -2, 0, 1, 3, 1],
             y: [1, 2, 3, 1, 2, 3, 1],
             marker: {
@@ -341,7 +341,7 @@ describe('Test sort transform interactions:', function() {
             expect(pt.fullData.ids[pt.pointNumber]).toEqual(id, 'id');
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             mode: 'markers',
             x: [-2, -1, -2, 0, 1, 3, 1],
             y: [1, 2, 3, 1, 2, 3, 1],
@@ -397,7 +397,7 @@ describe('Test sort transform interactions:', function() {
     it('should honor *categoryarray* when set', function(done) {
         var gd = createGraphDiv();
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: ['C', 'B', 'A'],
             y: [3, 1, 2],
             marker: {

--- a/test/jasmine/tests/transition_test.js
+++ b/test/jasmine/tests/transition_test.js
@@ -23,7 +23,7 @@ function runTests(transitionDuration) {
 
             var mockCopy = Lib.extendDeep({}, mock);
 
-            Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(done);
+            Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(done);
         });
 
         afterEach(function() {
@@ -1141,7 +1141,7 @@ describe('Plotly.react transitions:', function() {
             };
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             x: [0.1, 0.2, 0.3],
             y: [0.4, 0.5, 0.6],
         }, {
@@ -1192,7 +1192,7 @@ describe('Plotly.react transitions:', function() {
     });
 
     it('should update ranges of date and category axes', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {x: ['2018-01-01', '2019-01-01', '2020-01-01'], y: [1, 2, 3]},
             {x: ['a', 'b', 'c'], y: [1, 2, 3], xaxis: 'x2', yaxis: 'y2'}
         ], {

--- a/test/jasmine/tests/treemap_test.js
+++ b/test/jasmine/tests/treemap_test.js
@@ -572,7 +572,7 @@ describe('Test treemap plot:', function() {
     afterEach(destroyGraphDiv);
 
     it('should return early from the plot when there is no entry', function(done) {
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             labels: ['a', 'b'],
             parents: ['A', 'B'],
             type: 'treemap'
@@ -615,7 +615,7 @@ describe('Test treemap hover:', function() {
         var exp = spec.exp || {};
         var ptData = null;
 
-        return Plotly.plot(gd, data, layout)
+        return Plotly.newPlot(gd, data, layout)
             .then(function() {
                 gd.once('plotly_hover', function(d) { ptData = d.points[0]; });
             })
@@ -821,7 +821,7 @@ describe('Test treemap hover with and without levels', function() {
         var exp = spec.exp || {};
         var ptData = null;
 
-        return Plotly.plot(gd, data, layout)
+        return Plotly.newPlot(gd, data, layout)
             .then(function() {
                 gd.once('plotly_hover', function(d) { ptData = d.points[0]; });
             })
@@ -960,7 +960,7 @@ describe('Test treemap hover lifecycle:', function() {
     it('should fire the correct events', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/treemap_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(hover(gd, 1))
         .then(function() {
@@ -1036,7 +1036,7 @@ describe('Test treemap clicks:', function() {
     it('should trigger animation when clicking on branches', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/treemap_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(click(gd, 2))
         .then(function() {
@@ -1067,7 +1067,7 @@ describe('Test treemap clicks:', function() {
     it('should trigger plotly_click event when clicking on leaf node', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/treemap_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(click(gd, 8))
         .then(function() {
@@ -1090,7 +1090,7 @@ describe('Test treemap clicks:', function() {
     it('should not trigger animation when graph is transitioning', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/treemap_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners())
         .then(click(gd, 2))
         .then(function() {
@@ -1151,7 +1151,7 @@ describe('Test treemap clicks:', function() {
     it('should be able to override default click behavior using plotly_treemapclick handler ()', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/treemap_first.json'));
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(setupListeners({turnOffAnimation: true}))
         .then(click(gd, 2))
         .then(function() {
@@ -1196,7 +1196,7 @@ describe('Test treemap restyle:', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', 2))
         .then(_restyle({'visible': false}))
         .then(_assert('both visible:false', 0))
@@ -1222,7 +1222,7 @@ describe('Test treemap restyle:', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', 97))
         .then(function() {
             spyOn(Plots, 'doCalcdata').and.callThrough();
@@ -1277,7 +1277,7 @@ describe('Test treemap restyle:', function() {
             };
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_assert('base', ['Root', 'B', 'A\nnode1', 'b\nnode3']))
         .then(function() {
             spyOn(Plots, 'doCalcdata').and.callThrough();
@@ -1366,7 +1366,7 @@ describe('Test treemap tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 3))
         .then(function() {
             _assert('exit entry', 'd', 'Root',
@@ -1398,7 +1398,7 @@ describe('Test treemap tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 1))
         .then(function() {
             _assert('enter new entry', 'd', 'Root',
@@ -1430,7 +1430,7 @@ describe('Test treemap tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 3))
         .then(function() {
             _assert('exit entry', 'd', 'Root',
@@ -1463,7 +1463,7 @@ describe('Test treemap tweening:', function() {
             }]
         };
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(_run(gd, 1))
         .then(function() {
             _assert('exit b', 'd', 'b',
@@ -1509,7 +1509,7 @@ describe('Test treemap interactions edge cases', function() {
             unhoverCnt = 0;
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.on('plotly_hover', function() {
                 hoverCnt++;
@@ -1551,7 +1551,7 @@ describe('Test treemap interactions edge cases', function() {
     });
 
     it('should show falsy zero text', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'treemap',
                 parents: ['', 'A', 'B', 'C', 'D', 'E', 'F'],
@@ -1589,7 +1589,7 @@ describe('Test treemap interactions edge cases', function() {
                 .toBe(exp.treemapTraceCnt, '# of treemap traces');
         }
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             _assert('base', {
                 cartesianTraceCnt: 2,
@@ -1619,7 +1619,7 @@ describe('Test treemap interactions edge cases', function() {
 
         spyOn(Plots, 'transitionFromReact').and.callThrough();
 
-        Plotly.plot(gd, mock)
+        Plotly.newPlot(gd, mock)
         .then(function() {
             gd.data[1].level = 'B';
             return Plotly.react(gd, gd.data, gd.layout);
@@ -1776,7 +1776,7 @@ describe('treemap uniformtext', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextSizes('without uniformtext', {
             fontsizes: [12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12],
             scales: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.84],
@@ -1826,7 +1826,7 @@ describe('treemap uniformtext', function() {
     });
 
     it('should uniform text scales after transition', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'treemap',
                 tiling: { packing: 'dice'},
@@ -1923,7 +1923,7 @@ describe('treemap pathbar react', function() {
             };
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(_assert('default pathbar.visible: true', 4))
         .then(function() {
             fig.data[0].pathbar = {visible: false};

--- a/test/jasmine/tests/updatemenus_test.js
+++ b/test/jasmine/tests/updatemenus_test.js
@@ -279,7 +279,7 @@ describe('update menus buttons', function() {
         buttonMenus = allMenus.filter(function(opts) { return opts.type === 'buttons'; });
         dropdownMenus = allMenus.filter(function(opts) { return opts.type !== 'buttons'; });
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
         .then(done);
     });
 
@@ -313,7 +313,7 @@ describe('update menus initialization', function() {
     beforeEach(function(done) {
         gd = createGraphDiv();
 
-        Plotly.plot(gd, [{x: [1, 2, 3]}], {
+        Plotly.newPlot(gd, [{x: [1, 2, 3]}], {
             updatemenus: [{
                 buttons: [
                     {method: 'restyle', args: [], label: 'first'},
@@ -350,7 +350,7 @@ describe('update menus interactions', function() {
         var mockCopy = Lib.extendDeep({}, mock);
         mockCopy.layout.updatemenus[1].x = 1;
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout)
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout)
         .then(done);
     });
 
@@ -930,7 +930,7 @@ describe('update menus interaction with other components:', function() {
     afterEach(destroyGraphDiv);
 
     it('draws buttons above sliders', function(done) {
-        Plotly.plot(createGraphDiv(), [{
+        Plotly.newPlot(createGraphDiv(), [{
             x: [1, 2, 3],
             y: [1, 2, 1]
         }], {
@@ -1079,7 +1079,7 @@ describe('update menus interaction with scrollbox:', function() {
 
         var mockCopy = Lib.extendDeep({}, mock);
 
-        Plotly.plot(gd, mockCopy.data, mockCopy.layout).then(function() {
+        Plotly.newPlot(gd, mockCopy.data, mockCopy.layout).then(function() {
             var menus = document.getElementsByClassName('updatemenu-header');
 
             expect(menus.length).toBe(5);

--- a/test/jasmine/tests/violin_test.js
+++ b/test/jasmine/tests/violin_test.js
@@ -344,7 +344,7 @@ describe('Test violin hover:', function() {
 
         var pos = specs.pos || [200, 200];
 
-        return Plotly.plot(gd, fig).then(function() {
+        return Plotly.newPlot(gd, fig).then(function() {
             mouseEvent('mousemove', pos[0], pos[1]);
             assertHoverLabelContent(specs);
 
@@ -694,7 +694,7 @@ describe('Test violin hover:', function() {
         }
 
         it('should show in two-sided base case', function(done) {
-            Plotly.plot(gd, fig).then(function() {
+            Plotly.newPlot(gd, fig).then(function() {
                 mouseEvent('mousemove', 250, 250);
                 assertViolinHoverLine([299.35, 250, 200.65, 250]);
             })
@@ -705,7 +705,7 @@ describe('Test violin hover:', function() {
         it('should show in one-sided positive case', function(done) {
             fig.data[0].side = 'positive';
 
-            Plotly.plot(gd, fig).then(function() {
+            Plotly.newPlot(gd, fig).then(function() {
                 mouseEvent('mousemove', 300, 250);
                 assertViolinHoverLine([277.3609, 250, 80, 250]);
             })
@@ -716,7 +716,7 @@ describe('Test violin hover:', function() {
         it('should show in one-sided negative case', function(done) {
             fig.data[0].side = 'negative';
 
-            Plotly.plot(gd, fig).then(function() {
+            Plotly.newPlot(gd, fig).then(function() {
                 mouseEvent('mousemove', 200, 250);
                 assertViolinHoverLine([222.6391, 250, 420, 250]);
             })
@@ -732,7 +732,7 @@ describe('Test violin hover:', function() {
         fig.layout.width = 700;
         fig.layout.height = 450;
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             mouseEvent('mousemove', 350, 225);
 
@@ -789,7 +789,7 @@ describe('Test violin restyle:', function() {
             _assertOne(msg, exp, trace3, 'ptsCnt', 'path.point');
         }
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(function() {
             _assert('base', {violinCnt: 1});
         })

--- a/test/jasmine/tests/volume_test.js
+++ b/test/jasmine/tests/volume_test.js
@@ -220,7 +220,7 @@ describe('Test volume', function() {
             data.isomin = -Infinity;
             data.isomax = Infinity;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 assertCells(0, 'to be OK cells');
             })
@@ -241,7 +241,7 @@ describe('Test volume', function() {
             data.isomin = Infinity;
             data.isomax = Infinity;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 assertCells(0, 'to be OK cells');
             })
@@ -282,7 +282,7 @@ describe('Test volume', function() {
             fig.data[0].isomin = 0;
             fig.data[0].isomax = 3;
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(function() {
                 _assert([undefined, undefined, undefined], [true, 0, 3]);
 
@@ -343,7 +343,7 @@ describe('Test volume', function() {
                 return delay(20)();
             }
 
-            Plotly.plot(gd, fig)
+            Plotly.newPlot(gd, fig)
             .then(delay(20))
             .then(_hover1)
             .then(function() {
@@ -504,7 +504,7 @@ describe('Test volume grid', function() {
                     expect(exp.cellsLength).toBe(objs[0].cells.length, 'cells length - ' + msg);
                 }
 
-                Plotly.plot(gd, fig).then(function() {
+                Plotly.newPlot(gd, fig).then(function() {
                     _assert('lengths', {
                         positionsLength: 372,
                         cellsLength: 104
@@ -551,7 +551,7 @@ describe('Test volume grid', function() {
 
         spyOn(Lib, 'warn');
 
-        Plotly.plot(gd, fig).then(function() {
+        Plotly.newPlot(gd, fig).then(function() {
             _assert('arbitrary coordinates', {
                 positionsLength: 0,
                 cellsLength: 0

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -676,7 +676,7 @@ describe('A waterfall plot', function() {
         }];
         var layout = {};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var waterfallNodes = getAllWaterfallNodes(traceNodes[0]);
             var foundTextNodes;
@@ -706,7 +706,7 @@ describe('A waterfall plot', function() {
         }];
         var layout = {};
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var waterfallNodes = getAllWaterfallNodes(traceNodes[0]);
             var foundTextNodes;
@@ -750,7 +750,7 @@ describe('A waterfall plot', function() {
             decreasing: { marker: { color: 'rgba(0, 0, 0, 0.8)' } }
         };
 
-        Plotly.plot(gd, [trace])
+        Plotly.newPlot(gd, [trace])
           .then(assertTextFontColors([DARK, LIGHT]))
           .catch(failTest)
           .then(done);
@@ -759,7 +759,7 @@ describe('A waterfall plot', function() {
     it('should use defined textfont.color for inside text instead of the contrasting default', function(done) {
         var data = Lib.extendFlat({}, insideTextTestsTrace, { textfont: { color: '#09f' } });
 
-        Plotly.plot(gd, [data])
+        Plotly.newPlot(gd, [data])
           .then(assertTextFontColors(Lib.repeat('#09f', 6)))
           .catch(failTest)
           .then(done);
@@ -807,7 +807,7 @@ describe('A waterfall plot', function() {
             }
         };
 
-        Plotly.plot(gd, mock.data, mock.layout).then(function() {
+        Plotly.newPlot(gd, mock.data, mock.layout).then(function() {
             var cd = gd.calcdata;
             assertPointField(cd, 'x', [
                 [1, 2, 3, 4], [1, 2, 3, 4],
@@ -952,7 +952,7 @@ describe('A waterfall plot', function() {
             expect(sel.size()).toBe(cnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'waterfall',
             x: ['Initial', 'A', 'B', 'C', 'Total'],
             y: [10, 2, 3, 5],
@@ -1027,7 +1027,7 @@ describe('A waterfall plot', function() {
     });
 
     it('should be able to deal with transform that empty out the data coordinate arrays', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'waterfall',
                 x: [1, 2, 3],
@@ -1100,7 +1100,7 @@ describe('A waterfall plot', function() {
             }
         };
 
-        Plotly.plot(gd, data, layout).then(function() {
+        Plotly.newPlot(gd, data, layout).then(function() {
             var traceNodes = getAllTraceNodes(gd);
             var waterfallNodes = getAllWaterfallNodes(traceNodes[0]);
             var pathNodes = [
@@ -1143,7 +1143,7 @@ describe('A waterfall plot', function() {
             expect(sel.size()).toBe(cnt);
         }
 
-        Plotly.plot(gd, [{
+        Plotly.newPlot(gd, [{
             type: 'waterfall',
             x: ['Product A', 'Product B', 'Product C'],
             y: [20, 14, 23],
@@ -1225,7 +1225,7 @@ describe('A waterfall plot', function() {
     });
 
     it('should be able to adjust bars when reacting with new connector.line.width ', function(done) {
-        Plotly.plot(gd, {
+        Plotly.newPlot(gd, {
             data: [{
                 type: 'waterfall',
                 y: [1, 2, 3],
@@ -1292,7 +1292,7 @@ describe('waterfall visibility toggling:', function() {
     }
 
     it('should update axis range according to visible edits (group case)', function(done) {
-        Plotly.plot(gd, [
+        Plotly.newPlot(gd, [
             {type: 'waterfall', x: [1, 2, 3], y: [0.5, 1, 0.5]},
             {type: 'waterfall', x: [1, 2, 3], y: [-0.5, -1, -0.5]}
         ])
@@ -1381,7 +1381,7 @@ describe('waterfall hover', function() {
 
             var mock = Lib.extendDeep({}, require('@mocks/waterfall_11.json'));
 
-            Plotly.plot(gd, mock.data, mock.layout)
+            Plotly.newPlot(gd, mock.data, mock.layout)
             .catch(failTest)
             .then(done);
         });
@@ -1422,7 +1422,7 @@ describe('waterfall hover', function() {
             var mock = Lib.extendDeep({}, require('@mocks/text_chart_arrays'));
             mock.data.forEach(function(t) { t.type = 'waterfall'; });
 
-            Plotly.plot(gd, mock).then(function() {
+            Plotly.newPlot(gd, mock).then(function() {
                 var out = _hover(gd, -0.25, 0.5, 'closest');
                 expect(out.text).toEqual('Hover text\nA', 'hover text');
 
@@ -1466,7 +1466,7 @@ describe('waterfall hover', function() {
                 Fx.hover('graph', evt, 'xy');
             }
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(_hover)
             .then(function() {
                 expect(d3.selectAll('g.hovertext').size()).toBe(0);
@@ -1490,7 +1490,7 @@ describe('waterfall hover', function() {
                 Fx.hover('graph', evt, 'xy');
             }
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({
@@ -1521,7 +1521,7 @@ describe('waterfall hover', function() {
                 Fx.hover('graph', evt, 'xy');
             }
 
-            Plotly.plot(gd, mock)
+            Plotly.newPlot(gd, mock)
             .then(_hover)
             .then(function() {
                 assertHoverLabelContent({
@@ -1541,7 +1541,7 @@ describe('waterfall hover', function() {
         it('should format numbers - round hover precision', function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     x: ['A', 'B', 'C', 'D', 'E'],
                     y: [0, -1.1, 2.2, -3.3, 4.4],
@@ -1567,7 +1567,7 @@ describe('waterfall hover', function() {
         it('hover measure categories with axis prefix and suffix', function(done) {
             gd = createGraphDiv();
 
-            Plotly.plot(gd, {
+            Plotly.newPlot(gd, {
                 data: [{
                     x: ['A', 'B', 'C', 'D', 'E'],
                     y: [2.2, -1.1, null, 3.3, null],
@@ -1629,7 +1629,7 @@ describe('waterfall hover', function() {
         });
 
         it('should return correct hover data (single waterfall, trace width)', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'waterfall',
                 x: [1],
                 y: [2],
@@ -1672,7 +1672,7 @@ describe('waterfall hover', function() {
         });
 
         it('should return correct hover data (two waterfalls, array width)', function(done) {
-            Plotly.plot(gd, [{
+            Plotly.newPlot(gd, [{
                 type: 'waterfall',
                 x: [1, 200],
                 y: [2, 1],
@@ -1859,7 +1859,7 @@ describe('waterfall uniformtext', function() {
             }
         };
 
-        Plotly.plot(gd, fig)
+        Plotly.newPlot(gd, fig)
         .then(assertTextSizes('without uniformtext', {
             fontsizes: [12, 12, 12, 12, 12, 12, 12],
             scales: [0.48, 1, 1, 1, 1, 1, 1],


### PR DESCRIPTION
Follow up of https://github.com/plotly/plotly.js/pull/5340#discussion_r547562227
This PR basically replaces most of the `Plotly.plot` with `Plotly.newPlot` in jasmine tests.
We could investigate the remainings when/if we wanted to drop it in v2.

@plotly/plotly_js 
