### PR TITLE
Do not coerce tick prefix suffix twice

### DIFF
--- a/src/plots/cartesian/tick_label_defaults.js
+++ b/src/plots/cartesian/tick_label_defaults.js
@@ -28,12 +28,6 @@ function handlePrefixSuffix(containerIn, containerOut, coerce, axType, options) 
 function handleOtherDefaults(containerIn, containerOut, coerce, axType, options) {
     var showAttrDflt = getShowAttrDflt(containerIn);
 
-    var tickPrefix = coerce('tickprefix');
-    if(tickPrefix) coerce('showtickprefix', showAttrDflt);
-
-    var tickSuffix = coerce('ticksuffix', options.tickSuffixDflt);
-    if(tickSuffix) coerce('showticksuffix', showAttrDflt);
-
     var showTickLabels = coerce('showticklabels');
     if(showTickLabels) {
         var font = options.font || {};


### PR DESCRIPTION
Looks redundant as they coerced in `handlePrefixSuffix` function above.

cc: @plotly/plotly_js 