### PR TITLE
Avoid attaching selections to missing eventData

### DIFF
--- a/draftlogs/6260_fix.md
+++ b/draftlogs/6260_fix.md
@@ -1,0 +1,1 @@
+ - Avoid attaching selections to missing eventData (regression introduced in 2.13.0) [[#6260](https://github.com/plotly/plotly.js/pull/6260)]

--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -451,7 +451,6 @@ function prepSelect(evt, startX, startY, dragOptions, mode) {
                 dragOptions.doneFnCompleted(selection);
             }
 
-            eventData.selections = gd.layout.selections;
             emitSelected(gd, eventData);
         }).catch(Lib.error);
     };
@@ -530,7 +529,6 @@ function selectOnClick(evt, gd, xAxes, yAxes, subplot, dragOptions, polygonOutli
             }
 
             if(sendEvents) {
-                eventData.selections = gd.layout.selections;
                 emitSelected(gd, eventData);
             }
         }
@@ -1195,7 +1193,6 @@ function reselect(gd, selectionTesters, searchTraces, dragOptions) {
                 fillRangeItems(eventData, poly);
             }
 
-            eventData.selections = gd.layout.selections;
             emitSelected(gd, eventData);
         }
 
@@ -1216,7 +1213,6 @@ function reselect(gd, selectionTesters, searchTraces, dragOptions) {
 
         if(sendEvents) {
             if(eventData.points.length) {
-                eventData.selections = gd.layout.selections;
                 emitSelected(gd, eventData);
             } else {
                 gd.emit('plotly_deselect', null);
@@ -1511,6 +1507,10 @@ function emitSelecting(gd, eventData) {
 }
 
 function emitSelected(gd, eventData) {
+    if(eventData) {
+        eventData.selections = (gd.layout || {}).selections || [];
+    }
+
     gd.emit('plotly_selected', eventData);
 }
 

--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -1503,10 +1503,13 @@ function getFillRangeItems(dragOptions) {
 }
 
 function emitSelecting(gd, eventData) {
+    if(drawMode(gd._fullLayout.dragmode)) return;
     gd.emit('plotly_selecting', eventData);
 }
 
 function emitSelected(gd, eventData) {
+    if(drawMode(gd._fullLayout.dragmode)) return;
+
     if(eventData) {
         eventData.selections = (gd.layout || {}).selections || [];
     }
@@ -1515,6 +1518,7 @@ function emitSelected(gd, eventData) {
 }
 
 function emitDeselect(gd) {
+    if(drawMode(gd._fullLayout.dragmode)) return;
     gd.emit('plotly_deselect', null);
 }
 


### PR DESCRIPTION
Fixes #6259.

@plotly/plotly_js 