### PR TITLE
Handle missing drag layer of invisible `sankey` traces to fix select error

### DIFF
--- a/draftlogs/6267_fix.md
+++ b/draftlogs/6267_fix.md
@@ -1,0 +1,1 @@
+ - Handle missing drag layer of invisible `sankey` traces to fix select error [[#6267](https://github.com/plotly/plotly.js/pull/6267)]

--- a/src/traces/sankey/base_plot.js
+++ b/src/traces/sankey/base_plot.js
@@ -48,6 +48,7 @@ function subplotUpdateFx(gd, index) {
     var dragMode = fullLayout.dragmode;
     var cursor = fullLayout.dragmode === 'pan' ? 'move' : 'crosshair';
     var bgRect = trace._bgRect;
+    if(!bgRect) return;
 
     if(dragMode === 'pan' || dragMode === 'zoom') return;
 


### PR DESCRIPTION
Fix #6266.

@plotly/plotly_js 