### PR TITLE
reduce logs of domain_ref tests

### DIFF
--- a/test/jasmine/assets/domain_ref/components.js
+++ b/test/jasmine/assets/domain_ref/components.js
@@ -572,14 +572,9 @@ function describeShapeComboTest(combo) {
     var xid = axispair[0];
     var yid = axispair[1];
     return [
-        '#', gdId,
-        'should create a plot with parameters:', '\n',
-        'x-axis type:', xaxisType, '\n',
-        'y-axis type:', yaxisType, '\n',
-        'axis pair:', xid, yid, '\n',
-        'ARO position x:', JSON.stringify(xaroPos), '\n',
-        'ARO position y:', JSON.stringify(yaroPos), '\n',
-        'shape type:', shapeType, '\n',
+        'should plot shape:', shapeType, 'on', gdId,
+        xaxisType, xid, JSON.stringify(xaroPos),
+        yaxisType, yid, JSON.stringify(yaroPos),
     ].join(' ');
 }
 
@@ -619,21 +614,11 @@ function describeImageComboTest(combo) {
     var gdId = combo[7];
     var xid = axispair[0];
     var yid = axispair[1];
-    var xref = makeAxRef(xid, aroposx.ref);
-    var yref = makeAxRef(yid, aroposy.ref);
     // TODO Add image combo test description
     return [
-        '#', gdId,
-        'should create a plot with parameters:', '\n',
-        'x-axis type:', axistypex, '\n',
-        'y-axis type:', axistypey, '\n',
-        'axis pair:', xid, yid, '\n',
-        'ARO position x:', JSON.stringify(aroposx), '\n',
-        'ARO position y:', JSON.stringify(aroposy), '\n',
-        'xanchor:', xanchor, '\n',
-        'yanchor:', yanchor, '\n',
-        'xref:', xref, '\n',
-        'yref:', yref, '\n',
+        'should plot image on', gdId,
+        axistypex, xid, xanchor, JSON.stringify(aroposx),
+        axistypey, yid, yanchor, JSON.stringify(aroposy),
     ].join(' ');
 }
 
@@ -681,19 +666,10 @@ function describeAnnotationComboTest(combo) {
     var gdId = combo[6];
     var xid = axispair[0];
     var yid = axispair[1];
-    var xref = makeAxRef(xid, aroposx.ref);
-    var yref = makeAxRef(yid, aroposy.ref);
     return [
-        '#', gdId,
-        'should create a plot with parameters:', '\n',
-        'x-axis type:', axistypex, '\n',
-        'y-axis type:', axistypey, '\n',
-        'axis pair:', xid, yid, '\n',
-        'ARO position x:', JSON.stringify(aroposx), '\n',
-        'ARO position y:', JSON.stringify(aroposy), '\n',
-        'arrow axis pair:', arrowaxispair, '\n',
-        'xref:', xref, '\n',
-        'yref:', yref, '\n',
+        'should plot annotation', arrowaxispair, 'on', gdId,
+        axistypex, xid, JSON.stringify(aroposx),
+        axistypey, yid, JSON.stringify(aroposy),
     ].join(' ');
 }
 


### PR DESCRIPTION
Tests added in #5014 make way too much log!

![Screenshot from 2021-01-04 17-39-45](https://user-images.githubusercontent.com/33888540/103586701-9de3da00-4eb3-11eb-8371-6588d7711168.png)

The fact that one needs to download the log to see the workflow, make it hard to find which (other) tests are failing.
This PR reduces the logs for those tests.

@plotly/plotly_js 