### PR TITLE
Fix mapbox clearOutline calls

### DIFF
--- a/draftlogs/6367_fix.md
+++ b/draftlogs/6367_fix.md
@@ -1,0 +1,1 @@
+ - Fix mapbox clearOutline calls (regression introduced in 2.13.0) [[#6367](https://github.com/plotly/plotly.js/pull/6367)]

--- a/src/plots/mapbox/mapbox.js
+++ b/src/plots/mapbox/mapbox.js
@@ -593,7 +593,7 @@ proto.updateFx = function(fullLayout) {
     map.off('click', self.onClickInPanHandler);
     if(selectMode(dragMode) || drawMode(dragMode)) {
         map.dragPan.disable();
-        map.on('zoomstart', self.clearSelect);
+        map.on('zoomstart', self.clearOutline);
 
         self.dragOptions.prepFn = function(e, startX, startY) {
             prepSelect(e, startX, startY, self.dragOptions, dragMode);
@@ -602,7 +602,7 @@ proto.updateFx = function(fullLayout) {
         dragElement.init(self.dragOptions);
     } else {
         map.dragPan.enable();
-        map.off('zoomstart', self.clearSelect);
+        map.off('zoomstart', self.clearOutline);
         self.div.onmousedown = null;
         self.div.ontouchstart = null;
         self.div.removeEventListener('touchstart', self.div._ontouchstart);


### PR DESCRIPTION
Supersedes #6358.

Regression introduced in [v2.13.0](https://github.com/plotly/plotly.js/releases/tag/v2.13.0).

`clearSelect` method is renamed to `clearOutline` in #6243 by https://github.com/plotly/plotly.js/commit/23b812a0bbf0732f89e260904d6a793ed17d15a9.

cc: @plotly/plotly_js 
