### PR TITLE
bump Mathjax v3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To support MathJax, you could load either version two or version three of MathJa
 ```
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-svg.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg.js"></script>
 ```
 
 > When using MathJax version 3, it is also possible to use `chtml` output on the other parts of the page in addition to `svg` output for the plotly graph.

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "lodash": "^4.17.21",
         "madge": "^5.0.1",
         "mathjax-v2": "npm:mathjax@2.7.5",
-        "mathjax-v3": "npm:mathjax@^3.2.1",
+        "mathjax-v3": "npm:mathjax@^3.2.2",
         "minify-stream": "^2.1.0",
         "npm-link-check": "^4.0.0",
         "open": "^8.4.0",
@@ -6608,9 +6608,9 @@
     },
     "node_modules/mathjax-v3": {
       "name": "mathjax",
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.1.tgz",
-      "integrity": "sha512-blUch14trKnfQHjDjy1kdg5bN8jK0bdHbkerQBKCrZ3Anpb81zZ7xnj5J55vsqQoG+Irz3BHBDzRssjeehkzxg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz",
+      "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==",
       "dev": true
     },
     "node_modules/md5.js": {
@@ -15965,9 +15965,9 @@
       "dev": true
     },
     "mathjax-v3": {
-      "version": "npm:mathjax@3.2.1",
-      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.1.tgz",
-      "integrity": "sha512-blUch14trKnfQHjDjy1kdg5bN8jK0bdHbkerQBKCrZ3Anpb81zZ7xnj5J55vsqQoG+Irz3BHBDzRssjeehkzxg==",
+      "version": "npm:mathjax@3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz",
+      "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==",
       "dev": true
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "lodash": "^4.17.21",
     "madge": "^5.0.1",
     "mathjax-v2": "npm:mathjax@2.7.5",
-    "mathjax-v3": "npm:mathjax@^3.2.1",
+    "mathjax-v3": "npm:mathjax@^3.2.2",
     "minify-stream": "^2.1.0",
     "npm-link-check": "^4.0.0",
     "open": "^8.4.0",


### PR DESCRIPTION
release notes: https://github.com/mathjax/MathJax-src/releases/tag/3.2.2

cc: https://github.com/orgs/plotly/teams/plotly_js