### PR TITLE
Bump required npm version from 7 to 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "start": "node devtools/test_dashboard/server.js",
     "baseline": "node test/image/make_baseline.js",
     "noci-baseline": "npm run cibuild && ./tasks/noci_test.sh image && git checkout dist && echo 'Please do not commit unless the change was expected!'",
-    "preversion": "check-node-version --node 16 --npm 7 && npm-link-check && npm ls --prod --all",
+    "preversion": "check-node-version --node 16 --npm 8 && npm-link-check && npm ls --prod --all",
     "version": "npm run build && npm run no-bad-char && git add -A lib dist build src/version.js",
     "postversion": "node -e \"console.log('Version bumped and committed. If ok, run: git push && git push --tags')\"",
     "postpublish": "node tasks/sync_packages.js",


### PR DESCRIPTION
So that we could latest node 16 version (currently at v16.19.0) during the release process.

cc: @plotly/plotly_js 