### PR TITLE
bump canvas to v2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1776,13 +1776,13 @@
       }
     },
     "canvas": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.6.1.tgz",
-      "integrity": "sha512-S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.7.0.tgz",
+      "integrity": "sha512-pzCxtkHb+5su5MQjTtepMDlIOtaXo277x0C0u3nMOxtkhTyQ+h2yNKhlROAaDllWgRyePAUitC08sXw26Eb6aw==",
       "dev": true,
       "requires": {
         "nan": "^2.14.0",
-        "node-pre-gyp": "^0.11.0",
+        "node-pre-gyp": "^0.15.0",
         "simple-get": "^3.0.3"
       }
     },
@@ -8653,21 +8653,21 @@
       }
     },
     "node-pre-gyp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
-      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
         "nopt": "^4.0.1",
         "npm-packlist": "^1.1.6",
         "npmlog": "^4.0.2",
         "rc": "^1.2.7",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
-        "tar": "^4"
+        "tar": "^4.4.2"
       },
       "dependencies": {
         "chownr": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "browserify": "^17.0.0",
     "browserify-transform-tools": "^1.7.0",
     "bubleify": "^2.0.0",
-    "canvas": "^2.6.1",
+    "canvas": "^2.7.0",
     "check-node-version": "^4.0.3",
     "chttps": "^1.0.6",
     "deep-equal": "^2.0.5",


### PR DESCRIPTION
`canvas` module is needed for `tasks/test_requirejs.js`.
However current version (v2.6.1) is not working when running `npm ci` using `npm v7`.
This PR fixes that problem by upgrading [canvas](https://www.npmjs.com/package/canvas) to `v2.7.0`.

@plotly/plotly_js 
