### PR TITLE
Add deprecated warnings for pointcloud and heatmapgl

### DIFF
--- a/src/traces/heatmapgl/index.js
+++ b/src/traces/heatmapgl/index.js
@@ -1,5 +1,12 @@
 'use strict';
 
+var deprecationWarning = [
+    '*heatmapgl* trace is deprecated!',
+    'Please consider switching to the *heatmap* or *image* trace types.',
+    'Alternatively you could contribute/sponsor rewriting this trace type',
+    'based on cartesian features and using regl framework.'
+].join(' ');
+
 module.exports = {
     attributes: require('./attributes'),
     supplyDefaults: require('./defaults'),
@@ -14,6 +21,7 @@ module.exports = {
     categories: ['gl', 'gl2d', '2dMap'],
     meta: {
         description: [
+            deprecationWarning,
             'WebGL version of the heatmap trace type.'
         ].join(' ')
     }

--- a/src/traces/pointcloud/index.js
+++ b/src/traces/pointcloud/index.js
@@ -1,5 +1,10 @@
 'use strict';
 
+var deprecationWarning = [
+    '*pointcloud* trace is deprecated!',
+    'Please consider switching to the *scattergl* trace type.'
+].join(' ');
+
 module.exports = {
     attributes: require('./attributes'),
     supplyDefaults: require('./defaults'),
@@ -14,6 +19,7 @@ module.exports = {
     categories: ['gl', 'gl2d', 'showLegend'],
     meta: {
         description: [
+            deprecationWarning,
             'The data visualized as a point cloud set in `x` and `y`',
             'using the WebGl plotting engine.'
         ].join(' ')


### PR DESCRIPTION
Addressing parts 2 and 3 here: https://github.com/plotly/plotly.js/issues/5395#issuecomment-765450759

BTW am not 100% sure if this is the best place to put this warning?

@plotly/plotly_js 