### PR TITLE
Fix the list of traces for publishing packages to npm

### DIFF
--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -34,6 +34,7 @@ partialBundlePaths
             main: 'plotly-' + d.name + '.js',
             dist: d.dist,
             desc: 'Ready-to-use plotly.js ' + d.name + ' distributed bundle.',
+            traceList: constants.partialBundleTraces[d.name]
         };
     })
     .concat([{
@@ -42,6 +43,7 @@ partialBundlePaths
         main: 'plotly.js',
         dist: constants.pathToPlotlyDist,
         desc: 'Ready-to-use plotly.js distributed bundle.',
+        traceList: constants.allTraces
     }])
     .forEach(syncPartialBundlePkg);
 
@@ -54,6 +56,7 @@ partialBundlePaths
             main: 'plotly-' + d.name + '.min.js',
             dist: d.distMin,
             desc: 'Ready-to-use minified plotly.js ' + d.name + ' distributed bundle.',
+            traceList: constants.partialBundleTraces[d.name]
         };
     })
     .concat([{
@@ -62,6 +65,7 @@ partialBundlePaths
         main: 'plotly.min.js',
         dist: constants.pathToPlotlyDistMin,
         desc: 'Ready-to-use minified plotly.js distributed bundle.',
+        traceList: constants.allTraces
     }])
     .forEach(syncPartialBundlePkg);
 
@@ -105,14 +109,12 @@ function syncPartialBundlePkg(d) {
 
 
     function writeREADME(cb) {
-        var traceList = d.traceList;
-
         var cnt = [
             '# ' + d.name,
             '',
             d.desc,
             '',
-            'Contains trace modules ' + common.formatEnumeration(traceList) + '.',
+            'Contains trace modules ' + common.formatEnumeration(d.traceList) + '.',
             '',
             'For more info on plotly.js, go to https://github.com/plotly/plotly.js',
             '',

--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -168,6 +168,8 @@ module.exports = {
     pathToBuild: pathToBuild,
     pathToDist: pathToDist,
 
+    partialBundleTraces: partialBundleTraces,
+
     allTransforms: allTransforms,
     allTraces: allTraces,
     mainIndex: mainIndex,


### PR DESCRIPTION
I encountered missing lists when publishing `v2.0.0-rc.1` to `npm` likey as a result of the changes in #5508.
This was fixed by providing the list of traces to `syn_packages` script as reflected in this PR.

@plotly/plotly_js 