### PR TITLE
Bump probe-image-size to v7.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8345,9 +8345,9 @@
       "dev": true
     },
     "probe-image-size": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.1.0.tgz",
-      "integrity": "sha512-T7F4ZF4iWQJWhj/ijPyh88fHen9UtaUwtV+QMZ1NkmpUSDHmfYlZgRUTOcFKnqi95I6kpGBQ+3pF1dCtVmDeIg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.1.tgz",
+      "integrity": "sha512-d+6L3NvQBCNt4peRDoEfA7r9bPm6/qy18FnLKwg4NWBC5JrJm0pMLRg1kF4XNsPe1bUdt3WIMonPJzQWN2HXjQ==",
       "requires": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "ndarray-linear-interpolate": "^1.0.0",
     "parse-svg-path": "^0.1.2",
     "polybooljs": "^1.2.0",
-    "probe-image-size": "^7.1.0",
+    "probe-image-size": "^7.2.1",
     "regl": "^1.6.1",
     "regl-error2d": "^2.0.11",
     "regl-line2d": "^3.1.0",


### PR DESCRIPTION
Diff https://github.com/nodeca/probe-image-size/compare/7.1.0...7.2.1

@plotly/plotly_js 