### PR TITLE
Disallow inline config when running syntax test on bundles

### DIFF
--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -304,6 +304,7 @@ function assertES5() {
     var CLIEngine = eslint.CLIEngine;
 
     var cli = new CLIEngine({
+        allowInlineConfig: false,
         useEslintrc: false,
         ignore: false,
         parserOptions: {


### PR DESCRIPTION
The syntax test failed after updating the dist folder for `v2-rc.0` with the following message.

![syntax](https://user-images.githubusercontent.com/33888540/106777407-f7563a80-6612-11eb-857b-b2232fd43438.png)

This PR fixes the test and disallows in-line configs to try changing eslint setup. 

@plotly/plotly_js 
