### PR TITLE
Cleanup unused r and t attributes from bar

### DIFF
--- a/src/traces/bar/attributes.js
+++ b/src/traces/bar/attributes.js
@@ -250,9 +250,6 @@ module.exports = {
         editType: 'style'
     },
 
-    r: scatterAttrs.r,
-    t: scatterAttrs.t,
-
     _deprecated: {
         bardir: {
             valType: 'enumerated',


### PR DESCRIPTION
Followup of the cleanup in pull #5399, some unused attributes were found in the bar attributes.

@plotly/plotly_js 


