### PR TITLE
Should set opacity to 1 to be visible

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -3043,7 +3043,7 @@ axes.drawLabels = function(gd, ax, opts) {
                 });
 
                 if(isInside) {
-                    thisText.style('opacity', 0); // visible
+                    thisText.style('opacity', 1); // visible
 
                     if(ax._hideOutOfRangeInsideTickLabels) {
                         ax._hideOutOfRangeInsideTickLabels();


### PR DESCRIPTION
Addressing obvious bug.
See https://github.com/plotly/plotly.js/pull/5550/files#r609763296

cc: @plotly/plotly_js 