### PR TITLE
Speed up publishing dist on the CircleCI and testing bundles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,8 +188,6 @@ jobs:
           name: set up build environment
           command: .circleci/env_build.sh
       - run:
-          command: rm -rf .git
-      - run:
           name: Build dist/
           command: npm run build
       - store_artifacts:
@@ -212,18 +210,6 @@ jobs:
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plotly.js
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plotly.min.js
             echo https://$CIRCLE_BUILD_NUM-$PROJECT_NUM-gh.circle-artifacts.com/0/dist/plot-schema.json
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - plotly.js
-
-  test-dist1:
-    docker:
-      - image: circleci/node:12.22.1
-    working_directory: ~/plotly.js
-    steps:
-      - attach_workspace:
-          at: ~/
       - run:
           name: Test plotly.min.js import using requirejs
           command: npm run test-requirejs
@@ -274,6 +260,3 @@ workflows:
             - install-and-cibuild
 
       - publish-dist
-      - test-dist1:
-          requires:
-            - publish-dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,19 +15,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: set heap option before very first node.js call
-          command: |
-            export NODE_OPTIONS='--max-old-space-size=4096'
-      - run:
-          name: Install dependencies
-          command: |
-            npm ci
-      - run:
-          name: List dependency versions
-          command: |
-            echo "npm: $(npm --version)"
-            echo "node: $(node --version)"
-            npm ls || true
+          name: set up build environment
+          command: .circleci/env_build.sh
       - run:
           name: Pretest
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,14 +233,6 @@ jobs:
       - run:
           name: Test certain bundles against function constructors
           command: npm run no-new-func
-
-  test-dist2:
-    docker:
-      - image: circleci/node:12.22.1
-    working_directory: ~/plotly.js
-    steps:
-      - attach_workspace:
-          at: ~/
       - run:
           name: Test plotly bundles against es6
           command: npm run no-es6-dist
@@ -283,8 +275,5 @@ workflows:
 
       - publish-dist
       - test-dist1:
-          requires:
-            - publish-dist
-      - test-dist2:
           requires:
             - publish-dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,9 +244,6 @@ jobs:
       - run:
           name: Test plotly bundles against es6
           command: npm run no-es6-dist
-      - run:
-          name: Test plotly bundles againt duplicate keys
-          command: npm run no-dup-keys
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,8 +183,12 @@ jobs:
       - image: circleci/node:12.22.1
     working_directory: ~/plotly.js
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
+      - run:
+          name: set up build environment
+          command: .circleci/env_build.sh
+      - run:
+          command: rm -rf .git
       - run:
           name: Build dist/
           command: npm run build
@@ -279,9 +283,8 @@ workflows:
       - source-syntax:
           requires:
             - install-and-cibuild
-      - publish-dist:
-          requires:
-            - install-and-cibuild
+
+      - publish-dist
       - test-dist1:
           requires:
             - publish-dist

--- a/.circleci/env_build.sh
+++ b/.circleci/env_build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+export NODE_OPTIONS='--max-old-space-size=4096' && \
+echo "node version: $(node --version)" && \
+echo "npm version: $(npm --version)" && \
+npm ci && \
+npm ls || true


### PR DESCRIPTION
`dist-publish` not really needed to wait for slow `cibuild`, plus other improvements.
This simplification would also enable us to add other dist tests e.g. partial image tests using partial bundles, etc. in future.

cc: @plotly/plotly_js 