### PR TITLE
Fixup and simplify bar hover min and max positions with period

### DIFF
--- a/src/traces/bar/hover.js
+++ b/src/traces/bar/hover.js
@@ -39,17 +39,7 @@ function hoverOnBars(pointData, xval, yval, hovermode) {
     function thisBarMaxPos(di) { return thisBarExtPos(di, 1); }
 
     function thisBarExtPos(di, sgn) {
-        var w = di.w;
-        var delta = sgn * w;
-        if(trace[posLetter + 'period']) {
-            var alignment = trace[posLetter + 'periodalignment'];
-            if(alignment === 'start') {
-                delta = (sgn === -1) ? 0 : w;
-            } else if(alignment === 'end') {
-                delta = (sgn === -1) ? -w : 0;
-            }
-        }
-        return di[posLetter] + delta / 2;
+        return di[posLetter] + 0.5 * sgn * di.w;
     }
 
     var minPos = isClosest ?


### PR DESCRIPTION
Basically reverting this commit https://github.com/plotly/plotly.js/pull/5618/commits/c96bf994eb39eacebf42477222c5b3e09cb1a24f, the only trace specific adjustment made in #5618 which appears to be unnecessary and incorrect.

@plotly/plotly_js 
