### PR TITLE
scattergl: make selection's eventData the same as in scatter traces

### DIFF
--- a/src/traces/scattergl/select.js
+++ b/src/traces/scattergl/select.js
@@ -5,6 +5,8 @@ var styleTextSelection = require('./edit_style').styleTextSelection;
 
 module.exports = function select(searchInfo, selectionTester) {
     var cd = searchInfo.cd;
+    var xa = searchInfo.xaxis;
+    var ya = searchInfo.yaxis;
     var selection = [];
     var trace = cd[0].trace;
     var stash = cd[0].t;
@@ -33,8 +35,8 @@ module.exports = function select(searchInfo, selectionTester) {
                 els.push(i);
                 selection.push({
                     pointNumber: i,
-                    x: x[i],
-                    y: y[i]
+                    x: xa.c2d(x[i]),
+                    y: ya.c2d(y[i])
                 });
             } else {
                 unels.push(i);

--- a/test/jasmine/tests/scattergl_select_test.js
+++ b/test/jasmine/tests/scattergl_select_test.js
@@ -349,6 +349,49 @@ describe('Test gl2d lasso/select:', function() {
         })
         .then(done, done.fail);
     });
+
+    [
+      ['linear', [1, 2, 3]],
+      ['log', [1, 2, 3]],
+      ['category', ['A', 'B', 'C']],
+      ['date', ['1900-01-01', '2000-01-01', '2100-01-01']]
+    ].forEach(function(test) {
+        var axType = test[0];
+        var x = test[1];
+        it('@gl should return the same eventData as scatter on ' + axType + ' axis', function(done) {
+            var _mock = {
+                data: [{type: 'scatter', x: x, y: [6, 5, 4]}],
+                layout: {dragmode: 'select', width: 400, height: 400, xaxis: {type: axType}}
+            };
+            gd = createGraphDiv();
+            var scatterEventData = {};
+            var selectPath = [[150, 150], [250, 250]];
+
+            Plotly.newPlot(gd, _mock)
+            .then(delay(20))
+            .then(function() {
+                expect(gd._fullLayout.xaxis.type).toEqual(test[0]);
+                return select(gd, selectPath);
+            })
+            .then(delay(20))
+            .then(function(eventData) {
+                scatterEventData = eventData;
+                // Make sure we selected a point
+                expect(eventData.points.length).toBe(1);
+                return Plotly.restyle(gd, 'type', 'scattergl');
+            })
+            .then(delay(20))
+            .then(function() {
+                expect(gd._fullLayout.xaxis.type).toEqual(test[0]);
+                return select(gd, selectPath);
+            })
+            .then(delay(20))
+            .then(function(eventData) {
+                assertEventData(eventData, scatterEventData);
+            })
+            .then(done, done.fail);
+        });
+    });
 });
 
 describe('Test displayed selections:', function() {

--- a/test/jasmine/tests/scattergl_select_test.js
+++ b/test/jasmine/tests/scattergl_select_test.js
@@ -350,46 +350,50 @@ describe('Test gl2d lasso/select:', function() {
         .then(done, done.fail);
     });
 
-    [
-      ['linear', [1, 2, 3]],
-      ['log', [1, 2, 3]],
-      ['category', ['A', 'B', 'C']],
-      ['date', ['1900-01-01', '2000-01-01', '2100-01-01']]
-    ].forEach(function(test) {
-        var axType = test[0];
-        var x = test[1];
-        it('@gl should return the same eventData as scatter on ' + axType + ' axis', function(done) {
-            var _mock = {
-                data: [{type: 'scatter', x: x, y: [6, 5, 4]}],
-                layout: {dragmode: 'select', width: 400, height: 400, xaxis: {type: axType}}
-            };
-            gd = createGraphDiv();
-            var scatterEventData = {};
-            var selectPath = [[150, 150], [250, 250]];
+    ['x', 'y'].forEach(function(ax) {
+        [
+          ['linear', [1, 2, 3]],
+          ['log', [1, 2, 3]],
+          ['category', ['A', 'B', 'C']],
+          ['date', ['1900-01-01', '2000-01-01', '2100-01-01']]
+        ].forEach(function(test) {
+            var axType = test[0];
 
-            Plotly.newPlot(gd, _mock)
-            .then(delay(20))
-            .then(function() {
-                expect(gd._fullLayout.xaxis.type).toEqual(test[0]);
-                return select(gd, selectPath);
-            })
-            .then(delay(20))
-            .then(function(eventData) {
-                scatterEventData = eventData;
-                // Make sure we selected a point
-                expect(eventData.points.length).toBe(1);
-                return Plotly.restyle(gd, 'type', 'scattergl');
-            })
-            .then(delay(20))
-            .then(function() {
-                expect(gd._fullLayout.xaxis.type).toEqual(test[0]);
-                return select(gd, selectPath);
-            })
-            .then(delay(20))
-            .then(function(eventData) {
-                assertEventData(eventData, scatterEventData);
-            })
-            .then(done, done.fail);
+            it('@gl should return the same eventData as scatter on ' + axType + ' ' + ax + ' axis', function(done) {
+                var _mock = {
+                    data: [{type: 'scatter', x: [1, 2, 3], y: [6, 5, 4]}],
+                    layout: {dragmode: 'select', width: 400, height: 400, xaxis: {}, yaxis: {}}
+                };
+                _mock.data[0][ax] = test[1];
+                _mock.layout[ax + 'axis'].type = axType;
+                gd = createGraphDiv();
+                var scatterEventData = {};
+                var selectPath = [[150, 150], [250, 250]];
+
+                Plotly.newPlot(gd, _mock)
+                .then(delay(20))
+                .then(function() {
+                    expect(gd._fullLayout[ax + 'axis'].type).toEqual(test[0]);
+                    return select(gd, selectPath);
+                })
+                .then(delay(20))
+                .then(function(eventData) {
+                    scatterEventData = eventData;
+                    // Make sure we selected a point
+                    expect(eventData.points.length).toBe(1);
+                    return Plotly.restyle(gd, 'type', 'scattergl');
+                })
+                .then(delay(20))
+                .then(function() {
+                    expect(gd._fullLayout[ax + 'axis'].type).toEqual(test[0]);
+                    return select(gd, selectPath);
+                })
+                .then(delay(20))
+                .then(function(eventData) {
+                    assertEventData(eventData, scatterEventData);
+                })
+                .then(done, done.fail);
+            });
         });
     });
 });

--- a/test/jasmine/tests/scatterpolargl_test.js
+++ b/test/jasmine/tests/scatterpolargl_test.js
@@ -298,46 +298,50 @@ describe('Test scatterpolargl interactions:', function() {
         .then(done, done.fail);
     });
 
-    [
-      ['linear', [0, 180]],
-      ['category', ['A', 'B']],
-    ].forEach(function(test) {
-        var axType = test[0];
-        var x = test[1];
-        it('@gl should return the same eventData as scatter on ' + axType + ' axis', function(done) {
-            var _mock = {
-                data: [{type: 'scatterpolar', r: [5, 10], theta: x}],
-                layout: {dragmode: 'select', width: 400, height: 400}
-            };
-            gd = createGraphDiv();
-            var scatterpolarEventData = {};
-            var selectPath = [[200, 150], [400, 250]];
+    ['r', 'theta'].forEach(function(ax) {
+        [
+          ['linear', [0, 180]],
+          ['category', ['A', 'B']],
+        ].forEach(function(test) {
+            var axType = test[0];
+            var axNames = {'r': 'radialaxis', 'theta': 'angularaxis'};
+            it('@gl should return the same eventData as scatter on ' + axType + ' ' + ax + ' axis', function(done) {
+                var _mock = {
+                    data: [{type: 'scatterpolar', r: [5, 10], theta: [0, 180]}],
+                    layout: {dragmode: 'select', width: 400, height: 400}
+                };
+                _mock.data[0][ax] = test[1];
+                gd = createGraphDiv();
+                var scatterpolarEventData = {};
+                var selectPath = [[185, 150], [400, 250]];
 
-            Plotly.newPlot(gd, _mock)
-            .then(delay(20))
-            .then(function() {
-                expect(gd._fullLayout.polar.angularaxis.type).toEqual(test[0]);
-                return select(gd, selectPath);
-            })
-            .then(delay(20))
-            .then(function(eventData) {
-                scatterpolarEventData = eventData;
-                // Make sure we selected a point
-                expect(eventData.points.length).toBe(1);
-                return Plotly.restyle(gd, 'type', 'scatterpolargl');
-            })
-            .then(delay(20))
-            .then(function() {
-                expect(gd._fullLayout.polar.angularaxis.type).toEqual(test[0]);
-                return select(gd, selectPath);
-            })
-            .then(delay(20))
-            .then(function(eventData) {
-                assertEventData(eventData, scatterpolarEventData);
-            })
-            .then(done, done.fail);
+                Plotly.newPlot(gd, _mock)
+                .then(delay(20))
+                .then(function() {
+                    expect(gd._fullLayout.polar[axNames[ax]].type).toEqual(test[0]);
+                    return select(gd, selectPath);
+                })
+                .then(delay(20))
+                .then(function(eventData) {
+                    scatterpolarEventData = eventData;
+                    // Make sure we selected a point
+                    expect(eventData.points.length).toBe(1);
+                    return Plotly.restyle(gd, 'type', 'scatterpolargl');
+                })
+                .then(delay(20))
+                .then(function() {
+                    expect(gd._fullLayout.polar[axNames[ax]].type).toEqual(test[0]);
+                    return select(gd, selectPath);
+                })
+                .then(delay(20))
+                .then(function(eventData) {
+                    assertEventData(eventData, scatterpolarEventData);
+                })
+                .then(done, done.fail);
+            });
         });
-    });
+    })
+
 });
 
 describe('Test scatterpolargl autorange:', function() {

--- a/test/jasmine/tests/scatterpolargl_test.js
+++ b/test/jasmine/tests/scatterpolargl_test.js
@@ -340,8 +340,7 @@ describe('Test scatterpolargl interactions:', function() {
                 .then(done, done.fail);
             });
         });
-    })
-
+    });
 });
 
 describe('Test scatterpolargl autorange:', function() {


### PR DESCRIPTION
This PR makes `scattergl` traces return selection's eventData that's the same as in `scatter`.

Closes https://github.com/plotly/plotly.js/issues/5533