### PR TITLE
Require unminified mapbox-gl for unminified bundles and improve compression of minified bundles

### DIFF
--- a/src/plots/mapbox/index.js
+++ b/src/plots/mapbox/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var mapboxgl = require('mapbox-gl');
+var mapboxgl = require('mapbox-gl/dist/mapbox-gl-unminified');
 
 var Lib = require('../../lib');
 var strTranslate = Lib.strTranslate;

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var mapboxgl = require('mapbox-gl');
+var mapboxgl = require('mapbox-gl/dist/mapbox-gl-unminified');
 
 var Lib = require('../../lib');
 var geoUtils = require('../../lib/geo_location_utils');

--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -99,15 +99,6 @@ module.exports = {
     uglifyOptions: {
         ecma: 5,
         mangle: true,
-        compress: {
-            // see full list of compress option
-            // https://github.com/fabiosantoscode/terser#compress-options
-            //
-            // need to turn off 'typeofs' to make mapbox-gl work in
-            // minified bundles, for more info see:
-            // https://github.com/plotly/plotly.js/issues/2787
-            typeofs: false
-        },
         output: {
             beautify: false,
             ascii_only: true


### PR DESCRIPTION
Commit https://github.com/plotly/plotly.js/commit/23c863c4103e100ad2233b195cd4870e6b0a19ff adds unminified `mapbox-gl` code to the unminified `plotly.js` bundles. I think this can help debugging & developing easier and possibly more on par with the open source practice.

Commit https://github.com/plotly/plotly.js/commit/3084e7485b9ae9b104054212a22a9c091083ea19 removes the proposed solutions (#2789 & #2792) to minify the already minified `mapbox-gl` (see #2787) and drops the option for IE10 and older. See https://github.com/terser/terser#compress-options noting that _`typeofs: false was recommend to set this value to false for IE10 and earlier versions due to known issues._
cc: #5395 

@plotly/plotly_js 
