### PR TITLE
Set default max memory usage for all node.js processes on CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: set heap option before very first node.js call
+          command: |
+            export NODE_OPTIONS='--max-old-space-size=4096'
+      - run:
           name: Install dependencies
           command: |
             npm ci

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "plotly"
   ],
   "scripts": {
-    "preprocess": "export NODE_OPTIONS='--max-old-space-size=4096' && node tasks/preprocess.js",
+    "preprocess": "node tasks/preprocess.js",
     "bundle": "node tasks/bundle.js",
     "header-dist": "node tasks/header_dist.js",
     "stats": "node tasks/stats.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "plotly"
   ],
   "scripts": {
-    "preprocess": "node tasks/preprocess.js",
+    "preprocess": "export NODE_OPTIONS='--max-old-space-size=4096' && node tasks/preprocess.js",
     "bundle": "node tasks/bundle.js",
     "header-dist": "node tasks/header_dist.js",
     "stats": "node tasks/stats.js",


### PR DESCRIPTION
To avoid recent strange failures on circleci 
https://support.circleci.com/hc/en-us/articles/360009208393-How-can-I-increase-the-max-memory-for-Node- 

@plotly/plotly_js 