### PR TITLE
removed invalid .then call using lib.promiseError which does not exis…

### DIFF
--- a/draftlogs/5878_fix.md
+++ b/draftlogs/5878_fix.md
@@ -1,0 +1,2 @@
+ - Fix invalid call to `lib.promiseError` in lib.syncOrAsync  [[#5878](https://github.com/plotly/plotly.js/pull/5878)], 
+   with thanks to @jklimke for the contribution!

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -455,8 +455,7 @@ lib.syncOrAsync = function(sequence, arg, finalStep) {
         ret = fni(arg);
 
         if(ret && ret.then) {
-            return ret.then(continueAsync)
-                .then(undefined, lib.promiseError);
+            return ret.then(continueAsync);
         }
     }
 


### PR DESCRIPTION
…t anymore since 2016

Fixes #1705 and closes #5807 that caused warnings on every redraw when promises were used intensively.

It was caused by attaching a "then" call with an error handler to promise executions, but the error handler function "lib.promiseError" was deleted.
