### PR TITLE
Bump probe-image-size v7.2.2

### DIFF
--- a/draftlogs/6036_change.md
+++ b/draftlogs/6036_change.md
@@ -1,0 +1,1 @@
+ - Bump `probe-image-size` module to v7.2.2 [[#6036](https://github.com/plotly/plotly.js/pull/6036)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "native-promise-only": "^0.8.1",
         "parse-svg-path": "^0.1.2",
         "polybooljs": "^1.2.0",
-        "probe-image-size": "^7.2.1",
+        "probe-image-size": "^7.2.2",
         "regl": "^2.1.0",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.2",
@@ -8142,9 +8142,9 @@
       "dev": true
     },
     "node_modules/probe-image-size": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.1.tgz",
-      "integrity": "sha512-d+6L3NvQBCNt4peRDoEfA7r9bPm6/qy18FnLKwg4NWBC5JrJm0pMLRg1kF4XNsPe1bUdt3WIMonPJzQWN2HXjQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.2.tgz",
+      "integrity": "sha512-QUm+w1S9WTsT5GZB830u0BHExrUmF0J4fyRm5kbLUMEP3fl9UVYXc3xOBVqZNnH9tnvVEJO8vDk3PMtsLqjxug==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
@@ -17491,9 +17491,9 @@
       "dev": true
     },
     "probe-image-size": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.1.tgz",
-      "integrity": "sha512-d+6L3NvQBCNt4peRDoEfA7r9bPm6/qy18FnLKwg4NWBC5JrJm0pMLRg1kF4XNsPe1bUdt3WIMonPJzQWN2HXjQ==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.2.tgz",
+      "integrity": "sha512-QUm+w1S9WTsT5GZB830u0BHExrUmF0J4fyRm5kbLUMEP3fl9UVYXc3xOBVqZNnH9tnvVEJO8vDk3PMtsLqjxug==",
       "requires": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "native-promise-only": "^0.8.1",
     "parse-svg-path": "^0.1.2",
     "polybooljs": "^1.2.0",
-    "probe-image-size": "^7.2.1",
+    "probe-image-size": "^7.2.2",
     "regl": "^2.1.0",
     "regl-error2d": "^2.0.12",
     "regl-line2d": "^3.1.2",


### PR DESCRIPTION
See https://github.com/nodeca/probe-image-size/compare/7.2.1...7.2.2

@plotly/plotly_js 