### PR TITLE
Add `editSelection` option to config

### DIFF
--- a/draftlogs/6285_add.md
+++ b/draftlogs/6285_add.md
@@ -1,0 +1,1 @@
+ - Add `editSelection` option to config [[#6285](https://github.com/plotly/plotly.js/pull/6285)]

--- a/src/components/selections/draw.js
+++ b/src/components/selections/draw.js
@@ -46,6 +46,10 @@ function draw(gd) {
     }
 }
 
+function couldHaveActiveSelection(gd) {
+    return gd._context.editSelection;
+}
+
 function drawOne(gd, index) {
     // remove the existing selection if there is one.
     // because indices can change, we need to look in all selection layers
@@ -82,7 +86,7 @@ function drawOne(gd, index) {
             lineDash = 'solid';
         }
 
-        var isActiveSelection =
+        var isActiveSelection = couldHaveActiveSelection(gd) &&
             gd._fullLayout._activeSelectionIndex === index;
 
         if(isActiveSelection) {
@@ -149,6 +153,8 @@ function setClipPath(selectionPath, gd, selectionOptions) {
 
 
 function activateSelection(gd, path) {
+    if(!couldHaveActiveSelection(gd)) return;
+
     var element = path.node();
     var id = +element.getAttribute('data-index');
     if(id >= 0) {
@@ -165,6 +171,8 @@ function activateSelection(gd, path) {
 }
 
 function activateLastSelection(gd) {
+    if(!couldHaveActiveSelection(gd)) return;
+
     var id = gd._fullLayout.selections.length - 1;
     gd._fullLayout._activeSelectionIndex = id;
     gd._fullLayout._deactivateSelection = deactivateSelection;
@@ -172,6 +180,8 @@ function activateLastSelection(gd) {
 }
 
 function deactivateSelection(gd) {
+    if(!couldHaveActiveSelection(gd)) return;
+
     var id = gd._fullLayout._activeSelectionIndex;
     if(id >= 0) {
         clearOutlineControllers(gd);

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -114,6 +114,12 @@ var configAttributes = {
         }
     },
 
+    editSelection: {
+        valType: 'boolean',
+        dflt: true,
+        description: 'Disables moving selections.'
+    },
+
     autosizable: {
         valType: 'boolean',
         dflt: false,

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -117,7 +117,7 @@ var configAttributes = {
     editSelection: {
         valType: 'boolean',
         dflt: true,
-        description: 'Disables moving selections.'
+        description: 'Enables moving selections.'
     },
 
     autosizable: {

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -200,7 +200,7 @@
    }
   },
   "editSelection": {
-   "description": "Disables moving selections.",
+   "description": "Enables moving selections.",
    "dflt": true,
    "valType": "boolean"
   },

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -199,6 +199,11 @@
     "valType": "boolean"
    }
   },
+  "editSelection": {
+   "description": "Disables moving selections.",
+   "dflt": true,
+   "valType": "boolean"
+  },
   "fillFrame": {
    "description": "When `layout.autosize` is turned on, determines whether the graph fills the container (the default) or the screen (if set to *true*).",
    "dflt": false,


### PR DESCRIPTION
So that modifying selections after creation could be disabled.
@nicolaskruchten 
@plotly/plotly_js 