### PR TITLE
Use an object to pass various optional arguments into hoverPoints methods of modules

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -490,7 +490,10 @@ function _hover(gd, evt, subplot, noHoverEvent) {
             // Now if there is range to look in, find the points to hover.
             if(hoverdistance !== 0) {
                 if(trace._module && trace._module.hoverPoints) {
-                    var newPoints = trace._module.hoverPoints(pointData, xval, yval, mode, fullLayout._hoverlayer);
+                    var newPoints = trace._module.hoverPoints(pointData, xval, yval, mode, {
+                        hoverLayer: fullLayout._hoverlayer
+                    });
+
                     if(newPoints) {
                         var newPoint;
                         for(var newPointNum = 0; newPointNum < newPoints.length; newPointNum++) {
@@ -519,7 +522,9 @@ function _hover(gd, evt, subplot, noHoverEvent) {
                 if(hoverData.length === 0) {
                     pointData.distance = spikedistance;
                     pointData.index = false;
-                    var closestPoints = trace._module.hoverPoints(pointData, xval, yval, 'closest', fullLayout._hoverlayer);
+                    var closestPoints = trace._module.hoverPoints(pointData, xval, yval, 'closest', {
+                        hoverLayer: fullLayout._hoverlayer
+                    });
                     if(closestPoints) {
                         closestPoints = closestPoints.filter(function(point) {
                             // some hover points, like scatter fills, do not allow spikes,

--- a/src/traces/contour/hover.js
+++ b/src/traces/contour/hover.js
@@ -5,7 +5,7 @@ var Color = require('../../components/color');
 var heatmapHoverPoints = require('../heatmap/hover');
 
 module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer) {
-    var hoverData = heatmapHoverPoints(pointData, xval, yval, hovermode, hoverLayer, true);
+    var hoverData = heatmapHoverPoints(pointData, xval, yval, hovermode, hoverLayer, {isContour: true});
 
     if(hoverData) {
         hoverData.forEach(function(hoverPt) {

--- a/src/traces/contour/hover.js
+++ b/src/traces/contour/hover.js
@@ -4,8 +4,11 @@ var Color = require('../../components/color');
 
 var heatmapHoverPoints = require('../heatmap/hover');
 
-module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer) {
-    var hoverData = heatmapHoverPoints(pointData, xval, yval, hovermode, hoverLayer, {isContour: true});
+module.exports = function hoverPoints(pointData, xval, yval, hovermode, opts) {
+    if(!opts) opts = {};
+    opts.isContour = true;
+
+    var hoverData = heatmapHoverPoints(pointData, xval, yval, hovermode, opts);
 
     if(hoverData) {
         hoverData.forEach(function(hoverPt) {

--- a/src/traces/heatmap/hover.js
+++ b/src/traces/heatmap/hover.js
@@ -5,7 +5,7 @@ var Lib = require('../../lib');
 var Axes = require('../../plots/cartesian/axes');
 var extractOpts = require('../../components/colorscale').extractOpts;
 
-module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer, opts) {
+module.exports = function hoverPoints(pointData, xval, yval, hovermode, opts) {
     if(!opts) opts = {};
     var isContour = opts.isContour;
 

--- a/src/traces/heatmap/hover.js
+++ b/src/traces/heatmap/hover.js
@@ -5,7 +5,10 @@ var Lib = require('../../lib');
 var Axes = require('../../plots/cartesian/axes');
 var extractOpts = require('../../components/colorscale').extractOpts;
 
-module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer, contour) {
+module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer, opts) {
+    if(!opts) opts = {};
+    var isContour = opts.isContour;
+
     var cd0 = pointData.cd[0];
     var trace = cd0.trace;
     var xa = pointData.xa;
@@ -38,7 +41,7 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
             Fx.inbox(yval - y[0], yval - y[y.length - 1], 0) > 0) {
         return;
     } else {
-        if(contour) {
+        if(isContour) {
             var i2;
             x2 = [2 * x[0] - x[1]];
 
@@ -63,7 +66,7 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLay
     var y1 = ya.c2p(y[ny + 1]);
 
     var _x, _y;
-    if(contour) {
+    if(isContour) {
         _x = cd0.orig_x || x;
         _y = cd0.orig_y || y;
 

--- a/src/traces/histogram2d/hover.js
+++ b/src/traces/histogram2d/hover.js
@@ -3,8 +3,8 @@
 var heatmapHover = require('../heatmap/hover');
 var hoverLabelText = require('../../plots/cartesian/axes').hoverLabelText;
 
-module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer, contour) {
-    var pts = heatmapHover(pointData, xval, yval, hovermode, hoverLayer, contour);
+module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer, opts) {
+    var pts = heatmapHover(pointData, xval, yval, hovermode, hoverLayer, opts);
 
     if(!pts) return;
 

--- a/src/traces/histogram2d/hover.js
+++ b/src/traces/histogram2d/hover.js
@@ -3,8 +3,8 @@
 var heatmapHover = require('../heatmap/hover');
 var hoverLabelText = require('../../plots/cartesian/axes').hoverLabelText;
 
-module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer, opts) {
-    var pts = heatmapHover(pointData, xval, yval, hovermode, hoverLayer, opts);
+module.exports = function hoverPoints(pointData, xval, yval, hovermode, opts) {
+    var pts = heatmapHover(pointData, xval, yval, hovermode, opts);
 
     if(!pts) return;
 

--- a/src/traces/violin/hover.js
+++ b/src/traces/violin/hover.js
@@ -5,7 +5,10 @@ var Axes = require('../../plots/cartesian/axes');
 var boxHoverPoints = require('../box/hover');
 var helpers = require('./helpers');
 
-module.exports = function hoverPoints(pointData, xval, yval, hovermode, hoverLayer) {
+module.exports = function hoverPoints(pointData, xval, yval, hovermode, opts) {
+    if(!opts) opts = {};
+    var hoverLayer = opts.hoverLayer;
+
     var cd = pointData.cd;
     var trace = cd[0].trace;
     var hoveron = trace.hoveron;


### PR DESCRIPTION
Put optional `layer` and `contour` in `opts` so that we could easily add extra optional arguments when & where needed.

cc: @plotly/plotly_js 