### PR TITLE
Revisit setting timezone on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           name: Run syntax tests on source files
           command: .circleci/test.sh source-syntax
 
-  jasmine-bundle:
+  bundle-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: circleci/node:12.22.1-browsers
@@ -172,7 +172,7 @@ jobs:
           at: ~/
       - run:
           name: Run jasmine tests (part D)
-          command: .circleci/test.sh jasmine-bundle
+          command: .circleci/test.sh bundle-jasmine
 
   publish-dist:
     docker:
@@ -246,7 +246,7 @@ workflows:
   build-and-test:
     jobs:
       - install-and-cibuild
-      - jasmine-bundle:
+      - bundle-jasmine:
           requires:
             - install-and-cibuild
       - no-gl-jasmine:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -83,7 +83,7 @@ case $1 in
         exit $EXIT_STATE
         ;;
 
-    jasmine-bundle)
+    bundle-jasmine)
         set_timezone
 
         npm run test-bundle || EXIT_STATE=$?

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -33,16 +33,23 @@ retry () {
     fi
 }
 
-# set timezone to Alaska time (arbitrary timezone to test date logic)
-set_tz () {
-    sudo cp /usr/share/zoneinfo/America/Anchorage /etc/localtime
-    export TZ='America/Anchorage'
+set_timezone () {
+    # Alaska time (arbitrary timezone to test date logic)
+    TZ="America/Anchorage"
+
+    echo "set timezone to $TZ"
+    sudo cp /usr/share/zoneinfo/$TZ /etc/localtime
+
+    echo "display date in timezone"
+    date
+
+    export TZ
 }
 
 case $1 in
 
     no-gl-jasmine)
-        set_tz
+        set_timezone
 
         SUITE=$(circleci tests glob "$ROOT/test/jasmine/tests/*" | circleci tests split)
         MAX_AUTO_RETRY=2
@@ -52,7 +59,7 @@ case $1 in
         ;;
 
     webgl-jasmine)
-        set_tz
+        set_timezone
 
         SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --limit=5 --tag=gl | circleci tests split))
         for s in ${SHARDS[@]}; do
@@ -64,7 +71,7 @@ case $1 in
         ;;
 
     flaky-no-gl-jasmine)
-        set_tz
+        set_timezone
 
         SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --limit=1 --tag=flaky | circleci tests split))
 
@@ -88,7 +95,8 @@ case $1 in
         ;;
 
     jasmine-bundle)
-        set_tz
+        set_timezone
+
         npm run test-bundle || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -83,6 +83,13 @@ case $1 in
         exit $EXIT_STATE
         ;;
 
+    jasmine-bundle)
+        set_timezone
+
+        npm run test-bundle || EXIT_STATE=$?
+        exit $EXIT_STATE
+        ;;
+
     make-baselines)
         SUITE=$(find $ROOT/test/image/mocks/ -type f -printf "%f\n" | sed 's/\.json$//1' | circleci tests split)
         python3 test/image/make_baseline.py $SUITE || EXIT_STATE=$?
@@ -91,13 +98,6 @@ case $1 in
 
     test-image)
         node test/image/compare_pixels_test.js || { tar -cvf build/baselines.tar build/test_images/*.png ; exit 1 ; } || EXIT_STATE=$?
-        exit $EXIT_STATE
-        ;;
-
-    jasmine-bundle)
-        set_timezone
-
-        npm run test-bundle || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;
 


### PR DESCRIPTION
To make it slightly easier to switch the timezone and see if set.
Also moving and renaming `jasmine-bundle` to be close to other `*-jasmine` containers.

cc: @plotly/plotly_js 