### PR TITLE
Position hover in respect to the average of values in (x|y) unified modes

### DIFF
--- a/draftlogs/5845_fix.md
+++ b/draftlogs/5845_fix.md
@@ -1,0 +1,1 @@
+ - Position hover in respect to the average of values in (x|y) unified modes (regression introduced in 2.0.0) [[#5845](https://github.com/plotly/plotly.js/pull/5845)]

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1072,8 +1072,11 @@ function createHoverText(hoverData, opts, gd) {
 
         // Position the hover
         var winningPoint = hoverData[0];
-        var ly = (winningPoint.y0 + winningPoint.y1) / 2;
-        var lx = (winningPoint.x0 + winningPoint.x1) / 2;
+        var ly = axLetter === 'y' ?
+            (winningPoint.y0 + winningPoint.y1) / 2 : Lib.mean(hoverData.map(function(c) {return (c.y0 + c.y1) / 2;}));
+        var lx = axLetter === 'x' ?
+            (winningPoint.x0 + winningPoint.x1) / 2 : Lib.mean(hoverData.map(function(c) {return (c.x0 + c.x1) / 2;}));
+
         var legendContainer = container.select('g.legend');
         var tbb = legendContainer.node().getBoundingClientRect();
         lx += xa._offset;


### PR DESCRIPTION
Fixes #5844.

cc: @plotly/plotly_js 