### PR TITLE
add `Plotly.deleteActiveShape` command

### DIFF
--- a/draftlogs/6679_add.md
+++ b/draftlogs/6679_add.md
@@ -1,0 +1,1 @@
+ - add Plotly.deleteActiveShape command [[#6679](https://github.com/plotly/plotly.js/pull/6679)]

--- a/src/components/shapes/draw.js
+++ b/src/components/shapes/draw.js
@@ -669,7 +669,7 @@ function eraseActiveShape(gd) {
 
         delete gd._fullLayout._activeShapeIndex;
 
-        Registry.call('_guiRelayout', gd, {
+        return Registry.call('_guiRelayout', gd, {
             shapes: list
         });
     }

--- a/src/plot_api/index.js
+++ b/src/plot_api/index.js
@@ -24,6 +24,8 @@ exports.deleteFrames = main.deleteFrames;
 exports.animate = main.animate;
 exports.setPlotConfig = main.setPlotConfig;
 
+exports.eraseActiveShape = require('../components/shapes/draw').eraseActiveShape;
+
 exports.toImage = require('./to_image');
 exports.validate = require('./validate');
 exports.downloadImage = require('../snapshot/download');

--- a/src/plot_api/index.js
+++ b/src/plot_api/index.js
@@ -24,7 +24,11 @@ exports.deleteFrames = main.deleteFrames;
 exports.animate = main.animate;
 exports.setPlotConfig = main.setPlotConfig;
 
-exports.eraseActiveShape = require('../components/shapes/draw').eraseActiveShape;
+var getGraphDiv = require('../lib/dom').getGraphDiv;
+var eraseActiveShape = require('../components/shapes/draw').eraseActiveShape;
+exports.deleteActiveShape = function(gd) {
+    return eraseActiveShape(getGraphDiv(gd));
+};
 
 exports.toImage = require('./to_image');
 exports.validate = require('./validate');


### PR DESCRIPTION
Resolves #6678.
@tamidodo Using this [dist/plotly.min.js](https://output.circle-artifacts.com/output/job/30b1bc99-a8f8-4d3a-b099-b7b1edb894ce/artifacts/0/dist/plotly.min.js), you could call `Plotly.deleteActiveShape(gd)` to erase the active shape on the `gd`.

cc: @plotly/plotly_js 

From dash:
```py
clientside_callback(
    """
    function eraseShape(_, graph_id) {
        Plotly.deleteActiveShape(graph_id)
        return dash_clientside.no_update
    }
    """
    Output('my-graph', 'id'),
    Input('erase-button', 'n_clicks'),
    State('my-graph', 'id'),
    prevent_initial_call=True
)
```