### PR TITLE
Split header task into two tasks for dist and sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   "scripts": {
     "preprocess": "node tasks/preprocess.js",
     "bundle": "node tasks/bundle.js",
-    "header": "node tasks/header.js",
+    "header-dist": "node tasks/header_dist.js",
+    "header-src": "node tasks/header_src.js",
     "stats": "node tasks/stats.js",
     "find-strings": "node tasks/find_locale_strings.js",
-    "build": "npm run preprocess && npm run find-strings && npm run bundle && npm run header && npm run stats",
+    "build": "npm run preprocess && npm run find-strings && npm run bundle && npm run header-dist && npm run stats",
     "cibuild": "npm run preprocess && node tasks/cibundle.js",
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
@@ -46,7 +47,7 @@
     "start": "npm run start-test_dashboard",
     "baseline": "node tasks/baseline.js",
     "preversion": "check-node-version --node 12 --npm 6.14 && npm-link-check && npm ls --prod",
-    "version": "npm run build && npm run no-bad-char && git add -A dist src build",
+    "version": "npm run build && npm run no-bad-char && git add -A dist build src/version.js",
     "postversion": "node -e \"console.log('Version bumped and committed. If ok, run: git push && git push --tags')\"",
     "postpublish": "node tasks/sync_packages.js",
     "postshrinkwrap": "chttps ."

--- a/tasks/header_dist.js
+++ b/tasks/header_dist.js
@@ -2,7 +2,7 @@ var prependFile = require('prepend-file');
 var constants = require('./util/constants');
 var common = require('./util/common');
 
-(function addHeadersInDistFiles() {
+function addHeadersInDistFiles() {
     function _prepend(path, header) {
         prependFile(path, header + '\n', common.throwOnError);
     }
@@ -28,4 +28,6 @@ var common = require('./util/common');
             .replace('plotly.js', 'plotly.js (' + pathObj.name + ' - minified)');
         _prepend(pathObj.distMin, headerDistMin);
     });
-})();
+}
+
+addHeadersInDistFiles();

--- a/tasks/header_dist.js
+++ b/tasks/header_dist.js
@@ -1,0 +1,31 @@
+var prependFile = require('prepend-file');
+var constants = require('./util/constants');
+var common = require('./util/common');
+
+(function addHeadersInDistFiles() {
+    function _prepend(path, header) {
+        prependFile(path, header + '\n', common.throwOnError);
+    }
+
+    // add header to main dist bundles
+    var pathsDist = [
+        constants.pathToPlotlyDistMin,
+        constants.pathToPlotlyDist,
+        constants.pathToPlotlyDistWithMeta,
+        constants.pathToPlotlyGeoAssetsDist
+    ];
+    pathsDist.forEach(function(path) {
+        _prepend(path, constants.licenseDist);
+    });
+
+    // add header and bundle name to partial bundle
+    constants.partialBundlePaths.forEach(function(pathObj) {
+        var headerDist = constants.licenseDist
+            .replace('plotly.js', 'plotly.js (' + pathObj.name + ')');
+        _prepend(pathObj.dist, headerDist);
+
+        var headerDistMin = constants.licenseDist
+            .replace('plotly.js', 'plotly.js (' + pathObj.name + ' - minified)');
+        _prepend(pathObj.distMin, headerDistMin);
+    });
+})();

--- a/tasks/header_src.js
+++ b/tasks/header_src.js
@@ -1,48 +1,12 @@
 var path = require('path');
 var fs = require('fs');
-
-var prependFile = require('prepend-file');
 var falafel = require('falafel');
 var glob = require('glob');
 
 var constants = require('./util/constants');
 var common = require('./util/common');
 
-// main
-addHeadersInDistFiles();
-updateHeadersInSrcFiles();
-
-// add headers to dist files
-function addHeadersInDistFiles() {
-    function _prepend(path, header) {
-        prependFile(path, header + '\n', common.throwOnError);
-    }
-
-    // add header to main dist bundles
-    var pathsDist = [
-        constants.pathToPlotlyDistMin,
-        constants.pathToPlotlyDist,
-        constants.pathToPlotlyDistWithMeta,
-        constants.pathToPlotlyGeoAssetsDist
-    ];
-    pathsDist.forEach(function(path) {
-        _prepend(path, constants.licenseDist);
-    });
-
-    // add header and bundle name to partial bundle
-    constants.partialBundlePaths.forEach(function(pathObj) {
-        var headerDist = constants.licenseDist
-            .replace('plotly.js', 'plotly.js (' + pathObj.name + ')');
-        _prepend(pathObj.dist, headerDist);
-
-        var headerDistMin = constants.licenseDist
-            .replace('plotly.js', 'plotly.js (' + pathObj.name + ' - minified)');
-        _prepend(pathObj.distMin, headerDistMin);
-    });
-}
-
-// add or update header to src/ lib/ files
-function updateHeadersInSrcFiles() {
+(function updateHeadersInSrcAndLibFiles() {
     var srcGlob = path.join(constants.pathToSrc, '**/*.js');
     var libGlob = path.join(constants.pathToLib, '**/*.js');
 
@@ -96,4 +60,4 @@ function updateHeadersInSrcFiles() {
 
         return (header.value.replace(regex, '') === licenseStr.replace(regex, ''));
     }
-}
+})();

--- a/tasks/header_src.js
+++ b/tasks/header_src.js
@@ -6,7 +6,7 @@ var glob = require('glob');
 var constants = require('./util/constants');
 var common = require('./util/common');
 
-(function updateHeadersInSrcAndLibFiles() {
+function updateHeadersInSrcAndLibFiles() {
     var srcGlob = path.join(constants.pathToSrc, '**/*.js');
     var libGlob = path.join(constants.pathToLib, '**/*.js');
 
@@ -60,4 +60,6 @@ var common = require('./util/common');
 
         return (header.value.replace(regex, '') === licenseStr.replace(regex, ''));
     }
-})();
+}
+
+updateHeadersInSrcAndLibFiles();


### PR DESCRIPTION
adds a task for the `dist` folder;
adds a task for the `src` and the `lib` folders;

- at build time only runs `header-dist`
- at publish time only commits `version.js` from the `src`
- at new year simply run `npm run header-src` and it will no longer touch the `dist` folder so you could commit all the changes without excluding `dist`.

@plotly/plotly_js 
