### PR TITLE
no resize cursor on static sliders

### DIFF
--- a/draftlogs/6397_fix.md
+++ b/draftlogs/6397_fix.md
@@ -1,0 +1,1 @@
+ - Avoid displaying resize cursor on static sliders [[#6397](https://github.com/plotly/plotly.js/pull/6397)]

--- a/src/components/sliders/draw.js
+++ b/src/components/sliders/draw.js
@@ -17,6 +17,7 @@ var FROM_TL = alignmentConstants.FROM_TL;
 var FROM_BR = alignmentConstants.FROM_BR;
 
 module.exports = function draw(gd) {
+    var staticPlot = gd._context.staticPlot;
     var fullLayout = gd._fullLayout;
     var sliderData = makeSliderData(fullLayout, gd);
 
@@ -27,7 +28,7 @@ module.exports = function draw(gd) {
 
     sliders.enter().append('g')
         .classed(constants.containerClassName, true)
-        .style('cursor', 'ew-resize');
+        .style('cursor', staticPlot ? null : 'ew-resize');
 
     function clearSlider(sliderOpts) {
         if(sliderOpts._commandObserver) {


### PR DESCRIPTION
Fixes #6396.

@plotly/plotly_js 