### PR TITLE
Refactor Treemap Trace: remove extra if statement in default.js

### DIFF
--- a/src/traces/treemap/defaults.js
+++ b/src/traces/treemap/defaults.js
@@ -85,10 +85,6 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     coerce('marker.pad.r', headerSize / 4);
     coerce('marker.pad.b', bottomText ? headerSize : headerSize / 4);
 
-    if(withColorscale) {
-        colorscaleDefaults(traceIn, traceOut, layout, coerce, {prefix: 'marker.', cLetter: 'c'});
-    }
-
     traceOut._hovered = {
         marker: {
             line: {


### PR DESCRIPTION
PR to remove the extra `if` statement I found when working on the `icicle` plot.

More detail can be found here: https://github.com/plotly/plotly.js/pull/5546#discussion_r600780263
