### PR TITLE
Fixed @ d3-color vulnerable to ReDoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "d3-geo": "^1.12.1",
         "d3-geo-projection": "^2.9.0",
         "d3-hierarchy": "^1.1.9",
-        "d3-interpolate": "^1.4.0",
+        "d3-interpolate": "^3.0.1",
         "d3-time": "^1.1.0",
         "d3-time-format": "^2.2.3",
         "fast-isnumeric": "^1.1.4",


### PR DESCRIPTION
The d3-color module provides representations for various color spaces in the browser. Versions prior to 3.1.0 are vulnerable to a Regular expression Denial of Service. This issue has been patched in version 3.1.0. There are no known workarounds.

Weaknesses
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
GHSA-36jr-mh4h-2g58
