### PR TITLE
Fix mapbox getView scale for Retina display

### DIFF
--- a/draftlogs/6039_fix.md
+++ b/draftlogs/6039_fix.md
@@ -1,0 +1,1 @@
+ - Fix mapbox derived coordinate for Retina displays [[#6039](https://github.com/plotly/plotly.js/pull/6039)]

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -722,11 +722,29 @@ proto.project = function(v) {
 proto.getView = function() {
     var map = this.map;
     var mapCenter = map.getCenter();
-    var center = { lon: mapCenter.lng, lat: mapCenter.lat };
+    var lon = mapCenter.lng;
+    var lat = mapCenter.lat;
+    var center = { lon: lon, lat: lat };
 
     var canvas = map.getCanvas();
-    var w = canvas.width;
-    var h = canvas.height;
+    var width = canvas.width;
+    var height = canvas.height;
+
+    var p00, p10, p11, p01;
+
+    // attempt finding correct scale for Retina display
+    for(var scale = 2; scale > 0; scale--) {
+        var w = width / scale;
+        var h = height / scale;
+
+        p00 = map.unproject([0, 0]).toArray();
+        p10 = map.unproject([w, 0]).toArray();
+        p11 = map.unproject([w, h]).toArray();
+        p01 = map.unproject([0, h]).toArray();
+
+        if(Math.abs(lon - (p00[0] + p11[0]) / 2) < 0.0001) break;
+    }
+
     return {
         center: center,
         zoom: map.getZoom(),
@@ -734,10 +752,10 @@ proto.getView = function() {
         pitch: map.getPitch(),
         _derived: {
             coordinates: [
-                map.unproject([0, 0]).toArray(),
-                map.unproject([w, 0]).toArray(),
-                map.unproject([w, h]).toArray(),
-                map.unproject([0, h]).toArray()
+                p00,
+                p10,
+                p11,
+                p01
             ]
         }
     };

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -727,23 +727,8 @@ proto.getView = function() {
     var center = { lon: lon, lat: lat };
 
     var canvas = map.getCanvas();
-    var width = canvas.width;
-    var height = canvas.height;
-
-    var p00, p10, p11, p01;
-
-    // attempt finding correct scale for Retina display
-    for(var scale = 2; scale > 0; scale--) {
-        var w = width / scale;
-        var h = height / scale;
-
-        p00 = map.unproject([0, 0]).toArray();
-        p10 = map.unproject([w, 0]).toArray();
-        p11 = map.unproject([w, h]).toArray();
-        p01 = map.unproject([0, h]).toArray();
-
-        if(Math.abs(lon - (p00[0] + p11[0]) / 2) < 0.0001) break;
-    }
+    var w = parseInt(canvas.style.width);
+    var h = parseInt(canvas.style.height);
 
     return {
         center: center,
@@ -752,10 +737,10 @@ proto.getView = function() {
         pitch: map.getPitch(),
         _derived: {
             coordinates: [
-                p00,
-                p10,
-                p11,
-                p01
+                map.unproject([0, 0]).toArray(),
+                map.unproject([w, 0]).toArray(),
+                map.unproject([w, h]).toArray(),
+                map.unproject([0, h]).toArray()
             ]
         }
     };


### PR DESCRIPTION
cc: https://github.com/plotly/dashboard-engine/issues/828

Tested with Safari on `iPad Pro 12.9 2021`

@plotly/plotly_js 