### PR TITLE
Drop Plotly.Queue from the API

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -90,4 +90,3 @@ exports.Fx = {
 };
 exports.Snapshot = require('./snapshot');
 exports.PlotSchema = require('./plot_api/plot_schema');
-exports.Queue = require('./lib/queue');

--- a/test/jasmine/tests/frame_api_test.js
+++ b/test/jasmine/tests/frame_api_test.js
@@ -1,5 +1,6 @@
 var Plotly = require('@lib/index');
 var Lib = require('@src/lib');
+var Queue = require('@src/lib/queue');
 
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
@@ -181,7 +182,7 @@ describe('Test frame api', function() {
                 expect(f[7]).toEqual({name: 'frame7', data: [2]});
                 expect(f[10]).toEqual({name: 'frame10', data: [3]});
 
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             })
             .then(validate)
             .then(done, done.fail);
@@ -207,7 +208,7 @@ describe('Test frame api', function() {
                 expect(f[7]).toEqual({name: 'frame7', data: [2]});
                 expect(f[10]).toEqual({name: 'frame10', data: [3]});
 
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             })
             .then(validate)
             .then(done, done.fail);
@@ -220,12 +221,12 @@ describe('Test frame api', function() {
             }
 
             Plotly.addFrames(gd, [{name: 'frame 0'}, {name: 'frame 1'}]).then(validate).then(function() {
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             }).then(function() {
                 expect(f).toEqual([]);
                 expect(h).toEqual({});
 
-                return Plotly.Queue.redo(gd);
+                return Queue.redo(gd);
             })
             .then(validate)
             .then(done, done.fail);
@@ -242,12 +243,12 @@ describe('Test frame api', function() {
                 expect(f).toEqual([{name: 'test1'}, {name: 'test2'}, {name: 'test3'}]);
                 expect(Object.keys(h)).toEqual(['test1', 'test2', 'test3']);
 
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             }).then(function() {
                 expect(f).toEqual([{name: 'test1', data: ['y']}, {name: 'test2'}]);
                 expect(Object.keys(h)).toEqual(['test1', 'test2']);
 
-                return Plotly.Queue.redo(gd);
+                return Queue.redo(gd);
             }).then(function() {
                 expect(f).toEqual([{name: 'test1'}, {name: 'test2'}, {name: 'test3'}]);
                 expect(Object.keys(h)).toEqual(['test1', 'test2', 'test3']);
@@ -267,11 +268,11 @@ describe('Test frame api', function() {
                 expect(f).toEqual([]);
                 expect(Object.keys(h)).toEqual([]);
 
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             }).then(function() {
                 expect(f).toEqual([{name: 'frame1'}]);
 
-                return Plotly.Queue.redo(gd);
+                return Queue.redo(gd);
             }).then(function() {
                 expect(f).toEqual([]);
                 expect(Object.keys(h)).toEqual([]);
@@ -297,13 +298,13 @@ describe('Test frame api', function() {
             Plotly.addFrames(gd, frames).then(function() {
                 return Plotly.deleteFrames(gd, [2, 8, 4, 6]);
             }).then(validate).then(function() {
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             }).then(function() {
                 for(i = 0; i < 10; i++) {
                     expect(f[i]).toEqual({name: 'frame' + i});
                 }
 
-                return Plotly.Queue.redo(gd);
+                return Queue.redo(gd);
             })
             .then(validate)
             .then(done, done.fail);
@@ -328,13 +329,13 @@ describe('Test frame api', function() {
                 return Plotly.deleteFrames(gd);
             }).then(validateCount(0)).then(function() {
                 // Restore:
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             }).then(validateCount(n)).then(function() {
                 // Delete with null arg:
                 return Plotly.deleteFrames(gd, null);
             }).then(validateCount(0)).then(function() {
                 // Restore:
-                return Plotly.Queue.undo(gd);
+                return Queue.undo(gd);
             }).then(validateCount(n)).then(function() {
                 // Delete with undefined:
                 return Plotly.deleteFrames(gd, undefined);

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -1898,14 +1898,6 @@ describe('Test plot api', function() {
                 ]
             };
 
-            if(!Queue) {
-                Queue = {
-                    add: function() {},
-                    startSequence: function() {},
-                    endSequence: function() {}
-                };
-            }
-
             spyOn(plotApi, 'redraw');
             spyOn(Queue, 'add');
         });

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -1898,8 +1898,8 @@ describe('Test plot api', function() {
                 ]
             };
 
-            if(!Plotly.Queue) {
-                Plotly.Queue = {
+            if(!Queue) {
+                Queue = {
                     add: function() {},
                     startSequence: function() {},
                     endSequence: function() {}
@@ -1907,7 +1907,7 @@ describe('Test plot api', function() {
             }
 
             spyOn(plotApi, 'redraw');
-            spyOn(Plotly.Queue, 'add');
+            spyOn(Queue, 'add');
         });
 
         it('should throw an error when gd.data isn\'t an array.', function() {
@@ -2054,9 +2054,9 @@ describe('Test plot api', function() {
             }, [0, 1]);
 
             expect(gd.data).not.toEqual(cachedData);
-            expect(Plotly.Queue.add).toHaveBeenCalled();
+            expect(Queue.add).toHaveBeenCalled();
 
-            var undoArgs = Plotly.Queue.add.calls.first().args[2];
+            var undoArgs = Queue.add.calls.first().args[2];
 
             Plotly.prependTraces.apply(null, undoArgs);
 
@@ -2071,9 +2071,9 @@ describe('Test plot api', function() {
             }, [0, 1]);
 
             expect(gd.data).not.toEqual(cachedData);
-            expect(Plotly.Queue.add).toHaveBeenCalled();
+            expect(Queue.add).toHaveBeenCalled();
 
-            var undoArgs = Plotly.Queue.add.calls.first().args[2];
+            var undoArgs = Queue.add.calls.first().args[2];
 
             Plotly.extendTraces.apply(null, undoArgs);
 
@@ -2089,9 +2089,9 @@ describe('Test plot api', function() {
             }, [0, 1], maxPoints);
 
             expect(gd.data).not.toEqual(cachedData);
-            expect(Plotly.Queue.add).toHaveBeenCalled();
+            expect(Queue.add).toHaveBeenCalled();
 
-            var undoArgs = Plotly.Queue.add.calls.first().args[2];
+            var undoArgs = Queue.add.calls.first().args[2];
 
             Plotly.prependTraces.apply(null, undoArgs);
 
@@ -2148,12 +2148,12 @@ describe('Test plot api', function() {
                 }, [0, 1], args.maxp);
 
                 expect(plotApi.redraw).toHaveBeenCalled();
-                expect(Plotly.Queue.add).toHaveBeenCalled();
+                expect(Queue.add).toHaveBeenCalled();
 
                 expect(gd.data[0].x).toEqual(expectations.newArray);
                 expect(gd.data[1].x).toEqual(new Float32Array(expectations.newArray));
 
-                var cont = Plotly.Queue.add.calls.first().args[2][1].x;
+                var cont = Queue.add.calls.first().args[2][1].x;
                 expect(cont[0]).toEqual(expectations.remainder);
                 expect(cont[1]).toEqual(new Float32Array(expectations.remainder));
             }


### PR DESCRIPTION
cc: #5395 

@plotly/plotly_js 

@alexcjohnson Shoud we remove `lib/queue` as well?