### PR TITLE
Bump regl from 1.6.1 to v2.1.0

### DIFF
--- a/draftlogs/5870_change.md
+++ b/draftlogs/5870_change.md
@@ -1,0 +1,1 @@
+ - Upgrade `regl` module from version 1.6.1 to version 2.1.0 [[#5870](https://github.com/plotly/plotly.js/pull/5870)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,8 +5478,9 @@
       }
     },
     "gl-text": {
-      "version": "git://github.com/gl-vis/gl-text.git#6ae296c411d8611b548057adbb9ff126b590638f",
-      "from": "git://github.com/gl-vis/gl-text.git#6ae296c411d8611b548057adbb9ff126b590638f",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.2.0.tgz",
+      "integrity": "sha512-1X5yL8wKjyVMPenPKe7UvDAgyAOstuQ9gRfDBI3OK7ZHqHEnatTT5NaHWoY+II2ZHE35DvePxnOuayukowF0Ow==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,8 +5478,8 @@
       }
     },
     "gl-text": {
-      "version": "git://github.com/gl-vis/gl-text.git#e215cddf18bda17d8a0d4960d03b4b30fe7cc9df",
-      "from": "git://github.com/gl-vis/gl-text.git#e215cddf18bda17d8a0d4960d03b4b30fe7cc9df",
+      "version": "git://github.com/gl-vis/gl-text.git#6ae296c411d8611b548057adbb9ff126b590638f",
+      "from": "git://github.com/gl-vis/gl-text.git#6ae296c411d8611b548057adbb9ff126b590638f",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5478,9 +5478,8 @@
       }
     },
     "gl-text": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.8.tgz",
-      "integrity": "sha512-whnq9DEFYbW92C4ONwk2eT0YkzmVPHoADnEtuzMOmit87XhgAhBrNs3lK9EgGjU/MoWYvlF6RkI8Kl7Yuo1hUw==",
+      "version": "git://github.com/gl-vis/gl-text.git#e215cddf18bda17d8a0d4960d03b4b30fe7cc9df",
+      "from": "git://github.com/gl-vis/gl-text.git#e215cddf18bda17d8a0d4960d03b4b30fe7cc9df",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -5496,16 +5495,9 @@
         "parse-rect": "^1.2.0",
         "parse-unit": "^1.0.1",
         "pick-by-alias": "^1.2.0",
-        "regl": "^1.3.11",
+        "regl": "^2.0.0",
         "to-px": "^1.0.1",
         "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "regl": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/regl/-/regl-1.7.0.tgz",
-          "integrity": "sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w=="
-        }
       }
     },
     "gl-texture2d": {
@@ -5519,9 +5511,9 @@
       }
     },
     "gl-util": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.2.tgz",
-      "integrity": "sha512-8czWhGTGp/H4S35X1UxGbFlJ1hjtTFhm2mc85GcymEi1CDf633WJgtkCddEiSjIa4BnNxBrqOIhj6jlF6naPqw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
+      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
       "requires": {
         "is-browser": "^2.0.1",
         "is-firefox": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5499,6 +5499,13 @@
         "regl": "^1.3.11",
         "to-px": "^1.0.1",
         "typedarray-pool": "^1.1.0"
+      },
+      "dependencies": {
+        "regl": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/regl/-/regl-1.7.0.tgz",
+          "integrity": "sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w=="
+        }
       }
     },
     "gl-texture2d": {
@@ -8722,9 +8729,9 @@
       }
     },
     "regl": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.6.1.tgz",
-      "integrity": "sha512-7Z9rmpEqmLNwC9kCYCyfyu47eWZaQWeNpwZfwz99QueXN8B/Ow40DB0N+OeUeM/yu9pZAB01+JgJ+XghGveVoA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.0.tgz",
+      "integrity": "sha512-oWUce/aVoEvW5l2V0LK7O5KJMzUSKeiOwFuJehzpSFd43dO5spP9r+sSUfhKtsky4u6MCqWJaRL+abzExynfTg=="
     },
     "regl-error2d": {
       "version": "2.0.12",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.6.0",
-    "gl-text": "git://github.com/gl-vis/gl-text.git#e215cddf18bda17d8a0d4960d03b4b30fe7cc9df",
+    "gl-text": "git://github.com/gl-vis/gl-text.git#6ae296c411d8611b548057adbb9ff126b590638f",
     "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.6.0",
-    "gl-text": "git://github.com/gl-vis/gl-text.git#6ae296c411d8611b548057adbb9ff126b590638f",
+    "gl-text": "1.2.0",
     "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "parse-svg-path": "^0.1.2",
     "polybooljs": "^1.2.0",
     "probe-image-size": "^7.2.1",
-    "regl": "^1.6.1",
+    "regl": "^2.1.0",
     "regl-error2d": "^2.0.12",
     "regl-line2d": "^3.1.1",
     "regl-scatter2d": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.6.0",
-    "gl-text": "1.2.0",
+    "gl-text": "^1.2.0",
     "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.6.0",
-    "gl-text": "^1.1.8",
+    "gl-text": "git://github.com/gl-vis/gl-text.git#e215cddf18bda17d8a0d4960d03b4b30fe7cc9df",
     "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",


### PR DESCRIPTION
After this upgrade we could submit a PR to remove that one function constructor in `regl` see: #5865.

@plotly/plotly_js 