### PR TITLE
Fix missing `libnss3_3.42.1-1+deb10u3_amd64.deb` file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,9 @@ jobs:
           command: .circleci/env_image.sh
       - run:
           name: Install poppler-utils to have pdftops for exporting eps
-          command: sudo apt-get install poppler-utils
+          command: |
+              sudo apt-get update --allow-releaseinfo-change
+              sudo apt-get install poppler-utils
       - run:
           name: Create svg, jpg, jpeg, webp, pdf and eps files
           command: python3 test/image/make_exports.py


### PR DESCRIPTION
Fixes #6214 thanks to @antoinerg suggestion.

BTW - It is unfortunate that now we need to call `apt-get update` in the docker as a result of a breaking change.

@plotly/plotly_js 
