### PR TITLE
Improve detection of mobile & tablet devices

### DIFF
--- a/draftlogs/6432_change.md
+++ b/draftlogs/6432_change.md
@@ -1,0 +1,1 @@
+ - Improve detection of mobile & tablet devices by upgrading `is-mobile` [[#6432](https://github.com/plotly/plotly.js/pull/6432)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "glslify": "^7.1.1",
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
-        "is-mobile": "^2.2.2",
+        "is-mobile": "^3.1.1",
         "mapbox-gl": "1.10.1",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
@@ -7389,9 +7389,9 @@
       }
     },
     "node_modules/is-mobile": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
-      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-3.1.1.tgz",
+      "integrity": "sha512-RRoXXR2HNFxNkUnxtaBdGBXtFlUMFa06S0NUKf/LCF+MuGLu13gi9iBCkoEmc6+rpXuwi5Mso5V8Zf7mNynMBQ=="
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
@@ -18443,9 +18443,9 @@
       "dev": true
     },
     "is-mobile": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
-      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-3.1.1.tgz",
+      "integrity": "sha512-RRoXXR2HNFxNkUnxtaBdGBXtFlUMFa06S0NUKf/LCF+MuGLu13gi9iBCkoEmc6+rpXuwi5Mso5V8Zf7mNynMBQ=="
     },
     "is-nan": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "glslify": "^7.1.1",
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
-    "is-mobile": "^2.2.2",
+    "is-mobile": "^3.1.1",
     "mapbox-gl": "1.10.1",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",


### PR DESCRIPTION
Bump [`is-mobile`](https://www.npmjs.com/package/is-mobile) to v3.1.1 which includes following improvements:
 - detect armv7l-based mobile devices: https://github.com/juliangruber/is-mobile/releases/tag/v3.0.0
 - add support for SamsungBrowser: https://github.com/juliangruber/is-mobile/releases/tag/v3.1.0
 - fix CrOS being considered mobile: https://github.com/juliangruber/is-mobile/releases/tag/v3.1.1
 
`is-mobile` module is used in `preserveDrawingBuffer` for WebGL based traces.

 @plotly/plotly_js 