### PR TITLE
Update make_trace_groups.js

### DIFF
--- a/src/lib/make_trace_groups.js
+++ b/src/lib/make_trace_groups.js
@@ -15,6 +15,7 @@ var d3 = require('@plotly/d3');
  */
 module.exports = function makeTraceGroups(traceLayer, cdModule, cls) {
     var traces = traceLayer.selectAll('g.' + cls.replace(/\s/g, '.'))
+        .data(cdModule)
         .data(cdModule, function(cd) { return cd[0].trace.uid; });
 
     traces.exit().remove();


### PR DESCRIPTION
When using d3 in conjunction with plotly, d3 seems to be clearing out the __data__ property. This is making the function wrapped in the data function call here throw an exception since cd[0] is undefined. By setting the data to cdModule before this function call, we avoid the exception and fix d3's compatibility with plotly. 

Thanks,
Noah