### PR TITLE
[Documentation] Clarify x0,y0 in image trace

### DIFF
--- a/src/traces/image/attributes.js
+++ b/src/traces/image/attributes.js
@@ -84,7 +84,11 @@ module.exports = extendFlat({
         valType: 'any',
         dflt: 0,
         editType: 'calc+clearAxisTypes',
-        description: 'Set the image\'s x position. The bottom left corner of the image will be found at xmin=x0-dx/2'
+        description: [
+            'Set the image\'s x position. The left edge of the image',
+            '(or the right edge if the x axis is reversed or dx is negative)',
+            'will be found at xmin=x0-dx/2'
+        ].join(' ')
     },
     y0: {
         valType: 'any',

--- a/src/traces/image/attributes.js
+++ b/src/traces/image/attributes.js
@@ -94,7 +94,14 @@ module.exports = extendFlat({
         valType: 'any',
         dflt: 0,
         editType: 'calc+clearAxisTypes',
-        description: 'Set the image\'s y position. The bottom left corner of the image will be found at y0-dy/2'
+        description: [
+            'Set the image\'s y position. The top edge of the image',
+            '(or the bottom edge if the y axis is NOT reversed or if dy is negative)',
+            'will be found at ymin=y0-dy/2. By default when an image trace is',
+            'included, the y axis will be reversed so that the image is right-side-up,',
+            'but you can disable this by setting yaxis.autorange=true or by providing',
+            'an explicit y axis range.'
+        ].join(' ')
     },
     dx: {
         valType: 'number',

--- a/src/traces/image/attributes.js
+++ b/src/traces/image/attributes.js
@@ -84,13 +84,13 @@ module.exports = extendFlat({
         valType: 'any',
         dflt: 0,
         editType: 'calc+clearAxisTypes',
-        description: 'Set the image\'s x position.'
+        description: 'Set the image\'s x position. The bottom left corner of the image will be found at xmin=x0-dx/2'
     },
     y0: {
         valType: 'any',
         dflt: 0,
         editType: 'calc+clearAxisTypes',
-        description: 'Set the image\'s y position.'
+        description: 'Set the image\'s y position. The bottom left corner of the image will be found at y0-dy/2'
     },
     dx: {
         valType: 'number',

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -35043,7 +35043,7 @@
      ]
     },
     "x0": {
-     "description": "Set the image's x position.",
+     "description": "Set the image's x position. The left edge of the image (or the right edge if the x axis is reversed or dx is negative) will be found at xmin=x0-dx/2",
      "dflt": 0,
      "editType": "calc+clearAxisTypes",
      "valType": "any"
@@ -35055,7 +35055,7 @@
      "valType": "subplotid"
     },
     "y0": {
-     "description": "Set the image's y position.",
+     "description": "Set the image's y position. The top edge of the image (or the bottom edge if the y axis is NOT reversed or if dy is negative) will be found at ymin=y0-dy/2. By default when an image trace is included, the y axis will be reversed so that the image is right-side-up, but you can disable this by setting yaxis.autorange=true or by providing an explicit y axis range.",
      "dflt": 0,
      "editType": "calc+clearAxisTypes",
      "valType": "any"


### PR DESCRIPTION
The [image trace](https://plotly.com/javascript/reference/image/#image-x0) defines x0 and y0 properties as "Set the image's x position." 

In my opinion that's not very precise, because it is not clear if it refers to some corner or the center of the image.

From my experimentation, it refers to the "center of the bottom left pixel".

Therefore I suggest to use:

    Set the image\'s x position. The bottom left corner of the image will be found at xmin=x0-dx/2'

Please review this suggestion, since I am not sure if this holds true for any possible advanced axis transformations (I'm a plotly beginner). In my opinion it gives a more precise definition, at least for basic plots.

Thanks for your time and work