### PR TITLE
Adjust splom test to run smoothly on the CircleCI

### DIFF
--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -1585,7 +1585,7 @@ describe('Test splom select:', function() {
 
             var to = setTimeout(function() {
                 reject('fail: plotly_selected not emitter');
-            }, 200);
+            }, 300);
 
             gd.once('plotly_selected', function(d) {
                 clearTimeout(to);

--- a/test/jasmine/tests/splom_test.js
+++ b/test/jasmine/tests/splom_test.js
@@ -1684,7 +1684,7 @@ describe('Test splom select:', function() {
         .then(done, done.fail);
     });
 
-    it('@noCI @gl should redraw splom traces before scattergl trace (if any)', function(done) {
+    it('@gl should redraw splom traces before scattergl trace (if any)', function(done) {
         var fig = require('@mocks/splom_with-cartesian.json');
         fig.layout.dragmode = 'select';
         fig.layout.width = 400;


### PR DESCRIPTION
https://github.com/plotly/plotly.js/commit/08643811285a4cc0d4aac36f2e621e8b33042bbb Fixes the following error resulting in `webgl-jasmine` failures.

https://app.circleci.com/pipelines/github/plotly/plotly.js/3664/workflows/4b3e322b-fa05-4e0d-86c6-535bd400d538/jobs/110861
![splom-test](https://user-images.githubusercontent.com/33888540/117073351-c8c62980-acff-11eb-848b-238d8f7e4e92.png)

Also after https://github.com/plotly/plotly.js/commit/051e9067a6060cdfd3450409d8cd38ee2e28c27f now we run more `splom` test on the CircleCI.

`parcoords` tests are also flaky in webgl container; but we 'll address that issue in a separate PR.

@plotly/plotly_js 

