### PR TITLE
Avoid bar with text to jump when selected

### DIFF
--- a/draftlogs/6043_fix.md
+++ b/draftlogs/6043_fix.md
@@ -1,0 +1,1 @@
+ - Avoid bar with text to jump when selected [[#6043](https://github.com/plotly/plotly.js/pull/6043)]

--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -927,7 +927,7 @@ var TEXTOFFSETSIGN = {
     start: 1, end: -1, middle: 0, bottom: 1, top: -1
 };
 
-function textPointPosition(s, textPosition, fontSize, markerRadius) {
+function textPointPosition(s, textPosition, fontSize, markerRadius, dontTouchParent) {
     var group = d3.select(s.node().parentNode);
 
     var v = textPosition.indexOf('top') !== -1 ?
@@ -949,7 +949,9 @@ function textPointPosition(s, textPosition, fontSize, markerRadius) {
 
     // fix the overall text group position
     s.attr('text-anchor', h);
-    group.attr('transform', strTranslate(dx, dy));
+    if(!dontTouchParent) {
+        group.attr('transform', strTranslate(dx, dy));
+    }
 }
 
 function extracTextFontSize(d, trace) {
@@ -1019,7 +1021,8 @@ drawing.selectedTextStyle = function(s, trace) {
         var fontSize = extracTextFontSize(d, trace);
 
         Color.fill(tx, tc);
-        textPointPosition(tx, tp, fontSize, d.mrc2 || d.mrc);
+        var dontTouchParent = Registry.traceIs(trace, 'bar-like');
+        textPointPosition(tx, tp, fontSize, d.mrc2 || d.mrc, dontTouchParent);
     });
 };
 


### PR DESCRIPTION
Fixes #6041.

@plotly/plotly_js 