### PR TITLE
Fix for #6614

### DIFF
--- a/draftlogs/6615_fix.md
+++ b/draftlogs/6615_fix.md
@@ -1,0 +1,2 @@
+- Fix to prevent accessing undefined (hoverText.hoverLabels) in case all currently shown markers have hoverinfo: "none" [#6614]([https://github.com/plotly/plotly.js/pull/5854](https://github.com/plotly/plotly.js/issues/6614)),
+   with thanks to @Domino987 for the contribution!

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1126,7 +1126,7 @@ function createHoverText(hoverData, opts) {
         container.selectAll('g.hovertext').remove();
         var groupedHoverData = hoverData.filter(function(data) {return data.hoverinfo !== 'none';});
         // Return early if nothing is hovered on
-        if(groupedHoverData.length === 0) return;
+        if(groupedHoverData.length === 0) return [];
 
         // mock legend
         var hoverlabel = fullLayout.hoverlabel;

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4725,6 +4725,41 @@ describe('hovermode: (x|y)unified', function() {
         })
         .then(done, done.fail);
     });
+    
+    it('should not fail if only hoverinfo: "none" are current visible', function(done) {
+        Plotly.newPlot(gd, {
+            data: [{
+                name: 'A',
+                x: [1,100],
+                y: [1, 1]
+            }, {
+                name: 'B',
+                y: [1],
+                x:[50],
+                hoverinfo: 'none'
+            }],
+            layout: {
+                xaxis: {range: [40,60]},
+                hovermode: 'x unified',
+                showlegend: false,
+                width: 500,
+                height: 500,
+                margin: {
+                    t: 50,
+                    b: 50,
+                    l: 50,
+                    r: 50
+                }
+            }
+        })
+        .then(function() {
+            _hover(gd, { xpx: 200, ypx: 200 });
+            
+            expect(gd._hoverdata, undefined);
+            assertHoverLabelContent({});
+        })
+        .then(done, done.fail);
+    });
 
     it('y unified should work for x/y cartesian traces', function(done) {
         var mockCopy = Lib.extendDeep({}, mock);

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4725,12 +4725,12 @@ describe('hovermode: (x|y)unified', function() {
         })
         .then(done, done.fail);
     });
-    
+
     it('should not fail if only hoverinfo: "none" are current visible', function(done) {
         Plotly.newPlot(gd, {
             data: [{
                 name: 'A',
-                x: [1,100],
+                x: [1,100], 
                 y: [1, 1]
             }, {
                 name: 'B',
@@ -4739,7 +4739,7 @@ describe('hovermode: (x|y)unified', function() {
                 hoverinfo: 'none'
             }],
             layout: {
-                xaxis: {range: [40,60]},
+                xaxis: {range: [40,60]}, 
                 hovermode: 'x unified',
                 showlegend: false,
                 width: 500,
@@ -4754,7 +4754,6 @@ describe('hovermode: (x|y)unified', function() {
         })
         .then(function() {
             _hover(gd, { xpx: 200, ypx: 200 });
-            
             expect(gd._hoverdata, undefined);
             assertHoverLabelContent({});
         })

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4730,16 +4730,16 @@ describe('hovermode: (x|y)unified', function() {
         Plotly.newPlot(gd, {
             data: [{
                 name: 'A',
-                x: [1,100], 
+                x: [1, 100],
                 y: [1, 1]
             }, {
                 name: 'B',
                 y: [1],
-                x:[50],
+                x: [50],
                 hoverinfo: 'none'
             }],
             layout: {
-                xaxis: {range: [40,60]}, 
+                xaxis: {range: [40, 60]},
                 hovermode: 'x unified',
                 showlegend: false,
                 width: 500,


### PR DESCRIPTION
As written in the [issue](https://github.com/plotly/plotly.js/issues/6614), the hover fails, if the only markers currently visible  are hoverinfo: "none".

This fix returns an empty array instead of undefined in `createHoverText` if no points are currently shown.

Prev: ` if(groupedHoverData.length === 0) return;` [Link](https://github.com/plotly/plotly.js/blob/master/src/components/fx/hover.js#L1129)

Now: `if(groupedHoverData.length === 0) return [];`

So that `var hoverLabel = hoverText.hoverLabels;` does not fail.

A test for regression is also added. It fails without the given change.

