### PR TITLE
Fix library's imported name using `requirejs` AMD loader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,9 @@ jobs:
           name: Test plot-schema.json diff - If failed, after (npm start) you could run (npm run schema && git add test/plot-schema.json && git commit -m "update plot-schema diff")
           command: diff --unified --color dist/plot-schema.json test/plot-schema.json
       - run:
+          name: Test plotly.min.js import using amdefine
+          command: npm run test-amdefine
+      - run:
           name: Test plotly.min.js import using requirejs
           command: npm run test-requirejs
       - run:

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,6 @@ node_modules
 dist
 build
 
+tasks/test_amdefine.js
 tasks/test_requirejs.js
 test/jasmine/assets/jquery-1.8.3.min.js

--- a/devtools/test_dashboard/server.js
+++ b/devtools/test_dashboard/server.js
@@ -38,7 +38,7 @@ devtoolsConfig.output = {
     library: {
         name: 'Tabs',
         type: 'umd',
-        umdNamedDefine: true
+        umdNamedDefine: false
     }
 };
 

--- a/devtools/test_dashboard/server.js
+++ b/devtools/test_dashboard/server.js
@@ -35,7 +35,10 @@ devtoolsConfig.entry = path.join(devtoolsPath, 'devtools.js');
 devtoolsConfig.output = {
     path: config.output.path,
     filename: 'test_dashboard-bundle.js',
-    library: {...config.output.library, name: 'Tabs'}
+    library: {
+        name: 'Tabs',
+        type: 'umd'
+    }
 };
 
 devtoolsConfig.target = config.target;

--- a/devtools/test_dashboard/server.js
+++ b/devtools/test_dashboard/server.js
@@ -35,11 +35,7 @@ devtoolsConfig.entry = path.join(devtoolsPath, 'devtools.js');
 devtoolsConfig.output = {
     path: config.output.path,
     filename: 'test_dashboard-bundle.js',
-    library: {
-        name: 'Tabs',
-        type: 'umd',
-        umdNamedDefine: false
-    }
+    library: config.output.library
 };
 
 devtoolsConfig.target = config.target;

--- a/devtools/test_dashboard/server.js
+++ b/devtools/test_dashboard/server.js
@@ -35,7 +35,7 @@ devtoolsConfig.entry = path.join(devtoolsPath, 'devtools.js');
 devtoolsConfig.output = {
     path: config.output.path,
     filename: 'test_dashboard-bundle.js',
-    library: config.output.library
+    library: {...config.output.library, name: 'Tabs'}
 };
 
 devtoolsConfig.target = config.target;

--- a/draftlogs/6440_fix.md
+++ b/draftlogs/6440_fix.md
@@ -1,0 +1,1 @@
+ - Fix library's imported name using `requirejs` AMD loader (regression introduced in 2.17.0) [[#6440](https://github.com/plotly/plotly.js/pull/6440)]

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test-export": "node test/image/export_test.js",
     "test-syntax": "node tasks/test_syntax.js && npm run find-strings -- --no-output",
     "test-bundle": "node tasks/test_bundle.js",
+    "test-amdefine": "node tasks/test_amdefine.js",
     "test-requirejs": "node tasks/test_requirejs.js",
     "test-plain-obj": "node tasks/test_plain_obj.js",
     "test": "npm run test-jasmine -- --nowatch && npm run test-bundle && npm run test-image && npm run test-export && npm run test-syntax && npm run lint",

--- a/tasks/test_amdefine.js
+++ b/tasks/test_amdefine.js
@@ -8,19 +8,21 @@ global.DOMParser = global.window.DOMParser;
 global.getComputedStyle = global.window.getComputedStyle;
 global.window.URL.createObjectURL = function() {};
 
-var requirejs = require('requirejs');
+// see: Building node modules with AMD or RequireJS https://requirejs.org/docs/node.html
+if(typeof define !== 'function') {
+    var define = require('amdefine')(module);
+}
 
-requirejs.config({
-    paths: {
-        'plotly': '../dist/plotly.min'
-    }
-});
+define(function(require) {
+    var plotly = require('../dist/plotly.min.js');
 
-requirejs(['plotly'],
-function(plotly) {
     if(plotly) {
         console.log(plotly);
     } else {
-        throw 'Error: loading with requirejs';
+        throw 'Error: loading with amdefine';
     }
+
+    // The value returned from the function is
+    // used as the module export visible to Node.
+    return function() {};
 });

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -5,6 +5,7 @@ var minimist = require('minimist');
 var NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 var LoaderOptionsPlugin = require('webpack').LoaderOptionsPlugin;
 var constants = require('../../tasks/util/constants');
+var webpackConfig = require('../../webpack.config.js');
 
 var isCI = Boolean(process.env.CI);
 
@@ -298,11 +299,7 @@ func.defaultConfig = {
             new LoaderOptionsPlugin({
                 // test: /\.xxx$/, // may apply this only for some modules
                 options: {
-                    library: {
-                        name: 'Plotly',
-                        type: 'umd',
-                        umdNamedDefine: false
-                    }
+                    library: webpackConfig.output.library
                 }
             })
         ]

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -301,7 +301,7 @@ func.defaultConfig = {
                     library: {
                         name: 'Plotly',
                         type: 'umd',
-                        umdNamedDefine: true
+                        umdNamedDefine: false
                     }
                 }
             })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
         library: {
             name: 'Plotly',
             type: 'umd',
-            umdNamedDefine: true
+            umdNamedDefine: false
         }
     },
     module: {


### PR DESCRIPTION
Potential fix discovered by @alexcjohnson for AMD require in the docs

@plotly/plotly_js 