### PR TITLE
Specify public access flag to avoid failure on new packages

### DIFF
--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -306,6 +306,6 @@ function _publishToNPM(d, pkgPath) {
             cb();
             return;
         }
-        exec('npm publish', {cwd: pkgPath}, cb).stdout.pipe(process.stdout);
+        exec('npm publish --access public', {cwd: pkgPath}, cb).stdout.pipe(process.stdout);
     };
 }


### PR DESCRIPTION
This seems required to avoid failure during publishing new public packages to npm 
cc: #5413.

See https://docs.npmjs.com/cli/v6/commands/npm-publish for more info.

@plotly/plotly_js 