### PR TITLE
Fix y pos of dimension label in parcats trace

### DIFF
--- a/src/traces/parcats/parcats.js
+++ b/src/traces/parcats/parcats.js
@@ -285,7 +285,7 @@ function performPlot(parcatsModels, graphDiv, layout, svg) {
         .attr('x', function(d) {
             return d.width / 2;
         })
-        .attr('y', -5)
+        .attr('y', -15)
         .text(function(d, i) {
             if(i === 0) {
                 // Add dimension label above topmost category


### PR DESCRIPTION
This PR fixes the y position of the dimension labels in the parcats trace.

**Before**
![newplot-3](https://user-images.githubusercontent.com/11940172/169450043-9ab3f526-9d5f-4e83-87c0-6b541c052fc9.png)

**After**
![newplot-4](https://user-images.githubusercontent.com/11940172/169450076-87e459f6-f67b-472e-865f-f9ee8bbf4cc5.png)

Apologies if I am missing something in this PR – this is my first time contributing to plotly.js.
