### PR TITLE
Use node.js v14 in tests and publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2.0
 jobs:
   install-and-cibuild:
     docker:
-      - image: circleci/node:12.22.5
+      - image: circleci/node:14.17.5
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -34,7 +34,7 @@ jobs:
   timezone-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.5-browsers
+      - image: circleci/node:14.17.5-browsers
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -63,7 +63,7 @@ jobs:
   no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.5-browsers
+      - image: circleci/node:14.17.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -79,7 +79,7 @@ jobs:
   webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.5-browsers
+      - image: circleci/node:14.17.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -95,7 +95,7 @@ jobs:
   flaky-no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.5-browsers
+      - image: circleci/node:14.17.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -110,7 +110,7 @@ jobs:
   bundle-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:12.22.5-browsers
+      - image: circleci/node:14.17.5-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -143,7 +143,7 @@ jobs:
 
   test-baselines:
     docker:
-      - image: circleci/node:12.22.5
+      - image: circleci/node:14.17.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -178,7 +178,7 @@ jobs:
 
   test-exports:
     docker:
-      - image: circleci/node:12.22.5
+      - image: circleci/node:14.17.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -192,7 +192,7 @@ jobs:
 
   mock-validation:
     docker:
-      - image: circleci/node:12.22.5
+      - image: circleci/node:14.17.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -206,7 +206,7 @@ jobs:
 
   source-syntax:
     docker:
-      - image: circleci/node:12.22.5
+      - image: circleci/node:14.17.5
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -217,7 +217,7 @@ jobs:
 
   publish-dist:
     docker:
-      - image: circleci/node:12.22.5
+      - image: circleci/node:14.17.5
     working_directory: ~/plotly.js
     steps:
       - checkout

--- a/draftlogs/5919_change.md
+++ b/draftlogs/5919_change.md
@@ -1,0 +1,1 @@
+ - Use node.js v14 in tests and publishing [[#5919](https://github.com/plotly/plotly.js/pull/5919)]

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "start": "node devtools/test_dashboard/server.js",
     "baseline": "node test/image/make_baseline.js",
     "noci-baseline": "npm run cibuild && ./tasks/noci_test.sh image && git checkout dist && echo 'Please do not commit unless the change was expected!'",
-    "preversion": "check-node-version --node 12 --npm 6.14 && npm-link-check && npm ls --prod",
+    "preversion": "check-node-version --node 14 --npm 6.14 && npm-link-check && npm ls --prod",
     "version": "npm run build && npm run no-bad-char && git add -A lib dist build src/version.js",
     "postversion": "node -e \"console.log('Version bumped and committed. If ok, run: git push && git push --tags')\"",
     "postpublish": "node tasks/sync_packages.js",


### PR DESCRIPTION
According to https://nodejs.org/en/about/releases/ `node.js-v12` is in maintenance mode.

@plotly/plotly_js 