### PR TITLE
Disable all inline config comments in no-new-func test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
-    "no-new-func": "eslint --no-ignore --no-eslintrc --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js | grep -v MathJax.js)",
+    "no-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js | grep -v MathJax.js)",
     "docker": "node tasks/docker.js",
     "pretest": "node tasks/pretest.js",
     "test-jasmine": "karma start test/jasmine/karma.conf.js",


### PR DESCRIPTION
Since inline comments could potentially be used to override `eslint` rules, this PR disables all inline config comments for `no-new-func` test added in #5383.
cc: #897

@plotly/plotly_js 