### PR TITLE
Fix `sankey` select error on the first subplot indexed zero

### DIFF
--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -50,7 +50,14 @@ var p2r = helpers.p2r;
 var axValue = helpers.axValue;
 var getTransform = helpers.getTransform;
 
+function cartesianDrag(dragOptions) {
+    // N.B. subplot may be falsy e.g zero sankey index!
+    return dragOptions.subplot !== undefined;
+}
+
 function prepSelect(evt, startX, startY, dragOptions, mode) {
+    var isCartesianDrag = cartesianDrag(dragOptions);
+
     var isFreeMode = freeMode(mode);
     var isRectMode = rectMode(mode);
     var isOpenMode = openMode(mode);
@@ -64,7 +71,7 @@ function prepSelect(evt, startX, startY, dragOptions, mode) {
     var gd = dragOptions.gd;
     var fullLayout = gd._fullLayout;
     var immediateSelect = isSelectMode && fullLayout.newselection.mode === 'immediate' &&
-        !dragOptions.subplot; // N.B. only cartesian subplots have persistent selection
+        !isCartesianDrag; // N.B. only cartesian subplots have persistent selection
 
     var zoomLayer = fullLayout._zoomlayer;
     var dragBBox = dragOptions.element.getBoundingClientRect();
@@ -112,7 +119,7 @@ function prepSelect(evt, startX, startY, dragOptions, mode) {
             opacity: isDrawMode ? newStyle.opacity / 2 : 1,
             fill: (isDrawMode && !isOpenMode) ? newStyle.fillcolor : 'none',
             stroke: newStyle.line.color || (
-                dragOptions.subplot !== undefined ?
+                isCartesianDrag ?
                     '#7f7f7f' : // non-cartesian subplot
                     Color.contrast(gd._fullLayout.plot_bgcolor) // cartesian subplot
             ),
@@ -145,6 +152,8 @@ function prepSelect(evt, startX, startY, dragOptions, mode) {
 
     if(immediateSelect && !evt.shiftKey) {
         dragOptions._clearSubplotSelections = function() {
+            if(isCartesianDrag) return;
+
             var xRef = xAxis._id;
             var yRef = yAxis._id;
             deselectSubplot(gd, xRef, yRef, searchTraces);
@@ -709,7 +718,7 @@ function clearSelectionsCache(dragOptions, immediateSelect) {
             var selections;
             if(
                 isSelectMode &&
-                !dragOptions.subplot // only allow cartesian - no mapbox for now
+                !cartesianDrag(dragOptions) // only allow cartesian - no mapbox for now
             ) {
                 selections = newSelections(outlines, dragOptions);
             }
@@ -748,7 +757,10 @@ function determineSearchTraces(gd, xAxes, yAxes, subplot) {
 
         if(trace.visible !== true || !trace._module || !trace._module.selectPoints) continue;
 
-        if(subplot && (trace.subplot === subplot || trace.geo === subplot)) {
+        if(
+            cartesianDrag({subplot: subplot}) &&
+            (trace.subplot === subplot || trace.geo === subplot)
+        ) {
             searchTraces.push(createSearchInfo(trace._module, cd, xAxes[0], yAxes[0]));
         } else if(trace.type === 'splom') {
             // FIXME: make sure we don't have more than single axis for splom


### PR DESCRIPTION
Fixes #6264.
Regression introduced in `v2.13.0`.

@plotly/plotly_js 