### PR TITLE
Fix hover on IE

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -2124,8 +2124,8 @@ function getBoundingClientRect(gd, node) {
 
     var rect = node.getBoundingClientRect();
 
-    var x0 = rect.x;
-    var y0 = rect.y;
+    var x0 = rect.left;
+    var y0 = rect.top;
     var x1 = x0 + rect.width;
     var y1 = y0 + rect.height;
 

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -145,8 +145,6 @@ function isTransformableElement(element) {
 function equalDomRects(a, b) {
     return (
         a && b &&
-        a.x === b.x &&
-        a.y === b.y &&
         a.top === b.top &&
         a.left === b.left &&
         a.right === b.right &&


### PR DESCRIPTION
Fix regression introduced in [v2.5.0](https://github.com/plotly/plotly.js/releases/tag/v2.5.0 by https://github.com/plotly/plotly.js/commit/388986b777. cc: #5916.

It appears the [`getBoundingClientRect`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) method on IE does not return `x` and `y`!

Instead one should use `left` and `top`.

@plotly/plotly_js 