### PR TITLE
add `delta.prefix` and `delta.suffix` in Indicator trace

### DIFF
--- a/src/traces/indicator/attributes.js
+++ b/src/traces/indicator/attributes.js
@@ -248,6 +248,22 @@ module.exports = {
                 'Set the font used to display the delta'
             ].join(' ')
         }),
+        prefix: {
+            valType: 'string',
+            dflt: '',
+            editType: 'plot',
+            description: [
+                'Sets a prefix appearing before the delta.'
+            ].join(' ')
+        },
+        suffix: {
+            valType: 'string',
+            dflt: '',
+            editType: 'plot',
+            description: [
+                'Sets a suffix appearing next to the delta.'
+            ].join(' ')
+        },
         editType: 'calc'
     },
     gauge: {

--- a/src/traces/indicator/defaults.js
+++ b/src/traces/indicator/defaults.js
@@ -63,6 +63,8 @@ function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
         coerce('delta.decreasing.symbol');
         coerce('delta.decreasing.color');
         coerce('delta.position');
+        coerce('delta.prefix');
+        coerce('delta.suffix');
         deltaFontSize = traceOut.delta.font.size;
     }
     traceOut._scaleNumbers = (!traceOut._hasNumber || auto[0]) && (!traceOut._hasDelta || auto[1]) || false;

--- a/src/traces/indicator/plot.js
+++ b/src/traces/indicator/plot.js
@@ -571,7 +571,7 @@ function drawNumbers(gd, plotGroup, cd, opts) {
         bignumberAx.setScale();
         Axes.prepTicks(bignumberAx);
 
-        var fmt = function(v) { return Axes.tickText(bignumberAx, v).text;};
+        var bignumberFmt = function(v) { return Axes.tickText(bignumberAx, v).text;};
         var bignumberSuffix = trace.number.suffix;
         var bignumberPrefix = trace.number.prefix;
 
@@ -579,7 +579,7 @@ function drawNumbers(gd, plotGroup, cd, opts) {
 
         function writeNumber() {
             var txt = typeof cd[0].y === 'number' ?
-                bignumberPrefix + fmt(cd[0].y) + bignumberSuffix :
+                bignumberPrefix + bignumberFmt(cd[0].y) + bignumberSuffix :
                 '-';
             number.text(txt)
                 .call(Drawing.font, trace.number.font)
@@ -598,7 +598,7 @@ function drawNumbers(gd, plotGroup, cd, opts) {
                     var interpolator = interpolateNumber(cd[0].lastY, cd[0].y);
                     trace._lastValue = cd[0].y;
 
-                    var transitionFmt = transitionFormat(trace.number.valueformat, fmt, cd[0].lastY, cd[0].y);
+                    var transitionFmt = transitionFormat(trace.number.valueformat, bignumberFmt, cd[0].lastY, cd[0].y);
                     return function(t) {
                         that.text(bignumberPrefix + transitionFmt(interpolator(t)) + bignumberSuffix);
                     };
@@ -607,7 +607,7 @@ function drawNumbers(gd, plotGroup, cd, opts) {
             writeNumber();
         }
 
-        bignumberbBox = measureText(bignumberPrefix + fmt(cd[0].y) + bignumberSuffix, trace.number.font, numbersAnchor, gd);
+        bignumberbBox = measureText(bignumberPrefix + bignumberFmt(cd[0].y) + bignumberSuffix, trace.number.font, numbersAnchor, gd);
         return number;
     }
 
@@ -617,13 +617,16 @@ function drawNumbers(gd, plotGroup, cd, opts) {
         Axes.prepTicks(deltaAx);
 
         var deltaFmt = function(v) { return Axes.tickText(deltaAx, v).text;};
+        var deltaSuffix = trace.delta.suffix;
+        var deltaPrefix = trace.delta.prefix;
+
         var deltaValue = function(d) {
             var value = trace.delta.relative ? d.relativeDelta : d.delta;
             return value;
         };
         var deltaFormatText = function(value, numberFmt) {
             if(value === 0 || typeof value !== 'number' || isNaN(value)) return '-';
-            return (value > 0 ? trace.delta.increasing.symbol : trace.delta.decreasing.symbol) + numberFmt(value);
+            return (value > 0 ? trace.delta.increasing.symbol : trace.delta.decreasing.symbol) + deltaPrefix + numberFmt(value) + deltaSuffix;
         };
         var deltaFill = function(d) {
             return d.delta >= 0 ? trace.delta.increasing.color : trace.delta.decreasing.color;


### PR DESCRIPTION
- in `drawDelta` added `deltaSuffix`/`deltaPrefix`, following what was done in the respective suffix/prefix for `number` (implemented in `drawBignumber`)
- in `drawBignumber` renamed `fmt` to `bignumberFmt` for clarity

Closes https://github.com/plotly/plotly.js/issues/4824

![ezgif com-gif-maker](https://user-images.githubusercontent.com/2184309/173423325-ba76026f-1b64-48b9-89d6-85b669a6275e.gif)

