### PR TITLE
Preview plot-schema changes between previous and next release when building dist on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,13 +185,22 @@ jobs:
           command: .circleci/env_build.sh
       - run:
           name: Preview CHANGELOG for next release (only on master)
-          command: if [ $CIRCLE_BRANCH == "master" ]; then npm run use-draftlogs && git --no-pager diff --color-words CHANGELOG.md || true; fi
+          command: |
+            if [ $CIRCLE_BRANCH == "master" ]
+              then npm run use-draftlogs && git --no-pager diff --color-words CHANGELOG.md || true
+            fi
       - run:
           name: Build dist/
           command: npm run build
       - store_artifacts:
           path: dist
           destination: dist
+      - run:
+          name: Preview plot-schema diff between previous and next releases (only on master)
+          command: |
+            if [ $CIRCLE_BRANCH == "master" ]
+              then git --no-pager diff tags/$(git describe --tags --abbrev=0) dist/plot-schema.json || true
+            fi
       - run:
           name: Pack tarball
           command: |

--- a/draftlogs/5814_add.md
+++ b/draftlogs/5814_add.md
@@ -1,0 +1,1 @@
+ - Preview plot-schema changes between previous and next release when building dist on master [[#5814](https://github.com/plotly/plotly.js/pull/5814)]


### PR DESCRIPTION
Similar to #5808.
Considering sorting plot-schema in #5776, there is a big diff right now.
However after `v2.3.0` is out this PR would help illustrate schema changes between what is on `master` and the last release.

@plotly/plotly_js 