### PR TITLE
stable link for `squarifyratio`

### DIFF
--- a/src/traces/treemap/attributes.js
+++ b/src/traces/treemap/attributes.js
@@ -46,7 +46,7 @@ module.exports = {
             dflt: 1,
             editType: 'plot',
             description: [
-                'When using *squarify* `packing` algorithm, according to https://github.com/d3/d3-hierarchy/blob/master/README.md#squarify_ratio',
+                'When using *squarify* `packing` algorithm, according to https://github.com/d3/d3-hierarchy/blob/v3.1.1/README.md#squarify_ratio',
                 'this option specifies the desired aspect ratio of the generated rectangles.',
                 'The ratio must be specified as a number greater than or equal to one.',
                 'Note that the orientation of the generated rectangles (tall or wide)',

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -68075,7 +68075,7 @@
      },
      "role": "object",
      "squarifyratio": {
-      "description": "When using *squarify* `packing` algorithm, according to https://github.com/d3/d3-hierarchy/blob/master/README.md#squarify_ratio this option specifies the desired aspect ratio of the generated rectangles. The ratio must be specified as a number greater than or equal to one. Note that the orientation of the generated rectangles (tall or wide) is not implied by the ratio; for example, a ratio of two will attempt to produce a mixture of rectangles whose width:height ratio is either 2:1 or 1:2. When using *squarify*, unlike d3 which uses the Golden Ratio i.e. 1.618034, Plotly applies 1 to increase squares in treemap layouts.",
+      "description": "When using *squarify* `packing` algorithm, according to https://github.com/d3/d3-hierarchy/blob/v3.1.1/README.md#squarify_ratio this option specifies the desired aspect ratio of the generated rectangles. The ratio must be specified as a number greater than or equal to one. Note that the orientation of the generated rectangles (tall or wide) is not implied by the ratio; for example, a ratio of two will attempt to produce a mixture of rectangles whose width:height ratio is either 2:1 or 1:2. When using *squarify*, unlike d3 which uses the Golden Ratio i.e. 1.618034, Plotly applies 1 to increase squares in treemap layouts.",
       "dflt": 1,
       "editType": "plot",
       "min": 1,


### PR DESCRIPTION
use version tag instead of branch name
@plotly/plotly_js 