### PR TITLE
upgrade path-parse to version 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8128,9 +8128,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-platform": {
       "version": "0.11.15",


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/security/dependabot/package-lock.json/path-parse/open.

See https://github.com/advisories/GHSA-hj48-42vr-x3v9

cc: @plotly/plotly_js 