### PR TITLE
Disable publishing flavors e.g. plotly-rc-v2 to CDN

### DIFF
--- a/tasks/cdn_publish.sh
+++ b/tasks/cdn_publish.sh
@@ -11,8 +11,10 @@ version=$(node -e "console.log(require('./package.json').version);")
 major=$(node -e "console.log(require('./package.json').version.split('.')[0]);")
 
 # read tag either latest or rc
-tag=$(node -e "var rc = require('./package.json').version.split('-')[1]; console.log(rc ? rc.split('.')[0] : 'latest');")
+baseTag=$(node -e "var rc = require('./package.json').version.split('-')[1]; console.log(rc ? rc.split('.')[0] : 'latest');")
+
 # if not v1 add major version to the tag e.g. latest-v2
+tag=$baseTag
 if [ $major -ne 1 ]; then tag=$tag-v$major; fi
 echo $tag
 
@@ -34,7 +36,10 @@ for path in `ls $dist/plotly*`; do
     fi
 
     cp $path "$sync/${name}-${version}.$ext"
-    cp $path "$sync/${name}-${tag}.$ext"
+
+    if [ $baseTag = "latest" ]; then
+        cp $path "$sync/${name}-${tag}.$ext"
+    fi
 done
 
 # copy topojson files over to the sync folder


### PR DESCRIPTION
`plotly-rc-v2` could stand for latest release candidate for v2 versions.
But let's not publishing it (for now) as it may be confusing which exact versions were used during QA periods.

@plotly/plotly_js 