### PR TITLE
Fix Safari Download

### DIFF
--- a/src/snapshot/filesaver.js
+++ b/src/snapshot/filesaver.js
@@ -23,13 +23,6 @@ function fileSaver(url, name, format) {
         var blob;
         var objectUrl;
 
-        // Safari doesn't allow downloading of blob urls
-        if(Lib.isSafari()) {
-            var prefix = format === 'svg' ? ',' : ';base64,';
-            helpers.octetStream(prefix + encodeURIComponent(url));
-            return resolve(name);
-        }
-
         // IE 10+ (native saveAs)
         if(Lib.isIE()) {
             // At this point we are only dealing with a decoded SVG as


### PR DESCRIPTION
Fix for issue #1227. 

It appears that for Safari Version 14.0.1 (16610.2.11.51.8) the special code in fileSaver.js for handling Safari browsers is actually breaking the download. The filename is always "Unknown" and it doesn't download the entire image (in our case a scatter plot gave us only the axes and labels, but none of the points). Strangely a second try at the download will give the user the full plot, but the filename is still "Uknown".

Removing the special handling worked when testing with npm start.
