### PR TITLE
Refactor legend draw to make input/output and optional arguments clear

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1045,6 +1045,7 @@ function createHoverText(hoverData, opts, gd) {
         legendOpts.layer = container;
 
         // Draw unified hover label
+        legendOpts._inHover = true;
         legendDraw(gd, legendOpts);
 
         // Position the hover

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1010,10 +1010,10 @@ function createHoverText(hoverData, opts, gd) {
         };
         var mockLayoutOut = {};
         legendSupplyDefaults(mockLayoutIn, mockLayoutOut, gd._fullData);
-        var legendOpts = mockLayoutOut.legend;
+        var mockLegend = mockLayoutOut.legend;
 
         // prepare items for the legend
-        legendOpts.entries = [];
+        mockLegend.entries = [];
         for(var j = 0; j < hoverData.length; j++) {
             var texts = getHoverLabelText(hoverData[j], true, hovermode, fullLayout, t0);
             var text = texts[0];
@@ -1039,14 +1039,14 @@ function createHoverText(hoverData, opts, gd) {
             }
             pt._distinct = true;
 
-            legendOpts.entries.push([pt]);
+            mockLegend.entries.push([pt]);
         }
-        legendOpts.entries.sort(function(a, b) { return a[0].trace.index - b[0].trace.index;});
-        legendOpts.layer = container;
+        mockLegend.entries.sort(function(a, b) { return a[0].trace.index - b[0].trace.index;});
+        mockLegend.layer = container;
 
         // Draw unified hover label
-        legendOpts._inHover = true;
-        legendDraw(gd, legendOpts);
+        mockLegend._inHover = true;
+        legendDraw(gd, mockLegend);
 
         // Position the hover
         var ly = Lib.mean(hoverData.map(function(c) {return (c.y0 + c.y1) / 2;}));

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -24,18 +24,21 @@ var helpers = require('./helpers');
 
 var MAIN_TITLE = 1;
 
-module.exports = function draw(gd, container) {
+module.exports = function draw(gd, opts) {
+    if(!opts) opts = gd._fullLayout.legend || {};
+    return _draw(gd, opts);
+};
+
+function _draw(gd, container) {
     var fullLayout = gd._fullLayout;
     var clipId = 'legend' + fullLayout._uid;
     var layer;
 
-    // Check whether this is the main legend (ie. called without any container)
-    var inHover = container && container._inHover;
+    var inHover = container._inHover;
     if(inHover) {
         layer = container.layer;
         clipId += '-hover';
     } else {
-        container = fullLayout.legend || {};
         layer = fullLayout._infolayer;
     }
 
@@ -342,7 +345,7 @@ module.exports = function draw(gd, container) {
                 });
             }
         }], gd);
-};
+}
 
 function clickOrDoubleClick(gd, legend, legendItem, numClicks, evt) {
     var trace = legendItem.data()[0][0].trace;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -30,15 +30,14 @@ module.exports = function draw(gd, container) {
     var layer;
 
     // Check whether this is the main legend (ie. called without any container)
-    if(container && container._inHover) {
+    var inHover = container && container._inHover;
+    if(inHover) {
         layer = container.layer;
         clipId += '-hover';
     } else {
         container = fullLayout.legend || {};
         layer = fullLayout._infolayer;
     }
-
-    var inHover = !!container._inHover;
 
     if(!layer) return;
 

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -30,12 +30,12 @@ module.exports = function draw(gd, container) {
     var layer;
 
     // Check whether this is the main legend (ie. called without any container)
-    if(!container) {
-        container = fullLayout.legend || {};
-        layer = fullLayout._infolayer;
-    } else {
+    if(container) {
         layer = container.layer;
         clipId += '-hover';
+    } else {
+        container = fullLayout.legend || {};
+        layer = fullLayout._infolayer;
     }
 
     var inHover = !!container._inHover;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -30,7 +30,7 @@ module.exports = function draw(gd, container) {
     var layer;
 
     // Check whether this is the main legend (ie. called without any container)
-    if(container) {
+    if(container && container._inHover) {
         layer = container.layer;
         clipId += '-hover';
     } else {

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -30,7 +30,7 @@ module.exports = function draw(gd, opts) {
     // Check whether this is the main legend (ie. called without any opts)
     if(!opts) {
         opts = fullLayout.legend || {};
-        opts._main = true;
+        opts._isLegend = true;
         layer = fullLayout._infolayer;
     } else {
         layer = opts.layer;
@@ -42,7 +42,7 @@ module.exports = function draw(gd, opts) {
     if(!gd._legendMouseDownTime) gd._legendMouseDownTime = 0;
 
     var legendData;
-    if(opts._main) {
+    if(opts._isLegend) {
         if(!gd.calcdata) return;
         legendData = fullLayout.showlegend && getLegendData(gd.calcdata, opts);
     } else {
@@ -52,14 +52,14 @@ module.exports = function draw(gd, opts) {
 
     var hiddenSlices = fullLayout.hiddenlabels || [];
 
-    if(opts._main && (!fullLayout.showlegend || !legendData.length)) {
+    if(opts._isLegend && (!fullLayout.showlegend || !legendData.length)) {
         layer.selectAll('.legend').remove();
         fullLayout._topdefs.select('#' + clipId).remove();
         return Plots.autoMargin(gd, 'legend');
     }
 
     var legend = Lib.ensureSingle(layer, 'g', 'legend', function(s) {
-        if(opts._main) s.attr('pointer-events', 'all');
+        if(opts._isLegend) s.attr('pointer-events', 'all');
     });
 
     var clipPath = Lib.ensureSingleById(fullLayout._topdefs, 'clipPath', clipId, function(s) {
@@ -112,7 +112,7 @@ module.exports = function draw(gd, opts) {
     })
     .each(function() { d3.select(this).call(drawTexts, gd, opts); })
     .call(style, gd, opts)
-    .each(function() { if(opts._main) d3.select(this).call(setupTraceToggle, gd); });
+    .each(function() { if(opts._isLegend) d3.select(this).call(setupTraceToggle, gd); });
 
     Lib.syncOrAsync([
         Plots.previousPromises,
@@ -121,7 +121,7 @@ module.exports = function draw(gd, opts) {
             // IF expandMargin return a Promise (which is truthy),
             // we're under a doAutoMargin redraw, so we don't have to
             // draw the remaining pieces below
-            if(opts._main && expandMargin(gd)) return;
+            if(opts._isLegend && expandMargin(gd)) return;
 
             var gs = fullLayout._size;
             var bw = opts.borderwidth;
@@ -129,7 +129,7 @@ module.exports = function draw(gd, opts) {
             var lx = gs.l + gs.w * opts.x - FROM_TL[getXanchor(opts)] * opts._width;
             var ly = gs.t + gs.h * (1 - opts.y) - FROM_TL[getYanchor(opts)] * opts._effHeight;
 
-            if(opts._main && fullLayout.margin.autoexpand) {
+            if(opts._isLegend && fullLayout.margin.autoexpand) {
                 var lx0 = lx;
                 var ly0 = ly;
 
@@ -146,18 +146,18 @@ module.exports = function draw(gd, opts) {
 
             // Set size and position of all the elements that make up a legend:
             // legend, background and border, scroll box and scroll bar as well as title
-            if(opts._main) Drawing.setTranslate(legend, lx, ly);
+            if(opts._isLegend) Drawing.setTranslate(legend, lx, ly);
 
             // to be safe, remove previous listeners
             scrollBar.on('.drag', null);
             legend.on('wheel', null);
 
-            if(!opts._main || opts._height <= opts._maxHeight || gd._context.staticPlot) {
+            if(!opts._isLegend || opts._height <= opts._maxHeight || gd._context.staticPlot) {
                 // if scrollbar should not be shown.
                 var height = opts._effHeight;
 
-                // if not the main legend, let it be its full size
-                if(!opts._main) height = opts._height;
+                // if unified hover, let it be its full size
+                if(!opts._isLegend) height = opts._height;
 
                 bg.attr({
                     width: opts._width - bw,
@@ -386,7 +386,7 @@ function drawTexts(g, gd, opts) {
     var trace = legendItem.trace;
     var isPieLike = Registry.traceIs(trace, 'pie-like');
     var traceIndex = trace.index;
-    var isEditable = opts._main && gd._context.edits.legendText && !isPieLike;
+    var isEditable = opts._isLegend && gd._context.edits.legendText && !isPieLike;
     var maxNameLength = opts._maxNameLength;
 
     var name;
@@ -491,7 +491,7 @@ function setupTraceToggle(g, gd) {
 }
 
 function textLayout(s, g, gd, opts) {
-    if(!opts._main) s.attr('data-notex', true); // do not process MathJax if not main
+    if(!opts._isLegend) s.attr('data-notex', true); // do not process MathJax for unified hover
     svgTextUtils.convertToTspans(s, gd, function() {
         computeTextDimensions(g, gd, opts);
     });
@@ -499,7 +499,7 @@ function textLayout(s, g, gd, opts) {
 
 function computeTextDimensions(g, gd, opts) {
     var legendItem = g.data()[0][0];
-    if(opts._main && legendItem && !legendItem.trace.showlegend) {
+    if(opts._isLegend && legendItem && !legendItem.trace.showlegend) {
         g.remove();
         return;
     }

--- a/src/components/legend/get_legend_data.js
+++ b/src/components/legend/get_legend_data.js
@@ -11,7 +11,6 @@ module.exports = function getLegendData(calcdata, opts) {
     var lgroupi = 0;
     var maxNameLength = 0;
     var i, j;
-    var main = opts._main;
 
     function addOneItem(legendGroup, legendItem) {
         // each '' legend group is treated as a separate group
@@ -37,7 +36,7 @@ module.exports = function getLegendData(calcdata, opts) {
         var trace = cd0.trace;
         var lgroup = trace.legendgroup;
 
-        if(main && (!trace.visible || !trace.showlegend)) continue;
+        if(opts._isLegend && (!trace.visible || !trace.showlegend)) continue;
 
         if(Registry.traceIs(trace, 'pie-like')) {
             if(!slicesShown[lgroup]) slicesShown[lgroup] = {};

--- a/src/components/legend/get_legend_data.js
+++ b/src/components/legend/get_legend_data.js
@@ -36,7 +36,7 @@ module.exports = function getLegendData(calcdata, opts) {
         var trace = cd0.trace;
         var lgroup = trace.legendgroup;
 
-        if(opts._isLegend && (!trace.visible || !trace.showlegend)) continue;
+        if(!opts._inHover && (!trace.visible || !trace.showlegend)) continue;
 
         if(Registry.traceIs(trace, 'pie-like')) {
             if(!slicesShown[lgroup]) slicesShown[lgroup] = {};


### PR DESCRIPTION
#4620 reused `legend.draw` to display `unified` hovers which is great improvement.
But with an unresolved https://github.com/plotly/plotly.js/pull/4620#discussion_r391144891 it is now difficult to understand what  exactly is going on with the optional argument (`opts`) passing to `draw` function and downstream. 

Also `opts` is in fact essential (not optional) to most functions in `legend.draw` while different sizes are computed and stashed into this object (with the intent IN & OUT).

This PR is an attempt to address these internal issues before more progress on legends and unified hovers.

@plotly/plotly_js 



