### PR TITLE
Upgrade tar to version 6.1.2 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9927,9 +9927,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.3.tgz",
+      "integrity": "sha512-3rUqwucgVZXTeyJyL2jqtUau8/8r54SioM1xj3AmTX3HnWQdj2AydfJ2qYYayPyIIznSplcvU9mhBb7dR2XF3w==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/security/dependabot/package-lock.json/tar/open

See https://github.com/advisories/GHSA-3jfq-g458-7qm9

@plotly/plotly_js 