### PR TITLE
Emit selection events in drawmode when an existing selection modified

### DIFF
--- a/draftlogs/6262_fix.md
+++ b/draftlogs/6262_fix.md
@@ -1,0 +1,1 @@
+ - Emit selection event in shape drawing `dragmode`s when an existing selection modified [[#6262](https://github.com/plotly/plotly.js/pull/6262)]

--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -451,7 +451,9 @@ function prepSelect(evt, startX, startY, dragOptions, mode) {
                 dragOptions.doneFnCompleted(selection);
             }
 
-            emitSelected(gd, eventData);
+            if(isSelectMode) {
+                emitSelected(gd, eventData);
+            }
         }).catch(Lib.error);
     };
 }
@@ -673,15 +675,23 @@ function coerceSelectionsCache(evt, gd, dragOptions) {
     }
 }
 
+function hasActiveShape(gd) {
+    return gd._fullLayout._activeShapeIndex >= 0;
+}
+
+function hasActiveSelection(gd) {
+    return gd._fullLayout._activeSelectionIndex >= 0;
+}
+
 function clearSelectionsCache(dragOptions, immediateSelect) {
     var dragmode = dragOptions.dragmode;
     var plotinfo = dragOptions.plotinfo;
 
     var gd = dragOptions.gd;
-    if(gd._fullLayout._activeShapeIndex >= 0) {
+    if(hasActiveShape(gd)) {
         gd._fullLayout._deactivateShape(gd);
     }
-    if(gd._fullLayout._activeSelectionIndex >= 0) {
+    if(hasActiveSelection(gd)) {
         gd._fullLayout._deactivateSelection(gd);
     }
 
@@ -1503,13 +1513,10 @@ function getFillRangeItems(dragOptions) {
 }
 
 function emitSelecting(gd, eventData) {
-    if(drawMode(gd._fullLayout.dragmode)) return;
     gd.emit('plotly_selecting', eventData);
 }
 
 function emitSelected(gd, eventData) {
-    if(drawMode(gd._fullLayout.dragmode)) return;
-
     if(eventData) {
         eventData.selections = (gd.layout || {}).selections || [];
     }
@@ -1518,7 +1525,6 @@ function emitSelected(gd, eventData) {
 }
 
 function emitDeselect(gd) {
-    if(drawMode(gd._fullLayout.dragmode)) return;
     gd.emit('plotly_deselect', null);
 }
 


### PR DESCRIPTION
When a selection modified, selection events should be emitted in various drag modes i.e. including shape drawing modes, 
like the example below: 

```js
Plotly.newPlot(gd, {"data": [{y: [1, 2, 3]}], "layout": {
    "dragmode": "drawrect",
    "selections": [{ x0: 0.5, x1: 1.5, y0: 1.5, y1: 2.5}]
}})

gd.on('plotly_selected', function(data) { console.log(data); });
```

Right now the `v2.13.1` does not emit such events.
This PR fixes this bug.

@plotly/plotly_js 
