### PR TITLE
Fire unhover when dragging plot

### DIFF
--- a/src/components/dragelement/index.js
+++ b/src/components/dragelement/index.js
@@ -180,7 +180,7 @@ dragElement.init = function init(options) {
 
         if(dx || dy) {
             gd._dragged = true;
-            dragElement.unhover(gd);
+            dragElement.unhover(gd, e);
         }
 
         if(gd._dragged && options.moveFn && !rightClick) {

--- a/src/components/dragelement/unhover.js
+++ b/src/components/dragelement/unhover.js
@@ -44,7 +44,7 @@ unhover.raw = function raw(gd, evt) {
     fullLayout._hoverlayer.selectAll('circle').remove();
     gd._hoverdata = undefined;
 
-    if(evt.target && oldhoverdata) {
+    if((evt.target || gd._dragged) && oldhoverdata) {
         gd.emit('plotly_unhover', {
             event: evt,
             points: oldhoverdata

--- a/src/components/dragelement/unhover.js
+++ b/src/components/dragelement/unhover.js
@@ -34,7 +34,7 @@ unhover.raw = function raw(gd, evt) {
     var oldhoverdata = gd._hoverdata;
 
     if(!evt) evt = {};
-    if(evt.target &&
+    if(evt.target && !gd._dragged &&
        Events.triggerHandler(gd, 'plotly_beforehover', evt) === false) {
         return;
     }
@@ -44,7 +44,7 @@ unhover.raw = function raw(gd, evt) {
     fullLayout._hoverlayer.selectAll('circle').remove();
     gd._hoverdata = undefined;
 
-    if((evt.target || gd._dragged) && oldhoverdata) {
+    if(evt.target && oldhoverdata) {
         gd.emit('plotly_unhover', {
             event: evt,
             points: oldhoverdata

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -3632,6 +3632,55 @@ describe('hover updates', function() {
         })
         .then(done, done.fail);
     });
+
+    it('drag should trigger unhover', function(done) {
+        var data = [{y: [1]}];
+
+        var layout = {
+            hovermode: 'x',
+            width: 400,
+            height: 200,
+            margin: {l: 0, t: 0, r: 0, b: 0},
+            showlegend: false
+        };
+
+        var gd = createGraphDiv();
+
+        var hoverHandler = jasmine.createSpy('hover');
+        var unhoverHandler = jasmine.createSpy('unhover');
+
+        var hoverPt = [200, 100];
+        var dragPt = [210, 100];
+
+        function hover() {
+            mouseEvent('mousemove', hoverPt[0], hoverPt[1]);
+            Lib.clearThrottle();
+        }
+
+        function drag() {
+            mouseEvent('mousedown', hoverPt[0], hoverPt[1]);
+            mouseEvent('mousemove', dragPt[0], dragPt[1]);
+            mouseEvent('mouseup', dragPt[0], dragPt[1]);
+            Lib.clearThrottle();
+        }
+
+        Plotly.react(gd, data, layout)
+            .then(function() {
+                gd.on('plotly_hover', hoverHandler);
+                gd.on('plotly_unhover', unhoverHandler);
+            })
+            .then(hover)
+            .then(function() {
+                expect(hoverHandler).toHaveBeenCalled();
+                expect(unhoverHandler).not.toHaveBeenCalled();
+            })
+            .then(drag)
+            .then(function() {
+                expect(hoverHandler).toHaveBeenCalled();
+                expect(unhoverHandler).toHaveBeenCalled();
+            })
+            .then(done, done.fail);
+    });
 });
 
 describe('Test hover label custom styling:', function() {


### PR DESCRIPTION
Fixes #5437.

This PR makes a small change to unhover behavior. My premise is that, toward hooking up external HTML/CSS hovers, `plotly_hover` and `plotly_unhover` should be enough to manage hover state.

The GIF below shows plotly hover along with HTML/CSS hover. `plotly_unhover` does not currently fire when you drag the plot, resulting in a stray hover.

![badhover](https://user-images.githubusercontent.com/572717/104629529-78db2e00-564e-11eb-8522-9c20111c5079.gif)

The cause is this conditional, which is not passed the event from the onMove handler, hence `evt.target` is empty.

https://github.com/plotly/plotly.js/blob/af9d44037c304a0c17ff352e81f3f7b5797d1bcc/src/components/dragelement/unhover.js#L47

https://github.com/plotly/plotly.js/blob/af9d44037c304a0c17ff352e81f3f7b5797d1bcc/src/components/dragelement/index.js#L181-L184

One solution, without adding additional flags, is to check if the plot is being dragged and fire the event if so. Then, hover/unhover are sufficient to manage the state in this case.

![goodhover](https://user-images.githubusercontent.com/572717/104629751-bd66c980-564e-11eb-8b65-757d2bc3cacc.gif)

(It could pass the event from onMove in order to accomplish this, but then `plotly_beforehover` is fired many times while dragging, which would require other flags and fixes to avoid)

/cc @plotly/plotly_js @jonmmease and probably also @nicolaskruchten @alexcjohnson 