### PR TITLE
Fix scatter3d opacity restyle bug

### DIFF
--- a/draftlogs/5958_fix.md
+++ b/draftlogs/5958_fix.md
@@ -1,0 +1,2 @@
+ - Fix scatter3d opacity restyle bug [[#5958](https://github.com/plotly/plotly.js/pull/5958)],
+   with thanks to @dwoznicki for the contribution!

--- a/src/traces/scatter3d/attributes.js
+++ b/src/traces/scatter3d/attributes.js
@@ -161,6 +161,8 @@ var attrs = module.exports = overrideAll({
         family: extendFlat({}, scatterAttrs.textfont.family, {arrayOk: false})
     },
 
+    opacity: baseAttrs.opacity,
+
     hoverinfo: extendFlat({}, baseAttrs.hoverinfo)
 }, 'calc', 'nested');
 

--- a/test/jasmine/tests/scatter3d_test.js
+++ b/test/jasmine/tests/scatter3d_test.js
@@ -309,4 +309,24 @@ describe('Test scatter3d interactions:', function() {
         })
         .then(done, done.fail);
     });
+
+    it('@gl should change marker opacity when restyle is called', function(done) {
+        Plotly.newPlot(
+            gd,
+            [
+                {
+                    type: 'scatter3d',
+                    x: [0],
+                    y: [0],
+                    z: [0],
+                    mode: 'markers',
+                },
+            ]
+        ).then(function() {
+            Plotly.restyle(gd, 'opacity', 0.5).then(function() {
+                expect(gd._fullLayout.scene._scene.glplot.objects[0].hasAlpha).toEqual(true);
+            });
+        })
+        .then(done, done.fail);
+    });
 });

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -44927,7 +44927,7 @@
     "opacity": {
      "description": "Sets the opacity of the trace.",
      "dflt": 1,
-     "editType": "style",
+     "editType": "calc",
      "max": 1,
      "min": 0,
      "valType": "number"


### PR DESCRIPTION
This is a fix for #5957. I've modified the scatter3d attributes to make opacity trigger a full layout replot when the opacity is changed via `Plotly.restyle`. Note that this solution is derived from the scattergl trace (https://github.com/plotly/plotly.js/blob/master/src/traces/scattergl/attributes.js), which handles opacity changes correctly.