### PR TITLE
Fix fetching geojson when ES6 import is used to load the library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,8 +209,9 @@
       }
     },
     "@plotly/d3": {
-      "version": "git://github.com/plotly/d3.git#591467ae9c2939486ddeae4ed1bb0deca3d611f5",
-      "from": "git://github.com/plotly/d3.git#591467ae9c2939486ddeae4ed1bb0deca3d611f5"
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.6.1.tgz",
+      "integrity": "sha512-lM2dmUqRX1qGtrWczC7QNbQ4Bdgp9sII9i7NV6Hokw06kLH1++x0Ehlj193+PkLYvi1us1IcYjC7IIw+h6GywA=="
     },
     "@plotly/d3-sankey": {
       "version": "0.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,9 +209,8 @@
       }
     },
     "@plotly/d3": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.6.0.tgz",
-      "integrity": "sha512-5p6+3TlVn4k/xEfnohYzC2sWQBLW+4l0JbRdNJpO5dAVMOuNTXd0Bdbcsu299u/AjVHmBAGsXPrSNQSXugBrHA=="
+      "version": "git://github.com/plotly/d3.git#591467ae9c2939486ddeae4ed1bb0deca3d611f5",
+      "from": "git://github.com/plotly/d3.git#591467ae9c2939486ddeae4ed1bb0deca3d611f5"
     },
     "@plotly/d3-sankey": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     ]
   },
   "dependencies": {
-    "@plotly/d3": "git://github.com/plotly/d3.git#591467ae9c2939486ddeae4ed1bb0deca3d611f5",
+    "@plotly/d3": "^3.6.1",
     "@plotly/d3-sankey": "0.7.2",
     "@plotly/d3-sankey-circular": "0.33.1",
     "@plotly/point-cluster": "^3.1.9",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     ]
   },
   "dependencies": {
-    "@plotly/d3": "^3.6.0",
+    "@plotly/d3": "git://github.com/plotly/d3.git#591467ae9c2939486ddeae4ed1bb0deca3d611f5",
     "@plotly/d3-sankey": "0.7.2",
     "@plotly/d3-sankey-circular": "0.33.1",
     "@plotly/point-cluster": "^3.1.9",


### PR DESCRIPTION
Fixes #5753.

@plotly/plotly_js 