### PR TITLE
tag `mapbox_custom-style` mock as flaky

### DIFF
--- a/test/image/compare_pixels_test.js
+++ b/test/image/compare_pixels_test.js
@@ -128,6 +128,7 @@ for(var i = 0; i < allMockList.length; i++) {
                 // more flaky
                 'mapbox_angles',
                 'mapbox_layers',
+                'mapbox_custom-style',
                 'mapbox_geojson-attributes'
             ].indexOf(mockName) !== -1 ? 0.5 : 0.15
     });


### PR DESCRIPTION
Getting small diffs today perhaps thanks to ongoing constructions in Montreal island :) 
![diff-mapbox_custom-style](https://user-images.githubusercontent.com/33888540/128040410-65fb78c1-1c91-40e0-bcb0-e9fa68a5e654.png)


cc: @plotly/plotly_js 
