### PR TITLE
Fix heatmap/image traces without zsmooth on Safari/iOS

### DIFF
--- a/draftlogs/6605_fix.md
+++ b/draftlogs/6605_fix.md
@@ -1,0 +1,1 @@
+ - Fix heatmap rendering on Safari when `zsmooth` is set to false [[#6605](https://github.com/plotly/plotly.js/pull/6605)], with thanks to @lvlte for the contribution!

--- a/src/lib/supports_pixelated_image.js
+++ b/src/lib/supports_pixelated_image.js
@@ -15,7 +15,7 @@ function supportsPixelatedImage() {
     if(_supportsPixelated !== null) { // only run the feature detection once
         return _supportsPixelated;
     }
-    if(Lib.isIE() || Lib.isSafari()) {
+    if(Lib.isIE() || Lib.isSafari() || lib.isIOS()) {
         // NB. Safari passes the test below but the final rendering is not pixelated
         _supportsPixelated = false;
     } else {

--- a/src/lib/supports_pixelated_image.js
+++ b/src/lib/supports_pixelated_image.js
@@ -15,28 +15,39 @@ function supportsPixelatedImage() {
     if(_supportsPixelated !== null) { // only run the feature detection once
         return _supportsPixelated;
     }
-    if(Lib.isIE() || Lib.isSafari() || Lib.isIOS()) {
-        // NB. Safari passes the test below but the final rendering is not pixelated
-        _supportsPixelated = false;
-    } else {
+
+    _supportsPixelated = false;
+
+    // @see https://github.com/plotly/plotly.js/issues/6604
+    var unsupportedBrowser = Lib.isIE() || Lib.isSafari() || Lib.isIOS();
+
+    if(window.navigator.userAgent && !unsupportedBrowser) {
         var declarations = Array.from(constants.CSS_DECLARATIONS).reverse();
-        var supports = window.CSS && window.CSS.supports || window.supportsCSS;
+
+        var supports = (window.CSS && window.CSS.supports) || window.supportsCSS;
         if(typeof supports === 'function') {
             _supportsPixelated = declarations.some(function(d) {
                 return supports.apply(null, d);
             });
         } else {
-            var image3 = Drawing.tester.append('image');
+            var image3 = Drawing.tester.append('image')
+                .attr('style', constants.STYLE);
+
             var cStyles = window.getComputedStyle(image3.node());
-            image3.attr('style', constants.STYLE);
+            var imageRendering = cStyles.imageRendering;
+
             _supportsPixelated = declarations.some(function(d) {
                 var value = d[1];
-                return cStyles.imageRendering === value ||
-                       cStyles.imageRendering === value.toLowerCase();
+                return (
+                    imageRendering === value ||
+                    imageRendering === value.toLowerCase()
+                );
             });
+
             image3.remove();
         }
     }
+
     return _supportsPixelated;
 }
 

--- a/src/lib/supports_pixelated_image.js
+++ b/src/lib/supports_pixelated_image.js
@@ -15,7 +15,8 @@ function supportsPixelatedImage() {
     if(_supportsPixelated !== null) { // only run the feature detection once
         return _supportsPixelated;
     }
-    if(Lib.isIE()) {
+    if(Lib.isIE() || Lib.isSafari()) {
+        // NB. Safari passes the test below but the final rendering is not pixelated
         _supportsPixelated = false;
     } else {
         var declarations = Array.from(constants.CSS_DECLARATIONS).reverse();

--- a/src/lib/supports_pixelated_image.js
+++ b/src/lib/supports_pixelated_image.js
@@ -15,7 +15,7 @@ function supportsPixelatedImage() {
     if(_supportsPixelated !== null) { // only run the feature detection once
         return _supportsPixelated;
     }
-    if(Lib.isIE() || Lib.isSafari() || lib.isIOS()) {
+    if(Lib.isIE() || Lib.isSafari() || Lib.isIOS()) {
         // NB. Safari passes the test below but the final rendering is not pixelated
         _supportsPixelated = false;
     } else {


### PR DESCRIPTION
Fixes #6604

Safari doesn't behave consistently with pixelated image-rendering (depends on whether the target object is an `<image>` or an `<img>`, whether there is a transform applied on the object, etc.) although it's supposed to support it and even though it passes the css support test. It seems like a webkit bug (it should not pass the css support test) ? 

So I guess the best option for now is to prevent the pixelated rendering optimization on Safari. 