### PR TITLE
bump tar version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10032,9 +10032,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.3.tgz",
-      "integrity": "sha512-3rUqwucgVZXTeyJyL2jqtUau8/8r54SioM1xj3AmTX3HnWQdj2AydfJ2qYYayPyIIznSplcvU9mhBb7dR2XF3w==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/security/dependabot/package-lock.json/tar/open
See https://github.com/advisories/GHSA-9r2w-394v-53qc

@plotly/plotly_js 