### PR TITLE
disable interactions for `slider` when `staticPlot` is true

### DIFF
--- a/draftlogs/6393_fix.md
+++ b/draftlogs/6393_fix.md
@@ -1,0 +1,1 @@
+ - Disable slider interactions when `staticPlot` is true [[#6393](https://github.com/plotly/plotly.js/pull/6393)]

--- a/src/components/sliders/draw.js
+++ b/src/components/sliders/draw.js
@@ -449,6 +449,8 @@ function setActive(gd, sliderGroup, sliderOpts, index, doCallback, doTransition)
 }
 
 function attachGripEvents(item, gd, sliderGroup) {
+    if(gd._context.staticPlot) return;
+
     var node = sliderGroup.node();
     var $gd = d3.select(gd);
 


### PR DESCRIPTION
Fixes #6392.

@plotly/plotly_js 