### PR TITLE
bump node.js containers to v12.22.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2.0
 jobs:
   install-and-cibuild:
     docker:
-      - image: circleci/node:12.22.1
+      - image: circleci/node:12.22.5
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -34,7 +34,7 @@ jobs:
   timezone-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.1-browsers
+      - image: circleci/node:12.22.5-browsers
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -63,7 +63,7 @@ jobs:
   no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.1-browsers
+      - image: circleci/node:12.22.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -79,7 +79,7 @@ jobs:
   webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.1-browsers
+      - image: circleci/node:12.22.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -95,7 +95,7 @@ jobs:
   flaky-no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.1-browsers
+      - image: circleci/node:12.22.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -110,7 +110,7 @@ jobs:
   bundle-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.1-browsers
+      - image: circleci/node:12.22.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -143,7 +143,7 @@ jobs:
 
   test-baselines:
     docker:
-      - image: circleci/node:12.22.1
+      - image: circleci/node:12.22.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -178,7 +178,7 @@ jobs:
 
   test-exports:
     docker:
-      - image: circleci/node:12.22.1
+      - image: circleci/node:12.22.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -192,7 +192,7 @@ jobs:
 
   mock-validation:
     docker:
-      - image: circleci/node:12.22.1
+      - image: circleci/node:12.22.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -206,7 +206,7 @@ jobs:
 
   source-syntax:
     docker:
-      - image: circleci/node:12.22.1
+      - image: circleci/node:12.22.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -217,7 +217,7 @@ jobs:
 
   publish-dist:
     docker:
-      - image: circleci/node:12.22.1
+      - image: circleci/node:12.22.5
     working_directory: ~/plotly.js
     steps:
       - checkout

--- a/test/jasmine/tests/bar_test.js
+++ b/test/jasmine/tests/bar_test.js
@@ -1664,7 +1664,7 @@ describe('A bar plot', function() {
         }
     });
 
-    it('should be able to restyle', function(done) {
+    it('@noCI should be able to restyle', function(done) {
         var mock = Lib.extendDeep({}, require('@mocks/bar_attrs_relative'));
 
         Plotly.newPlot(gd, mock.data, mock.layout).then(function() {

--- a/test/jasmine/tests/funnel_test.js
+++ b/test/jasmine/tests/funnel_test.js
@@ -761,7 +761,7 @@ describe('A funnel plot', function() {
           .then(done, done.fail);
     });
 
-    it('should be able to restyle', function(done) {
+    it('@noCI should be able to restyle', function(done) {
         var mock = {
             data: [
                 {

--- a/test/jasmine/tests/waterfall_test.js
+++ b/test/jasmine/tests/waterfall_test.js
@@ -770,7 +770,7 @@ describe('A waterfall plot', function() {
           .then(done, done.fail);
     });
 
-    it('should be able to restyle', function(done) {
+    it('@noCI should be able to restyle', function(done) {
         var mock = {
             data: [
                 {


### PR DESCRIPTION
google-chrome upgraded to `92.0.4515.159`

cc: @plotly/plotly_js 