### PR TITLE
use CircleCI environment TZ to set timezone

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: circleci/node:12.22.1-browsers
+    environment:
+      # Alaska time (arbitrary timezone to test date logic)
+      TZ: "America/Anchorage"
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
@@ -48,6 +51,9 @@ jobs:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: circleci/node:12.22.1-browsers
+    environment:
+      # Alaska time (arbitrary timezone to test date logic)
+      TZ: "America/Anchorage"
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
@@ -61,6 +67,9 @@ jobs:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: circleci/node:12.22.1-browsers
+    environment:
+      # Alaska time (arbitrary timezone to test date logic)
+      TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -73,6 +82,9 @@ jobs:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: circleci/node:12.22.1-browsers
+    environment:
+      # Alaska time (arbitrary timezone to test date logic)
+      TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -33,24 +33,9 @@ retry () {
     fi
 }
 
-set_timezone () {
-    # Alaska time (arbitrary timezone to test date logic)
-    TZ="America/Anchorage"
-
-    echo "set timezone to $TZ"
-    sudo cp /usr/share/zoneinfo/$TZ /etc/localtime
-
-    echo "display date in timezone"
-    date
-
-    export TZ
-}
-
 case $1 in
 
     no-gl-jasmine)
-        set_timezone
-
         SUITE=$(circleci tests glob "$ROOT/test/jasmine/tests/*" | circleci tests split)
         MAX_AUTO_RETRY=2
         retry npm run test-jasmine -- $SUITE --skip-tags=gl,noCI,flaky || EXIT_STATE=$?
@@ -59,8 +44,6 @@ case $1 in
         ;;
 
     webgl-jasmine)
-        set_timezone
-
         SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --limit=5 --tag=gl | circleci tests split))
         for s in ${SHARDS[@]}; do
             MAX_AUTO_RETRY=2
@@ -71,8 +54,6 @@ case $1 in
         ;;
 
     flaky-no-gl-jasmine)
-        set_timezone
-
         SHARDS=($(node $ROOT/tasks/shard_jasmine_tests.js --limit=1 --tag=flaky | circleci tests split))
 
         for s in ${SHARDS[@]}; do
@@ -84,8 +65,6 @@ case $1 in
         ;;
 
     bundle-jasmine)
-        set_timezone
-
         npm run test-bundle || EXIT_STATE=$?
         exit $EXIT_STATE
         ;;


### PR DESCRIPTION
This will make it possible to test different time zones using CircleCI config.
cc: #5861 

@plotly/plotly_js 