### PR TITLE
Fixup hidden mathjax ticklabel

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -3005,8 +3005,7 @@ axes.drawLabels = function(gd, ax, opts) {
                     // sync label: just position it now.
                     positionLabels(thisLabel, tickAngle);
                 }
-            })
-            .style('display', null); // visible
+            });
 
     hideCounterAxisInsideTickLabels(ax, [TICK_TEXT]);
 


### PR DESCRIPTION
Fixes regression introduced in #5550 causing hidden mathjax to showup on the graph.

![mathjax-bug](https://user-images.githubusercontent.com/33888540/119586332-732eeb00-bd9a-11eb-8cab-30c30c33f637.png)


cc: @plotly/plotly_js 