### PR TITLE
Combine all differing baselines for easy download from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             npm run docker -- setup
       - run:
           name: Run image tests (part A)
-          command: ./.circleci/test.sh stable-image ; find build -maxdepth 1 -type f -delete
+          command: ./.circleci/test.sh stable-image || { tar -cvf build/baselines.tar build/test_images/ ; return 1; } ; find build -maxdepth 1 -type f -delete
       - store_artifacts:
           path: build
           destination: /


### PR DESCRIPTION
In case of a failing image (namely when a change requires many baseline updates), we often need to download several images.
This PR combines the differing baselines in each container so that it would be easier to download all those updates all at once (i.e. per container).
The tar file would be named `baselines.tar`  (if any) and presented on top of the Artifacts.

cc: @plotly/plotly_js 
