### PR TITLE
added tabletmode to fire plotly_click event for mobile devices.

### DIFF
--- a/draftlogs/6563_fix.md
+++ b/draftlogs/6563_fix.md
@@ -1,1 +1,2 @@
- - fix condition of `plotly_click` to fire it on touch devices [[#6563](https://github.com/plotly/plotly.js/pull/6563)]
+ - fix `plotly_click` in gl3d scenes to fire on touch devices [[#6563](https://github.com/plotly/plotly.js/pull/6563)],
+   with thanks to @NickTominaga for the contribution!

--- a/draftlogs/6563_fix.md
+++ b/draftlogs/6563_fix.md
@@ -1,0 +1,1 @@
+ - fix condition of `plotly_click` to fire it on touch devices [[#6563](https://github.com/plotly/plotly.js/pull/6563)]

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -454,9 +454,7 @@ proto.render = function() {
             pointData.bbox = bbox[0];
         }
 
-        if(selection.buttons && selection.distance < 5 && !tabletmode) {
-            gd.emit('plotly_click', eventData);
-        } else if(tabletmode && selection.distance < 5) {
+        if(selection.distance < 5 && (selection.buttons || tabletmode)) {
             gd.emit('plotly_click', eventData);
         } else {
             gd.emit('plotly_hover', eventData);

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -24,6 +24,8 @@ var computeTickMarks = require('./layout/tick_marks');
 
 var STATIC_CANVAS, STATIC_CONTEXT;
 
+var tabletmode = false;
+
 function Scene(options, fullLayout) {
     // create sub container for plot
     var sceneContainer = document.createElement('div');
@@ -241,6 +243,10 @@ proto.initializeGLPlot = function() {
             relayoutCallback(scene);
         });
 
+        scene.glplot.canvas.addEventListener('touchstart', function() {
+            tabletmode = true;
+        });
+
         scene.glplot.canvas.addEventListener('wheel', function(e) {
             if(gd._context._scrollZoom.gl3d) {
                 if(scene.camera._ortho) {
@@ -448,7 +454,9 @@ proto.render = function() {
             pointData.bbox = bbox[0];
         }
 
-        if(selection.buttons && selection.distance < 5) {
+        if(selection.buttons && selection.distance < 5 && !tabletmode) {
+            gd.emit('plotly_click', eventData);
+        }else if(tabletmode && selection.distance < 5) {
             gd.emit('plotly_click', eventData);
         } else {
             gd.emit('plotly_hover', eventData);

--- a/src/plots/gl3d/scene.js
+++ b/src/plots/gl3d/scene.js
@@ -456,7 +456,7 @@ proto.render = function() {
 
         if(selection.buttons && selection.distance < 5 && !tabletmode) {
             gd.emit('plotly_click', eventData);
-        }else if(tabletmode && selection.distance < 5) {
+        } else if(tabletmode && selection.distance < 5) {
             gd.emit('plotly_click', eventData);
         } else {
             gd.emit('plotly_hover', eventData);


### PR DESCRIPTION
I added tabletmode flag and touchstart event to fire `plotly_click` event on `scatter3d` plot for mobile devices.