### PR TITLE
Bump matrix-camera-controller to use binary-search-bounds v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4897,6 +4897,11 @@
         }
       }
     },
+    "gl-mat3": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
+      "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+    },
     "gl-mat4": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
@@ -5145,13 +5150,6 @@
         "gl-mat3": "^1.0.0",
         "gl-vec3": "^1.0.3",
         "gl-vec4": "^1.0.0"
-      },
-      "dependencies": {
-        "gl-mat3": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
-          "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
-        }
       }
     },
     "gl-scatter3d": {
@@ -7421,21 +7419,14 @@
       "dev": true
     },
     "matrix-camera-controller": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
-      "integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.4.tgz",
+      "integrity": "sha512-zsPGPONclrKSImNpqqKDTcqFpWLAIwMXEJtCde4IFPOw1dA9udzFg4HOFytOTosOFanchrx7+Hqq6glLATIxBA==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
+        "binary-search-bounds": "^2.0.0",
         "gl-mat4": "^1.1.2",
         "gl-vec3": "^1.0.3",
         "mat4-interpolate": "^1.0.3"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-          "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
-        }
       }
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "has-passive-events": "^1.0.0",
     "is-mobile": "^2.2.2",
     "mapbox-gl": "1.10.1",
-    "matrix-camera-controller": "^2.1.3",
+    "matrix-camera-controller": "^2.1.4",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",
     "mouse-wheel": "^1.2.0",


### PR DESCRIPTION
Followup of https://github.com/mikolalysenko/matrix-camera-controller/pull/2.
cc: #897

@plotly/plotly_js 

