### PR TITLE
Remove espree and mkdirp packages from root install

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "derequire": "^2.1.1",
     "ecstatic": "^4.1.4",
     "eslint": "git://github.com/archmoj/eslint.git#d20c16e440a73764e7450139bc6b5c0afbd60b0b",
-    "espree": "^7.3.1",
     "extra-iterable": "^2.5.22",
     "falafel": "^2.2.4",
     "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
     "madge": "^4.0.2",
     "mathjax": "2.7.5",
     "minify-stream": "^2.1.0",
-    "mkdirp": "^1.0.4",
     "npm-link-check": "^4.0.0",
     "open": "^8.2.1",
     "pixelmatch": "^5.2.1",


### PR DESCRIPTION
No longer need to control the versions at root. cc: #4800

@plotly/plotly_js 