### PR TITLE
Run Firefox MathJax tests on circleci instead of in the noci step at publish time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,25 @@ jobs:
           name: Run jasmine tests (part D)
           command: .circleci/test.sh bundle-jasmine
 
+  mathjax-firefox81:
+    docker:
+      # need '-browsers' version to test in real (xvfb-wrapped) browsers
+      - image: cimg/node:16.8.0-browsers
+    environment:
+      # Alaska time (arbitrary timezone to test date logic)
+      TZ: "America/Anchorage"
+    working_directory: ~/plotly.js
+    steps:
+      - browser-tools/install-browser-tools: &browser-versions
+          firefox-version: '81.0'
+          install-chrome: false
+          install-chromedriver: false
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Test MathJax on firefox-81
+          command: .circleci/test.sh mathjax-firefox
+
   make-baselines:
     parallelism: 4
     docker:
@@ -319,6 +338,9 @@ workflows:
           requires:
             - install-and-cibuild
       - bundle-jasmine:
+          requires:
+            - install-and-cibuild
+      - mathjax-firefox81:
           requires:
             - install-and-cibuild
       - no-gl-jasmine:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -69,6 +69,11 @@ case $1 in
         exit $EXIT_STATE
         ;;
 
+    mathjax-firefox)
+        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --nowatch || EXIT_STATE=$?
+        exit $EXIT_STATE
+        ;;
+
     make-baselines)
         SUITE=$(find $ROOT/test/image/mocks/ -type f -printf "%f\n" | sed 's/\.json$//1' | circleci tests split)
         python3 test/image/make_baseline.py $SUITE || EXIT_STATE=$?

--- a/tasks/noci_test.sh
+++ b/tasks/noci_test.sh
@@ -18,8 +18,6 @@ root=$(dirname $0)/..
 
 # jasmine specs with @noCI tag
 test_jasmine () {
-    # run MathJax on FireFox
-    ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --nowatch && \
     # run noCI tests
     npm run test-jasmine -- --tags=noCI,noCIdep --nowatch || EXIT_STATE=$?
 }


### PR DESCRIPTION
FYI - I used Firefox `v81` as higher versions appear to trigger #5374.

cc: @plotly/plotly_js 