### PR TITLE
Allow creation of DOM element from newPlot and react methods

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -32,6 +32,22 @@ function getGraphDiv(gd) {
     return gd;
 }
 
+/**
+ * Allow referencing a graph DOM element either directly
+ * or by its id string, if undefined will create a new element
+ *
+ * @param {HTMLDivElement|string} gd: a graph element or its id, may be undefined
+ *
+ * @returns {HTMLDivElement} the DOM element of the graph
+ */
+function getOrCreateGraphDiv(gd) {
+    if(gd === null || gd === undefined) {
+        return document.createElement('div');
+    }
+
+    return getGraphDiv(gd);
+}
+
 function isPlotDiv(el) {
     var el3 = d3.select(el);
     return el3.node() instanceof HTMLElement &&
@@ -156,6 +172,7 @@ function equalDomRects(a, b) {
 
 module.exports = {
     getGraphDiv: getGraphDiv,
+    getOrCreateGraphDiv: getOrCreateGraphDiv,
     isPlotDiv: isPlotDiv,
     removeElement: removeElement,
     addStyleRule: addStyleRule,

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -557,7 +557,7 @@ function redraw(gd) {
  * @param {Object} config
  */
 function newPlot(gd, data, layout, config) {
-    gd = Lib.getGraphDiv(gd);
+    gd = Lib.getOrCreateGraphDiv(gd);
 
     // remove gl contexts
     Plots.cleanPlot([], {}, gd._fullData || [], gd._fullLayout || {});
@@ -2612,7 +2612,7 @@ function react(gd, data, layout, config) {
 
     function addFrames() { return exports.addFrames(gd, frames); }
 
-    gd = Lib.getGraphDiv(gd);
+    gd = Lib.getOrCreateGraphDiv(gd);
     helpers.clearPromiseQueue(gd);
 
     var oldFullData = gd._fullData;


### PR DESCRIPTION
It would sometimes be convenient to have plotly take care of the details of creating the DOM element used in the plot. For example, in the context of Observable, [all of these examples](https://observablehq.com/@jashkenas/plotly-js) have the following boilerplate:

```js
...
const div = DOM.element('div');
Plotly.newPlot(div, data, layout);
return div;
```

It would be much nicer if I could do something like this:

```js
...
return await Plotly.newPlot(undefined, data, layout);
```

Is this a feature you would consider adding? I believe technically this would not be breaking the API, just adding a feature. Here's a pull request demonstrating the idea (untested).

todo if this idea is accepted:

```
After opening a pull request, developer:
 - should create a new small markdown log file using the PR number e.g. `1010_fix.md` or `1010_add.md` inside `draftlogs` folder as described in this [README](https://github.com/plotly/plotly.js/blob/master/draftlogs/README.md), commit it and push.
```