### PR TITLE
Emit plotly_click event on touchscreens with "select" dragmode 

### DIFF
--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -456,7 +456,7 @@ function prepSelect(evt, startX, startY, dragOptions, mode) {
                 }
             }
 
-            Fx.click(gd, evt);
+            Fx.click(gd, evt, plotinfo.id);
         }).catch(Lib.error);
     };
 


### PR DESCRIPTION
Addresses #6721 

Passing sublot id to `Fx.click()` will force trigger `Fx.hover()` so that plotly_click event can be emitted with proper data (ie. hoverdata) on touchscreens.