### PR TITLE
heatmapgl with axis constraints

### DIFF
--- a/src/plots/gl2d/scene2d.js
+++ b/src/plots/gl2d/scene2d.js
@@ -401,9 +401,10 @@ proto.plot = function(fullData, calcData, fullLayout) {
     options.screenBox = [0, 0, width, height];
 
     var mockGraphDiv = {_fullLayout: {
-        _axisConstraintGroups: this.graphDiv._fullLayout._axisConstraintGroups,
+        _axisConstraintGroups: fullLayout._axisConstraintGroups,
         xaxis: this.xaxis,
-        yaxis: this.yaxis
+        yaxis: this.yaxis,
+        _size: fullLayout._size
     }};
 
     cleanAxisConstraints(mockGraphDiv, this.xaxis);

--- a/test/jasmine/tests/heatmapgl_test.js
+++ b/test/jasmine/tests/heatmapgl_test.js
@@ -4,6 +4,9 @@ var Plotly = require('@lib/index');
 var schema = Plotly.PlotSchema.get();
 var attributeList = Object.getOwnPropertyNames(schema.traces.heatmapgl.attributes);
 
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+
 describe('heatmapgl supplyDefaults', function() {
     'use strict';
 
@@ -95,5 +98,34 @@ describe('heatmapgl supplyDefaults', function() {
                 expect(attributeList.indexOf(key)).not.toBe(-1, key);
             }
         });
+    });
+});
+
+describe('heatmapgl plotting', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('can do scaleanchor', function(done) {
+        var data = [{
+            z: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            type: 'heatmapgl',
+            showscale: false
+        }];
+        var layout = {
+            xaxis: {scaleanchor: 'y'},
+            width: 500,
+            height: 300,
+            margin: {l: 50, r: 50, t: 50, b: 50}
+        };
+        Plotly.newPlot(gd, data, layout)
+        .then(function() {
+            expect(layout.xaxis.range).toBeCloseToArray([-1, 3], 3);
+        })
+        .then(done, done.fail);
     });
 });


### PR DESCRIPTION
Fix #5474 - turns out gl2d is essentially compatible with `scaleanchor`, just needed a little more context

@archmoj

