### PR TITLE
Fix CSP Strict Style Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "schema": "node tasks/schema.js",
     "stats": "node tasks/stats.js",
     "find-strings": "node tasks/find_locale_strings.js",
-    "preprocess": "node tasks/preprocess.js",
+    "preprocess": "node tasks/preprocess.js %npm_config_cspNoInlineStyle% %npm_config_pathToCSS%",
     "use-draftlogs": "node tasks/use_draftlogs.js",
     "empty-draftlogs": "node tasks/empty_draftlogs.js",
     "empty-dist": "node tasks/empty_dist.js",

--- a/src/components/modebar/modebar.js
+++ b/src/components/modebar/modebar.js
@@ -7,6 +7,8 @@ var Lib = require('../../lib');
 var Icons = require('../../fonts/ploticon');
 var version = require('../../version').version;
 
+var cspNoInlineStyle = require('./../../lib').cspNoInlineStyle;
+
 var Parser = new DOMParser();
 
 /**
@@ -56,11 +58,19 @@ proto.update = function(graphInfo, buttons) {
     var style = fullLayout.modebar;
     var bgSelector = context.displayModeBar === 'hover' ? '.js-plotly-plot .plotly:hover ' : '';
 
-    Lib.deleteRelatedStyleRule(modeBarId);
-    Lib.addRelatedStyleRule(modeBarId, bgSelector + '#' + modeBarId + ' .modebar-group', 'background-color: ' + style.bgcolor);
-    Lib.addRelatedStyleRule(modeBarId, '#' + modeBarId + ' .modebar-btn .icon path', 'fill: ' + style.color);
-    Lib.addRelatedStyleRule(modeBarId, '#' + modeBarId + ' .modebar-btn:hover .icon path', 'fill: ' + style.activecolor);
-    Lib.addRelatedStyleRule(modeBarId, '#' + modeBarId + ' .modebar-btn.active .icon path', 'fill: ' + style.activecolor);
+    if(cspNoInlineStyle) {
+        // set style rules on elements in csp strict style src compliant manner
+        Lib.setStyleOnElements(bgSelector + '#' + modeBarId + ' .modebar-group', 'background-color: ' + style.bgcolor);
+        Lib.setStyleOnElements('#' + modeBarId + ' .modebar-btn .icon path', 'fill: ' + style.color);
+        Lib.setStyleOnElementForEvent('#' + modeBarId + ' .modebar-btn', 'hover', '.icon path', 'fill: ' + style.activecolor, 'fill: ' + style.color);
+        Lib.setStyleOnElementForEvent('#' + modeBarId + ' .modebar-btn', 'active', '.icon path', 'fill: ' + style.activecolor, 'fill: ' + style.color);
+    } else {
+        Lib.deleteRelatedStyleRule(modeBarId);
+        Lib.addRelatedStyleRule(modeBarId, bgSelector + '#' + modeBarId + ' .modebar-group', 'background-color: ' + style.bgcolor);
+        Lib.addRelatedStyleRule(modeBarId, '#' + modeBarId + ' .modebar-btn .icon path', 'fill: ' + style.color);
+        Lib.addRelatedStyleRule(modeBarId, '#' + modeBarId + ' .modebar-btn:hover .icon path', 'fill: ' + style.activecolor);
+        Lib.addRelatedStyleRule(modeBarId, '#' + modeBarId + ' .modebar-btn.active .icon path', 'fill: ' + style.activecolor);
+    }
 
     // if buttons or logo have changed, redraw modebar interior
     var needsNewButtons = !this.hasButtons(buttons);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -12,6 +12,8 @@ var BADNUM = numConstants.BADNUM;
 
 var lib = module.exports = {};
 
+lib.cspNoInlineStyle = false;
+
 lib.adjustFormat = function adjustFormat(formatStr) {
     if(
         !formatStr ||
@@ -187,6 +189,8 @@ lib.removeElement = domModule.removeElement;
 lib.addStyleRule = domModule.addStyleRule;
 lib.addRelatedStyleRule = domModule.addRelatedStyleRule;
 lib.deleteRelatedStyleRule = domModule.deleteRelatedStyleRule;
+lib.setStyleOnElements = domModule.setStyleOnElements;
+lib.setStyleOnElementForEvent = domModule.setStyleOnElementForEvent;
 lib.getFullTransformMatrix = domModule.getFullTransformMatrix;
 lib.getElementTransformMatrix = domModule.getElementTransformMatrix;
 lib.getElementAndAncestors = domModule.getElementAndAncestors;

--- a/src/registry.js
+++ b/src/registry.js
@@ -10,6 +10,8 @@ var ExtendModule = require('./lib/extend');
 var basePlotAttributes = require('./plots/attributes');
 var baseLayoutAttributes = require('./plots/layout_attributes');
 
+var cspNoInlineStyle = require('./lib').cspNoInlineStyle;
+
 var extendFlat = ExtendModule.extendFlat;
 var extendDeepAll = ExtendModule.extendDeepAll;
 
@@ -265,7 +267,8 @@ function registerTraceModule(_module) {
     var bpmName = basePlotModule.name;
 
     // add mapbox-gl CSS here to avoid console warning on instantiation
-    if(bpmName === 'mapbox') {
+    // in case of cspNoInlineStyle we will add the styles in a static style sheet during preprocess task
+    if(bpmName === 'mapbox' && !cspNoInlineStyle) {
         var styleRules = basePlotModule.constants.styleRules;
         for(var k in styleRules) {
             addStyleRule('.js-plotly-plot .plotly .mapboxgl-' + k, styleRules[k]);

--- a/tasks/preprocess.js
+++ b/tasks/preprocess.js
@@ -21,8 +21,17 @@ function makeBuildCSS() {
     }, function(err, result) {
         if(err) throw err;
 
-        // css to js
-        pullCSS(String(result.css), constants.pathToCSSBuild);
+        var cspNoInlineStyle = process.argv[2];
+        var pathToCSS = process.argv[3] || 'plot-csp.css';
+        if(cspNoInlineStyle) {
+            // if csp no inline style then build css file to include at path relative to build folder
+            fs.writeFile(constants.pathToBuild + pathToCSS, String(result.css), function(err) {
+                if(err) throw err;
+            });
+        } else {
+            // css to js
+            pullCSS(String(result.css), constants.pathToCSSBuild);
+        }
     });
 }
 

--- a/tasks/preprocess.js
+++ b/tasks/preprocess.js
@@ -21,11 +21,11 @@ function makeBuildCSS() {
     }, function(err, result) {
         if(err) throw err;
 
-        var cspNoInlineStyle = process.argv[2];
-        var pathToCSS = process.argv[3] || 'plot-csp.css';
+        var cspNoInlineStyle = process.env.npm_config_cspNoInlineStyle;
+        var pathToCSS = process.env.npm_config_pathToCSS || 'plot-csp.css';
         if(cspNoInlineStyle) {
-            // if csp no inline style then build css file to include at path relative to build folder
-            fs.writeFile(constants.pathToBuild + pathToCSS, String(result.css), function(err) {
+            // if csp no inline style then build css file to include at path relative to dist folder
+            fs.writeFile(constants.pathToDist + pathToCSS, String(result.css), function(err) {
                 if(err) throw err;
             });
         } else {


### PR DESCRIPTION
Fixes #2355 Plotly uses inline CSS

* Only piece of code violating the CSP strict style rule is the `addStyleRule` function which is appending a dynamic stylesheet to the head. In all other cases, the plotly.js is setting up a dynamic style using CSP-compliant methods.
* In the case of a CSP compliant build, we will create a static CSS stylesheet in a CSS file that applications can include on their end.
* Providing switch in the build process to enable CSP strict style build and providing a path for static CSS stylesheet relative to dist folder. 
* Creating a static CSS file at command line provided path defaulting to build folder with name plot-csp.css
