### PR TITLE
Avoid redundant plotly.js copyright comments in bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "browserify": {
     "transform": [
       "glslify",
+      "./tasks/compress_headers.js",
       "./tasks/compress_attributes.js"
     ]
   },

--- a/tasks/compress_headers.js
+++ b/tasks/compress_headers.js
@@ -1,0 +1,27 @@
+var through = require('through2');
+
+var licenseSrc = require('./util/constants').licenseSrc
+    .replace(/\//g, '\\/')
+    .replace(/\*/g, '\\*')
+    .replace(/\n/g, '[^]');
+
+/**
+ * Browserify transform that strips redundant plotly.js Copyright comments out
+ * of the plotly.js bundles
+ */
+
+var WHITESPACE_BEFORE = '\\s*';
+
+module.exports = function() {
+    var allChunks = [];
+    return through(function(chunk, enc, next) {
+        allChunks.push(chunk);
+        next();
+    }, function(done) {
+        var str = Buffer.concat(allChunks).toString('utf-8');
+        this.push(
+            str.replace(new RegExp(WHITESPACE_BEFORE + licenseSrc, 'g'), '')
+        );
+        done();
+    });
+};


### PR DESCRIPTION
Currently in each non-minified bundle there are 787 blocks of comments related to plotly.js headers.

The transform browserify task added in this PR help avoid this redundant info to endup in the bundles.

Here is a temporary commit to compare before and after diffs: https://github.com/plotly/plotly.js/commit/8c829a7cedbf24299b9c968611b922bd8960a538

@plotly/plotly_js 

