### PR TITLE
Avoid extra redraw calls when updating axes with `tickmode` other than sync

### DIFF
--- a/draftlogs/6356_add.md
+++ b/draftlogs/6356_add.md
@@ -1,1 +1,1 @@
-- Add `sync` tickmode option [[#6356](https://github.com/plotly/plotly.js/pull/6356)]
+- Add `sync` tickmode option [[#6356](https://github.com/plotly/plotly.js/pull/6356), [#6443](https://github.com/plotly/plotly.js/pull/6443)]

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -729,7 +729,9 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
 
         function pushActiveAxIdsSynced(axList, axisType) {
             for(i = 0; i < axList.length; i++) {
-                if(!axList[i].fixedrange && axList[i][axisType]) {activeAxIds.push(axList[i][axisType]._id);}
+                var axListI = axList[i];
+                var axListIType = axListI[axisType];
+                if(!axListI.fixedrange && axListIType.tickmode === 'sync') activeAxIds.push(axListIType._id);
             }
         }
 


### PR DESCRIPTION
Follow up of #6356. 
Fix for cartesian interact noCi test: https://github.com/plotly/plotly.js/blob/360213e73deb959d1f0d360c7f570d92b427dc22/test/jasmine/tests/cartesian_interact_test.js#L1452

cc: @plotly/plotly_js 
