### PR TITLE
Reduce bundle size by removing unused code from robust-determinant module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "regl-scatter2d": "^3.2.7",
         "regl-splom": "^1.0.14",
         "right-now": "^1.0.0",
-        "robust-determinant": "plotly/robust-determinant#v1.2.0",
+        "robust-determinant": "plotly/robust-determinant#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
         "robust-in-sphere": "1.2.1",
         "robust-linear-solve": "plotly/robust-linear-solve#v1.1.0",
         "robust-orientation": "1.2.1",
@@ -10419,8 +10419,8 @@
     },
     "node_modules/robust-determinant": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/plotly/robust-determinant.git#9c631c6e96472e76ed9a7347041d7f4cb2bf6761",
-      "integrity": "sha512-pzwx7EVgVms3PRxj+wkoNlKAYCO2qnN/kVnGWDPVsv+SBdoY49Tic1kvkn1xSdM/09z5VIESiPtksJssGwzTsQ==",
+      "resolved": "git+ssh://git@github.com/plotly/robust-determinant.git#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
+      "integrity": "sha512-ISAEIWFnfQGg3qJad/1+NaZSjEhIX5JXcNoDp+A3vgDPCWyzji2r6t+iLlftgnjWyc3UTh7ekesLXpKvm6pCQA==",
       "license": "MIT",
       "dependencies": {
         "robust-compress": "^1.0.0",
@@ -21579,9 +21579,9 @@
       "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs="
     },
     "robust-determinant": {
-      "version": "git+ssh://git@github.com/plotly/robust-determinant.git#9c631c6e96472e76ed9a7347041d7f4cb2bf6761",
-      "integrity": "sha512-pzwx7EVgVms3PRxj+wkoNlKAYCO2qnN/kVnGWDPVsv+SBdoY49Tic1kvkn1xSdM/09z5VIESiPtksJssGwzTsQ==",
-      "from": "robust-determinant@plotly/robust-determinant#v1.2.0",
+      "version": "git+ssh://git@github.com/plotly/robust-determinant.git#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
+      "integrity": "sha512-ISAEIWFnfQGg3qJad/1+NaZSjEhIX5JXcNoDp+A3vgDPCWyzji2r6t+iLlftgnjWyc3UTh7ekesLXpKvm6pCQA==",
+      "from": "robust-determinant@plotly/robust-determinant#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
       "requires": {
         "robust-compress": "^1.0.0",
         "robust-scale": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "regl-scatter2d": "^3.2.7",
         "regl-splom": "^1.0.14",
         "right-now": "^1.0.0",
-        "robust-determinant": "plotly/robust-determinant#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
+        "robust-determinant": "plotly/robust-determinant#v1.2.1",
         "robust-in-sphere": "1.2.1",
         "robust-linear-solve": "plotly/robust-linear-solve#v1.1.0",
         "robust-orientation": "1.2.1",
@@ -21581,7 +21581,7 @@
     "robust-determinant": {
       "version": "git+ssh://git@github.com/plotly/robust-determinant.git#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
       "integrity": "sha512-ISAEIWFnfQGg3qJad/1+NaZSjEhIX5JXcNoDp+A3vgDPCWyzji2r6t+iLlftgnjWyc3UTh7ekesLXpKvm6pCQA==",
-      "from": "robust-determinant@plotly/robust-determinant#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
+      "from": "robust-determinant@plotly/robust-determinant#v1.2.1",
       "requires": {
         "robust-compress": "^1.0.0",
         "robust-scale": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "regl-scatter2d": "^3.2.7",
     "regl-splom": "^1.0.14",
     "right-now": "^1.0.0",
-    "robust-determinant": "plotly/robust-determinant#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
+    "robust-determinant": "plotly/robust-determinant#v1.2.1",
     "robust-in-sphere": "1.2.1",
     "robust-linear-solve": "plotly/robust-linear-solve#v1.1.0",
     "robust-orientation": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "regl-scatter2d": "^3.2.7",
     "regl-splom": "^1.0.14",
     "right-now": "^1.0.0",
-    "robust-determinant": "plotly/robust-determinant#v1.2.0",
+    "robust-determinant": "plotly/robust-determinant#300761b3d887e88a8d2232e7c70dad59ab7ff01f",
     "robust-in-sphere": "1.2.1",
     "robust-linear-solve": "plotly/robust-linear-solve#v1.1.0",
     "robust-orientation": "1.2.1",


### PR DESCRIPTION
Followup of in-lining functions for #897 
cc: @plotly/plotly_js 