### PR TITLE
pin `jasmine` version for npm v8 users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "gzip-size": "^6.0.0",
         "ify-loader": "^1.1.0",
         "into-stream": "^6.0.0",
+        "jasmine": "3.5.0",
         "jasmine-core": "3.5.0",
         "jsdom": "^19.0.0",
         "karma": "^6.4.0",
@@ -7656,6 +7657,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jasmine": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
+      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "jasmine-core": "~3.5.0"
+      },
+      "bin": {
+        "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
@@ -18611,6 +18625,16 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
+    },
+    "jasmine": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.5.0.tgz",
+      "integrity": "sha512-DYypSryORqzsGoMazemIHUfMkXM7I7easFaxAvNM3Mr6Xz3Fy36TupTrAOxZWN8MVKEU5xECv22J4tUQf3uBzQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.4",
+        "jasmine-core": "~3.5.0"
+      }
     },
     "jasmine-core": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "gzip-size": "^6.0.0",
     "ify-loader": "^1.1.0",
     "into-stream": "^6.0.0",
+    "jasmine": "3.5.0",
     "jasmine-core": "3.5.0",
     "jsdom": "^19.0.0",
     "karma": "^6.4.0",


### PR DESCRIPTION
Avoid making `package-lock` diff when `npm install` using npm v8.
Supersedes #6418.

cc: @plotly/plotly_js 