### PR TITLE
Migrate most of legacy `circleci` images to new `cimg`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,18 @@
-version: 2.0
+version: 2.1
+orbs:
+  browser-tools: circleci/browser-tools@1.2.2
 
 # Inspired by:
 # https://github.com/CircleCI-Public/circleci-demo-workflows/blob/workspace-forwarding/.circleci/config.yml
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 #
 # For list of official CircleCI node.js images, go to:
-# https://hub.docker.com/r/circleci/node/tags/
+# https://hub.docker.com/r/cimg/node/tags/
 
 jobs:
   install-and-cibuild:
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:16.8.0
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -34,9 +36,13 @@ jobs:
   timezone-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:16.8.0-browsers
+      - image: cimg/node:16.8.0-browsers
     working_directory: ~/plotly.js
     steps:
+      - browser-tools/install-browser-tools: &browser-versions
+          chrome-version: 93.0.4577.63
+          install-firefox: false
+          install-geckodriver: false
       - attach_workspace:
           at: ~/
       - run:
@@ -63,13 +69,17 @@ jobs:
   no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:16.8.0-browsers
+      - image: cimg/node:16.8.0-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
+      - browser-tools/install-browser-tools: &browser-versions
+          chrome-version: 93.0.4577.63
+          install-firefox: false
+          install-geckodriver: false
       - attach_workspace:
           at: ~/
       - run:
@@ -79,13 +89,17 @@ jobs:
   webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:16.8.0-browsers
+      - image: cimg/node:16.8.0-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
+      - browser-tools/install-browser-tools: &browser-versions
+          chrome-version: 93.0.4577.63
+          install-firefox: false
+          install-geckodriver: false
       - attach_workspace:
           at: ~/
       - run:
@@ -95,12 +109,16 @@ jobs:
   flaky-no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:16.8.0-browsers
+      - image: cimg/node:16.8.0-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
+      - browser-tools/install-browser-tools: &browser-versions
+          chrome-version: 93.0.4577.63
+          install-firefox: false
+          install-geckodriver: false
       - attach_workspace:
           at: ~/
       - run:
@@ -110,12 +128,16 @@ jobs:
   bundle-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: circleci/node:16.8.0-browsers
+      - image: cimg/node:16.8.0-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
+      - browser-tools/install-browser-tools: &browser-versions
+          chrome-version: 93.0.4577.63
+          install-firefox: false
+          install-geckodriver: false
       - attach_workspace:
           at: ~/
       - run:
@@ -192,7 +214,7 @@ jobs:
 
   mock-validation:
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:16.8.0
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -206,7 +228,7 @@ jobs:
 
   source-syntax:
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:16.8.0
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -217,7 +239,7 @@ jobs:
 
   publish-dist:
     docker:
-      - image: circleci/node:16.8.0
+      - image: cimg/node:16.8.0
     working_directory: ~/plotly.js
     steps:
       - checkout


### PR DESCRIPTION
Thanks @antoinerg's https://github.com/plotly/dashboard-engine/pull/748.
This would allow testing using different browser versions in future.
More info is available [here](https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/).

For the moment I did not migrate `image-test` containers as it required extra installations for `fonts-config`.

cc: @plotly/plotly_js 
