### PR TITLE
increase compare tolerance for mapbox_layers mock

### DIFF
--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -127,6 +127,7 @@ for(var i = 0; i < allMockList.length; i++) {
             [
                 // more flaky
                 'mapbox_angles',
+                'mapbox_layers',
                 'mapbox_geojson-attributes'
             ].indexOf(mockName) !== -1 ? 0.5 : 0.15
     });


### PR DESCRIPTION
This could help avoid Montreal's construction sites :) 

![diff-mapbox_layers](https://user-images.githubusercontent.com/33888540/126215731-cdedd9c6-6be8-47bf-a4a1-c50c171d4e12.png)

cc: @plotly/plotly_js 