### PR TITLE
Drop various methods from Plotly.Fx and Plotly.Plots in the API

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -74,8 +74,19 @@ if(window.PlotlyLocales && Array.isArray(window.PlotlyLocales)) {
 exports.Icons = require('./fonts/ploticon');
 
 // unofficial 'beta' plot methods, use at your own risk
-exports.Plots = require('./plots/plots');
-exports.Fx = require('./components/fx');
+var Fx = require('./components/fx');
+var Plots = require('./plots/plots');
+
+exports.Plots = {
+    resize: Plots.resize,
+    graphJson: Plots.graphJson
+};
+exports.Fx = {
+    hover: Fx.hover,
+    unhover: Fx.unhover,
+    loneHover: Fx.loneHover,
+    loneUnhover: Fx.loneUnhover
+};
 exports.Snapshot = require('./snapshot');
 exports.PlotSchema = require('./plot_api/plot_schema');
 exports.Queue = require('./lib/queue');

--- a/src/core.js
+++ b/src/core.js
@@ -79,7 +79,8 @@ var Plots = require('./plots/plots');
 
 exports.Plots = {
     resize: Plots.resize,
-    graphJson: Plots.graphJson
+    graphJson: Plots.graphJson,
+    sendDataToCloud: Plots.sendDataToCloud
 };
 exports.Fx = {
     hover: Fx.hover,

--- a/test/jasmine/bundle_tests/finance_test.js
+++ b/test/jasmine/bundle_tests/finance_test.js
@@ -1,3 +1,4 @@
+var Plots = require('@src/plots/plots');
 var Plotly = require('@lib/core');
 var ohlc = require('@lib/ohlc');
 var candlestick = require('@lib/candlestick');
@@ -14,13 +15,13 @@ describe('Bundle with finance trace type', function() {
     var mock = require('@mocks/finance_style.json');
 
     it('should not register transforms anymore', function() {
-        var transformModules = Object.keys(Plotly.Plots.transformsRegistry);
+        var transformModules = Object.keys(Plots.transformsRegistry);
 
         expect(transformModules).toEqual([]);
     });
 
     it('should register the correct trace modules for the generated traces', function() {
-        var traceModules = Object.keys(Plotly.Plots.modules);
+        var traceModules = Object.keys(Plots.modules);
 
         // scatter is registered no matter what
         // ohlc uses some parts of box by direct require but does not need to register it.

--- a/test/jasmine/tests/animate_test.js
+++ b/test/jasmine/tests/animate_test.js
@@ -1,7 +1,7 @@
 var Plotly = require('@lib/index');
 var Lib = require('@src/lib');
 var Registry = require('@src/registry');
-var Plots = Plotly.Plots;
+var Plots = require('@src/plots/plots');
 
 var d3Select = require('../../strict-d3').select;
 var d3SelectAll = require('../../strict-d3').selectAll;

--- a/test/jasmine/tests/click_test.js
+++ b/test/jasmine/tests/click_test.js
@@ -1,4 +1,5 @@
 var Plotly = require('@lib/index');
+var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
 var Drawing = require('@src/components/drawing');
 var DBLCLICKDELAY = require('@src/plot_api/plot_config').dfltConfig.doubleClickDelay;
@@ -50,7 +51,7 @@ describe('Test click interactions:', function() {
 
     function doubleClick(x, y) {
         return doubleClickRaw(x, y).then(function() {
-            return Plotly.Plots.previousPromises(gd);
+            return Plots.previousPromises(gd);
         });
     }
 

--- a/test/jasmine/tests/command_test.js
+++ b/test/jasmine/tests/command_test.js
@@ -1,6 +1,6 @@
 var Plotly = require('@lib/index');
 var Registry = require('@src/registry');
-var Plots = Plotly.Plots;
+var Plots = require('@src/plots/plots');
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var failTest = require('../assets/fail_test');

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -1,5 +1,5 @@
 var Plotly = require('@lib/index');
-var Plots = Plotly.Plots;
+var Plots = require('@src/plots/plots');
 var Lib = require('@src/lib');
 
 var d3Select = require('../../strict-d3').select;
@@ -533,7 +533,7 @@ describe('config argument', function() {
                 expect(gd._context.plotlyServerURL).not.toBe('https://chart-studio.plotly.com');
                 expect(gd._context.plotlyServerURL).toBe('');
 
-                Plotly.Plots.sendDataToCloud(gd);
+                Plots.sendDataToCloud(gd);
                 expect(form).toBe(undefined);
             })
             .then(done, done.fail);
@@ -546,7 +546,7 @@ describe('config argument', function() {
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('https://chart-studio.plotly.com');
 
-                Plotly.Plots.sendDataToCloud(gd);
+                Plots.sendDataToCloud(gd);
                 expect(form.action).toBe('https://chart-studio.plotly.com/external');
                 expect(form.method).toBe('post');
             })
@@ -558,7 +558,7 @@ describe('config argument', function() {
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('dummy');
 
-                Plotly.Plots.sendDataToCloud(gd);
+                Plots.sendDataToCloud(gd);
                 expect(form.action).toContain('/dummy/external');
                 expect(form.method).toBe('post');
             })
@@ -572,7 +572,7 @@ describe('config argument', function() {
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('dummy');
 
-                Plotly.Plots.sendDataToCloud(gd);
+                Plots.sendDataToCloud(gd);
                 expect(form.action).toContain('/yo/external');
                 expect(form.method).toBe('post');
             })
@@ -687,7 +687,7 @@ describe('config argument', function() {
                 fillParent(1, 1);
                 var cntWindowResize = 0;
                 window.addEventListener('resize', function() {cntWindowResize++;});
-                spyOn(Plotly.Plots, 'resize').and.callThrough();
+                spyOn(Plots, 'resize').and.callThrough();
 
                 Plotly.newPlot(gd, data, {}, {responsive: true})
                 .then(function() {return Plotly.restyle(gd, 'y[0]', data[0].y[0] + 2);})
@@ -696,7 +696,7 @@ describe('config argument', function() {
                 // .then(function() {viewport.set(newWidth, 2 * newHeight);}).then(delay(200))
                 .then(function() {
                     expect(cntWindowResize).toBe(1);
-                    expect(Plotly.Plots.resize.calls.count()).toBe(1);
+                    expect(Plots.resize.calls.count()).toBe(1);
                 })
                 .then(done, done.fail);
             });
@@ -807,7 +807,7 @@ describe('config argument', function() {
             });
 
             it('should not resize if gd is hidden', function(done) {
-                spyOn(Plotly.Plots, 'resize').and.callThrough();
+                spyOn(Plots, 'resize').and.callThrough();
 
                 fillParent(1, 1);
                 Plotly.newPlot(gd, data, {}, {responsive: true})
@@ -817,7 +817,7 @@ describe('config argument', function() {
                 })
                 .then(delay(RESIZE_DELAY))
                 .then(function() {
-                    expect(Plotly.Plots.resize.calls.count()).toBe(0);
+                    expect(Plots.resize.calls.count()).toBe(0);
                 })
                 .then(done, done.fail);
             });

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -533,7 +533,7 @@ describe('config argument', function() {
                 expect(gd._context.plotlyServerURL).not.toBe('https://chart-studio.plotly.com');
                 expect(gd._context.plotlyServerURL).toBe('');
 
-                Plots.sendDataToCloud(gd);
+                Plotly.Plots.sendDataToCloud(gd);
                 expect(form).toBe(undefined);
             })
             .then(done, done.fail);
@@ -546,7 +546,7 @@ describe('config argument', function() {
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('https://chart-studio.plotly.com');
 
-                Plots.sendDataToCloud(gd);
+                Plotly.Plots.sendDataToCloud(gd);
                 expect(form.action).toBe('https://chart-studio.plotly.com/external');
                 expect(form.method).toBe('post');
             })
@@ -558,7 +558,7 @@ describe('config argument', function() {
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('dummy');
 
-                Plots.sendDataToCloud(gd);
+                Plotly.Plots.sendDataToCloud(gd);
                 expect(form.action).toContain('/dummy/external');
                 expect(form.method).toBe('post');
             })
@@ -572,7 +572,7 @@ describe('config argument', function() {
             .then(function() {
                 expect(gd._context.plotlyServerURL).toBe('dummy');
 
-                Plots.sendDataToCloud(gd);
+                Plotly.Plots.sendDataToCloud(gd);
                 expect(form.action).toContain('/yo/external');
                 expect(form.method).toBe('post');
             })

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -336,7 +336,7 @@ describe('Test Plots', function() {
                         gd.style.width = '400px';
                         gd.style.height = '400px';
 
-                        return Plotly.Plots.resize(gd);
+                        return Plots.resize(gd);
                     })
                     .then(done);
             });
@@ -390,7 +390,7 @@ describe('Test Plots', function() {
                 expect(typeof gd.id).toBe('string');
                 expect(gd.id).toBeTruthy();
 
-                Plotly.Plots.resize(gd.id)
+                Plots.resize(gd.id)
                 .then(done, done.fail);
             });
         });
@@ -412,7 +412,7 @@ describe('Test Plots', function() {
 
                 Plotly.newPlot(gd, [], {})
                     .then(function() { _assert({l: 74, r: 74, t: 82, b: 66}); })
-                    .then(function() { return Plotly.Plots.resize(gd); })
+                    .then(function() { return Plots.resize(gd); })
                     .then(function() { _assert({l: 74, r: 74, t: 82, b: 66}); })
                     .then(done, done.fail);
             });
@@ -428,9 +428,9 @@ describe('Test Plots', function() {
                     .then(function() {
                         gd.style.width = '500px';
                         gd.style.height = '500px';
-                        p.push(Plotly.Plots.resize(gd));
-                        p.push(Plotly.Plots.resize(gd));
-                        p.push(Plotly.Plots.resize(gd));
+                        p.push(Plots.resize(gd));
+                        p.push(Plots.resize(gd));
+                        p.push(Plots.resize(gd));
                         return Promise.all(p);
                     })
                     .then(function(v) {

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -336,7 +336,7 @@ describe('Test Plots', function() {
                         gd.style.width = '400px';
                         gd.style.height = '400px';
 
-                        return Plots.resize(gd);
+                        return Plotly.Plots.resize(gd);
                     })
                     .then(done);
             });
@@ -390,7 +390,7 @@ describe('Test Plots', function() {
                 expect(typeof gd.id).toBe('string');
                 expect(gd.id).toBeTruthy();
 
-                Plots.resize(gd.id)
+                Plotly.Plots.resize(gd.id)
                 .then(done, done.fail);
             });
         });
@@ -412,7 +412,7 @@ describe('Test Plots', function() {
 
                 Plotly.newPlot(gd, [], {})
                     .then(function() { _assert({l: 74, r: 74, t: 82, b: 66}); })
-                    .then(function() { return Plots.resize(gd); })
+                    .then(function() { return Plotly.Plots.resize(gd); })
                     .then(function() { _assert({l: 74, r: 74, t: 82, b: 66}); })
                     .then(done, done.fail);
             });
@@ -428,9 +428,9 @@ describe('Test Plots', function() {
                     .then(function() {
                         gd.style.width = '500px';
                         gd.style.height = '500px';
-                        p.push(Plots.resize(gd));
-                        p.push(Plots.resize(gd));
-                        p.push(Plots.resize(gd));
+                        p.push(Plotly.Plots.resize(gd));
+                        p.push(Plotly.Plots.resize(gd));
+                        p.push(Plotly.Plots.resize(gd));
                         return Promise.all(p);
                     })
                     .then(function(v) {

--- a/test/jasmine/tests/transition_test.js
+++ b/test/jasmine/tests/transition_test.js
@@ -1,6 +1,6 @@
 var Plotly = require('@lib/index');
 var Lib = require('@src/lib');
-var Plots = Plotly.Plots;
+var Plots = require('@src/plots/plots');
 var plotApiHelpers = require('@src/plot_api/helpers');
 var Axes = require('@src/plots/cartesian/axes');
 var Registry = require('@src/registry');


### PR DESCRIPTION
Addressing part 2 of https://github.com/plotly/plotly.js/issues/5395#issuecomment-758229255

@plotly/plotly_js 

@dmt0 is there any of the removed methods used in streambed?