### PR TITLE
Fixed Mapbox Touch Event on Mobile After Switching Back from Select Mode

### DIFF
--- a/draftlogs/6281_fix.md
+++ b/draftlogs/6281_fix.md
@@ -1,1 +1,2 @@
-- Fix mapbox `touch event` after switching back from select mode [[#6281](https://github.com/plotly/plotly.js/pull/6281)]
+ - Fix mapbox `touch event` after switching back from select mode [[#6281](https://github.com/plotly/plotly.js/pull/6281)],
+   with thanks to @mmtmr for the contribution!

--- a/draftlogs/6281_fix.md
+++ b/draftlogs/6281_fix.md
@@ -1,0 +1,1 @@
+- Fix mapbox `touch event` after switching back from select mode [[#6281](https://github.com/plotly/plotly.js/pull/6281)]

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -600,7 +600,8 @@ proto.updateFx = function(fullLayout) {
         map.dragPan.enable();
         map.off('zoomstart', self.clearSelect);
         self.div.onmousedown = null;
-
+        self.div.ontouchstart = null;
+        self.div.removeEventListener('touchstart', self.div._ontouchstart);
         // TODO: this does not support right-click. If we want to support it, we
         // would likely need to change mapbox to use dragElement instead of straight
         // mapbox event binding. Or perhaps better, make a simple wrapper with the


### PR DESCRIPTION
Note: "Mobile" in the following context means touch screen device.

Issue: When mobile user switched back to "Pan" mode from "Box Select" or "Lasso Select" on the mapbox graph, the user is unable to trigger events (eg: hover, click) that are initially trigger-able before switching to "Select" mode.

Problem: The event listener of "touchStart" is not removed.

Solution: Added remove event listener of "touchStart" code below remove event listener of "mouseDown" code when the mapbox graph is not in "Select" mode.

Other Observation: Double Touch on Screen to Clear Selection on "Pan" mode is not working after implementing this solution. But I guess it shouldn't be working at first since double click on "Pan" in non-mobile settings is also not clearing the selection.

Example: First graph in https://plotly.com/python/mapbox-layers/