### PR TITLE
Migrating from eslint-v6 API to eslint-v7 API

### DIFF
--- a/tasks/no_es6_dist.js
+++ b/tasks/no_es6_dist.js
@@ -8,22 +8,24 @@ assertES5();
 
 // Ensure no ES6 has snuck through into the build:
 function assertES5() {
-    var CLIEngine = eslint.CLIEngine;
+    var ESLint = eslint.ESLint;
 
-    var cli = new CLIEngine({
+    var cli = new ESLint({
         allowInlineConfig: false,
         useEslintrc: false,
         ignore: false,
-        parserOptions: {
-            ecmaVersion: 5
+        overrideConfig: {
+            parserOptions: {
+                ecmaVersion: 5
+            }
         }
     });
 
     var files = partialBundlePaths.map(function(f) { return f.dist; });
     files.unshift(constants.pathToPlotlyDist);
 
-    var report = cli.executeOnFiles(files);
-    var formatter = cli.getFormatter();
+    var report = cli.lintFiles(files);
+    var formatter = cli.loadFormatter();
 
     var errors = [];
     if(report.errorCount > 0) {


### PR DESCRIPTION
While we are using eslint v7 at the moment, we need to migrate from eslint-v6 API to eslint-v7 API as certain deprecated features won't be accessible in the upcoming eslint v8.
https://app.circleci.com/pipelines/github/plotly/plotly.js?branch=eslint-v7-api-no-deprecated

cc: @plotly/plotly_js 