### PR TITLE
Improve readme sync packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To learn and build more with plotly.js please visit [plotly.js documentation](ht
 ### Un-minified versions are also available on CDN
 While non-minified source files may contain characters outside UTF-8, it is recommended that you specify the `charset` when loading those bundles.
 ```html
-    <script src="https://cdn.plot.ly/plotly-2.0.0-rc.3.js" charset="utf-8"></script>
+<script src="https://cdn.plot.ly/plotly-2.0.0-rc.3.js" charset="utf-8"></script>
 ```
 
 > Please note that as of v2 the "plotly-latest" outputs (e.g. https://cdn.plot.ly/plotly-latest.min.js) will no longer be updated on the CDN, and will stay at the last v1 patch v1.58.4. Therefore, to use the CDN with plotly.js v2 and higher, you must specify an exact plotly.js version.
@@ -87,8 +87,8 @@ While non-minified source files may contain characters outside UTF-8, it is reco
 ### To support MathJax
 Load relevant MathJax (v2) files *Before* the plotly.js script tag:
 ```html
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG.js"></script>
-    <script src="https://cdn.plot.ly/plotly-2.0.0-rc.3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG.js"></script>
+<script src="https://cdn.plot.ly/plotly-2.0.0-rc.3.min.js"></script>
 ```
 
 ## Bundles

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -116,7 +116,7 @@ function syncPartialBundlePkg(d) {
             '',
             'Contains trace modules ' + common.formatEnumeration(d.traceList) + '.',
             '',
-            'For more info on plotly.js, go to https://github.com/plotly/plotly.js',
+            'For more info on plotly.js, go to https://github.com/plotly/plotly.js#readme',
             '',
             '## Installation',
             '',
@@ -127,13 +127,14 @@ function syncPartialBundlePkg(d) {
             '',
             '```js',
             '// ES6 module',
-            'import Plotly from \'' + d.name + '\';',
+            'import Plotly from \'' + d.name + '\'',
             '',
             '// CommonJS',
-            'var Plotly = require(\'' + d.name + '\');',
+            'var Plotly = require(\'' + d.name + '\')',
             '```',
             '',
-            copyrightAndLicense
+            copyrightAndLicense,
+            'Please visit [complete list of dependencies](https://www.npmjs.com/package/plotly.js/v/' + pkg.version + '?activeTab=dependencies).'
         ];
 
         fs.writeFile(
@@ -209,7 +210,7 @@ function syncLocalesPkg(d) {
             '',
             d.desc,
             '',
-            'For more info on plotly.js, go to https://github.com/plotly/plotly.js',
+            'For more info on plotly.js, go to https://github.com/plotly/plotly.js#readme',
             '',
             '## Installation',
             '',
@@ -222,15 +223,15 @@ function syncLocalesPkg(d) {
             '',
             '```js',
             '// ES6 module',
-            'import Plotly from \'plotly.js\';',
-            'import locale from \'' + d.name + '/fr' + '\';',
+            'import Plotly from \'plotly.js\'',
+            'import locale from \'' + d.name + '/fr' + '\'',
             '',
             '// CommonJS',
-            'var Plotly = require(\'plotly.js\');',
-            'var locale = require(\'' + d.name + '/fr\');',
+            'var Plotly = require(\'plotly.js\')',
+            'var locale = require(\'' + d.name + '/fr\')',
             '',
             '// then',
-            'Plotly.register(locale);',
+            'Plotly.register(locale)',
             'Plotly.setPlotConfig({locale: \'fr\'})',
             '```',
             '',
@@ -248,7 +249,7 @@ function syncLocalesPkg(d) {
         var cnt = [constants.licenseDist, ''];
         localeFiles.forEach(function(f) {
             var n = path.basename(f, '.js');
-            cnt.push('exports[\'' + n + '\'] = require(\'./' + n + '.js\');');
+            cnt.push('exports[\'' + n + '\'] = require(\'./' + n + '.js\')');
         });
         cnt.push('');
 


### PR DESCRIPTION
Provide a link to complete list of dependencies when creating readme for plotly.js-dist* `npm` packages.
cc: #5300

Current `plotly.js-dist` page is at https://www.npmjs.com/package/plotly.js-dist/v/2.0.0-rc.3.

@plotly/plotly_js 