### PR TITLE
Document enabling predefined hidden modebar buttons via config.modeBarButtonsToAdd

### DIFF
--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -287,7 +287,13 @@ var configAttributes = {
         dflt: [],
         description: [
             'Add mode bar button using config objects',
-            'See ./components/modebar/buttons.js for list of arguments.'
+            'See ./components/modebar/buttons.js for list of arguments.',
+            'To enable predefined modebar buttons e.g. shape drawing, hover and spikelines,',
+            'simply provide their string name(s). This could include:',
+            '*v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*,',
+            '*drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect* and *eraseshape*.',
+            'Please note that these predefined button(s) may not show up in case of being incompatible',
+            'with all the plot types used in a graph.'
         ].join(' ')
     },
     modeBarButtons: {

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -292,8 +292,8 @@ var configAttributes = {
             'simply provide their string name(s). This could include:',
             '*v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*,',
             '*drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect* and *eraseshape*.',
-            'Please note that these predefined button(s) may not show up in case of being incompatible',
-            'with all the plot types used in a graph.'
+            'Please note that these predefined buttons will only be shown if they are compatible',
+            'with all trace types used in a graph.'
         ].join(' ')
     },
     modeBarButtons: {


### PR DESCRIPTION
Followup of #5642 and #4775.

@plotly/plotly_js 