### PR TITLE
Separate command line script for making custom bundles and rename it to "custom-bundle"

### DIFF
--- a/CUSTOM_BUNDLE.md
+++ b/CUSTOM_BUNDLE.md
@@ -10,41 +10,41 @@ npm i
 
 By default all traces and transforms are included in the bundle if you simply run:
 ```sh
-npm run partial-bundle
+npm run custom-bundle
 ```
 
 Use the `traces` option to include just the trace types you need.
 ```sh
-npm run partial-bundle -- --traces scatter,scattergl,scatter3d
+npm run custom-bundle -- --traces scatter,scattergl,scatter3d
 ```
 Please note that the `scatter` trace is currently included in all bundles and cannot be removed.
 [This behaviour may change in the future](https://github.com/plotly/plotly.js/pull/5535), so we recommend that you explicitly include `scatter` anyway if you need it in your bundle.
 
 Use the `transforms` option to specify which should be included.
 ```sh
-npm run partial-bundle -- --transforms sort,filter
+npm run custom-bundle -- --transforms sort,filter
 ```
 
 Or use `transforms none` to exclude them all.
 ```sh
-npm run partial-bundle -- --transforms none
+npm run custom-bundle -- --transforms none
 ```
 
 Use the `out` option to change the bundle filename (default `custom`).
 The new bundle will be created in the `dist/` directory and named `plotly-<out>.min.js` or `plotly-<out>.js` if unminified.
 ```sh
-npm run partial-bundle -- --out myBundleName
+npm run custom-bundle -- --out myBundleName
 ```
 
 Use the `unminified` option to disable compression.
 ```sh
-npm run partial-bundle -- --unminified
+npm run custom-bundle -- --unminified
 ```
 
 # Example illustrating use of different options together
 To create an unminified custom bundle named `myScatters` including `scatter`, `scattergl` and `scatter3d` traces without any transforms:
 ```sh
-npm run partial-bundle -- \
+npm run custom-bundle -- \
     --unminified \
     --out myScatters \
     --traces scatter,scattergl,scatter3d \
@@ -52,5 +52,5 @@ npm run partial-bundle -- \
 ```
 Or simply on one line:
 ```sh
-npm run partial-bundle -- --unminified --out myScatters --traces scatter,scattergl,scatter3d --transforms none
+npm run custom-bundle -- --unminified --out myScatters --traces scatter,scattergl,scatter3d --transforms none
 ```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "plotly"
   ],
   "scripts": {
-    "partial-bundle": "node tasks/partial_bundle.js",
+    "custom-bundle": "node tasks/custom_bundle.js",
     "bundle": "node tasks/bundle.js",
     "extra-bundles": "node tasks/extra_bundles.js",
     "stats": "node tasks/stats.js",

--- a/tasks/custom_bundle.js
+++ b/tasks/custom_bundle.js
@@ -1,0 +1,86 @@
+var path = require('path');
+var minimist = require('minimist');
+var runSeries = require('run-series');
+
+var partialBundle = require('./partial_bundle');
+var constants = require('./util/constants');
+
+var allTransforms = constants.allTransforms;
+var allTraces = constants.allTraces;
+
+function createList(outList, inList, allList, type) {
+    for(var i = 0; i < inList.length; i++) {
+        var t = inList[i];
+        if(
+            outList.indexOf(t) === -1 // not added before
+        ) {
+            if(allList.indexOf(t) === -1) {
+                console.error(t, 'is not a valid ' + type + '!', 'Valid ' + type + 's are:', allList);
+            } else {
+                outList.push(t);
+            }
+        }
+    }
+
+    return outList.sort();
+}
+
+function isFalse(a) {
+    return (
+        a === 'none' ||
+        a === 'false'
+    );
+}
+
+function inputBoolean(a, dflt) {
+    return !a ? dflt : !isFalse(a);
+}
+
+function inputArray(a, dflt) {
+    dflt = dflt.slice();
+
+    return (
+        isFalse(a) ? [] :
+            !a || a === 'all' ? dflt :
+                a.split(',')
+    );
+}
+
+if(process.argv.length > 2) {
+    // command line
+
+    var args = minimist(process.argv.slice(2), {});
+
+    // parse arguments
+    var unminified = inputBoolean(args.unminified, false);
+    var out = args.out ? args.out : 'custom';
+    var traces = inputArray(args.traces, allTraces);
+    var transforms = inputArray(args.transforms, allTransforms);
+
+    var opts = {
+        traceList: createList(['scatter'], traces, allTraces, 'trace'),
+        transformList: createList([], transforms, allTransforms, 'transform'),
+
+        name: out,
+        index: path.join(constants.pathToLib, 'index-' + out + '.js')
+    };
+
+    if(unminified) {
+        opts.dist = path.join(constants.pathToDist, 'plotly-' + out + '.js');
+    } else {
+        opts.distMin = path.join(constants.pathToDist, 'plotly-' + out + '.min.js');
+    }
+
+    console.log(opts);
+
+    opts.calendars = true;
+    opts.deleteIndex = true;
+
+    var tasks = [];
+
+    partialBundle(tasks, opts);
+
+    runSeries(tasks, function(err) {
+        if(err) throw err;
+    });
+}

--- a/tasks/extra_bundles.js
+++ b/tasks/extra_bundles.js
@@ -1,14 +1,34 @@
+var minimist = require('minimist');
 var runSeries = require('run-series');
 
 var partialBundle = require('./partial_bundle');
 var constants = require('./util/constants');
 var partialBundlePaths = constants.partialBundleNames.map(constants.makePartialBundleOpts);
 
+var list = partialBundlePaths;
+
+if(process.argv.length > 2) {
+    // command line
+
+    var args = minimist(process.argv.slice(2), {});
+    var names = args._;
+    list = [];
+    for(var k = 0; k < names.length; k++) {
+        for(var q = 0; q < partialBundlePaths.length; q++) {
+            var p = partialBundlePaths[q];
+            if(partialBundlePaths[q].name === names[k]) {
+                list.push(p);
+                break;
+            }
+        }
+    }
+}
+
 var tasks = [];
 
 // Browserify the plotly.js partial bundles
-for(var i = 0; i < partialBundlePaths.length; i++) {
-    var opts = partialBundlePaths[i];
+for(var i = 0; i < list.length; i++) {
+    var opts = list[i];
 
     partialBundle(tasks, {
         name: opts.name,


### PR DESCRIPTION
Adds command line option to `extra_bundles` script to specify which dist bundles to generate/update.
```sh
npm run extra-bundles -- strict gl3d
```

Also makes `custom-bundle` script a separate script which would allow adding command line options to `extra_bundles` script e.g. to rebuild `strict` and/or `gl3d` (as added by this PR).

Also it is important to note that `custom-bundle` may be used to include features (e.g. traces, transforms) that are not in the main bundle in future.
So it is better to named it this way instead of `partial_bundle` which is now an internal module.

@plotly/plotly_js 