### PR TITLE
Avoid attaching internal d3 object to the window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.18.1",
       "license": "MIT",
       "dependencies": {
-        "@plotly/d3": "3.8.0",
+        "@plotly/d3": "3.8.1",
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
         "@turf/area": "^6.4.0",
@@ -2160,9 +2160,9 @@
       }
     },
     "node_modules/@plotly/d3": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.0.tgz",
-      "integrity": "sha512-L10iHgzvw3uSic/nQpYehlNzxUQvImwms5U7S95pJAEhrllzkrdQNy1Mc5DW9ab881Yr4fh300gJztKXWZDfkQ=="
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.1.tgz",
+      "integrity": "sha512-x49ThEu1FRA00kTso4Jdfyf2byaCPLBGmLjAYQz5OzaPyLUhHesX3/Nfv2OHEhynhdy2UB39DLXq6thYe2L2kg=="
     },
     "node_modules/@plotly/d3-sankey": {
       "version": "0.7.2",
@@ -14107,9 +14107,9 @@
       }
     },
     "@plotly/d3": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.0.tgz",
-      "integrity": "sha512-L10iHgzvw3uSic/nQpYehlNzxUQvImwms5U7S95pJAEhrllzkrdQNy1Mc5DW9ab881Yr4fh300gJztKXWZDfkQ=="
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.1.tgz",
+      "integrity": "sha512-x49ThEu1FRA00kTso4Jdfyf2byaCPLBGmLjAYQz5OzaPyLUhHesX3/Nfv2OHEhynhdy2UB39DLXq6thYe2L2kg=="
     },
     "@plotly/d3-sankey": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     ]
   },
   "dependencies": {
-    "@plotly/d3": "3.8.0",
+    "@plotly/d3": "3.8.1",
     "@plotly/d3-sankey": "0.7.2",
     "@plotly/d3-sankey-circular": "0.33.1",
     "@turf/area": "^6.4.0",

--- a/test/jasmine/bundle_tests/minified_bundle_test.js
+++ b/test/jasmine/bundle_tests/minified_bundle_test.js
@@ -25,4 +25,8 @@ describe('Test plotly.min.js', function() {
             Plotly.newPlot(gd, mockSpec[1]).catch(fail).then(done);
         }, LONG_TIMEOUT_INTERVAL);
     });
+
+    it('should not expose d3', function() {
+        expect(window.d3).not.toBeDefined();
+    });
 });


### PR DESCRIPTION
Fixes #6483.
Regression introduced in v2.17.0 bundles.
@plotly/plotly_js 