### PR TITLE
update flaky list of image-test

### DIFF
--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -116,10 +116,9 @@ if(allMock || argv.filter) {
 
 var FLAKY_LIST = [
     'treemap_coffee',
-    'treemap_sunburst_marker_colors',
     'treemap_textposition',
     'treemap_with-without_values',
-    'gl3d_directions-streamtube1',
+    'sunburst_with-without_values'
 ];
 
 console.log('');


### PR DESCRIPTION
Simply to bring `image-test` back to green after merging #5546. 
Until we could merge #5724. 

@plotly/plotly_js 