### PR TITLE
Drop duplicate set scale call it polar

### DIFF
--- a/src/plots/polar/polar.js
+++ b/src/plots/polar/polar.js
@@ -334,7 +334,6 @@ proto.doAutoRange = function(fullLayout, polarLayout) {
     var radialAxis = this.radialAxis;
     var radialLayout = polarLayout.radialaxis;
 
-    radialAxis.setScale();
     doAutoRange(gd, radialAxis);
 
     var rng = radialAxis.range;


### PR DESCRIPTION
`doAutoRange` function on the next line calls `setScale` so I think this one is unnecessary.

@plotly/plotly_js 