### PR TITLE
Simplify makeSchema by returning the results

### DIFF
--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -75,7 +75,7 @@ tasks.push(function(done) {
     }, function() {
         prependFile(pathToPlotlyDistWithMeta, header, common.throwOnError);
 
-        makeSchema(pathToPlotlyDistWithMeta, pathToSchema)();
+        makeSchema(pathToPlotlyDistWithMeta, pathToSchema);
         done();
     });
 });

--- a/tasks/util/make_schema.js
+++ b/tasks/util/make_schema.js
@@ -3,13 +3,11 @@ var path = require('path');
 var plotlyNode = require('./plotly_node');
 
 module.exports = function makeSchema(plotlyPath, schemaPath) {
-    return function() {
-        var Plotly = plotlyNode(plotlyPath);
+    var Plotly = plotlyNode(plotlyPath);
 
-        var plotSchema = Plotly.PlotSchema.get();
-        var plotSchemaStr = JSON.stringify(plotSchema, null, 1);
-        fs.writeFileSync(schemaPath, plotSchemaStr);
+    var plotSchema = Plotly.PlotSchema.get();
+    var plotSchemaStr = JSON.stringify(plotSchema, null, 1);
+    fs.writeFileSync(schemaPath, plotSchemaStr);
 
-        console.log('ok ' + path.basename(schemaPath));
-    };
+    console.log('ok ' + path.basename(schemaPath));
 };


### PR DESCRIPTION
No need to return a function and then execute it when you can return the result.

cc: @plotly/plotly_js 