### PR TITLE
Add willReadFrequently to 2d canvas contexts to heatmap

### DIFF
--- a/src/traces/heatmap/plot.js
+++ b/src/traces/heatmap/plot.js
@@ -162,7 +162,7 @@ module.exports = function(gd, plotinfo, cdheatmaps, heatmapLayer) {
         var canvas = document.createElement('canvas');
         canvas.width = canvasW;
         canvas.height = canvasH;
-        var context = canvas.getContext('2d');
+        var context = canvas.getContext('2d', {willReadFrequently: true});
 
         var sclFunc = makeColorScaleFuncFromTrace(trace, {noNumericCheck: true, returnArray: true});
 


### PR DESCRIPTION
fix for https://github.com/plotly/plotly.js/issues/6740

This change adds the willReadFrequently:true 2d context creation
attribute to the heatmap plotly. This is a performance hint that tells
the browser to optimize for readbacks.

See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently