### PR TITLE
Relates to #3735, adds `itemsymbol: 'constant'` legend option, which uses a circle symbol for all legend entries.

### DIFF
--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -77,6 +77,16 @@ module.exports = {
             'or remain *constant* independent of the symbol size on the graph.'
         ].join(' ')
     },
+    itemsymbol: {
+        valType: 'enumerated',
+        values: ['trace', 'constant'],
+        dflt: 'trace',
+        editType: 'legend',
+        description: [
+            'Determines if the legend items symbols use the symbol of the first point in each *trace*',
+            'or use a *constant* circle symbol.'
+        ].join(' ')
+    },
     itemwidth: {
         valType: 'number',
         min: 30,

--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -79,12 +79,12 @@ module.exports = {
     },
     itemsymbol: {
         valType: 'enumerated',
-        values: ['trace', 'constant'],
+        values: ['trace', 'circle'],
         dflt: 'trace',
         editType: 'legend',
         description: [
             'Determines if the legend items symbols use the symbol of the first point in each *trace*',
-            'or use a *constant* circle symbol.'
+            'or use a circle symbol.'
         ].join(' ')
     },
     itemwidth: {

--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -79,7 +79,7 @@ module.exports = {
     },
     itemsymbol: {
         valType: 'enumerated',
-        values: ['trace', ...Drawing.symbolList],
+        values: ['trace'].concat(Drawing.symbolList),
         dflt: 'trace',
         editType: 'legend',
         description: [

--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -2,7 +2,7 @@
 
 var fontAttrs = require('../../plots/font_attributes');
 var colorAttrs = require('../color/attributes');
-
+var Drawing = require('../drawing');
 
 module.exports = {
     bgcolor: {
@@ -79,12 +79,12 @@ module.exports = {
     },
     itemsymbol: {
         valType: 'enumerated',
-        values: ['trace', 'circle'],
+        values: ['trace', ...Drawing.symbolList],
         dflt: 'trace',
         editType: 'legend',
         description: [
             'Determines if the legend items symbols use the symbol of the first point in each *trace*',
-            'or use a circle symbol.'
+            'or the specified symbol name.'
         ].join(' ')
     },
     itemwidth: {

--- a/src/components/legend/defaults.js
+++ b/src/components/legend/defaults.js
@@ -105,6 +105,7 @@ module.exports = function legendDefaults(layoutIn, layoutOut, fullData) {
     if(helpers.isGrouped(layoutOut.legend)) coerce('tracegroupgap');
 
     coerce('itemsizing');
+    coerce('itemsymbol');
     coerce('itemwidth');
 
     coerce('itemclick');

--- a/src/components/legend/style.js
+++ b/src/components/legend/style.js
@@ -25,7 +25,7 @@ module.exports = function style(s, gd, legend) {
     var fullLayout = gd._fullLayout;
     if(!legend) legend = fullLayout.legend;
     var constantItemSizing = legend.itemsizing === 'constant';
-    var constantItemSymbol = legend.itemsymbol === 'constant';
+    var customItemSymbol = legend.itemsymbol && legend.itemsymbol !== 'trace';
     var itemWidth = legend.itemwidth;
     var centerPos = (itemWidth + constants.itemGap * 2) / 2;
     var centerTransform = strTranslate(centerPos, 0);
@@ -205,8 +205,8 @@ module.exports = function style(s, gd, legend) {
                 valToBound = cst;
             }
 
-            if(constantItemSymbol && attrIn === 'marker.symbol') {
-                valToBound = 'circle';
+            if(customItemSymbol && attrIn === 'marker.symbol') {
+                valToBound = legend.itemsymbol;
             }
 
             if(bounds) {

--- a/src/components/legend/style.js
+++ b/src/components/legend/style.js
@@ -204,7 +204,7 @@ module.exports = function style(s, gd, legend) {
             if(constantItemSizing && valToBound && cst !== undefined) {
                 valToBound = cst;
             }
-            
+
             if(constantItemSymbol && attrIn === 'marker.symbol') {
                 valToBound = 'circle';
             }

--- a/src/components/legend/style.js
+++ b/src/components/legend/style.js
@@ -25,6 +25,7 @@ module.exports = function style(s, gd, legend) {
     var fullLayout = gd._fullLayout;
     if(!legend) legend = fullLayout.legend;
     var constantItemSizing = legend.itemsizing === 'constant';
+    var constantItemSymbol = legend.itemsymbol === 'constant';
     var itemWidth = legend.itemwidth;
     var centerPos = (itemWidth + constants.itemGap * 2) / 2;
     var centerTransform = strTranslate(centerPos, 0);
@@ -202,6 +203,10 @@ module.exports = function style(s, gd, legend) {
 
             if(constantItemSizing && valToBound && cst !== undefined) {
                 valToBound = cst;
+            }
+            
+            if(constantItemSymbol && attrIn === 'marker.symbol') {
+                valToBound = 'circle';
             }
 
             if(bounds) {


### PR DESCRIPTION
As the title says, this is similar to the `itemsizing` legend option, but uses a constant legend symbol (circle) instead of using the symbol of the first point in the trace.