### PR TITLE
Fixup strict d3 require in devtools

### DIFF
--- a/devtools/image_viewer/viewer.js
+++ b/devtools/image_viewer/viewer.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 
-var d3Json = require('../../test/strict_d3').json;
+var d3Json = require('../../test/strict-d3').json;
 
 var $plotlist = document.getElementById('plot-list');
 var $toggles = document.getElementById('plot-toggles');

--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -6,7 +6,7 @@ var Fuse = require('fuse.js/dist/fuse.common.js');
 var mocks = require('../../build/test_dashboard_mocks.json');
 var credentials = require('../../build/credentials.json');
 var Lib = require('@src/lib');
-var d3 = require('../../test/strict_d3');
+var d3 = require('../../test/strict-d3');
 var d3Json = d3.json;
 
 require('./perf');


### PR DESCRIPTION
Problem introduced in #5400.

cc: @plotly/plotly_js 