### PR TITLE
bump mathjax v3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "lodash": "^4.17.21",
         "madge": "^5.0.1",
         "mathjax-v2": "npm:mathjax@2.7.5",
-        "mathjax-v3": "npm:mathjax@^3.2.0",
+        "mathjax-v3": "npm:mathjax@^3.2.1",
         "minify-stream": "^2.1.0",
         "npm-link-check": "^4.0.0",
         "open": "^8.4.0",
@@ -6608,9 +6608,9 @@
     },
     "node_modules/mathjax-v3": {
       "name": "mathjax",
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.0.tgz",
-      "integrity": "sha512-PL+rdYRK4Wxif+SQ94zP/L0sv6/oW/1WdQiIx0Jvn9FZaU5W9E6nlIv8liYAXBNPL2Fw/i+o/mZ1212eSzn0Cw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.1.tgz",
+      "integrity": "sha512-blUch14trKnfQHjDjy1kdg5bN8jK0bdHbkerQBKCrZ3Anpb81zZ7xnj5J55vsqQoG+Irz3BHBDzRssjeehkzxg==",
       "dev": true
     },
     "node_modules/md5.js": {
@@ -15965,9 +15965,9 @@
       "dev": true
     },
     "mathjax-v3": {
-      "version": "npm:mathjax@3.2.0",
-      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.0.tgz",
-      "integrity": "sha512-PL+rdYRK4Wxif+SQ94zP/L0sv6/oW/1WdQiIx0Jvn9FZaU5W9E6nlIv8liYAXBNPL2Fw/i+o/mZ1212eSzn0Cw==",
+      "version": "npm:mathjax@3.2.1",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.1.tgz",
+      "integrity": "sha512-blUch14trKnfQHjDjy1kdg5bN8jK0bdHbkerQBKCrZ3Anpb81zZ7xnj5J55vsqQoG+Irz3BHBDzRssjeehkzxg==",
       "dev": true
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "lodash": "^4.17.21",
     "madge": "^5.0.1",
     "mathjax-v2": "npm:mathjax@2.7.5",
-    "mathjax-v3": "npm:mathjax@^3.2.0",
+    "mathjax-v3": "npm:mathjax@^3.2.1",
     "minify-stream": "^2.1.0",
     "npm-link-check": "^4.0.0",
     "open": "^8.4.0",


### PR DESCRIPTION
release notes: https://github.com/mathjax/MathJax-src/releases/tag/3.2.1

cc: @plotly/plotly_js 