### PR TITLE
Address scattergl performance issue with TypeArrays

### DIFF
--- a/src/components/color/index.js
+++ b/src/components/color/index.js
@@ -2,6 +2,7 @@
 
 var tinycolor = require('tinycolor2');
 var isNumeric = require('fast-isnumeric');
+var isTypedArray = require('../../lib/array').isTypedArray;
 
 var color = module.exports = {};
 
@@ -116,7 +117,7 @@ color.clean = function(container) {
             if(!Array.isArray(el0) && el0 && typeof el0 === 'object') {
                 for(j = 0; j < val.length; j++) color.clean(val[j]);
             }
-        } else if(val && typeof val === 'object' && !ArrayBuffer.isView(val)) color.clean(val);
+        } else if(val && typeof val === 'object' && !isTypedArray(val)) color.clean(val);
     }
 };
 

--- a/src/components/color/index.js
+++ b/src/components/color/index.js
@@ -116,7 +116,7 @@ color.clean = function(container) {
             if(!Array.isArray(el0) && el0 && typeof el0 === 'object') {
                 for(j = 0; j < val.length; j++) color.clean(val[j]);
             }
-        } else if(val && typeof val === 'object') color.clean(val);
+        } else if(val && typeof val === 'object' && !ArrayBuffer.isView(val)) color.clean(val);
     }
 };
 

--- a/src/traces/scattergl/calc.js
+++ b/src/traces/scattergl/calc.js
@@ -27,7 +27,7 @@ module.exports = function calc(gd, trace) {
     var hasTooManyPoints = len >= TOO_MANY_POINTS;
     var len2 = len * 2;
     var stash = {};
-    var i, xx, yy;
+    var i;
 
     var origX = xa.makeCalcdata(trace, 'x');
     var origY = ya.makeCalcdata(trace, 'y');
@@ -42,11 +42,12 @@ module.exports = function calc(gd, trace) {
     // we need hi-precision for scatter2d,
     // regl-scatter2d uses NaNs for bad/missing values
     var positions = new Array(len2);
+    var _ids = new Array(len);
     for(i = 0; i < len; i++) {
-        xx = x[i];
-        yy = y[i];
-        positions[i * 2] = xx === BADNUM ? NaN : xx;
-        positions[i * 2 + 1] = yy === BADNUM ? NaN : yy;
+        positions[i * 2] = x[i] === BADNUM ? NaN : x[i];
+        positions[i * 2 + 1] = y[i] === BADNUM ? NaN : y[i];
+        // Pre-compute ids.
+        _ids[i] = i;
     }
 
     if(xa.type === 'log') {
@@ -66,10 +67,7 @@ module.exports = function calc(gd, trace) {
         // FIXME: delegate this to webworker
         stash.tree = cluster(positions);
     } else {
-        var ids = stash.ids = new Array(len);
-        for(i = 0; i < len; i++) {
-            ids[i] = i;
-        }
+        stash.ids = _ids;
     }
 
     // create scene options and scene


### PR DESCRIPTION
Address: #4401

Overview of the Pull Request:

Address an unavoidable loop phase inside color clean function where
it iterates all over the graph points if data used is a derivative of a ArrayBuffer.
This causes graph to have way less performance relative to Array types.

Also added a little performance enhancement to calc function. Tell if this is out of scope :)

Simple Demo: [here](https://codepen.io/Seranicio/pen/LYWPKKG) (adapted from @archmoj)

Function performance checkup:

![Screenshot 2021-05-05 at 12 47 00](https://user-images.githubusercontent.com/17353925/117136262-0bd7d980-ada0-11eb-8bd2-722739a89b9f.png)

