### PR TITLE
Add strict partial bundles

### DIFF
--- a/dist/plotly-strict.js
+++ b/dist/plotly-strict.js
@@ -1,0 +1,6 @@
+/**
+* plotly.js (strict) v2.0.0
+* Copyright 2012-2021, Plotly, Inc.
+* All rights reserved.
+* Licensed under the MIT license
+*/

--- a/dist/plotly-strict.min.js
+++ b/dist/plotly-strict.min.js
@@ -1,0 +1,6 @@
+/**
+* plotly.js (strict) v2.0.0
+* Copyright 2012-2021, Plotly, Inc.
+* All rights reserved.
+* Licensed under the MIT license
+*/

--- a/lib/index-strict.js
+++ b/lib/index-strict.js
@@ -1,0 +1,72 @@
+/**
+* Copyright 2012-2021, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+'use strict';
+
+var Plotly = require('./core');
+
+// traces
+Plotly.register([
+    require('./bar'),
+    require('./box'),
+    require('./heatmap'),
+    require('./histogram'),
+    require('./histogram2d'),
+    require('./histogram2dcontour'),
+    require('./contour'),
+    require('./scatterternary'),
+    require('./violin'),
+    require('./funnel'),
+    require('./waterfall'),
+    require('./image'),
+
+    require('./pie'),
+    require('./sunburst'),
+    require('./treemap'),
+    require('./funnelarea'),
+
+    require('./scattergeo'),
+    require('./choropleth'),
+
+    require('./parcoords'),
+    require('./parcats'),
+
+    require('./scattermapbox'),
+    require('./choroplethmapbox'),
+    require('./densitymapbox'),
+
+    require('./sankey'),
+    require('./indicator'),
+
+    require('./table'),
+
+    require('./carpet'),
+    require('./scattercarpet'),
+    require('./contourcarpet'),
+
+    require('./ohlc'),
+    require('./candlestick'),
+
+    require('./scatterpolar'),
+    require('./barpolar')
+]);
+
+// transforms
+Plotly.register([
+    require('./aggregate'),
+    require('./filter'),
+    require('./groupby'),
+    require('./sort')
+]);
+
+// components
+Plotly.register([
+    require('./calendars')
+]);
+
+module.exports = Plotly;

--- a/tasks/stats.js
+++ b/tasks/stats.js
@@ -136,6 +136,8 @@ function getMainBundleInfo() {
         'Starting in `v1.39.0`, each plotly.js partial bundle has a corresponding npm package with no dependencies.',
         '',
         'Starting in `v1.50.0`, the minified version of each partial bundle is also published to npm in a separate "dist min" package.',
+        '',
+        'Starting in `v2.0.0`, the strict partial bundle includes everything except the traces that require function constructor.',
         ''
     ];
 }

--- a/tasks/stats.js
+++ b/tasks/stats.js
@@ -137,7 +137,9 @@ function getMainBundleInfo() {
         '',
         'Starting in `v1.50.0`, the minified version of each partial bundle is also published to npm in a separate "dist min" package.',
         '',
-        'Starting in `v2.0.0`, the strict partial bundle includes everything except the traces that require function constructor.',
+        'Starting in `v2.0.0`, the strict partial bundle includes everything except the traces that require function constructors.',
+        'Over time we hope to include more of the remaining trace types here, after which we intend to work on other strict CSP issues ',
+        'such as inline CSS that we may not be able to include in the main bundle.',
         ''
     ];
 }

--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -25,7 +25,7 @@ try {
 }
 
 var partialBundleNames = [
-    'basic', 'cartesian', 'geo', 'gl3d', 'gl2d', 'mapbox', 'finance'
+    'basic', 'cartesian', 'geo', 'gl3d', 'gl2d', 'mapbox', 'finance', 'strict'
 ];
 
 var partialBundlePaths = partialBundleNames.map(function(name) {


### PR DESCRIPTION
This includes everything (all the trace types) not depending on function constructors in respect to #897.
Unlike other partial bundles, `calendars` would also be included in these bundles.

cc: #5395 

@plotly/plotly_js 