### PR TITLE
Don't hide compilation errors

### DIFF
--- a/draftlogs/6739_fix.md
+++ b/draftlogs/6739_fix.md
@@ -1,0 +1,1 @@
+ - Fix error display for failing builds [[#6739](https://github.com/plotly/plotly.js/pull/6739)]

--- a/tasks/util/bundle_wrapper.js
+++ b/tasks/util/bundle_wrapper.js
@@ -76,6 +76,8 @@ module.exports = function _bundle(pathToIndex, pathToBundle, opts, cb) {
                         console.log('err:', err);
                     } else if(stats.errors && stats.errors.length) {
                         console.log('stats.errors:', stats.errors);
+                    } else if(stats.compilation && stats.compilation.errors && stats.compilation.errors.length) {
+                        console.log('stats.compilation.errors:', stats.compilation.errors);
                     } else {
                         console.log('success:', config.output.path + '/' + config.output.filename);
 


### PR DESCRIPTION
Some compilation errors get hidden and "success" message gets shown even though the build failed.