### PR TITLE
Add publish test for avoiding function constructors in non-gl(2d|3d) partial bundles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
           at: ~/
       - run:
           name: Build dist/
-          command: npm run build
+          command: npm run build && npm run no-new-func
       - store_artifacts:
           path: dist
           destination: dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
           at: ~/
       - run:
           name: Build dist/
-          command: npm run build && npm run no-new-func
+          command: npm run build
       - store_artifacts:
           path: dist
           destination: dist
@@ -166,6 +166,9 @@ jobs:
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plotly.js
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plotly.min.js
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plot-schema.json
+      - run:
+          name: Test bundles
+          command: npm run no-new-func
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
+    "no-new-func": "eslint --no-ignore --no-eslintrc --rule '{no-new-func: error}' dist/plotly-finance.js dist/plotly-basic.js dist/plotly-cartesian.js dist/plotly-geo.js dist/plotly-mapbox.js",
     "docker": "node tasks/docker.js",
     "pretest": "node tasks/pretest.js",
     "test-jasmine": "karma start test/jasmine/karma.conf.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
-    "no-new-func": "eslint --debug --no-ignore --no-eslintrc --rule '{no-new-func: error}' $(ls dist/plotly*.js | grep -v plotly-locale* | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js)",
+    "no-new-func": "eslint --no-ignore --no-eslintrc --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js)",
     "docker": "node tasks/docker.js",
     "pretest": "node tasks/pretest.js",
     "test-jasmine": "karma start test/jasmine/karma.conf.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
-    "no-new-func": "eslint --no-ignore --no-eslintrc --rule '{no-new-func: error}' dist/plotly-finance.js dist/plotly-basic.js dist/plotly-cartesian.js dist/plotly-geo.js dist/plotly-mapbox.js",
+    "no-new-func": "eslint --debug --no-ignore --no-eslintrc --rule '{no-new-func: error}' $(ls dist/plotly*.js | grep -v plotly-locale* | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js)",
     "docker": "node tasks/docker.js",
     "pretest": "node tasks/pretest.js",
     "test-jasmine": "karma start test/jasmine/karma.conf.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
-    "no-new-func": "eslint --no-ignore --no-eslintrc --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js)",
+    "no-new-func": "eslint --no-ignore --no-eslintrc --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js | grep -v MathJax.js)",
     "docker": "node tasks/docker.js",
     "pretest": "node tasks/pretest.js",
     "test-jasmine": "karma start test/jasmine/karma.conf.js",


### PR DESCRIPTION
Thanks to #5358 and #5359 pull requests, most partial bundles namely `basic`, `cartesian`, `finance`, `geo` and `mapbox` no longer have function constructors. 

This PR adds tests in `publish` container to lock this for future bundles.
cc: #897

@plotly/plotly_js 