### PR TITLE
Fix dx/dy mix up in  display_outlines.js

### DIFF
--- a/src/components/shapes/display_outlines.js
+++ b/src/components/shapes/display_outlines.js
@@ -249,8 +249,8 @@ module.exports = function displayOutlines(polygons, outlines, dragOptions, nCall
                     var dx = nextPoint[1] - x;
                     var dy = nextPoint[2] - y;
 
-                    var width = dy ? 5 : Math.max(Math.min(25, Math.abs(dx) - 5), 5);
-                    var height = dx ? 5 : Math.max(Math.min(25, Math.abs(dy) - 5), 5);
+                    var width = dx ? 5 : Math.max(Math.min(25, Math.abs(dx) - 5), 5);
+                    var height = dy ? 5 : Math.max(Math.min(25, Math.abs(dy) - 5), 5);
 
                     vertex.classed(dy ? 'cursor-ew-resize' : 'cursor-ns-resize', true)
                         .attr('width', width)

--- a/src/components/shapes/display_outlines.js
+++ b/src/components/shapes/display_outlines.js
@@ -249,8 +249,8 @@ module.exports = function displayOutlines(polygons, outlines, dragOptions, nCall
                     var dx = nextPoint[1] - x;
                     var dy = nextPoint[2] - y;
 
-                    var width = dx ? 5 : Math.max(Math.min(25, Math.abs(dx) - 5), 5);
-                    var height = dy ? 5 : Math.max(Math.min(25, Math.abs(dy) - 5), 5);
+                    var width = dx ? Math.max(Math.min(25, Math.abs(dx) - 5), 5): 5;
+                    var height = dy ? Math.max(Math.min(25, Math.abs(dy) - 5), 5): 5;
 
                     vertex.classed(dy ? 'cursor-ew-resize' : 'cursor-ns-resize', true)
                         .attr('width', width)

--- a/src/components/shapes/display_outlines.js
+++ b/src/components/shapes/display_outlines.js
@@ -249,8 +249,8 @@ module.exports = function displayOutlines(polygons, outlines, dragOptions, nCall
                     var dx = nextPoint[1] - x;
                     var dy = nextPoint[2] - y;
 
-                    var width = dx ? Math.max(Math.min(25, Math.abs(dx) - 5), 5): 5;
-                    var height = dy ? Math.max(Math.min(25, Math.abs(dy) - 5), 5): 5;
+                    var width = dx ? Math.max(Math.min(25, Math.abs(dx) - 5), 5) : 5;
+                    var height = dy ? Math.max(Math.min(25, Math.abs(dy) - 5), 5) : 5;
 
                     vertex.classed(dy ? 'cursor-ew-resize' : 'cursor-ns-resize', true)
                         .attr('width', width)


### PR DESCRIPTION
The dx and dy variables were swapped here. This causes an error in making one region too big, preventing other functions (like select) from being available.

As the following video shows, the areas these regions cover is off on a few: some are over to right, one covers the whole plot. I believe that fixing this bug will fix them all.

![plotly-dx-dy-bug](https://user-images.githubusercontent.com/168568/232250218-066e9a0a-886c-4447-8c3a-4952d9364e55.gif)
