### PR TITLE
Output bounding box to hover event data

### DIFF
--- a/src/components/fx/helpers.js
+++ b/src/components/fx/helpers.js
@@ -138,6 +138,11 @@ exports.makeEventData = function(pt, trace, cd) {
         if('yVal' in pt) out.y = pt.yVal;
         else if('y' in pt) out.y = pt.y;
 
+        if ('x0' in pt) out.x0 = pt.x0;
+        if ('x1' in pt) out.x1 = pt.x1;
+        if ('y0' in pt) out.y0 = pt.y0;
+        if ('y1' in pt) out.y1 = pt.y1;
+
         if(pt.xa) out.xaxis = pt.xa;
         if(pt.ya) out.yaxis = pt.ya;
         if(pt.zLabelVal !== undefined) out.z = pt.zLabelVal;

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -680,6 +680,12 @@ function _hover(gd, evt, subplot, noHoverEvent) {
     var oldhoverdata = gd._hoverdata;
     var newhoverdata = [];
 
+    // Top/left hover offsets relative to graph div. As long as hover content is
+    // a sibling of the graph div, it will be positioned correctly relative to
+    // the offset parent, whatever that may be.
+    var hot = gd.offsetTop + gd.clientTop;
+    var hol = gd.offsetLeft + gd.clientLeft;
+
     // pull out just the data that's useful to
     // other people and send it to the event
     for(itemnum = 0; itemnum < hoverData.length; itemnum++) {
@@ -693,6 +699,14 @@ function _hover(gd, evt, subplot, noHoverEvent) {
             }
             pt.hovertemplate = ht || pt.trace.hovertemplate || false;
         }
+
+        var bbox = {};
+        eventData.bbox = bbox;
+
+        if ('x0' in pt) bbox.x0 = hol + pt.x0 + pt.xa._offset;
+        if ('x1' in pt) bbox.x1 = hol + pt.x1 + pt.xa._offset;
+        if ('y0' in pt) bbox.y0 = hot + pt.y0 + pt.ya._offset;
+        if ('y1' in pt) bbox.y1 = hot + pt.y1 + pt.ya._offset;
 
         pt.eventData = [eventData];
         newhoverdata.push(eventData);

--- a/src/traces/bar/event_data.js
+++ b/src/traces/bar/event_data.js
@@ -7,6 +7,11 @@ module.exports = function eventData(out, pt, trace) {
     if(pt.xa) out.xaxis = pt.xa;
     if(pt.ya) out.yaxis = pt.ya;
 
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     if(trace.orientation === 'h') {
         out.label = out.y;
         out.value = out.x;

--- a/src/traces/box/event_data.js
+++ b/src/traces/box/event_data.js
@@ -11,5 +11,10 @@ module.exports = function eventData(out, pt) {
     if(pt.xa) out.xaxis = pt.xa;
     if(pt.ya) out.yaxis = pt.ya;
 
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     return out;
 };

--- a/src/traces/funnel/event_data.js
+++ b/src/traces/funnel/event_data.js
@@ -13,5 +13,10 @@ module.exports = function eventData(out, pt /* , trace, cd, pointNumber */) {
     if(pt.xa) out.xaxis = pt.xa;
     if(pt.ya) out.yaxis = pt.ya;
 
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     return out;
 };

--- a/src/traces/histogram/event_data.js
+++ b/src/traces/histogram/event_data.js
@@ -11,6 +11,11 @@ module.exports = function eventData(out, pt, trace, cd, pointNumber) {
     if(pt.xa) out.xaxis = pt.xa;
     if(pt.ya) out.yaxis = pt.ya;
 
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     // specific to histogram - CDFs do not have pts (yet?)
     if(!(trace.cumulative || {}).enabled) {
         var pts = Array.isArray(pointNumber) ?

--- a/src/traces/image/event_data.js
+++ b/src/traces/image/event_data.js
@@ -3,6 +3,12 @@
 module.exports = function eventData(out, pt) {
     if('xVal' in pt) out.x = pt.xVal;
     if('yVal' in pt) out.y = pt.yVal;
+
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     if(pt.xa) out.xaxis = pt.xa;
     if(pt.ya) out.yaxis = pt.ya;
     out.color = pt.color;

--- a/src/traces/pie/event_data.js
+++ b/src/traces/pie/event_data.js
@@ -18,7 +18,16 @@ module.exports = function eventData(pt, trace) {
         text: pt.text,
 
         // pt.v (and pt.i below) for backward compatibility
-        v: pt.v
+        v: pt.v,
+
+        // TODO: These coordinates aren't quite correct and don't take into account some offset
+        // I still haven't quite located (similar to xa._offset)
+        bbox: {
+            x0: pt.x0,
+            x1: pt.x1,
+            y0: pt.y0,
+            y1: pt.y1,
+        },
     };
 
     // Only include pointNumber if it's unambiguous

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -379,12 +379,20 @@ function attachFxHandlers(sliceTop, gd, cd) {
 
         if(hoverinfo === 'all') hoverinfo = 'label+text+value+percent+name';
 
+        // If hoverinfo === 'none', we still want the *coordinates* of hover to be
+        // output, just not the hover to actually display
+        var rInscribed = pt.rInscribed || 0;
+        var hoverCenterX = cx + pt.pxmid[0] * (1 - rInscribed);
+        var hoverCenterY = cy + pt.pxmid[1] * (1 - rInscribed);
+        pt.x0 = hoverCenterX - rInscribed * cd0.r;
+        pt.x1 = hoverCenterX + rInscribed * cd0.r;
+        pt.y0 = hoverCenterY;
+        pt.y1 = hoverCenterY;
+
         // in case we dragged over the pie from another subplot,
         // or if hover is turned off
         if(trace2.hovertemplate || (hoverinfo !== 'none' && hoverinfo !== 'skip' && hoverinfo)) {
-            var rInscribed = pt.rInscribed || 0;
-            var hoverCenterX = cx + pt.pxmid[0] * (1 - rInscribed);
-            var hoverCenterY = cy + pt.pxmid[1] * (1 - rInscribed);
+
             var separators = fullLayout2.separators;
             var text = [];
 
@@ -406,9 +414,9 @@ function attachFxHandlers(sliceTop, gd, cd) {
 
             Fx.loneHover({
                 trace: trace,
-                x0: hoverCenterX - rInscribed * cd0.r,
-                x1: hoverCenterX + rInscribed * cd0.r,
-                y: hoverCenterY,
+                x0: pt.x0,
+                x1: pt.x1,
+                y: pt.y0,
                 text: text.join('<br>'),
                 name: (trace2.hovertemplate || hoverinfo.indexOf('name') !== -1) ? trace2.name : undefined,
                 idealAlign: pt.pxmid[0] < 0 ? 'left' : 'right',

--- a/src/traces/scattercarpet/event_data.js
+++ b/src/traces/scattercarpet/event_data.js
@@ -7,5 +7,10 @@ module.exports = function eventData(out, pt, trace, cd, pointNumber) {
     out.b = cdi.b;
     out.y = cdi.y;
 
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     return out;
 };

--- a/src/traces/scatterternary/event_data.js
+++ b/src/traces/scatterternary/event_data.js
@@ -4,6 +4,11 @@ module.exports = function eventData(out, pt, trace, cd, pointNumber) {
     if(pt.xa) out.xaxis = pt.xa;
     if(pt.ya) out.yaxis = pt.ya;
 
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     if(cd[pointNumber]) {
         var cdi = cd[pointNumber];
 

--- a/src/traces/waterfall/event_data.js
+++ b/src/traces/waterfall/event_data.js
@@ -13,5 +13,10 @@ module.exports = function eventData(out, pt /* , trace, cd, pointNumber */) {
     if(pt.xa) out.xaxis = pt.xa;
     if(pt.ya) out.yaxis = pt.ya;
 
+    if ('x0' in pt) out.x0 = pt.x0;
+    if ('x1' in pt) out.x1 = pt.x1;
+    if ('y0' in pt) out.y0 = pt.y0;
+    if ('y1' in pt) out.y1 = pt.y1;
+
     return out;
 };


### PR DESCRIPTION
See: https://github.com/plotly/plotly.js/issues/1323

This PR adds `bbox: {x0, x1, y0, y1}` data to the points of hover event data. I've so far opted to keep the same format as the original hover data since I think it's very easy understand and doesn't bring in complicated information about the righthand side of the plot, which I think is best left to the user.

A short todo list:

- [ ] fix pie
- [ ] ensure it works with CSS transforms
- [ ] figure out the clearest way to convey the meaning of the coordinates

Regarding the last point, the coordinates are basically `gd.offsetTop + gd.clientTop + offsetWithinPlot`. The benefit of this is that positioning hovers within the plot should be very simple. You simply place a hover element as a sibling of the graph div, assign it the coordinates, and it should work without needing to worry about the margins, borders, or the offset parent (nearest element with position: 'relative' | 'absolute'). The downside is that this brings in position information from outside the graph div itself, but I think a reasonable solution is to state that if you want coordinates strictly limited to the plot, you should place HTML hover content and the graph div as direct children of a relative|absolute-positioned element.

Regarding CSS transforms, I think that I just need to apply `layout._invTransform` to the coordinates within the plot, but I haven't yet confirmed this. In matrix pseudocode, that would make the coordinates `[offsetLeft, offsetTop] + [clientLeft, clientTop] + invTransform * [plotOffsetLeft, plotOffsetTop]`.

The current list of trace types supported is:

- [x] bar 
- [x] barpolar
- [x] box 
- [x] candlestick
- [x] choropleth
- [x] choroplethmapbox
- [ ] cone
- [x] contour
- [ ] ~contourcarpet~ (no hover info)
- [ ] densitymapbox
- [x] funnel
- [ ] funnelarea (fixing pie should catch this?)
- [x] heatmap
- [ ] heatmapgl
- [x] histogram2d
- [x] histogram2dcontour
- [x] image
- [ ] ~indicator~ (does not apply?)
- [ ] mesh3d
- [x] ohlc
- [ ] parcats
- [ ] ~parcoords~ (does not apply?)
- [ ] pie 
- [ ] pointcloud
- [ ] sankey
- [x] scatter
- [ ] scatter3d
- [x] scattercarpet
- [x] scattergeo
- [ ] scattergl (x coordinate but not y coordinate, somehow??)
- [x] scatterpolar
- [x] scatterpolargl
- [x] scatterternary
- [x] splom
- [ ] streamtube
- [ ] sunburst
- [ ] surface
- [ ] ~table~ (does not apply)
- [ ] treemap
- [x] violin
- [ ] volume

Obviously some of these aren't so important, but I think if there are some not worth supporting (e.g. pointcloud?), it'd at least be nicely to clearly state expectations around what does happen.

Some of them (e.g. ohlc) also require particular knowledge of what the hover points mean since you get a flat list of maybe five points (bounding box, o, h, l, c?), but I think the main thing for now is that the data is there.