### PR TITLE
Drop failing `npm ls` calls

### DIFF
--- a/.circleci/env_build.sh
+++ b/.circleci/env_build.sh
@@ -2,5 +2,4 @@
 export NODE_OPTIONS='--max-old-space-size=4096' && \
 echo "node version: $(node --version)" && \
 echo "npm version: $(npm --version)" && \
-npm ci && \
-npm ls || true
+npm ci

--- a/draftlogs/5888_add.md
+++ b/draftlogs/5888_add.md
@@ -1,2 +1,2 @@
  - Add `surface`, `isosurface`, `volume`, `streamtube`, `cone`, `mesh3d`, `scatter3d`, `pointcloud`
-   and `heatmapgl` to the "strict" bundle by avoid function generation for these traces at runtime [[#5888](https://github.com/plotly/plotly.js/pull/5888)]
+   and `heatmapgl` to the "strict" bundle by avoid function generation for these traces at runtime [[#5888](https://github.com/plotly/plotly.js/pull/5888), [#5921](https://github.com/plotly/plotly.js/pull/5921)]

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "start": "node devtools/test_dashboard/server.js",
     "baseline": "node test/image/make_baseline.js",
     "noci-baseline": "npm run cibuild && ./tasks/noci_test.sh image && git checkout dist && echo 'Please do not commit unless the change was expected!'",
-    "preversion": "check-node-version --node 14 --npm 6.14 && npm-link-check && npm ls --prod",
+    "preversion": "check-node-version --node 14 --npm 6.14 && npm-link-check",
     "version": "npm run build && npm run no-bad-char && git add -A lib dist build src/version.js",
     "postversion": "node -e \"console.log('Version bumped and committed. If ok, run: git push && git push --tags')\"",
     "postpublish": "node tasks/sync_packages.js",


### PR DESCRIPTION
`npm ls` complains about plotly forks after #5888 resulting in `preversion` script to fail.

![npm-ls](https://user-images.githubusercontent.com/33888540/132012282-87fc6a08-8e1f-4fdc-b52a-1abdce4a7993.png)

While we could successfully bundle, this PR drops those from the build step.

@plotly/plotly_js 
