### PR TITLE
bump plotly.py to v5.5.0

### DIFF
--- a/.circleci/env_image.sh
+++ b/.circleci/env_image.sh
@@ -5,4 +5,4 @@ sudo python3 .circleci/download_google_fonts.py && \
 sudo cp -r .circleci/fonts/ /usr/share/ && \
 sudo fc-cache -f && \
 # install kaleido & plotly
-sudo python3 -m pip install kaleido==0.2.1 plotly==5.2.1 --progress-bar off
+sudo python3 -m pip install kaleido==0.2.1 plotly==5.5.0 --progress-bar off


### PR DESCRIPTION
N.B. looks like after this we may need to set mathjax to v3 somewhere in plotly.py so that we could use Kaleido  (via plotly.io) for generating baselines for image test.

cc: @plotly/plotly_js 