### PR TITLE
use the sync method of `prependFile` when creating bundles

### DIFF
--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -37,8 +37,8 @@ tasks.push(function(done) {
         standalone: 'Plotly',
         pathToMinBundle: pathToPlotlyDistMin
     }, function() {
-        prependFile(pathToPlotlyDist, header, common.throwOnError);
-        prependFile(pathToPlotlyDistMin, header, common.throwOnError);
+        prependFile.sync(pathToPlotlyDist, header, common.throwOnError);
+        prependFile.sync(pathToPlotlyDistMin, header, common.throwOnError);
 
         done();
     });
@@ -50,8 +50,8 @@ tasks.push(function(done) {
         standalone: 'Plotly',
         pathToMinBundle: pathToPlotlyStrictDistMin
     }, function() {
-        prependFile(pathToPlotlyStrictDist, header, common.throwOnError);
-        prependFile(pathToPlotlyStrictDistMin, header, common.throwOnError);
+        prependFile.sync(pathToPlotlyStrictDist, header, common.throwOnError);
+        prependFile.sync(pathToPlotlyStrictDistMin, header, common.throwOnError);
 
         done();
     });
@@ -62,7 +62,7 @@ tasks.push(function(done) {
     _bundle(pathToPlotlyGeoAssetsSrc, pathToPlotlyGeoAssetsDist, {
         standalone: 'PlotlyGeoAssets'
     }, function() {
-        prependFile(pathToPlotlyGeoAssetsDist, header, common.throwOnError);
+        prependFile.sync(pathToPlotlyGeoAssetsDist, header, common.throwOnError);
 
         done();
     });
@@ -74,7 +74,7 @@ tasks.push(function(done) {
         standalone: 'Plotly',
         noCompress: true
     }, function() {
-        prependFile(pathToPlotlyDistWithMeta, header, common.throwOnError);
+        prependFile.sync(pathToPlotlyDistWithMeta, header, common.throwOnError);
 
         done();
     });

--- a/tasks/partial_bundle.js
+++ b/tasks/partial_bundle.js
@@ -63,8 +63,8 @@ module.exports = function partialBundle(tasks, opts) {
             var headerDist = header.replace('plotly.js', 'plotly.js (' + name + ')');
             var headerDistMin = header.replace('plotly.js', 'plotly.js (' + name + ' - minified)');
 
-            if(dist) prependFile(dist, headerDist, common.throwOnError);
-            if(distMin) prependFile(distMin, headerDistMin, common.throwOnError);
+            if(dist) prependFile.sync(dist, headerDist, common.throwOnError);
+            if(distMin) prependFile.sync(distMin, headerDistMin, common.throwOnError);
 
             done();
         });


### PR DESCRIPTION
The [prependFile module](https://www.npmjs.com/package/prepend-file/v/2.0.1) has a `sync` method.
I think that's the one we should have used in the existing bundle tasks before calling `done()`.
cc: @plotly/plotly_js 