### PR TITLE
Reduce bundle size by removing unused code from robust-linear-solve module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "right-now": "^1.0.0",
         "robust-determinant": "plotly/robust-determinant#v1.2.1",
         "robust-in-sphere": "1.2.1",
-        "robust-linear-solve": "plotly/robust-linear-solve#v1.1.0",
+        "robust-linear-solve": "plotly/robust-linear-solve#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
         "robust-orientation": "1.2.1",
         "simplicial-complex-contour": "plotly/simplicial-complex-contour#v1.1.0",
         "strongly-connected-components": "^1.0.1",
@@ -10451,8 +10451,8 @@
     },
     "node_modules/robust-linear-solve": {
       "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/plotly/robust-linear-solve.git#467e63853031691dfe0f0dff87d06a4322dd95c5",
-      "integrity": "sha512-/LmfySIaq10qHIYNyJ8PwWKmSwrgiF2BhVmFCPQMwR7I/vCRq1Xw7d+CkShiIoNaorG0D1zzx/t+7+M/sCS0hA==",
+      "resolved": "git+ssh://git@github.com/plotly/robust-linear-solve.git#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
+      "integrity": "sha512-+BQtI3HLi1RJ+45Cl/Dwz1V0TIWek3WtclqWHGWqOvHGGUbozgMOsIKbZ1SIRyYDlNkAAEn0MrRyGx1qmSJ1qQ==",
       "license": "MIT",
       "dependencies": {
         "robust-determinant": "^1.1.0"
@@ -21610,9 +21610,9 @@
       }
     },
     "robust-linear-solve": {
-      "version": "git+ssh://git@github.com/plotly/robust-linear-solve.git#467e63853031691dfe0f0dff87d06a4322dd95c5",
-      "integrity": "sha512-/LmfySIaq10qHIYNyJ8PwWKmSwrgiF2BhVmFCPQMwR7I/vCRq1Xw7d+CkShiIoNaorG0D1zzx/t+7+M/sCS0hA==",
-      "from": "robust-linear-solve@plotly/robust-linear-solve#v1.1.0",
+      "version": "git+ssh://git@github.com/plotly/robust-linear-solve.git#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
+      "integrity": "sha512-+BQtI3HLi1RJ+45Cl/Dwz1V0TIWek3WtclqWHGWqOvHGGUbozgMOsIKbZ1SIRyYDlNkAAEn0MrRyGx1qmSJ1qQ==",
+      "from": "robust-linear-solve@plotly/robust-linear-solve#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
       "requires": {
         "robust-determinant": "^1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "right-now": "^1.0.0",
         "robust-determinant": "plotly/robust-determinant#v1.2.1",
         "robust-in-sphere": "1.2.1",
-        "robust-linear-solve": "plotly/robust-linear-solve#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
+        "robust-linear-solve": "plotly/robust-linear-solve#v1.1.1",
         "robust-orientation": "1.2.1",
         "simplicial-complex-contour": "plotly/simplicial-complex-contour#v1.1.0",
         "strongly-connected-components": "^1.0.1",
@@ -21612,7 +21612,7 @@
     "robust-linear-solve": {
       "version": "git+ssh://git@github.com/plotly/robust-linear-solve.git#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
       "integrity": "sha512-+BQtI3HLi1RJ+45Cl/Dwz1V0TIWek3WtclqWHGWqOvHGGUbozgMOsIKbZ1SIRyYDlNkAAEn0MrRyGx1qmSJ1qQ==",
-      "from": "robust-linear-solve@plotly/robust-linear-solve#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
+      "from": "robust-linear-solve@plotly/robust-linear-solve#v1.1.1",
       "requires": {
         "robust-determinant": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "right-now": "^1.0.0",
     "robust-determinant": "plotly/robust-determinant#v1.2.1",
     "robust-in-sphere": "1.2.1",
-    "robust-linear-solve": "plotly/robust-linear-solve#v1.1.0",
+    "robust-linear-solve": "plotly/robust-linear-solve#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
     "robust-orientation": "1.2.1",
     "simplicial-complex-contour": "plotly/simplicial-complex-contour#v1.1.0",
     "strongly-connected-components": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "right-now": "^1.0.0",
     "robust-determinant": "plotly/robust-determinant#v1.2.1",
     "robust-in-sphere": "1.2.1",
-    "robust-linear-solve": "plotly/robust-linear-solve#9be05a38f931f61ec8883f6be2c5bf2cd66a9a8b",
+    "robust-linear-solve": "plotly/robust-linear-solve#v1.1.1",
     "robust-orientation": "1.2.1",
     "simplicial-complex-contour": "plotly/simplicial-complex-contour#v1.1.0",
     "strongly-connected-components": "^1.0.1",


### PR DESCRIPTION
Followup of in-lining functions for #897 
cc: @plotly/plotly_js 