### PR TITLE
Add scattergl traces to the strict bundle

### DIFF
--- a/lib/index-strict.js
+++ b/lib/index-strict.js
@@ -33,6 +33,9 @@ Plotly.register([
     require('./scattergeo'),
     require('./choropleth'),
 
+    require('./scattergl'),
+    require('./splom'),
+
     require('./parcoords'),
     require('./parcats'),
 
@@ -53,6 +56,7 @@ Plotly.register([
     require('./candlestick'),
 
     require('./scatterpolar'),
+    require('./scatterpolargl'),
     require('./barpolar')
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -981,9 +981,9 @@
       "dev": true
     },
     "binary-search-bounds": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-      "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
     },
     "bindings": {
       "version": "1.5.0",


### PR DESCRIPTION
Thanks to @mikolalysenko, @tdelmas and @bpostlethwaite,
this PR bumps the version of `binary-search-bounds` from `v2.0.4` to v2.0.5 and adds `scattergl`, `splom` and `scatterpolargl` traces to the `strict` bundle. cc: #897, #5395.
 
Please note we still use version 1 of `binary-search-bounds` in certain packages which mostly impacted gl[2/3]d traces. 
I opened four PRs (as listed in #897) to bump `binary-search-bounds` at v2 in those sub-modules. 
We could upgrade those in a separate pull once new patches become available.

@plotly/plotly_js 
