### PR TITLE
fix-6507 fixed colorbar.showticklabels: false

### DIFF
--- a/src/components/colorbar/defaults.js
+++ b/src/components/colorbar/defaults.js
@@ -82,7 +82,7 @@ module.exports = function colorbarDefaults(containerIn, containerOut, layout) {
 
     coerce('title.text', layout._dfltTitle.colorbar);
 
-    var tickFont = colorbarOut.tickfont;
+    var tickFont = colorbarOut.showticklabels ? colorbarOut.tickfont : font;
     var dfltTitleFont = Lib.extendFlat({}, tickFont, {
         color: font.color,
         size: Lib.bigFont(tickFont.size)


### PR DESCRIPTION
Fixes #6507.
fixed cannot read properties of undefined (reading 'size') for attr colorbarOut.tickfont in file src/components/colorbar/defaults.js
