### PR TITLE
Keep comments in plotly-with-meta only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5090,9 +5090,8 @@
       }
     },
     "gl-heatmap2d": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.1.0.tgz",
-      "integrity": "sha512-0FLXyxv6UBCzzhi4Q2u+9fUs6BX1+r5ZztFe27VikE9FUVw7hZiuSHmgDng92EpydogcSYHXCIK8+58RagODug==",
+      "version": "git://github.com/gl-vis/gl-heatmap2d.git#9b7ce755fb91fb602f8422fc4ebfc8494a571429",
+      "from": "git://github.com/gl-vis/gl-heatmap2d.git#9b7ce755fb91fb602f8422fc4ebfc8494a571429",
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",
@@ -5100,86 +5099,6 @@
         "glslify": "^7.0.0",
         "iota-array": "^1.0.0",
         "typedarray-pool": "^1.2.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
-          "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
-          "requires": {
-            "bl": "^2.2.1",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.5",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.5",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "glslify-deps": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
-          "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
-          "requires": {
-            "@choojs/findup": "^0.2.0",
-            "events": "^3.2.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-tokenizer": "^2.0.0",
-            "graceful-fs": "^4.1.2",
-            "inherits": "^2.0.1",
-            "map-limit": "0.0.1",
-            "resolve": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-line3d": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11733,6 +11733,12 @@
         "is-utf8": "^0.2.0"
       }
     },
+    "strip-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+      "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+      "dev": true
+    },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5090,8 +5090,9 @@
       }
     },
     "gl-heatmap2d": {
-      "version": "git://github.com/gl-vis/gl-heatmap2d.git#9b7ce755fb91fb602f8422fc4ebfc8494a571429",
-      "from": "git://github.com/gl-vis/gl-heatmap2d.git#9b7ce755fb91fb602f8422fc4ebfc8494a571429",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.1.1.tgz",
+      "integrity": "sha512-6Vo1fPIB1vQFWBA/MR6JAA16XuQuhwvZRbSjYEq++m4QV33iqjGS2HcVIRfJGX+fomd5eiz6bwkVZcKm69zQPw==",
       "requires": {
         "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "fast-isnumeric": "^1.1.4",
     "gl-cone3d": "^1.5.2",
     "gl-error3d": "^1.0.16",
-    "gl-heatmap2d": "^1.1.0",
+    "gl-heatmap2d": "git://github.com/gl-vis/gl-heatmap2d.git#9b7ce755fb91fb602f8422fc4ebfc8494a571429",
     "gl-line3d": "1.2.1",
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "header-dist": "node tasks/header_dist.js",
     "stats": "node tasks/stats.js",
     "find-strings": "node tasks/find_locale_strings.js",
-    "build": "npm run preprocess && npm run find-strings && npm run bundle && npm run header-dist && npm run stats",
+    "build": "npm run preprocess && npm run find-strings && npm run bundle && npm run strip-comments && npm run header-dist && npm run stats",
     "cibuild": "npm run preprocess && node tasks/cibundle.js",
+    "strip-comments": "node tasks/strip_comments.js",
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
@@ -170,6 +171,7 @@
     "read-last-lines": "^1.7.2",
     "requirejs": "^2.3.6",
     "run-series": "^1.1.9",
+    "strip-comments": "^2.0.1",
     "through2": "^4.0.2",
     "true-case-path": "^2.2.1",
     "watchify": "^3.11.1"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "fast-isnumeric": "^1.1.4",
     "gl-cone3d": "^1.5.2",
     "gl-error3d": "^1.0.16",
-    "gl-heatmap2d": "git://github.com/gl-vis/gl-heatmap2d.git#9b7ce755fb91fb602f8422fc4ebfc8494a571429",
+    "gl-heatmap2d": "^1.1.1",
     "gl-line3d": "1.2.1",
     "gl-mat4": "^1.2.0",
     "gl-mesh3d": "^2.3.1",

--- a/tasks/strip_comments.js
+++ b/tasks/strip_comments.js
@@ -1,0 +1,37 @@
+var path = require('path');
+var fs = require('fs');
+var glob = require('glob');
+var stripComments = require('strip-comments');
+
+var constants = require('./util/constants');
+
+function removeCommentsFromUnminifiedBundles() {
+    var distGlob = path.join(constants.pathToDist, '**/plotly*.js');
+
+    glob(distGlob, function(err, allFileNames) {
+        allFileNames.forEach(function(fileName) {
+            if(
+                -1 === fileName.indexOf('.min.js') &&
+                -1 === fileName.indexOf('-with-meta') && // keeps all the comments in plotly-with-meta
+                -1 === fileName.indexOf('geo-assets.js') &&
+                -1 === fileName.indexOf('plotly-locale-')
+            ) {
+                console.log('processing:', fileName);
+
+                var fileIn = fs.openSync(fileName, 'r');
+                var strIn = fs.readFileSync(fileIn, 'utf8');
+
+                var fileOut = fs.openSync(fileName, 'w');
+                var strOut = stripComments(strIn, {
+                    line: true,
+                    block: true,
+                    preserveNewlines: false
+                });
+
+                fs.writeFileSync(fileOut, strOut);
+            }
+        });
+    });
+}
+
+removeCommentsFromUnminifiedBundles();


### PR DESCRIPTION
Strip comments from unminified bundles. 
We keep all the comments in `plotly-with-meta` bundle.

Before vs After

![strip-comments](https://user-images.githubusercontent.com/33888540/106166672-6d155e80-615a-11eb-94f5-958a43945c99.png)

@plotly/plotly_js 

