### PR TITLE
run no-new-func test on gl3d bundles as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint --version && eslint .",
     "lint-fix": "eslint . --fix || true",
     "log-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: error}' dist/plotly.js 2>&1 | ./tasks/show_eval_lines.sh",
-    "no-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js)",
+    "no-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: error}' $(find dist -type f -iname '*.js' | grep -v plotly-gl2d* | grep -v plotly-with-meta.* | grep -v plotly.js | grep -v plotly.min.js)",
     "no-bad-char": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-misleading-character-class: error}' $(find dist -type f -iname '*.js' | grep plotly)",
     "no-dup-keys": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-dupe-keys: error}' $(find dist -type f -iname '*.js' | grep plotly)",
     "no-es6-dist": "node tasks/no_es6_dist.js",


### PR DESCRIPTION
Improve `no-new-func` test coverage for `gl3d` bundles in respect to cc: #897.

@plotly/plotly_js 