### PR TITLE
provide MathJax label in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ While non-minified source files may contain characters outside UTF-8, it is reco
 
 > Please note that as of v2 the "plotly-latest" outputs (e.g. https://cdn.plot.ly/plotly-latest.min.js) will no longer be updated on the CDN, and will stay at the last v1 patch v1.58.5. Therefore, to use the CDN with plotly.js v2 and higher, you must specify an exact plotly.js version.
 
-To support MathJax, you could load either version two or version three of MathJax files, for example:
+### MathJax
+You could load either version two or version three of MathJax files, for example:
 ```html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG.js"></script>
 ```


### PR DESCRIPTION
So that we could share a link to it.

@plotly/plotly_js 