### PR TITLE
Revise CI tests to have a more stable run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,18 @@ jobs:
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plotly.js
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plotly.min.js
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plot-schema.json
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - plotly.js
+
+  test-dist1:
+    docker:
+      - image: circleci/node:12.13.0
+    working_directory: ~/plotly.js
+    steps:
+      - attach_workspace:
+          at: ~/
       - run:
           name: Test validation using node.js and jsdom
           command: npm run test-plain-obj
@@ -182,13 +194,19 @@ jobs:
       - run:
           name: Test certain bundles against function constructors
           command: npm run no-new-func
+
+  test-dist2:
+    docker:
+      - image: circleci/node:12.13.0
+    working_directory: ~/plotly.js
+    steps:
+      - attach_workspace:
+          at: ~/
       - run:
           name: Test plotly bundles against es6
           command: npm run no-es6-dist
       - run:
           name: Test plotly bundles againt duplicate keys
-          environment:
-            NODE_OPTIONS: --max_old_space_size=4096
           command: npm run no-dup-keys
 
 workflows:
@@ -220,3 +238,9 @@ workflows:
       - publish-dist:
           requires:
             - install-and-cibuild
+      - test-dist1:
+          requires:
+            - publish-dist
+      - test-dist2:
+          requires:
+            - publish-dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: circleci/node:12.13.0-browsers
-    parallelism: 2
+    parallelism: 8
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -57,7 +57,7 @@ jobs:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: circleci/node:12.13.0-browsers
-    parallelism: 3
+    parallelism: 8
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -1318,7 +1318,7 @@ describe('sankey tests', function() {
                       .then(done, done.fail);
                 });
 
-                it('should persist the position of every nodes after drag in attributes nodes.(x|y)', function(done) {
+                it('@flaky should persist the position of every nodes after drag in attributes nodes.(x|y)', function(done) {
                     mockCopy.data[0].arrangement = arrangement;
                     var move = [50, -50];
                     var nodes;

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -1684,7 +1684,7 @@ describe('Test splom select:', function() {
         .then(done, done.fail);
     });
 
-    it('@gl should redraw splom traces before scattergl trace (if any)', function(done) {
+    it('@noci @gl should redraw splom traces before scattergl trace (if any)', function(done) {
         var fig = require('@mocks/splom_with-cartesian.json');
         fig.layout.dragmode = 'select';
         fig.layout.width = 400;


### PR DESCRIPTION
In the past months, we encountered some issues when running our tests on the CI.
Namely `no-gl-jasmine` container regularly failed due to not finding the test files.
Also the `publish-dist` take several minutes to complete. 
As a result it took several (or infinite) re-runs to get a green light.

This PR helps fix these problems by splitting tests.

@plotly/plotly_js 