### PR TITLE
Improve README for ES6 module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You may also consider using [`plotly.js-dist`](https://www.npmjs.com/package/plo
 
 Alternatively you may consider using [native ES6 import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) in the script tag.
 ```html
-<script>
+<script type="module">
     import "https://cdn.plot.ly/plotly-2.2.0.min.js"
     Plotly.newPlot("gd", [{ y: [1, 2, 3] }])
 </script>


### PR DESCRIPTION
Added ´type="module"´ to fix "Cannot use import statement outside a module" error.

