### PR TITLE
Fix cartesian hover toggle

### DIFF
--- a/src/components/modebar/manage.js
+++ b/src/components/modebar/manage.js
@@ -183,7 +183,7 @@ function getButtonGroups(gd) {
     // regardless of what other types are on the plot, since they'll all
     // just treat any truthy hovermode as 'closest'
     if(hasCartesian) {
-        hoverGroup = ['toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian'];
+        hoverGroup.push('toggleSpikelines', 'hoverClosestCartesian', 'hoverCompareCartesian');
     }
     if(hasNoHover(fullData) || hasUnifiedHoverLabel) {
         hoverGroup = [];


### PR DESCRIPTION
The hover toggle button couldn't be enabled on cartesian plots because the later setup completely overwrote the initial allowed groups.  So just make it add the cartesian buttons instead of replacing the groups completely.