### PR TITLE
bump socket.io to use engine.io v6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.0.0.tgz",
-      "integrity": "sha512-Ui7yl3JajEIaACg8MOUwWvuuwU7jepZqX3BKs1ho7NQRuP4LhN4XIykXhp8bEy+x/DhA0LBZZXYSCkZDqrwMMg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.1.tgz",
+      "integrity": "sha512-AyMc20q8JUUdvKd46+thc9o7yCZ6iC6MoBCChG5Z1XmFMpp+2+y/oKvwpZTUJB0KCjxScw1dV9c2h5pjiYBLuQ==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -3674,9 +3674,9 @@
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.1.tgz",
-      "integrity": "sha512-j4p3WwJrG2k92VISM0op7wiq60vO92MlF3CRGxhKHy9ywG1/Dkc72g0dXeDQ+//hrcDn8gqQzoEkdO9FN0d9AA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+      "integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
       "dev": true,
       "dependencies": {
         "base64-arraybuffer": "~1.0.1"
@@ -9019,16 +9019,16 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.3.1.tgz",
-      "integrity": "sha512-HC5w5Olv2XZ0XJ4gOLGzzHEuOCfj3G0SmoW3jLHYYh34EVsIr3EkW9h6kgfW+K3TFEcmYy8JcPWe//KUkBp5jA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
+      "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.0.0",
-        "socket.io-adapter": "~2.3.2",
+        "engine.io": "~6.1.0",
+        "socket.io-adapter": "~2.3.3",
         "socket.io-parser": "~4.0.4"
       },
       "engines": {
@@ -9036,9 +9036,9 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz",
-      "integrity": "sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+      "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
       "dev": true
     },
     "node_modules/socket.io-parser": {
@@ -13918,9 +13918,9 @@
       }
     },
     "engine.io": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.0.0.tgz",
-      "integrity": "sha512-Ui7yl3JajEIaACg8MOUwWvuuwU7jepZqX3BKs1ho7NQRuP4LhN4XIykXhp8bEy+x/DhA0LBZZXYSCkZDqrwMMg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.1.tgz",
+      "integrity": "sha512-AyMc20q8JUUdvKd46+thc9o7yCZ6iC6MoBCChG5Z1XmFMpp+2+y/oKvwpZTUJB0KCjxScw1dV9c2h5pjiYBLuQ==",
       "dev": true,
       "requires": {
         "@types/cookie": "^0.4.1",
@@ -13936,9 +13936,9 @@
       }
     },
     "engine.io-parser": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.1.tgz",
-      "integrity": "sha512-j4p3WwJrG2k92VISM0op7wiq60vO92MlF3CRGxhKHy9ywG1/Dkc72g0dXeDQ+//hrcDn8gqQzoEkdO9FN0d9AA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
+      "integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
       "dev": true,
       "requires": {
         "base64-arraybuffer": "~1.0.1"
@@ -18209,23 +18209,23 @@
       "dev": true
     },
     "socket.io": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.3.1.tgz",
-      "integrity": "sha512-HC5w5Olv2XZ0XJ4gOLGzzHEuOCfj3G0SmoW3jLHYYh34EVsIr3EkW9h6kgfW+K3TFEcmYy8JcPWe//KUkBp5jA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
+      "integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.0.0",
-        "socket.io-adapter": "~2.3.2",
+        "engine.io": "~6.1.0",
+        "socket.io-adapter": "~2.3.3",
         "socket.io-parser": "~4.0.4"
       }
     },
     "socket.io-adapter": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz",
-      "integrity": "sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
+      "integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
       "dev": true
     },
     "socket.io-parser": {


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/security/dependabot/package-lock.json/engine.io/open
See https://github.com/advisories/GHSA-273r-mgr4-v34f

cc: @plotly/plotly_js 