### PR TITLE
Handle case of div with zero dimension when positioning unified hover box

### DIFF
--- a/draftlogs/5913_fix.md
+++ b/draftlogs/5913_fix.md
@@ -1,0 +1,2 @@
+ - Handle the case of div with zero (width or) height when positioning unified hover box
+   (regression introduced in 2.3.0) [[#5913](https://github.com/plotly/plotly.js/pull/5913)]

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -657,7 +657,6 @@ function _hover(gd, evt, subplot, noHoverEvent) {
     var spikelineOpts = {
         fullLayout: fullLayout,
         container: fullLayout._hoverlayer,
-        outerContainer: fullLayout._paperdiv,
         event: evt
     };
     var oldspikepoints = gd._spikepoints;

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1199,44 +1199,36 @@ function createHoverText(hoverData, opts, gd) {
         var lx, ly; // top and left positions of the hover box
 
         // horizontal alignment to end up on screen
-        if(outerWidth > 0) {
-            if(lxRight + tWidth < outerWidth && lxRight >= 0) {
-                lx = lxRight;
-            } else if(lxLeft + tWidth < outerWidth && lxLeft >= 0) {
-                lx = lxLeft;
-            } else if(outerWidth > 0 && xOffset + tWidth < outerWidth) {
-                lx = xOffset; // subplot left corner
-            } else {
-                // closest left or right side of the paper
-                if(lxRight - avgX < avgX - lxLeft + tWidth) {
-                    lx = outerWidth - tWidth;
-                } else {
-                    lx = 0;
-                }
-            }
-        } else {
+        if(lxRight + tWidth < outerWidth && lxRight >= 0) {
+            lx = lxRight;
+        } else if(lxLeft + tWidth < outerWidth && lxLeft >= 0) {
             lx = lxLeft;
+        } else if(xOffset + tWidth < outerWidth) {
+            lx = xOffset; // subplot left corner
+        } else {
+            // closest left or right side of the paper
+            if(lxRight - avgX < avgX - lxLeft + tWidth) {
+                lx = outerWidth - tWidth;
+            } else {
+                lx = 0;
+            }
         }
         lx += HOVERTEXTPAD;
 
         // vertical alignement to end up on screen
-        if(outerHeight > 0) {
-            if(lyBottom + tHeight < outerHeight && lyBottom >= 0) {
-                ly = lyBottom;
-            } else if(lyTop + tHeight < outerHeight && lyTop >= 0) {
-                ly = lyTop;
-            } else if(yOffset + tHeight < outerHeight) {
-                ly = yOffset; // subplot top corner
-            } else {
-                // closest top or bottom side of the paper
-                if(lyBottom - avgY < avgY - lyTop + tHeight) {
-                    ly = outerHeight - tHeight;
-                } else {
-                    ly = 0;
-                }
-            }
-        } else { // N.B. this case happens on documentation website (outerHeight: 0)
+        if(lyBottom + tHeight < outerHeight && lyBottom >= 0) {
+            ly = lyBottom;
+        } else if(lyTop + tHeight < outerHeight && lyTop >= 0) {
             ly = lyTop;
+        } else if(yOffset + tHeight < outerHeight) {
+            ly = yOffset; // subplot top corner
+        } else {
+            // closest top or bottom side of the paper
+            if(lyBottom - avgY < avgY - lyTop + tHeight) {
+                ly = outerHeight - tHeight;
+            } else {
+                ly = 0;
+            }
         }
         ly += HOVERTEXTPAD;
 

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -205,15 +205,16 @@ exports.loneHover = function loneHover(hoverItems, opts) {
         };
     });
 
-    var fullOpts = {
+    var rotateLabels = false;
+
+    var hoverLabel = createHoverText(pointsData, {
+        gd: gd,
         hovermode: 'closest',
-        rotateLabels: false,
+        rotateLabels: rotateLabels,
         bgColor: opts.bgColor || Color.background,
         container: d3.select(opts.container),
         outerContainer: opts.outerContainer || opts.container
-    };
-
-    var hoverLabel = createHoverText(pointsData, fullOpts, gd);
+    });
 
     // Fix vertical overlap
     var tooltipSpacing = 5;
@@ -240,7 +241,7 @@ exports.loneHover = function loneHover(hoverItems, opts) {
 
     var scaleX = gd._fullLayout._invScaleX;
     var scaleY = gd._fullLayout._invScaleY;
-    alignHoverText(hoverLabel, fullOpts.rotateLabels, scaleX, scaleY);
+    alignHoverText(hoverLabel, rotateLabels, scaleX, scaleY);
 
     return multiHover ? hoverLabel : hoverLabel.node();
 };
@@ -822,7 +823,8 @@ function _hover(gd, evt, subplot, noHoverEvent) {
         fullLayout.paper_bgcolor
     );
 
-    var labelOpts = {
+    var hoverLabels = createHoverText(hoverData, {
+        gd: gd,
         hovermode: hovermode,
         rotateLabels: rotateLabels,
         bgColor: bgColor,
@@ -830,9 +832,7 @@ function _hover(gd, evt, subplot, noHoverEvent) {
         outerContainer: fullLayout._paper.node(),
         commonLabelOpts: fullLayout.hoverlabel,
         hoverdistance: fullLayout.hoverdistance
-    };
-
-    var hoverLabels = createHoverText(hoverData, labelOpts, gd);
+    });
 
     if(!helpers.isUnifiedHover(hovermode)) {
         hoverAvoidOverlaps(hoverLabels, rotateLabels ? 'xa' : 'ya', fullLayout);
@@ -870,7 +870,8 @@ function hoverDataKey(d) {
 
 var EXTRA_STRING_REGEX = /<extra>([\s\S]*)<\/extra>/;
 
-function createHoverText(hoverData, opts, gd) {
+function createHoverText(hoverData, opts) {
+    var gd = opts.gd;
     var fullLayout = gd._fullLayout;
     var hovermode = opts.hovermode;
     var rotateLabels = opts.rotateLabels;

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -830,7 +830,7 @@ function _hover(gd, evt, subplot, noHoverEvent) {
         rotateLabels: rotateLabels,
         bgColor: bgColor,
         container: fullLayout._hoverlayer,
-        outerContainer: fullLayout._paper,
+        outerContainer: fullLayout._paper.node(),
         commonLabelOpts: fullLayout.hoverlabel,
         hoverdistance: fullLayout.hoverdistance
     };
@@ -893,7 +893,7 @@ function createHoverText(hoverData, opts, gd) {
     var ya = c0.ya;
     var axLetter = hovermode.charAt(0);
     var t0 = c0[axLetter + 'Label'];
-    var outerContainerBB = outerContainer.node().getBoundingClientRect();
+    var outerContainerBB = outerContainer.getBoundingClientRect();
     var outerTop = outerContainerBB.top;
     var outerWidth = outerContainerBB.width;
     var outerHeight = outerContainerBB.height;

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -206,7 +206,7 @@ exports.loneHover = function loneHover(hoverItems, opts) {
     });
 
     var container3 = d3.select(opts.container);
-    var outerContainer3 = opts.outerContainer ? d3.select(opts.outerContainer) : container3;
+    var outerContainer3 = opts.outerContainer ? opts.outerContainer : container3;
 
     var fullOpts = {
         hovermode: 'closest',

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1199,36 +1199,44 @@ function createHoverText(hoverData, opts, gd) {
         var lx, ly; // top and left positions of the hover box
 
         // horizontal alignment to end up on screen
-        if(lxRight + tWidth < outerWidth && lxRight >= 0) {
-            lx = lxRight;
-        } else if(lxLeft + tWidth < outerWidth && lxLeft >= 0) {
-            lx = lxLeft;
-        } else if(xOffset + tWidth < outerWidth) {
-            lx = xOffset; // subplot left corner
-        } else {
-            // closest left or right side of the paper
-            if(lxRight - avgX < avgX - lxLeft + tWidth) {
-                lx = outerWidth - tWidth;
+        if(outerWidth > 0) {
+            if(lxRight + tWidth < outerWidth && lxRight >= 0) {
+                lx = lxRight;
+            } else if(lxLeft + tWidth < outerWidth && lxLeft >= 0) {
+                lx = lxLeft;
+            } else if(outerWidth > 0 && xOffset + tWidth < outerWidth) {
+                lx = xOffset; // subplot left corner
             } else {
-                lx = 0;
+                // closest left or right side of the paper
+                if(lxRight - avgX < avgX - lxLeft + tWidth) {
+                    lx = outerWidth - tWidth;
+                } else {
+                    lx = 0;
+                }
             }
+        } else {
+            lx = lxLeft;
         }
         lx += HOVERTEXTPAD;
 
         // vertical alignement to end up on screen
-        if(lyBottom + tHeight < outerHeight && lyBottom >= 0) {
-            ly = lyBottom;
-        } else if(lyTop + tHeight < outerHeight && lyTop >= 0) {
-            ly = lyTop;
-        } else if(yOffset + tHeight < outerHeight) {
-            ly = yOffset; // subplot top corner
-        } else {
-            // closest top or bottom side of the paper
-            if(lyBottom - avgY < avgY - lyTop + tHeight) {
-                ly = outerHeight - tHeight;
+        if(outerHeight > 0) {
+            if(lyBottom + tHeight < outerHeight && lyBottom >= 0) {
+                ly = lyBottom;
+            } else if(lyTop + tHeight < outerHeight && lyTop >= 0) {
+                ly = lyTop;
+            } else if(yOffset + tHeight < outerHeight) {
+                ly = yOffset; // subplot top corner
             } else {
-                ly = 0;
+                // closest top or bottom side of the paper
+                if(lyBottom - avgY < avgY - lyTop + tHeight) {
+                    ly = outerHeight - tHeight;
+                } else {
+                    ly = 0;
+                }
             }
+        } else { // N.B. this case happens on documentation website (outerHeight: 0)
+            ly = lyTop;
         }
         ly += HOVERTEXTPAD;
 

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -831,7 +831,7 @@ function _hover(gd, evt, subplot, noHoverEvent) {
         rotateLabels: rotateLabels,
         bgColor: bgColor,
         container: fullLayout._hoverlayer,
-        outerContainer: fullLayout._paperdiv,
+        outerContainer: fullLayout._paper,
         commonLabelOpts: fullLayout.hoverlabel,
         hoverdistance: fullLayout.hoverdistance
     };
@@ -896,8 +896,8 @@ function createHoverText(hoverData, opts, gd) {
     var t0 = c0[axLetter + 'Label'];
     var outerContainerBB = outerContainer.node().getBoundingClientRect();
     var outerTop = outerContainerBB.top;
-    var outerWidth = outerContainerBB.width || fullLayout.width;
-    var outerHeight = outerContainerBB.height || fullLayout.height;
+    var outerWidth = outerContainerBB.width;
+    var outerHeight = outerContainerBB.height;
 
     // show the common label, if any, on the axis
     // never show a common label in array mode,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -206,7 +206,7 @@ exports.loneHover = function loneHover(hoverItems, opts) {
     });
 
     var container3 = d3.select(opts.container);
-    var outerContainer3 = opts.outerContainer || container3.node();
+    var outerContainer3 = opts.outerContainer || opts.container;
 
     var fullOpts = {
         hovermode: 'closest',

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -206,7 +206,7 @@ exports.loneHover = function loneHover(hoverItems, opts) {
     });
 
     var container3 = d3.select(opts.container);
-    var outerContainer3 = opts.outerContainer || container3;
+    var outerContainer3 = opts.outerContainer || container3.node();
 
     var fullOpts = {
         hovermode: 'closest',

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -896,8 +896,8 @@ function createHoverText(hoverData, opts, gd) {
     var t0 = c0[axLetter + 'Label'];
     var outerContainerBB = outerContainer.node().getBoundingClientRect();
     var outerTop = outerContainerBB.top;
-    var outerWidth = outerContainerBB.width;
-    var outerHeight = outerContainerBB.height;
+    var outerWidth = outerContainerBB.width || fullLayout.width;
+    var outerHeight = outerContainerBB.height || fullLayout.height;
 
     // show the common label, if any, on the axis
     // never show a common label in array mode,

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -205,15 +205,12 @@ exports.loneHover = function loneHover(hoverItems, opts) {
         };
     });
 
-    var container3 = d3.select(opts.container);
-    var outerContainer3 = opts.outerContainer || opts.container;
-
     var fullOpts = {
         hovermode: 'closest',
         rotateLabels: false,
         bgColor: opts.bgColor || Color.background,
-        container: container3,
-        outerContainer: outerContainer3
+        container: d3.select(opts.container),
+        outerContainer: opts.outerContainer || opts.container
     };
 
     var hoverLabel = createHoverText(pointsData, fullOpts, gd);

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -206,7 +206,7 @@ exports.loneHover = function loneHover(hoverItems, opts) {
     });
 
     var container3 = d3.select(opts.container);
-    var outerContainer3 = opts.outerContainer ? opts.outerContainer : container3;
+    var outerContainer3 = opts.outerContainer || container3;
 
     var fullOpts = {
         hovermode: 'closest',


### PR DESCRIPTION
Fix to bring back unified hover in [documentation website](https://plotly.com/python/hover-text-and-formatting/).
Regression introduced by #5846 in [v2.3.0](https://github.com/plotly/plotly.js/releases/tag/v2.3.0).

@plotly/plotly_js 