### PR TITLE
devtools/test_dashboard: tweak ES6 import

### DIFF
--- a/devtools/test_dashboard/index.html
+++ b/devtools/test_dashboard/index.html
@@ -21,7 +21,7 @@
   <div id="snapshot"></div>
 
   <script src="../../node_modules/mathjax/MathJax.js?config=TeX-AMS-MML_SVG"></script>
-  <script charset="utf-8" id="source"  type="module">import "../../build/plotly.js"</script>
+  <script charset="utf-8" id="source" src="../../build/plotly.js" type="module"></script>
   <script charset="utf-8" src="../../build/test_dashboard-bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This way of importing is more 'standard', and might clarify things for new users who look at this file for inspiration.

See https://javascript.info/modules-intro

Feel free to merge/close this PR without discussion