### PR TITLE
Ensure `jasmine-core` v3.5.0 is installed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "gzip-size": "^6.0.0",
         "ify-loader": "^1.1.0",
         "into-stream": "^6.0.0",
-        "jasmine-core": "^3.5.0",
+        "jasmine-core": "3.5.0",
         "jsdom": "^19.0.0",
         "karma": "^6.4.0",
         "karma-chrome-launcher": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "gzip-size": "^6.0.0",
     "ify-loader": "^1.1.0",
     "into-stream": "^6.0.0",
-    "jasmine-core": "^3.5.0",
+    "jasmine-core": "3.5.0",
     "jsdom": "^19.0.0",
     "karma": "^6.4.0",
     "karma-chrome-launcher": "^3.1.1",


### PR DESCRIPTION
Pinning down `jasmine-core` to v3.5.0 for now.
There are newer versions of `jasmine-core` available; but bumping to those versions require adjusting tests.
cc: @plotly/plotly_js 