### PR TITLE
correct noCI tag

### DIFF
--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -1684,7 +1684,7 @@ describe('Test splom select:', function() {
         .then(done, done.fail);
     });
 
-    it('@noci @gl should redraw splom traces before scattergl trace (if any)', function(done) {
+    it('@noCI @gl should redraw splom traces before scattergl trace (if any)', function(done) {
         var fig = require('@mocks/splom_with-cartesian.json');
         fig.layout.dragmode = 'select';
         fig.layout.width = 400;


### PR DESCRIPTION
The tag added in #5602 to a flaky `gl` test should be `noCI`.

cc: @plotly/plotly_js 