### PR TITLE
Fixup texttemplate on log axes

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -943,7 +943,8 @@ drawing.textPointStyle = function(s, trace, gd) {
         }
 
         if(texttemplate) {
-            var labels = trace._module.formatLabels ? trace._module.formatLabels(d, trace, fullLayout) : {};
+            var fn = trace._module.formatLabels;
+            var labels = fn ? fn(d, trace, fullLayout) : {};
             var pointValues = {};
             appendArrayPointValue(pointValues, trace, d.i);
             var meta = trace._meta || {};

--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -647,10 +647,14 @@ function calcTexttemplate(fullLayout, cd, index, xa, ya) {
     }
 
     function formatLabel(u) {
+        if(pAxis.type === 'log') u = pAxis.c2r(u);
+
         return tickText(pAxis, u, true).text;
     }
 
     function formatNumber(v) {
+        if(vAxis.type === 'log') v = vAxis.c2r(v);
+
         return tickText(vAxis, +v, true).text;
     }
 

--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -647,15 +647,11 @@ function calcTexttemplate(fullLayout, cd, index, xa, ya) {
     }
 
     function formatLabel(u) {
-        if(pAxis.type === 'log') u = pAxis.c2r(u);
-
-        return tickText(pAxis, u, true).text;
+        return tickText(pAxis, pAxis.c2l(u), true).text;
     }
 
     function formatNumber(v) {
-        if(vAxis.type === 'log') v = vAxis.c2r(v);
-
-        return tickText(vAxis, +v, true).text;
+        return tickText(vAxis, vAxis.c2l(v), true).text;
     }
 
     var cdi = cd[index];

--- a/src/traces/scatter/format_labels.js
+++ b/src/traces/scatter/format_labels.js
@@ -9,8 +9,14 @@ module.exports = function formatLabels(cdi, trace, fullLayout) {
     var xa = Axes.getFromTrace(mockGd, trace, 'x');
     var ya = Axes.getFromTrace(mockGd, trace, 'y');
 
-    labels.xLabel = Axes.tickText(xa, cdi.x, true).text;
-    labels.yLabel = Axes.tickText(ya, cdi.y, true).text;
+    var x = cdi.x;
+    var y = cdi.y;
+
+    if(xa.type === 'log') x = xa.c2r(x);
+    if(ya.type === 'log') y = ya.c2r(y);
+
+    labels.xLabel = Axes.tickText(xa, x, true).text;
+    labels.yLabel = Axes.tickText(ya, y, true).text;
 
     return labels;
 };

--- a/src/traces/scatter/format_labels.js
+++ b/src/traces/scatter/format_labels.js
@@ -9,14 +9,8 @@ module.exports = function formatLabels(cdi, trace, fullLayout) {
     var xa = Axes.getFromTrace(mockGd, trace, 'x');
     var ya = Axes.getFromTrace(mockGd, trace, 'y');
 
-    var x = cdi.x;
-    var y = cdi.y;
-
-    if(xa.type === 'log') x = xa.c2r(x);
-    if(ya.type === 'log') y = ya.c2r(y);
-
-    labels.xLabel = Axes.tickText(xa, x, true).text;
-    labels.yLabel = Axes.tickText(ya, y, true).text;
+    labels.xLabel = Axes.tickText(xa, xa.c2l(cdi.x), true).text;
+    labels.yLabel = Axes.tickText(ya, ya.c2l(cdi.y), true).text;
 
     return labels;
 };

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -2712,6 +2712,23 @@ describe('Text templates on bar traces:', function() {
     checkTextTemplate({
         data: [{
             type: 'bar',
+            textposition: 'outside',
+            x: [1, 2, 3],
+            y: [3, 2, 1],
+            hovertemplate: '%{x}-%{y}',
+            texttemplate: '%{x}-%{y}'
+        }],
+        layout: {
+            xaxis: {type: 'log'},
+            yaxis: {type: 'log'},
+        }
+    }, 'text.bartext', [
+      ['%{x}-%{y}', ['1-3', '2-2', '3-1']]
+    ]);
+
+    checkTextTemplate({
+        data: [{
+            type: 'bar',
             textposition: 'inside',
             x: ['a', 'b'],
             y: ['1000', '1200'],

--- a/test/jasmine/tests/scatter_test.js
+++ b/test/jasmine/tests/scatter_test.js
@@ -1245,6 +1245,22 @@ describe('Text templates on scatter traces:', function() {
         data: [{
             type: 'scatter',
             mode: 'text',
+            x: [1, 2, 3],
+            y: [3, 2, 1],
+            texttemplate: '%{x}-%{y}'
+        }],
+        layout: {
+            xaxis: {type: 'log'},
+            yaxis: {type: 'log'},
+        }
+    }, '.textpoint', [
+      ['%{x}-%{y}', ['1-3', '2-2', '3-1']]
+    ]);
+
+    checkTextTemplate({
+        data: [{
+            type: 'scatter',
+            mode: 'text',
             x: ['a', 'b'],
             y: ['1000', '1200']
         }],


### PR DESCRIPTION
Fixes #5585 for `scatter` and `bar`.

@plotly/plotly_js 