### PR TITLE
Add --strict option to custom bundle

### DIFF
--- a/CUSTOM_BUNDLE.md
+++ b/CUSTOM_BUNDLE.md
@@ -30,6 +30,11 @@ Or use `transforms none` to exclude them all.
 npm run custom-bundle -- --transforms none
 ```
 
+Use the `strict` option to use strict trace types where possible.
+```sh
+npm run custom-bundle -- --traces scatter,scattergl --strict
+```
+
 Use the `out` option to change the bundle filename (default `custom`).
 The new bundle will be created in the `dist/` directory and named `plotly-<out>.min.js` or `plotly-<out>.js` if unminified.
 ```sh

--- a/draftlogs/6557_add.md
+++ b/draftlogs/6557_add.md
@@ -1,0 +1,1 @@
+- Add --strict option to custom bundle command so that strict traces can be used in a custom bundle. [[#6557](https://github.com/plotly/plotly.js/pull/6557)]

--- a/draftlogs/6557_add.md
+++ b/draftlogs/6557_add.md
@@ -1,1 +1,1 @@
-- Add --strict option to custom bundle command so that strict traces can be used in a custom bundle. [[#6557](https://github.com/plotly/plotly.js/pull/6557)]
+ - Add strict option to custom bundle command [[#6557](https://github.com/plotly/plotly.js/pull/6557)], with thanks to @CallumNZ for the contribution!

--- a/tasks/custom_bundle.js
+++ b/tasks/custom_bundle.js
@@ -56,13 +56,15 @@ if(process.argv.length > 2) {
     var out = args.out ? args.out : 'custom';
     var traces = inputArray(args.traces, allTraces);
     var transforms = inputArray(args.transforms, allTransforms);
+    var strict = inputBoolean(args.strict, false);
 
     var opts = {
         traceList: createList(['scatter'], traces, allTraces, 'trace'),
         transformList: createList([], transforms, allTransforms, 'transform'),
 
         name: out,
-        index: path.join(constants.pathToLib, 'index-' + out + '.js')
+        index: path.join(constants.pathToLib, 'index-' + (strict ? 'strict-' : '') + out + '.js'),
+        strict: strict,
     };
 
     if(unminified) {

--- a/tasks/partial_bundle.js
+++ b/tasks/partial_bundle.js
@@ -36,7 +36,7 @@ module.exports = function partialBundle(tasks, opts) {
                 // remove require
                 var regEx = WHITESPACE_BEFORE + 'require\\(\'\\./' + t + '\'\\),';
                 if(strict) {
-                    regEx += '|require\\(\'\\.\\./src/traces/' + t + '/strict\'\\),'
+                    regEx += '|require\\(\'\\.\\./src/traces/' + t + '/strict\'\\),';
                 }
                 var newCode = partialIndex.replace(new RegExp(regEx, 'g'), '');
 

--- a/tasks/partial_bundle.js
+++ b/tasks/partial_bundle.js
@@ -8,6 +8,7 @@ var header = constants.licenseDist + '\n';
 var allTransforms = constants.allTransforms;
 var allTraces = constants.allTraces;
 var mainIndex = constants.mainIndex;
+var strictIndex = constants.strictIndex;
 
 // Bundle the plotly.js partial bundles
 module.exports = function partialBundle(tasks, opts) {
@@ -19,11 +20,12 @@ module.exports = function partialBundle(tasks, opts) {
     var traceList = opts.traceList;
     var transformList = opts.transformList;
     var calendars = opts.calendars;
+    var strict = opts.strict;
 
     // skip strict bundle which is no longer a partial bundle and has a special index file for regl traces
     if(name !== 'strict') {
         tasks.push(function(done) {
-            var partialIndex = mainIndex;
+            var partialIndex = (strict) ? strictIndex : mainIndex;
 
             var all = ['calendars'].concat(allTransforms).concat(allTraces);
             var includes = (calendars ? ['calendars'] : []).concat(transformList).concat(traceList);
@@ -35,8 +37,9 @@ module.exports = function partialBundle(tasks, opts) {
                 var newCode = partialIndex.replace(
                     new RegExp(
                         WHITESPACE_BEFORE +
-                        'require\\(\'\\./' + t + '\'\\),',
-                    'g'), ''
+                        'require\\(\'\\./' + t + '\'\\),' + '|' +
+                        'require\\(\'\\.\\./src/traces/' + t + '/strict\'\\),',
+                        'g'), ''
                 );
 
                 // test removal

--- a/tasks/partial_bundle.js
+++ b/tasks/partial_bundle.js
@@ -35,7 +35,7 @@ module.exports = function partialBundle(tasks, opts) {
                 var WHITESPACE_BEFORE = '\\s*';
                 // remove require
                 var regEx = WHITESPACE_BEFORE + 'require\\(\'\\./' + t + '\'\\),';
-                if (strict) {
+                if(strict) {
                     regEx += '|require\\(\'\\.\\./src/traces/' + t + '/strict\'\\),'
                 }
                 var newCode = partialIndex.replace(new RegExp(regEx, 'g'), '');

--- a/tasks/partial_bundle.js
+++ b/tasks/partial_bundle.js
@@ -34,13 +34,11 @@ module.exports = function partialBundle(tasks, opts) {
             excludes.forEach(function(t) {
                 var WHITESPACE_BEFORE = '\\s*';
                 // remove require
-                var newCode = partialIndex.replace(
-                    new RegExp(
-                        WHITESPACE_BEFORE +
-                        'require\\(\'\\./' + t + '\'\\),' + '|' +
-                        'require\\(\'\\.\\./src/traces/' + t + '/strict\'\\),',
-                        'g'), ''
-                );
+                var regEx = WHITESPACE_BEFORE + 'require\\(\'\\./' + t + '\'\\),';
+                if (strict) {
+                    regEx += '|require\\(\'\\.\\./src/traces/' + t + '/strict\'\\),'
+                }
+                var newCode = partialIndex.replace(new RegExp(regEx, 'g'), '');
 
                 // test removal
                 if(newCode === partialIndex) {

--- a/tasks/util/constants.js
+++ b/tasks/util/constants.js
@@ -20,6 +20,7 @@ function startsWithLowerCase(v) {
 var pathToPlotlyIndex = path.join(pathToLib, 'index.js');
 var pathToPlotlyStrict = path.join(pathToLib, 'index-strict.js');
 var mainIndex = fs.readFileSync(pathToPlotlyIndex, 'utf-8');
+var strictIndex = fs.readFileSync(pathToPlotlyStrict, 'utf-8');
 var allTraces = fs.readdirSync(path.join(pathToSrc, 'traces'))
     .filter(startsWithLowerCase);
 
@@ -191,6 +192,7 @@ module.exports = {
     allTransforms: allTransforms,
     allTraces: allTraces,
     mainIndex: mainIndex,
+    strictIndex: strictIndex,
     pathToPlotlyIndex: pathToPlotlyIndex,
     pathToPlotlyStrict: pathToPlotlyStrict,
     pathToPlotlyCore: path.join(pathToSrc, 'core.js'),


### PR DESCRIPTION
Reference: https://github.com/plotly/plotly.js/issues/6496

**Changes:**
- Add --strict option to custom bundle command so that strict traces can be used in a custom bundle.