### PR TITLE
bump dockers to `cimg` node 16.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
   install-and-cibuild: # main cibuild using node 16 & npm 7
     docker:
-      - image: cimg/node:16.8.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
   timezone-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
@@ -85,7 +85,7 @@ jobs:
   no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -105,7 +105,7 @@ jobs:
   webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -125,7 +125,7 @@ jobs:
   flaky-no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -144,7 +144,7 @@ jobs:
   bundle-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -163,7 +163,7 @@ jobs:
   mathjax-firefox81:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -182,7 +182,7 @@ jobs:
   mathjax-firefox82:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -201,7 +201,7 @@ jobs:
   mathjax-firefoxLatest:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.8.0-browsers
+      - image: cimg/node:16.17.1-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -255,7 +255,7 @@ jobs:
 
   test-baselines:
     docker:
-      - image: circleci/node:16.8.0
+      - image: circleci/node:16.9.0
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -269,7 +269,7 @@ jobs:
 
   test-baselines-mathjax3:
     docker:
-      - image: circleci/node:16.8.0
+      - image: circleci/node:16.9.0
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -306,7 +306,7 @@ jobs:
 
   test-exports:
     docker:
-      - image: circleci/node:16.8.0
+      - image: circleci/node:16.9.0
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -320,7 +320,7 @@ jobs:
 
   mock-validation:
     docker:
-      - image: cimg/node:16.8.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -334,7 +334,7 @@ jobs:
 
   source-syntax:
     docker:
-      - image: cimg/node:16.8.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -345,7 +345,7 @@ jobs:
 
   publish-dist:
     docker:
-      - image: cimg/node:16.8.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - checkout


### PR DESCRIPTION
Test for old FireFox versions fail on most recent versions i.e. `16.18` and `16.19` containers which may be addressed by CircleCI later. cc: @antoinerg 
Upgrading to 16.17.1 for now.

cc: @plotly/plotly_js 