### PR TITLE
Display prefix and suffix of invisible polar axes in hover

### DIFF
--- a/draftlogs/5964_fix.md
+++ b/draftlogs/5964_fix.md
@@ -1,0 +1,1 @@
+ - Display prefix and suffix of invisible polar axes in hover [[#5964](https://github.com/plotly/plotly.js/pull/5964)]

--- a/src/plots/polar/layout_defaults.js
+++ b/src/plots/polar/layout_defaults.js
@@ -137,11 +137,12 @@ function handleDefaults(contIn, contOut, coerce, opts) {
                 break;
         }
 
+        handlePrefixSuffixDefaults(axIn, axOut, coerceAxis, axOut.type, {
+            tickSuffixDflt: axOut.thetaunit === 'degrees' ? '°' : undefined
+        });
+
         if(visible) {
             handleTickValueDefaults(axIn, axOut, coerceAxis, axOut.type);
-            handlePrefixSuffixDefaults(axIn, axOut, coerceAxis, axOut.type, {
-                tickSuffixDflt: axOut.thetaunit === 'degrees' ? '°' : undefined
-            });
             handleTickLabelDefaults(axIn, axOut, coerceAxis, axOut.type);
             handleTickMarkDefaults(axIn, axOut, coerceAxis, {outerTicks: true});
 

--- a/test/jasmine/tests/scatterpolar_test.js
+++ b/test/jasmine/tests/scatterpolar_test.js
@@ -192,6 +192,30 @@ describe('Test scatterpolar hover:', function() {
         },
         nums: 'r: 4.022892\nθ: 128.342°\n4.02289202968',
         name: 'Trial 3'
+    }, {
+        desc: 'with prefix and suffix',
+        patch: function(fig) {
+            fig.layout.polar.radialaxis.tickprefix = '(';
+            fig.layout.polar.radialaxis.ticksuffix = ')';
+            fig.layout.polar.angularaxis.tickprefix = '[';
+            fig.layout.polar.angularaxis.ticksuffix = ']';
+            return fig;
+        },
+        nums: 'r: (4.022892)\nθ: [128.342]',
+        name: 'Trial 3'
+    }, {
+        desc: 'with prefix and suffix on invisible axes',
+        patch: function(fig) {
+            fig.layout.polar.radialaxis.visible = false,
+            fig.layout.polar.radialaxis.tickprefix = '(';
+            fig.layout.polar.radialaxis.ticksuffix = ')';
+            fig.layout.polar.angularaxis.visible = false;
+            fig.layout.polar.angularaxis.tickprefix = '[';
+            fig.layout.polar.angularaxis.ticksuffix = ']';
+            return fig;
+        },
+        nums: 'r: (4.022892)\nθ: [128.342]',
+        name: 'Trial 3'
     }]
     .forEach(function(specs) {
         it('should generate correct hover labels ' + specs.desc, function(done) {


### PR DESCRIPTION
Fixes #5962.
cc: @plotly/plotly_js 