### PR TITLE
Adjust parcoords tests and revise karma config

### DIFF
--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -218,10 +218,10 @@ func.defaultConfig = {
     singleRun: argv.nowatch,
 
     // how long will Karma wait for a message from a browser before disconnecting (30 ms)
-    browserNoActivityTimeout: 30000,
+    browserNoActivityTimeout: 60000,
 
     // how long does Karma wait for a browser to reconnect (in ms).
-    browserDisconnectTimeout: 30000,
+    browserDisconnectTimeout: 60000,
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -220,6 +220,9 @@ func.defaultConfig = {
     // how long will Karma wait for a message from a browser before disconnecting (30 ms)
     browserNoActivityTimeout: 30000,
 
+    // how long does Karma wait for a browser to reconnect (in ms).
+    browserDisconnectTimeout: 30000,
+
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     //

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -58,14 +58,6 @@ function mostOfDrag(x1, y1, x2, y2) {
     mouseEvent('mousemove', x2, y2);
 }
 
-function purgeGraphDiv(done) {
-    var gd = d3Select('.js-plotly-plot').node();
-    if(gd) Plotly.purge(gd);
-    destroyGraphDiv();
-
-    return delay(50)().then(done);
-}
-
 function getAvgPixelByChannel(id) {
     var canvas = d3Select(id).node();
 
@@ -376,7 +368,7 @@ describe('parcoords edge cases', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(purgeGraphDiv);
+    afterEach(destroyGraphDiv);
 
     it('@gl Works fine with one panel only', function(done) {
         var mockCopy = Lib.extendDeep({}, mock2);
@@ -645,7 +637,7 @@ describe('parcoords edge cases', function() {
 describe('parcoords Lifecycle methods', function() {
     var gd;
     beforeEach(function() { gd = createGraphDiv(); });
-    afterEach(purgeGraphDiv);
+    afterEach(destroyGraphDiv);
 
     it('Plotly.deleteTraces with one trace removes the plot', function(done) {
         var mockCopy = Lib.extendDeep({}, mock);
@@ -915,7 +907,7 @@ describe('parcoords basic use', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(purgeGraphDiv);
+    afterEach(destroyGraphDiv);
 
     it('@gl should create three WebGL contexts per graph', function(done) {
         Plotly.react(gd, mockCopy)
@@ -1223,7 +1215,7 @@ describe('parcoords react more attributes', function() {
         gd = createGraphDiv();
     });
 
-    afterEach(purgeGraphDiv);
+    afterEach(destroyGraphDiv);
 
     it('@gl should change various axis parameters', function(done) {
         Plotly.react(gd, mock3)
@@ -1372,7 +1364,7 @@ describe('parcoords constraint interactions - without defined axis ranges', func
     });
 
     afterAll(function() {
-        purgeGraphDiv();
+        destroyGraphDiv();
         PC.bar.snapDuration = initialSnapDuration;
     });
 
@@ -1380,7 +1372,7 @@ describe('parcoords constraint interactions - without defined axis ranges', func
         gd = createGraphDiv();
     });
 
-    afterEach(purgeGraphDiv);
+    afterEach(destroyGraphDiv);
 
     function getDashArray(index) {
         var highlight = document.querySelectorAll('.highlight')[index];
@@ -1658,7 +1650,7 @@ describe('parcoords constraint interactions - with defined axis ranges', functio
     });
 
     afterAll(function() {
-        purgeGraphDiv();
+        destroyGraphDiv();
         PC.bar.snapDuration = initialSnapDuration;
     });
 
@@ -1666,7 +1658,7 @@ describe('parcoords constraint interactions - with defined axis ranges', functio
         gd = createGraphDiv();
     });
 
-    afterEach(purgeGraphDiv);
+    afterEach(destroyGraphDiv);
 
     it('@gl updates constraints above and below axis ranges', function(done) {
         var x = 295;
@@ -1740,7 +1732,7 @@ describe('parcoords constraint click interactions - with pre-defined constraint 
     });
 
     afterAll(function() {
-        purgeGraphDiv();
+        destroyGraphDiv();
         PC.bar.snapDuration = initialSnapDuration;
     });
 
@@ -1748,7 +1740,7 @@ describe('parcoords constraint click interactions - with pre-defined constraint 
         gd = createGraphDiv();
     });
 
-    afterEach(purgeGraphDiv);
+    afterEach(destroyGraphDiv);
 
     it('@gl should not drop constraintrange on click', function(done) {
         Plotly.react(gd, initialFigure())

--- a/test/jasmine/tests/parcoords_test.js
+++ b/test/jasmine/tests/parcoords_test.js
@@ -363,7 +363,7 @@ describe('parcoords initialization tests', function() {
 describe('parcoords edge cases', function() {
     var gd;
     beforeEach(function() {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
 
         gd = createGraphDiv();
     });
@@ -636,7 +636,10 @@ describe('parcoords edge cases', function() {
 
 describe('parcoords Lifecycle methods', function() {
     var gd;
-    beforeEach(function() { gd = createGraphDiv(); });
+    beforeEach(function() {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+        gd = createGraphDiv();
+    });
     afterEach(destroyGraphDiv);
 
     it('Plotly.deleteTraces with one trace removes the plot', function(done) {
@@ -896,7 +899,7 @@ describe('parcoords basic use', function() {
     var gd;
 
     beforeEach(function() {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
 
         mockCopy = Lib.extendDeep({}, mock);
         mockCopy.data[0].domain = {
@@ -1212,6 +1215,7 @@ describe('parcoords react more attributes', function() {
     var gd;
 
     beforeEach(function() {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
         gd = createGraphDiv();
     });
 
@@ -1357,8 +1361,6 @@ describe('parcoords constraint interactions - without defined axis ranges', func
     var snapDelay = 100;
     var noSnapDelay = 20;
     beforeAll(function() {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-
         initialSnapDuration = PC.bar.snapDuration;
         PC.bar.snapDuration = shortenedSnapDuration;
     });
@@ -1369,6 +1371,7 @@ describe('parcoords constraint interactions - without defined axis ranges', func
     });
 
     beforeEach(function() {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
         gd = createGraphDiv();
     });
 
@@ -1643,8 +1646,6 @@ describe('parcoords constraint interactions - with defined axis ranges', functio
     var shortenedSnapDuration = 20;
     var noSnapDelay = 20;
     beforeAll(function() {
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-
         initialSnapDuration = PC.bar.snapDuration;
         PC.bar.snapDuration = shortenedSnapDuration;
     });
@@ -1655,6 +1656,7 @@ describe('parcoords constraint interactions - with defined axis ranges', functio
     });
 
     beforeEach(function() {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
         gd = createGraphDiv();
     });
 
@@ -1737,6 +1739,7 @@ describe('parcoords constraint click interactions - with pre-defined constraint 
     });
 
     beforeEach(function() {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
         gd = createGraphDiv();
     });
 


### PR DESCRIPTION
Before this PR `webgl-jasmine` `parcoords` tests fail randomly as the browser disconnect (sometimes succeed once out of 8 runs). 

https://app.circleci.com/pipelines/github/plotly/plotly.js/3731/workflows/98768ace-6fe1-47c7-9db4-0f586e85b9c1/jobs/111372
![parcoords_test](https://user-images.githubusercontent.com/33888540/117188271-e3a1a800-adaa-11eb-88a1-c71555f425c5.png)

This was clearly annoying (also hard to debug) for any development/maintenance work.
This PR addresses that by making each run more stable.

@plotly/plotly_js 