### PR TITLE
Explore axes

### DIFF
--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -69,6 +69,7 @@ function lsInner(gd) {
 
     function getLinePosition(ax, counterAx, side) {
         var lwHalf = ax._lw / 2;
+        var xshift = ax.position > 0 ? 0 : ax._xshift; 
 
         if(ax._id.charAt(0) === 'x') {
             if(!counterAx) return gs.t + gs.h * (1 - (ax.position || 0)) + (lwHalf % 1);
@@ -76,7 +77,7 @@ function lsInner(gd) {
             return counterAx._offset + counterAx._length + pad + lwHalf;
         }
 
-        if(!counterAx) return gs.l + gs.w * (ax.position || 0) + (lwHalf % 1);
+        if(!counterAx) return gs.l + gs.w * (ax.position || 0) + (lwHalf % 1) + xshift;
         else if(side === 'right') return counterAx._offset + counterAx._length + pad + lwHalf;
         return counterAx._offset - pad - lwHalf;
     }

--- a/src/plot_api/subroutines.js
+++ b/src/plot_api/subroutines.js
@@ -713,3 +713,15 @@ exports.drawMarginPushers = function(gd) {
     Registry.getComponentMethod('updatemenus', 'draw')(gd);
     Registry.getComponentMethod('colorbar', 'draw')(gd);
 };
+
+// function getAxDepth(ax) {
+//     var depth = null;
+//     if (ax.type == 'multicategory') {
+//         depth = majorTickSigns[4] * (getLabelLevelBbox('tick2')[ax.side] - mainLinePosition);
+
+//     } else if(ax.title.hasOwnProperty('standoff')) {
+//         depth = majorTickSigns[4] * (getLabelLevelBbox()[ax.side] - mainLinePosition);
+//     }
+
+// }
+    

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -2248,16 +2248,23 @@ axes.draw = function(gd, arg, opts) {
 
     var axList = (!arg || arg === 'redraw') ? axes.listIds(gd) : arg;
 
+    var allDepths = [0] // Or dict w keys/values?
+
     return Lib.syncOrAsync(axList.map(function(axId) {
         return function() {
             if(!axId) return;
 
             var ax = axes.getFromId(gd, axId);
-            var axDone = axes.drawOne(gd, ax, opts);
+            var axDone = axes.drawOne(gd, ax, opts, allDepths);
 
+            var depth = ax._depth 
+            console.log(depth)
+            //var depthPrev = allDepths.pop
+            allDepths.push(depth)
+            
             ax._r = ax.range.slice();
             ax._rl = Lib.simpleMap(ax._r, ax.r2l);
-
+            //debugger;
             return axDone;
         };
     }));
@@ -2290,11 +2297,12 @@ axes.draw = function(gd, arg, opts) {
  * - ax._depth (when required only):
  * - and calls ax.setScale
  */
-axes.drawOne = function(gd, ax, opts) {
+axes.drawOne = function(gd, ax, opts, allDepths) {
+    //debugger;
     opts = opts || {};
 
     var i, sp, plotinfo;
-
+    console.log(allDepths)
     ax.setScale();
 
     var fullLayout = gd._fullLayout;
@@ -2541,6 +2549,7 @@ axes.drawOne = function(gd, ax, opts) {
         var s = ax.side.charAt(0);
         var sMirror = OPPOSITE_SIDE[ax.side].charAt(0);
         var pos = axes.getPxPosition(gd, ax);
+        console.log(pos)
         var outsideTickLen = outsideTicks ? ax.ticklen : 0;
         var llbbox;
 
@@ -2646,7 +2655,7 @@ axes.drawOne = function(gd, ax, opts) {
     ) {
         seq.push(function() { return drawTitle(gd, ax); });
     }
-
+    console.log(seq)
     return Lib.syncOrAsync(seq);
 };
 
@@ -3764,7 +3773,7 @@ function drawDividers(gd, ax, opts) {
  *  - {number} position
  * @return {number}
  */
-axes.getPxPosition = function(gd, ax) {
+axes.getPxPosition = function(gd, ax, offset) {
     var gs = gd._fullLayout._size;
     var axLetter = ax._id.charAt(0);
     var side = ax.side;

--- a/test/image/mocks/multiple_axes_multiple.json
+++ b/test/image/mocks/multiple_axes_multiple.json
@@ -80,7 +80,8 @@
                     "color": "#1f77b4"
                 },
                 "text": "yaxis title"
-            }
+            },
+            "automargin": true
         },
         "yaxis2": {
             "title": {
@@ -95,7 +96,8 @@
             "anchor": "free",
             "side": "left",
             "position": 0.15,
-            "overlaying": "y"
+            "overlaying": "y",
+            "automargin": true
         },
         "yaxis3": {
             "title": {
@@ -109,7 +111,8 @@
             },
             "anchor": "x",
             "side": "right",
-            "overlaying": "y"
+            "overlaying": "y",
+            "automargin": true
         },
         "yaxis4": {
             "title": {
@@ -124,7 +127,8 @@
             "anchor": "free",
             "side": "right",
             "position": 0.85,
-            "overlaying": "y"
+            "overlaying": "y",
+            "automargin": true
         }
     }
 }

--- a/test/image/mocks/z-multiple-yaxes-complex.json
+++ b/test/image/mocks/z-multiple-yaxes-complex.json
@@ -1,0 +1,112 @@
+{
+    "data": [
+        {
+            "x": [
+                1,
+                2,
+                3
+            ],
+            "y": [
+                4,
+                5,
+                6
+            ],
+            "name": "yaxis1 data",
+            "type": "scatter"
+        },
+        {
+            "x": [
+                2,
+                3,
+                4
+            ],
+            "y": [
+                40,
+                50,
+                60
+            ],
+            "name": "yaxis2 data",
+            "yaxis": "y2",
+            "type": "scatter"
+        },
+        {
+            "x": [
+                3,
+                4,
+                5
+            ],
+            "y": [
+                400,
+                500,
+                600
+            ],
+            "name": "yaxis3 data",
+            "yaxis": "y3",
+            "type": "scatter"
+        },
+        {
+            "x": [
+                4,
+                5,
+                6
+            ],
+            "y": [
+                4000,
+                5000,
+                6000
+            ],
+            "name": "yaxis4 data",
+            "yaxis": "y4",
+            "type": "scatter"
+        }
+    ],
+    "layout": {
+        "title": {
+            "text": "multiple y-axes example - complex formatting"
+        },
+        "width": 800,
+        "xaxis": {
+            "domain": [
+                0.5,
+                1
+            ]
+        },
+        
+        "yaxis": {
+            "title": {
+                "text": "yaxis title"
+
+            },
+            "automargin": true,
+            "anchor": "free"
+        },
+        "yaxis2": {
+            "title": {"text": "yaxis2 title"},
+            "anchor": "free",
+            "overlaying": "y",
+            "automargin": true,
+            "ticklen":25
+            
+        },
+        "yaxis3": {
+            "title": {
+                "text": "yaxis3 title",
+                "font": {"size": 28}
+            },
+            "tickfont": {"size": 28},
+            "anchor": "free",
+            "overlaying": "y",
+            "automargin": true
+        },
+        "yaxis4": {
+            "anchor": "free",
+            "title": {
+                "text": "yaxis4 title",
+                "font": {"size": 8}
+            },
+            "tickfont": {"size": 8},
+            "overlaying": "y",
+            "automargin": true
+        }
+    }
+}

--- a/test/image/mocks/z-multiple-yaxes-layout.json
+++ b/test/image/mocks/z-multiple-yaxes-layout.json
@@ -28,6 +28,36 @@
             "name": "yaxis2 data",
             "yaxis": "y2",
             "type": "scatter"
+        },
+        {
+            "x": [
+                3,
+                4,
+                5
+            ],
+            "y": [
+                400,
+                500,
+                600
+            ],
+            "name": "yaxis3 data",
+            "yaxis": "y3",
+            "type": "scatter"
+        },
+        {
+            "x": [
+                4,
+                5,
+                6
+            ],
+            "y": [
+                4000,
+                5000,
+                6000
+            ],
+            "name": "yaxis4 data",
+            "yaxis": "y4",
+            "type": "scatter"
         }
     ],
     "layout": {
@@ -48,6 +78,18 @@
         },
         "yaxis2": {
             "title": {"text": "yaxis2 title"},
+            "anchor": "free",
+            "overlaying": "y",
+            "automargin": true
+        },
+        "yaxis3": {
+            "title": {"text": "yaxis3 title"},
+            "anchor": "free",
+            "overlaying": "y",
+            "automargin": true
+        },
+        "yaxis4": {
+            "title": {"text": "yaxis4 title"},
             "anchor": "free",
             "overlaying": "y",
             "automargin": true

--- a/test/image/mocks/z-multiple-yaxes-layout.json
+++ b/test/image/mocks/z-multiple-yaxes-layout.json
@@ -1,0 +1,56 @@
+{
+    "data": [
+        {
+            "x": [
+                1,
+                2,
+                3
+            ],
+            "y": [
+                4,
+                5,
+                6
+            ],
+            "name": "yaxis1 data",
+            "type": "scatter"
+        },
+        {
+            "x": [
+                2,
+                3,
+                4
+            ],
+            "y": [
+                40,
+                50,
+                60
+            ],
+            "name": "yaxis2 data",
+            "yaxis": "y2",
+            "type": "scatter"
+        }
+    ],
+    "layout": {
+        "title": {
+            "text": "multiple y-axes example"
+        },
+        "width": 800,
+        "xaxis": {
+            "domain": [
+                0.5,
+                1
+            ]
+        },
+        "yaxis": {
+            "title": {"text": "yaxis title"},
+            "automargin": true,
+            "anchor": "free"
+        },
+        "yaxis2": {
+            "title": {"text": "yaxis2 title"},
+            "anchor": "free",
+            "overlaying": "y",
+            "automargin": true
+        }
+    }
+}

--- a/test/image/mocks/z-multiple-yaxes-simple.json
+++ b/test/image/mocks/z-multiple-yaxes-simple.json
@@ -62,7 +62,7 @@
     ],
     "layout": {
         "title": {
-            "text": "multiple y-axes example"
+            "text": "multiple y-axes example - uniform formatting"
         },
         "width": 800,
         "xaxis": {
@@ -71,8 +71,12 @@
                 1
             ]
         },
+        
         "yaxis": {
-            "title": {"text": "yaxis title"},
+            "title": {
+                "text": "yaxis title"
+
+            },
             "automargin": true,
             "anchor": "free"
         },
@@ -83,14 +87,20 @@
             "automargin": true
         },
         "yaxis3": {
-            "title": {"text": "yaxis3 title"},
+            "title": {
+                "text": "yaxis3 title"
+
+            },
             "anchor": "free",
             "overlaying": "y",
             "automargin": true
         },
         "yaxis4": {
-            "title": {"text": "yaxis4 title"},
             "anchor": "free",
+            "title": {
+                "text": "yaxis4 title"
+
+            },
             "overlaying": "y",
             "automargin": true
         }


### PR DESCRIPTION
WIP to automatically place multiple cartesian y-axes on a plot area. For now, I'm working to manually set the `xaxis` domain to make space for multiple axes and have multiple y-axes automatically drawn without overlap in that space. 

Some challenges/open questions: 
- My understanding is that `ax._depth` and `titleStandoff` can be added to give the full pixel width of an axis, including its ticks, tick labels, and title. 
- The current implementation seems to be resulting in the plot being redrawn multiple times. I'm not sure why this is.
- I've also set the axes to `automargin=True` to calculate the `ax._depth`, but this should ideally be refactored?