### PR TITLE
adjust comparison tolerance for some flaky mapbox mocks

### DIFF
--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -128,7 +128,7 @@ for(var i = 0; i < allMockList.length; i++) {
                 // more flaky
                 'mapbox_angles',
                 'mapbox_geojson-attributes'
-            ].indexOf(mockName) !== -1 ? 0.25 : 0.15
+            ].indexOf(mockName) !== -1 ? 0.5 : 0.15
     });
 
     if(numDiffPixels) {


### PR DESCRIPTION
cc: @plotly/plotly_js 