### PR TITLE
Adjust `OpenStreetMap` and `Mapbox` tests 

### DIFF
--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -1551,7 +1551,7 @@ describe('mapbox plots', function() {
                 assertLinks(s, [
                     'https://www.mapbox.com/about/maps/',
                     'https://www.openstreetmap.org/about/',
-                    'https://www.mapbox.com/map-feedback/' // Improve this map
+                    'https://apps.mapbox.com/feedback/?owner=mapbox&id=basic-v9&access_token=' + MAPBOX_ACCESS_TOKEN // Improve this map
                 ]);
             })
             .then(done, done.fail);


### PR DESCRIPTION
`OpenStreetMap` as well as `Mapbox` feedback links have been changed causing the `webgl-jasmine` container to fail.
This PR fixes that.

cc: @plotly/plotly_js 