### PR TITLE
Leave no whitespace in compress_attributes when removing an attribute

### DIFF
--- a/tasks/compress_attributes.js
+++ b/tasks/compress_attributes.js
@@ -5,25 +5,26 @@ var through = require('through2');
  * of the plotly.js bundles
  */
 
+var OPTIONAL_COMMA = ',?';
 
 // one line string with or without trailing comma
 function makeStringRegex(attr) {
     return makeRegex(
-        attr + ': \'.*\'' + ',?'
+        attr + ': \'.*\'' + OPTIONAL_COMMA
     );
 }
 
 // joined array of strings with or without trailing comma
 function makeJoinedArrayRegex(attr) {
     return makeRegex(
-        attr + ': \\[[\\s\\S]*?\\]' + '\\.join\\(.*' + ',?'
+        attr + ': \\[[\\s\\S]*?\\]' + '\\.join\\(.*' + OPTIONAL_COMMA
     );
 }
 
 // array with or without trailing comma
 function makeArrayRegex(attr) {
     return makeRegex(
-        attr + ': \\[[\\s\\S]*?\\]' + ',?'
+        attr + ': \\[[\\s\\S]*?\\]' + OPTIONAL_COMMA
     );
 }
 

--- a/tasks/compress_attributes.js
+++ b/tasks/compress_attributes.js
@@ -5,26 +5,27 @@ var through = require('through2');
  * of the plotly.js bundles
  */
 
+var WHITESPACE_BEFORE = '\\s*';
 var OPTIONAL_COMMA = ',?';
 
 // one line string with or without trailing comma
 function makeStringRegex(attr) {
     return makeRegex(
-        attr + ': \'.*\'' + OPTIONAL_COMMA
+        WHITESPACE_BEFORE + attr + ': \'.*\'' + OPTIONAL_COMMA
     );
 }
 
 // joined array of strings with or without trailing comma
 function makeJoinedArrayRegex(attr) {
     return makeRegex(
-        attr + ': \\[[\\s\\S]*?\\]' + '\\.join\\(.*' + OPTIONAL_COMMA
+        WHITESPACE_BEFORE + attr + ': \\[[\\s\\S]*?\\]' + '\\.join\\(.*' + OPTIONAL_COMMA
     );
 }
 
 // array with or without trailing comma
 function makeArrayRegex(attr) {
     return makeRegex(
-        attr + ': \\[[\\s\\S]*?\\]' + OPTIONAL_COMMA
+        WHITESPACE_BEFORE + attr + ': \\[[\\s\\S]*?\\]' + OPTIONAL_COMMA
     );
 }
 


### PR DESCRIPTION
Like

![noWhiteSpace](https://user-images.githubusercontent.com/33888540/105393916-ed801080-5bea-11eb-9303-24a2f19e485a.png)

Complete temporary diff dist commit: https://github.com/plotly/plotly.js/commit/f5fafa7595d2d3ed5ea08d36f587ef40b9e4588d

@plotly/plotly_js 