### PR TITLE
Skip "hoverinfo": "none" traces for x/y unified

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -772,7 +772,10 @@ function _hover(gd, evt, subplot, noHoverEvent) {
         hoverdistance: fullLayout.hoverdistance
     };
 
-    var hoverLabels = createHoverText(hoverData, labelOpts, gd);
+    var actualHoverData = hoverData.filter(function(d) {
+        return d.hoverinfo !== 'none';
+    });
+    var hoverLabels = createHoverText(actualHoverData, labelOpts, gd);
 
     if(!helpers.isUnifiedHover(hovermode)) {
         hoverAvoidOverlaps(hoverLabels, rotateLabels ? 'xa' : 'ya', fullLayout);


### PR DESCRIPTION
Fixes #5516 5516

As [documented](https://plotly.com/javascript/reference/#scatter-hoverinfo), hoverinfo: none should trigger hove events, but should not be displayed in the hover.

Currently, if the `hovermode` is "x/y unified", it groups the labels together but does not skip over the 'hoverinfo': 'none' data.
It skips the text resulting in an empty row.
![image](https://user-images.githubusercontent.com/17567991/127011297-7768ec28-ede8-4385-89b1-afc3478e60bd.png)

This PR skips the 'hoverinfo': 'none' data for the labels so that the events are still triggerd but the empty row is not displayed.
![image](https://user-images.githubusercontent.com/17567991/127011101-d4d5cde5-a384-4a32-8ca3-b0ff8a20fb98.png)

