### PR TITLE
Bump probe-image-size v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,11 +2680,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
-    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -7090,6 +7085,11 @@
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -8960,11 +8960,11 @@
       "dev": true
     },
     "probe-image-size": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-6.0.0.tgz",
-      "integrity": "sha512-99PZ5+RU4gqiTfK5ZDMDkZtn6eL4WlKfFyVJV7lFQvH3iGmQ85DqMTOdxorERO26LHkevR2qsxnHp0x/2UDJPA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.1.0.tgz",
+      "integrity": "sha512-T7F4ZF4iWQJWhj/ijPyh88fHen9UtaUwtV+QMZ1NkmpUSDHmfYlZgRUTOcFKnqi95I6kpGBQ+3pF1dCtVmDeIg==",
       "requires": {
-        "deepmerge": "^4.0.0",
+        "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
         "stream-parser": "~0.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "ndarray-linear-interpolate": "^1.0.0",
     "parse-svg-path": "^0.1.2",
     "polybooljs": "^1.2.0",
-    "probe-image-size": "^6.0.0",
+    "probe-image-size": "^7.1.0",
     "regl": "^1.6.1",
     "regl-error2d": "^2.0.11",
     "regl-line2d": "^3.1.0",


### PR DESCRIPTION
`probe-image-size` was added in #5388.
This PR bumpt its version to the latest version.

cc: @plotly/plotly_js 