### PR TITLE
Fix modeBarButtons issue

### DIFF
--- a/draftlogs/6177_fix.md
+++ b/draftlogs/6177_fix.md
@@ -1,1 +1,1 @@
- - Fix modeBarButtons mutate the input, issue [[#1157](https://github.com/plotly/dash/issues/1157)]
+ - Fix custom modebar buttons mutate the input [[#6177](https://github.com/plotly/plotly.js/pull/6177)]

--- a/draftlogs/6177_fix.md
+++ b/draftlogs/6177_fix.md
@@ -1,0 +1,1 @@
+ - Fix modeBarButtons mutate the input, issue [[#1157](https://github.com/plotly/dash/issues/1157)]

--- a/src/components/modebar/manage.js
+++ b/src/components/modebar/manage.js
@@ -8,7 +8,7 @@ var isUnifiedHover = require('../fx/helpers').isUnifiedHover;
 var createModeBar = require('./modebar');
 var modeBarButtons = require('./buttons');
 var DRAW_MODES = require('./constants').DRAW_MODES;
-var cloneDeep = require('lodash').cloneDeep;
+var extendDeep = require('../../lib').extendDeep;
 
 /**
  * ModeBar wrapper around 'create' and 'update',
@@ -45,7 +45,7 @@ module.exports = function manageModeBar(gd) {
         ].join(' '));
     }
 
-    var customButtons = cloneDeep(context.modeBarButtons);
+    var customButtons = extendDeep([], context.modeBarButtons);
     var buttonGroups;
 
     if(Array.isArray(customButtons) && customButtons.length) {

--- a/src/components/modebar/manage.js
+++ b/src/components/modebar/manage.js
@@ -45,7 +45,7 @@ module.exports = function manageModeBar(gd) {
         ].join(' '));
     }
 
-    var customButtons = extendDeep([], context.modeBarButtons);
+    var customButtons = context.modeBarButtons;
     var buttonGroups;
 
     if(Array.isArray(customButtons) && customButtons.length) {
@@ -331,7 +331,9 @@ function appendButtonsToGroups(groups, buttons) {
 }
 
 // fill in custom buttons referring to default mode bar buttons
-function fillCustomButton(customButtons) {
+function fillCustomButton(originalModeBarButtons) {
+    var customButtons = extendDeep([], originalModeBarButtons);
+
     for(var i = 0; i < customButtons.length; i++) {
         var buttonGroup = customButtons[i];
 

--- a/src/components/modebar/manage.js
+++ b/src/components/modebar/manage.js
@@ -8,6 +8,7 @@ var isUnifiedHover = require('../fx/helpers').isUnifiedHover;
 var createModeBar = require('./modebar');
 var modeBarButtons = require('./buttons');
 var DRAW_MODES = require('./constants').DRAW_MODES;
+var cloneDeep = require('lodash').cloneDeep;
 
 /**
  * ModeBar wrapper around 'create' and 'update',
@@ -44,7 +45,7 @@ module.exports = function manageModeBar(gd) {
         ].join(' '));
     }
 
-    var customButtons = context.modeBarButtons;
+    var customButtons = cloneDeep(context.modeBarButtons);
     var buttonGroups;
 
     if(Array.isArray(customButtons) && customButtons.length) {

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -996,6 +996,15 @@ describe('ModeBar', function() {
             expect(countButtons(gd._fullLayout._modeBar))
                 .toEqual(initialButtonCount + 6);
         });
+
+        it('sets up buttons without changing the input', function() {
+            var config = [['toImage']];
+            var gd = setupGraphInfo();
+            gd._context.modeBarButtons = config;
+            manageModeBar(gd);
+            expect(config).toEqual([['toImage']]);
+            expect(countButtons(gd._fullLayout._modeBar)).toEqual(2);
+        });
     });
 
     describe('modebar on clicks', function() {


### PR DESCRIPTION
Fixes [dash](https://github.com/plotly/dash) issue [#1157](https://github.com/plotly/dash/issues/1157)
As @alexcjohnson wrote:
> The problem is [here](https://github.com/plotly/plotly.js/blob/b8905568ee672a60f1749a73dd8703835849087e/src/components/modebar/manage.js#L342) where we mutate the input - which is the user-provided array, something we should not alter. Instead we should create a copy with the object inserted in place of the string. Would be a one-line change if we used `ramda` in plotly.js, but we don't...