### PR TITLE
No longer publish or overwrite any "latest" bundles on CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ and use the `Plotly` object in the window scope.
 
 Fastly supports Plotly.js with free CDN service. Read more at <https://www.fastly.com/open-source>
 
-### Download the latest release
+### Download the latest release or a release candidates (rc)
 
-[Latest Release on GitHub](https://github.com/plotly/plotly.js/releases/)
+[Latest and rc releases on GitHub](https://github.com/plotly/plotly.js/releases/)
 
 and use the plotly.js `dist` file(s). More info [here](https://github.com/plotly/plotly.js/blob/master/dist/README.md).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and use the `Plotly` object in the window scope.
 
 Fastly supports Plotly.js with free CDN service. Read more at <https://www.fastly.com/open-source>
 
-### Download the latest release or a release candidates (rc)
+### Download the latest release or a release candidate (rc)
 
 [Latest and rc releases on GitHub](https://github.com/plotly/plotly.js/releases/)
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,19 @@ var Plotly = require('plotly.js-dist')
 
 ### Use the plotly.js CDN hosted by Fastly
 
+#### A minified plotly.js X.Y.Z release
 ```html
-<!-- Latest compiled and minified plotly.js JavaScript -->
-<script src="https://cdn.plot.ly/plotly-latest.min.js" charset="utf-8"></script>
+<script src="https://cdn.plot.ly/plotly-1.58.4.min.js" charset="utf-8"></script>
+```
 
-<!-- OR use a specific plotly.js release (e.g. version 1.52.3) -->
-<script src="https://cdn.plot.ly/plotly-1.52.3.min.js" charset="utf-8"></script>
-
-<!-- OR an un-minified version is also available -->
-<script src="https://cdn.plot.ly/plotly-latest.js" charset="utf-8"></script>
+#### An un-minified version is also available
+```html
+<script src="https://cdn.plot.ly/plotly-1.58.4.js" charset="utf-8"></script>
 ```
 
 and use the `Plotly` object in the window scope.
+
+##### Please note that after v2 the "plotly-latest" outputs (e.g. https://cdn.plot.ly/plotly-latest.min.js) will no longer be updated on the CDN and stay at last v1 patch i.e. v1.58.4. Therefore, in order to upgrade to plotly.js v2 and higher, you may consider switching to a specific plotly.js version.
 
 Fastly supports Plotly.js with free CDN service. Read more at <https://www.fastly.com/open-source>
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var Plotly = require('plotly.js-dist')
 
 and use the `Plotly` object in the window scope.
 
-##### Please note that after v2 the "plotly-latest" outputs (e.g. https://cdn.plot.ly/plotly-latest.min.js) will no longer be updated on the CDN and stay at last v1 patch i.e. v1.58.4. Therefore, in order to upgrade to plotly.js v2 and higher, you may consider switching to a specific plotly.js version.
+##### Please note that as of v2 the "plotly-latest" outputs (e.g. https://cdn.plot.ly/plotly-latest.min.js) will no longer be updated on the CDN, and will stay at the last v1 patch v1.58.4. Therefore, to use the CDN with plotly.js v2 and higher, you must specify an exact plotly.js version.
 
 Fastly supports Plotly.js with free CDN service. Read more at <https://www.fastly.com/open-source>
 

--- a/tasks/cdn_publish.sh
+++ b/tasks/cdn_publish.sh
@@ -8,16 +8,6 @@ fi
 
 # get plotly.js version from its package json
 version=$(node -e "console.log(require('./package.json').version);")
-major=$(node -e "console.log(require('./package.json').version.split('.')[0]);")
-
-# read tag either latest or rc
-baseTag=$(node -e "var rc = require('./package.json').version.split('-')[1]; console.log(rc ? rc.split('.')[0] : 'latest');")
-
-# if not v1 add major version to the tag e.g. latest-v2
-tag=$baseTag
-if [ $major -ne 1 ]; then tag=$tag-v$major; fi
-echo $tag
-
 dist=dist
 sync=build/sync
 
@@ -36,10 +26,6 @@ for path in `ls $dist/plotly*`; do
     fi
 
     cp $path "$sync/${name}-${version}.$ext"
-
-    if [ $baseTag = "latest" ]; then
-        cp $path "$sync/${name}-${tag}.$ext"
-    fi
 done
 
 # copy topojson files over to the sync folder

--- a/tasks/stats.js
+++ b/tasks/stats.js
@@ -7,10 +7,6 @@ var prettySize = require('prettysize');
 var common = require('./util/common');
 var constants = require('./util/constants');
 var pkgVersion = require('../package.json').version;
-var majorVersion = pkgVersion.split('.')[0];
-var theLatest = 'latest' + (
-    (majorVersion === '1') ? '' : ('-v' + majorVersion)
-);
 
 var pathDistREADME = path.join(constants.pathToDist, 'README.md');
 var cdnRoot = 'https://cdn.plot.ly/plotly-';
@@ -81,7 +77,6 @@ function getInfoContent() {
         'Plotly.js defaults to US English (en-US) and includes British English (en) in the standard bundle.',
         'Many other localizations are available - here is an example using Swiss-German (de-CH),',
         'see the contents of this directory for the full list.',
-        'They are also available on our CDN as ' + cdnRoot + 'locale-de-ch-' + theLatest + '.js OR ' + cdnRoot + 'locale-de-ch-' + pkgVersion + '.js',
         'Note that the file names are all lowercase, even though the region is uppercase when you apply a locale.',
         '',
         '*After* the plotly.js script tag, add:',
@@ -116,12 +111,12 @@ function getMainBundleInfo() {
         '',
         'It be can imported as minified javascript',
         '- using dist file `dist/plotly.min.js`',
-        '- using CDN URL ' + cdnRoot + theLatest + MINJS + ' OR ' + cdnRoot + pkgVersion + MINJS,
+        '- using CDN URL ' + cdnRoot + pkgVersion + MINJS,
         '',
         'or as raw javascript:',
         '- using the `plotly.js-dist` npm package (starting in `v1.39.0`)',
         '- using dist file `dist/plotly.js`',
-        '- using CDN URL ' + cdnRoot + theLatest + JS + ' OR ' + cdnRoot + pkgVersion + JS,
+        '- using CDN URL ' + cdnRoot + pkgVersion + JS,
         '- using CommonJS with `require(\'plotly.js\')`',
         '',
         'If you would like to have access to the attribute meta information ' +
@@ -192,8 +187,6 @@ function makeBundleInfo(pathObj) {
         '',
         '| Flavor | URL |',
         '| ------ | --- |',
-        '| Latest | ' + cdnRoot + name + '-' + theLatest + JS + ' |',
-        '| Latest minified | ' + cdnRoot + name + '-' + theLatest + MINJS + ' |',
         '| Tagged | ' + cdnRoot + name + '-' + pkgVersion + JS + ' |',
         '| Tagged minified | ' + cdnRoot + name + '-' + pkgVersion + MINJS + ' |',
         '',


### PR DESCRIPTION
Resolves #5695.

@plotly/plotly_js 
