### PR TITLE
do not depend on recursive remove directory for node.js < v12.10

### DIFF
--- a/tasks/empty_dist.js
+++ b/tasks/empty_dist.js
@@ -1,20 +1,35 @@
+var path = require('path');
 var fs = require('fs-extra');
 var common = require('./util/common');
 var constants = require('./util/constants');
 
+var dist = constants.pathToDist; // dist
+var distTopojson = constants.pathToTopojsonDist; // dist/topojson
 // main
-emptyDist();
+emptyDir(distTopojson);
+emptyDir(dist);
+makeDir(dist);
+makeDir(distTopojson);
 
-function emptyDist() {
-    var dir = constants.pathToDist;
+function emptyDir(dir) {
     if(common.doesDirExist(dir)) {
         console.log('empty ' + dir);
         try {
-            fs.rmdirSync(dir, { recursive: true });
+            var allFiles = fs.readdirSync(dir);
+            allFiles.forEach(function(file) {
+                // remove file
+                fs.unlinkSync(path.join(dir, file));
+            });
+
+            fs.rmdirSync(dir);
         } catch(err) {
             console.error(err);
         }
+    }
+}
 
+function makeDir(dir) {
+    if(!common.doesDirExist(dir)) {
         // create folder
         fs.mkdirSync(dir);
     }


### PR DESCRIPTION
The recursive `fs.rmdirSync` is added in node.js `v12.10`.
In order to keep build scripts working with other node versions, 
this PR empties `dist` and `dist/topojson` folders without depending on that option.

@plotly/plotly_js 

