### PR TITLE
Avoid duplicate keys in plotly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,9 @@ jobs:
           name: Test plotly bundles againt unexpected characters
           command: npm run no-bad-char
       - run:
+          name: Test plotly bundles againt duplicate keys
+          command: npm run no-dup-keys
+      - run:
           name: Test certain bundles against function constructors
           command: npm run no-new-func
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2067,9 +2067,9 @@
       }
     },
     "colormap": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
-      "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.2.tgz",
+      "integrity": "sha512-jDOjaoEEmA9AgA11B/jCSAvYE95r3wRoAyTf3LEHGiUVlNHJaL1mRkf5AyLSpQBVGfTEPwGEqCIzL+kgr2WgNA==",
       "requires": {
         "lerp": "^1.0.3"
       }
@@ -4891,86 +4891,6 @@
         "glsl-specular-cook-torrance": "^2.0.1",
         "glslify": "^7.0.0",
         "ndarray": "^1.0.18"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
-          "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
-          "requires": {
-            "bl": "^2.2.1",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.5",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.5",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "glslify-deps": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
-          "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
-          "requires": {
-            "@choojs/findup": "^0.2.0",
-            "events": "^3.2.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-tokenizer": "^2.0.0",
-            "graceful-fs": "^4.1.2",
-            "inherits": "^2.0.1",
-            "map-limit": "0.0.1",
-            "resolve": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-constants": {
@@ -5227,86 +5147,6 @@
         "polytope-closest-point": "^1.0.0",
         "simplicial-complex-contour": "^1.0.2",
         "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
-          "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
-          "requires": {
-            "bl": "^2.2.1",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.5",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.5",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "glslify-deps": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
-          "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
-          "requires": {
-            "@choojs/findup": "^0.2.0",
-            "events": "^3.2.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-tokenizer": "^2.0.0",
-            "graceful-fs": "^4.1.2",
-            "inherits": "^2.0.1",
-            "map-limit": "0.0.1",
-            "resolve": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-plot2d": {
@@ -5962,86 +5802,6 @@
         "ndarray-scratch": "^1.2.0",
         "surface-nets": "^1.0.2",
         "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "glslify": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
-          "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
-          "requires": {
-            "bl": "^2.2.1",
-            "concat-stream": "^1.5.2",
-            "duplexify": "^3.4.5",
-            "falafel": "^2.1.0",
-            "from2": "^2.3.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-token-whitespace-trim": "^1.0.0",
-            "glslify-bundle": "^5.0.0",
-            "glslify-deps": "^1.2.5",
-            "minimist": "^1.2.5",
-            "resolve": "^1.1.5",
-            "stack-trace": "0.0.9",
-            "static-eval": "^2.0.5",
-            "through2": "^2.0.1",
-            "xtend": "^4.0.0"
-          }
-        },
-        "glslify-deps": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
-          "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
-          "requires": {
-            "@choojs/findup": "^0.2.0",
-            "events": "^3.2.0",
-            "glsl-resolve": "0.0.1",
-            "glsl-tokenizer": "^2.0.0",
-            "graceful-fs": "^4.1.2",
-            "inherits": "^2.0.1",
-            "map-limit": "0.0.1",
-            "resolve": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "gl-text": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint-fix": "eslint . --fix || true",
     "no-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js | grep -v MathJax.js)",
     "no-bad-char": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-misleading-character-class: error}' $(find dist -type f -iname '*.js' | grep plotly)",
+    "no-dup-keys": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-dupe-keys: error}' $(find dist -type f -iname '*.js' | grep plotly)",
     "docker": "node tasks/docker.js",
     "pretest": "node tasks/pretest.js",
     "test-jasmine": "karma start test/jasmine/karma.conf.js",


### PR DESCRIPTION
Fixes #5457. 

bump `colormap` by reinstalling `gl-cone3d`, `gl-mesh3d` and `gl-surface3d`.

@plotly/plotly_js 