### PR TITLE
Use `hoverlabel.font` for group titles in unified hover modes

### DIFF
--- a/draftlogs/5895_fix.md
+++ b/draftlogs/5895_fix.md
@@ -1,1 +1,1 @@
- - Use hoverlabel.font for group titles and increase the size of main hover label in unified hover modes
+ - Use hoverlabel.font for group titles in unified hover modes

--- a/draftlogs/5895_fix.md
+++ b/draftlogs/5895_fix.md
@@ -1,0 +1,1 @@
+ - Use hoverlabel.font for group titles and increase the size of main hover label in unified hover modes

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1030,16 +1030,12 @@ function createHoverText(hoverData, opts, gd) {
 
         // mock legend
         var hoverlabel = fullLayout.hoverlabel;
+        var font = hoverlabel.font;
         var mockLayoutIn = {
             showlegend: true,
             legend: {
-                title: {
-                    text: t0,
-                    font: Lib.extendFlat({}, hoverlabel.font, {
-                        size: Math.round(hoverlabel.font.size * 1.2) // larger font size
-                    })
-                },
-                font: hoverlabel.font,
+                title: {text: t0, font: font},
+                font: font,
                 bgcolor: hoverlabel.bgcolor,
                 bordercolor: hoverlabel.bordercolor,
                 borderwidth: 1,
@@ -1086,9 +1082,7 @@ function createHoverText(hoverData, opts, gd) {
 
         // Draw unified hover label
         mockLegend._inHover = true;
-        mockLegend._groupTitleFont = Lib.extendFlat({}, hoverlabel.font, {
-            size: Math.round(hoverlabel.font.size * 1.1) // larger font size
-        });
+        mockLegend._groupTitleFont = font;
         legendDraw(gd, mockLegend);
 
         // Position the hover

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1029,13 +1029,14 @@ function createHoverText(hoverData, opts, gd) {
         if(hoverData.length === 0) return;
 
         // mock legend
+        var hoverlabel = fullLayout.hoverlabel;
         var mockLayoutIn = {
             showlegend: true,
             legend: {
-                title: {text: t0, font: fullLayout.hoverlabel.font},
-                font: fullLayout.hoverlabel.font,
-                bgcolor: fullLayout.hoverlabel.bgcolor,
-                bordercolor: fullLayout.hoverlabel.bordercolor,
+                title: {text: t0, font: hoverlabel.font},
+                font: hoverlabel.font,
+                bgcolor: hoverlabel.bgcolor,
+                bordercolor: hoverlabel.bordercolor,
                 borderwidth: 1,
                 tracegroupgap: 7,
                 traceorder: fullLayout.legend ? fullLayout.legend.traceorder : undefined,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1033,7 +1033,12 @@ function createHoverText(hoverData, opts, gd) {
         var mockLayoutIn = {
             showlegend: true,
             legend: {
-                title: {text: t0, font: hoverlabel.font},
+                title: {
+                    text: t0,
+                    font: Lib.extendFlat({}, hoverlabel.font, {
+                        size: Math.round(hoverlabel.font.size * 1.2) // larger font size
+                    })
+                },
                 font: hoverlabel.font,
                 bgcolor: hoverlabel.bgcolor,
                 bordercolor: hoverlabel.bordercolor,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1081,6 +1081,9 @@ function createHoverText(hoverData, opts, gd) {
 
         // Draw unified hover label
         mockLegend._inHover = true;
+        mockLegend._groupTitleFont = Lib.extendFlat({}, hoverlabel.font, {
+            size: Math.round(hoverlabel.font.size * 1.1) // larger font size
+        });
         legendDraw(gd, mockLegend);
 
         // Position the hover

--- a/src/components/legend/get_legend_data.js
+++ b/src/components/legend/get_legend_data.js
@@ -4,6 +4,7 @@ var Registry = require('../../registry');
 var helpers = require('./helpers');
 
 module.exports = function getLegendData(calcdata, opts) {
+    var inHover = opts._inHover;
     var grouped = helpers.isGrouped(opts);
     var reversed = helpers.isReversed(opts);
 
@@ -39,7 +40,7 @@ module.exports = function getLegendData(calcdata, opts) {
         var trace = cd0.trace;
         var lgroup = trace.legendgroup;
 
-        if(!opts._inHover && (!trace.visible || !trace.showlegend)) continue;
+        if(!inHover && (!trace.visible || !trace.showlegend)) continue;
 
         if(Registry.traceIs(trace, 'pie-like')) {
             if(!slicesShown[lgroup]) slicesShown[lgroup] = {};
@@ -126,6 +127,7 @@ module.exports = function getLegendData(calcdata, opts) {
             var gt = legendData[i][j].trace.legendgrouptitle;
             if(gt && gt.text) {
                 groupTitle = gt;
+                if(inHover) gt.font = opts._groupTitleFont;
                 break;
             }
         }

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -26,6 +26,8 @@ var assertElemRightTo = customAssertions.assertElemRightTo;
 var assertElemTopsAligned = customAssertions.assertElemTopsAligned;
 var assertElemInside = customAssertions.assertElemInside;
 
+var groupTitlesMock = require('@mocks/legendgroup-titles');
+
 function touch(path, options) {
     var len = path.length;
     Lib.clearThrottle();
@@ -6074,6 +6076,38 @@ describe('hovermode: (x|y)unified', function() {
                 _hover(gd, { xval: 3 });
 
                 assertFont('Mono', '30px', 'rgb(255, 0, 0)');
+            })
+            .then(done, done.fail);
+    });
+
+    it('should use hoverlabel.font for group titles as well as traces', function(done) {
+        function assertFont(fontFamily, fontSize, fontColor) {
+            var hover = getHoverLabel();
+            var traces = hover.selectAll('g.traces');
+
+            traces.each(function() {
+                var e = d3Select(this);
+                var text = e.select('text.legendtext');
+                var node = text.node();
+
+                var textStyle = window.getComputedStyle(node);
+                expect(textStyle.fontFamily.split(',')[0]).toBe(fontFamily, 'wrong font family');
+                expect(textStyle.fontSize).toBe(fontSize, 'wrong font size');
+                expect(textStyle.fill).toBe(fontColor, 'wrong font color');
+            });
+        }
+
+        var mockCopy = Lib.extendDeep({}, groupTitlesMock);
+
+        mockCopy.layout.hoverlabel = {
+            font: {size: 20, family: 'Mono', color: 'rgb(255, 127, 0)'}
+        };
+
+        Plotly.newPlot(gd, mockCopy)
+            .then(function(gd) {
+                _hover(gd, { xval: 0});
+
+                assertFont('Mono', '20px', 'rgb(255, 127, 0)');
             })
             .then(done, done.fail);
     });

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4547,17 +4547,6 @@ describe('hovermode: (x|y)unified', function() {
         });
     }
 
-    function assertFont(fontFamily, fontSize, fontColor) {
-        var hover = getHoverLabel();
-        var text = hover.select('text.legendtext');
-        var node = text.node();
-
-        var textStyle = window.getComputedStyle(node);
-        expect(textStyle.fontFamily.split(',')[0]).toBe(fontFamily, 'wrong font family');
-        expect(textStyle.fontSize).toBe(fontSize, 'wrong font size');
-        expect(textStyle.fill).toBe(fontColor, 'wrong font color');
-    }
-
     it('set smart defaults for spikeline in x unified', function(done) {
         Plotly.newPlot(gd, [{y: [4, 6, 5]}], {'hovermode': 'x unified', 'xaxis': {'color': 'red'}})
             .then(function(gd) {
@@ -6011,6 +6000,17 @@ describe('hovermode: (x|y)unified', function() {
     });
 
     it('should use hoverlabel.font or legend.font or layout.font', function(done) {
+        function assertFont(fontFamily, fontSize, fontColor) {
+            var hover = getHoverLabel();
+            var text = hover.select('text.legendtext');
+            var node = text.node();
+
+            var textStyle = window.getComputedStyle(node);
+            expect(textStyle.fontFamily.split(',')[0]).toBe(fontFamily, 'wrong font family');
+            expect(textStyle.fontSize).toBe(fontSize, 'wrong font size');
+            expect(textStyle.fill).toBe(fontColor, 'wrong font color');
+        }
+
         var mockCopy = Lib.extendDeep({}, mock);
 
         // Set layout.font


### PR DESCRIPTION
Addressing https://github.com/plotly/plotly.py/issues/3318.

@plotly/plotly_js 