### PR TITLE
Fixing issue #5350 by moving the 'false' check

### DIFF
--- a/draftlogs/6727_fix.md
+++ b/draftlogs/6727_fix.md
@@ -1,0 +1,1 @@
+ - Addressing issue [[#5350](https://github.com/plotly/plotly.js/issues/5350)] via pull request [[#6727](https://github.com/plotly/plotly.js/pull/6727)]. This small change allows custom plotly_legenddoubleclick handlers to execute even when the default plotly_legendclick event is cancelled (returns false).

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -465,10 +465,10 @@ function clickOrDoubleClick(gd, legend, legendItem, numClicks, evt) {
         evtData.label = legendItem.datum()[0].label;
     }
 
-    var clickVal = Events.triggerHandler(gd, 'plotly_legendclick', evtData);
-    if(clickVal === false) return;
-
     if(numClicks === 1) {
+        var clickVal = Events.triggerHandler(gd, 'plotly_legendclick', evtData);
+        if(clickVal === false) return;
+    
         legend._clickTimeout = setTimeout(function() {
             if(!gd._fullLayout) return;
             handleClick(legendItem, gd, numClicks);

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -464,11 +464,9 @@ function clickOrDoubleClick(gd, legend, legendItem, numClicks, evt) {
     if(Registry.traceIs(trace, 'pie-like')) {
         evtData.label = legendItem.datum()[0].label;
     }
-
+    var clickVal = Events.triggerHandler(gd, 'plotly_legendclick', evtData);
     if(numClicks === 1) {
-        var clickVal = Events.triggerHandler(gd, 'plotly_legendclick', evtData);
         if(clickVal === false) return;
-
         legend._clickTimeout = setTimeout(function() {
             if(!gd._fullLayout) return;
             handleClick(legendItem, gd, numClicks);

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -464,7 +464,7 @@ function clickOrDoubleClick(gd, legend, legendItem, numClicks, evt) {
     if(Registry.traceIs(trace, 'pie-like')) {
         evtData.label = legendItem.datum()[0].label;
     }
-        
+
     if(numClicks === 1) {
         var clickVal = Events.triggerHandler(gd, 'plotly_legendclick', evtData);
         if(clickVal === false) return;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -464,11 +464,11 @@ function clickOrDoubleClick(gd, legend, legendItem, numClicks, evt) {
     if(Registry.traceIs(trace, 'pie-like')) {
         evtData.label = legendItem.datum()[0].label;
     }
-
+        
     if(numClicks === 1) {
         var clickVal = Events.triggerHandler(gd, 'plotly_legendclick', evtData);
         if(clickVal === false) return;
-    
+
         legend._clickTimeout = setTimeout(function() {
             if(!gd._fullLayout) return;
             handleClick(legendItem, gd, numClicks);

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -476,7 +476,8 @@ function clickOrDoubleClick(gd, legend, legendItem, numClicks, evt) {
         gd._legendMouseDownTime = 0;
 
         var dblClickVal = Events.triggerHandler(gd, 'plotly_legenddoubleclick', evtData);
-        if(dblClickVal !== false) handleClick(legendItem, gd, numClicks);
+        // Activate default double click behaviour only when both single click and double click values are not false
+        if(dblClickVal !== false && clickVal !== false) handleClick(legendItem, gd, numClicks);
     }
 }
 

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -2742,6 +2742,38 @@ describe('legend with custom doubleClickDelay', function() {
         .then(_assert('[short] after click + (1.1*t) delay + click', 2, 0))
         .then(done, done.fail);
     }, 3 * jasmine.DEFAULT_TIMEOUT_INTERVAL);
+
+    it('custom plotly_legenddoubleclick handler should fire even when plotly_legendclick has been cancelled', function(done) {
+        var tShort = 0.75 * DBLCLICKDELAY;
+        var dblClickCnt = 0;
+        var newPlot = function(fig) {
+            return Plotly.newPlot(gd, fig).then(function() {
+                gd.on('plotly_legendclick', function() { return false; });
+                gd.on('plotly_legenddoubleclick', function() { dblClickCnt++; });
+            });
+        };
+
+        function _assert(msg, _dblClickCnt) {
+            return function() {
+                expect(dblClickCnt).toBe(_dblClickCnt, msg + '| dblClickCnt');
+                dblClickCnt = 0;
+            };
+        }
+
+        newPlot({
+            data: [
+                {y: [1, 2, 1]},
+                {y: [2, 1, 2]}
+            ],
+            layout: {},
+            config: {}
+        })
+        .then(click(0))
+        .then(delay(tShort))
+        .then(click(0))
+        .then(_assert('Double click increases count', 1))
+        .then(done);
+    }, 3 * jasmine.DEFAULT_TIMEOUT_INTERVAL);
 });
 
 describe('legend with custom legendwidth', function() {

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -2720,7 +2720,7 @@ describe('legend with custom doubleClickDelay', function() {
         .then(_assert('[long] after click + (t/2) delay', 1, 0))
         .then(delay(tLong + 10))
         .then(click(0)).then(delay(DBLCLICKDELAY + 1)).then(click(0))
-        .then(_assert('[long] after click + (DBLCLICKDELAY+1) delay + click', 1, 1))
+        .then(_assert('[long] after click + (DBLCLICKDELAY+1) delay + click', 2, 1))
         .then(delay(tLong + 10))
         .then(click(0)).then(delay(1.1 * tLong)).then(click(0))
         .then(_assert('[long] after click + (1.1*t) delay + click', 2, 0))

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -2720,7 +2720,7 @@ describe('legend with custom doubleClickDelay', function() {
         .then(_assert('[long] after click + (t/2) delay', 1, 0))
         .then(delay(tLong + 10))
         .then(click(0)).then(delay(DBLCLICKDELAY + 1)).then(click(0))
-        .then(_assert('[long] after click + (DBLCLICKDELAY+1) delay + click', 2, 1))
+        .then(_assert('[long] after click + (DBLCLICKDELAY+1) delay + click', 1, 1))
         .then(delay(tLong + 10))
         .then(click(0)).then(delay(1.1 * tLong)).then(click(0))
         .then(_assert('[long] after click + (1.1*t) delay + click', 2, 0))


### PR DESCRIPTION
This is the most minimal change that I could think of to maintain all existing functionality but to prevent canceled single click events from canceling the double click as well. This is my first PR to this project so let me know if I'm missing something.

Note that I had to modify one unit test because the way the code was before, it would call the single click handler even for double click events which the unit test took into account for the expected number of clicks.

type: bug