### PR TITLE
Set indentation for plot-schema to 1

### DIFF
--- a/tasks/util/make_schema.js
+++ b/tasks/util/make_schema.js
@@ -17,7 +17,7 @@ module.exports = function makeSchema(plotlyPath, schemaPath) {
         w.eval(plotlyjsCode);
 
         var plotSchema = w.Plotly.PlotSchema.get();
-        var plotSchemaStr = JSON.stringify(plotSchema, null, 4);
+        var plotSchemaStr = JSON.stringify(plotSchema, null, 1);
         fs.writeFileSync(schemaPath, plotSchemaStr);
 
         console.log('ok ' + path.basename(schemaPath));


### PR DESCRIPTION
Setting indentation from 4 to 1 i.e. to help reduce the file size and make it easier to manage when addressing #5588.
[Before](https://113398-45646037-gh.circle-artifacts.com/0/dist/plot-schema.json) vs [After](https://113424-45646037-gh.circle-artifacts.com/0/dist/plot-schema.json)

cc: @plotly/plotly_js 