### PR TITLE
Utility to display location and number of function constructors in plotly.js source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,9 @@ jobs:
           name: Test plotly bundles againt unexpected characters
           command: npm run no-bad-char
       - run:
+          name: Display function constructors in plotly.js bundle
+          command: npm run log-new-func
+      - run:
           name: Test certain bundles against function constructors
           command: npm run no-new-func
       - run:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "watch": "node tasks/watch.js",
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
+    "log-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: error}' dist/plotly.js 2>&1 | ./tasks/show_eval_lines.sh",
     "no-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js)",
     "no-bad-char": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-misleading-character-class: error}' $(find dist -type f -iname '*.js' | grep plotly)",
     "no-dup-keys": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-dupe-keys: error}' $(find dist -type f -iname '*.js' | grep plotly)",

--- a/tasks/show_eval_lines.sh
+++ b/tasks/show_eval_lines.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+err=0
+src=""
+while IFS= read -r str
+do
+    if [[ "$str" == *"plotly.js/dist"* ]]; then
+        src="$str"
+    fi
+
+    if [[ "$str" == *"error  The Function constructor is eval  no-new-func"* ]]; then
+        str=${str%error*}
+        col=${str#*:}
+        row=${str%:*}
+        pre=$((row-10))
+        err=$((err+1))
+        echo "________________________________________________________________________________"
+        sed -n "${pre},${row}p" "$src"
+
+        for ((i = 0 ; i <= col + 10 ; i++)); do
+            echo -n "^"
+        done
+        echo
+
+        echo "Count: $err | Line: $row"
+    fi
+done


### PR DESCRIPTION
While addressing #897, we need a utility to help slightly better display the number and location of function constructors.
This PR adds that.

@plotly/plotly_js 