### PR TITLE
Ignore stackgl node_modules folder when using `npm pack`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,8 @@ build/*
 !build/plotcss.js
 !build/README.md
 
+stackgl_modules/node_modules
+
 devtools
 test
 dist/extras

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ stackgl_modules/node_modules
 
 devtools
 test
+draftlogs
 dist/extras
 
 circle.yml

--- a/draftlogs/6008_fix.md
+++ b/draftlogs/6008_fix.md
@@ -1,0 +1,1 @@
+ - Fix to avoid including local stackgl_modules/node_modules in the package (regression introduced in 2.6.0) [[#6008](https://github.com/plotly/plotly.js/pull/6008)]


### PR DESCRIPTION
Fixes #6007.

@plotly/plotly_js 