### PR TITLE
Depend on the latest `probe-image-size` module v7.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "native-promise-only": "^0.8.1",
         "parse-svg-path": "^0.1.2",
         "polybooljs": "^1.2.0",
-        "probe-image-size": "^7.2.2",
+        "probe-image-size": "^7.2.3",
         "regl": "^2.1.0",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.2",
@@ -7983,9 +7983,9 @@
       "dev": true
     },
     "node_modules/probe-image-size": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.2.tgz",
-      "integrity": "sha512-QUm+w1S9WTsT5GZB830u0BHExrUmF0J4fyRm5kbLUMEP3fl9UVYXc3xOBVqZNnH9tnvVEJO8vDk3PMtsLqjxug==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
@@ -17165,9 +17165,9 @@
       "dev": true
     },
     "probe-image-size": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.2.tgz",
-      "integrity": "sha512-QUm+w1S9WTsT5GZB830u0BHExrUmF0J4fyRm5kbLUMEP3fl9UVYXc3xOBVqZNnH9tnvVEJO8vDk3PMtsLqjxug==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
       "requires": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "native-promise-only": "^0.8.1",
     "parse-svg-path": "^0.1.2",
     "polybooljs": "^1.2.0",
-    "probe-image-size": "^7.2.2",
+    "probe-image-size": "^7.2.3",
     "regl": "^2.1.0",
     "regl-error2d": "^2.0.12",
     "regl-line2d": "^3.1.2",


### PR DESCRIPTION
Includes a fix for FireFox:
https://github.com/nodeca/probe-image-size/compare/7.2.2...7.2.3 

cc: @plotly/plotly_js 