### PR TITLE
Fix issue 6751: epoch date formats '%H:%M:%S' as 'undefined'

### DIFF
--- a/draftlogs/6751_fix.md
+++ b/draftlogs/6751_fix.md
@@ -1,0 +1,1 @@
+-  Timestamp '1970-01-01 00:00:00' formats hoverformat '%H:%M:%S' as 'undefined' [[#6752](https://github.com/plotly/plotly.js/pull/6752)]

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1744,6 +1744,9 @@ function formatDate(ax, out, hover, extraPrecision) {
     var tr = ax._tickround;
     var fmt = (hover && ax.hoverformat) || axes.getTickFormat(ax);
 
+    // Only apply extra precision if no explicit format was provided.
+    extraPrecision = !fmt && extraPrecision;
+
     if(extraPrecision) {
         // second or sub-second precision: extra always shows max digits.
         // for other fields, extra precision just adds one field.
@@ -1768,7 +1771,7 @@ function formatDate(ax, out, hover, extraPrecision) {
         // anything to be uniform with!)
 
         // can we remove the whole time part?
-        if(dateStr === '00:00:00' || dateStr === '00:00') {
+        if(headStr !== undefined && (dateStr === '00:00:00' || dateStr === '00:00')) {
             dateStr = headStr;
             headStr = '';
         } else if(dateStr.length === 8) {


### PR DESCRIPTION
Hi all! This is my first time contributing to plotly so open for feedback & comments :)

This patch fixes issue #6751, where the epoch timestamp '1970-01-01 00:00:00', with 'hoverformat' '%H:%M:%S' is formatted as 'undefined'.
