### PR TITLE
Bump gl-text module with simplified shader programs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "gl-spikes2d": "^1.0.2",
         "gl-streamtube3d": "^1.4.1",
         "gl-surface3d": "^1.6.0",
-        "gl-text": "git://github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
+        "gl-text": "^1.3.0",
         "glslify": "^7.1.1",
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
@@ -6119,10 +6119,9 @@
       }
     },
     "node_modules/gl-text": {
-      "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
-      "integrity": "sha512-mqYjo1D1gajQEclV1UwBWqjxzQ0JE2wuH+LnFnWMyVBgmTv4Uf0F4+G9IMML9S8o2Feq1QrVJn/SDnVTOay2cA==",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.0.tgz",
+      "integrity": "sha512-LxwYO4CwqofibxCyRJJEk4aON8lCfX3VK/Tl4XouM/7iHg+VFcCeRXwNvCW4RuKDLiqjDEO5DCzC90rs7b4auQ==",
       "dependencies": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -18126,9 +18125,9 @@
       }
     },
     "gl-text": {
-      "version": "git+ssh://git@github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
-      "integrity": "sha512-mqYjo1D1gajQEclV1UwBWqjxzQ0JE2wuH+LnFnWMyVBgmTv4Uf0F4+G9IMML9S8o2Feq1QrVJn/SDnVTOay2cA==",
-      "from": "gl-text@git://github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.0.tgz",
+      "integrity": "sha512-LxwYO4CwqofibxCyRJJEk4aON8lCfX3VK/Tl4XouM/7iHg+VFcCeRXwNvCW4RuKDLiqjDEO5DCzC90rs7b4auQ==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "gl-spikes2d": "^1.0.2",
         "gl-streamtube3d": "^1.4.1",
         "gl-surface3d": "^1.6.0",
-        "gl-text": "^1.2.0",
+        "gl-text": "git://github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
         "glslify": "^7.1.1",
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
@@ -6120,8 +6120,9 @@
     },
     "node_modules/gl-text": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.2.0.tgz",
-      "integrity": "sha512-1X5yL8wKjyVMPenPKe7UvDAgyAOstuQ9gRfDBI3OK7ZHqHEnatTT5NaHWoY+II2ZHE35DvePxnOuayukowF0Ow==",
+      "resolved": "git+ssh://git@github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
+      "integrity": "sha512-mqYjo1D1gajQEclV1UwBWqjxzQ0JE2wuH+LnFnWMyVBgmTv4Uf0F4+G9IMML9S8o2Feq1QrVJn/SDnVTOay2cA==",
+      "license": "MIT",
       "dependencies": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -18125,9 +18126,9 @@
       }
     },
     "gl-text": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.2.0.tgz",
-      "integrity": "sha512-1X5yL8wKjyVMPenPKe7UvDAgyAOstuQ9gRfDBI3OK7ZHqHEnatTT5NaHWoY+II2ZHE35DvePxnOuayukowF0Ow==",
+      "version": "git+ssh://git@github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
+      "integrity": "sha512-mqYjo1D1gajQEclV1UwBWqjxzQ0JE2wuH+LnFnWMyVBgmTv4Uf0F4+G9IMML9S8o2Feq1QrVJn/SDnVTOay2cA==",
+      "from": "gl-text@git://github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.6.0",
-    "gl-text": "git://github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
+    "gl-text": "^1.3.0",
     "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "gl-spikes2d": "^1.0.2",
     "gl-streamtube3d": "^1.4.1",
     "gl-surface3d": "^1.6.0",
-    "gl-text": "^1.2.0",
+    "gl-text": "git://github.com/gl-vis/gl-text.git#79582ccbc1049ac2ab1c491d898657826c686b46",
     "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",


### PR DESCRIPTION
Helps tackle portable `regl` for #897 | https://github.com/gl-vis/gl-text/pull/9

cc: @plotly/plotly_js