### PR TITLE
Add a test to for custom hover format of epoch timestamp

### DIFF
--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -4380,6 +4380,21 @@ describe('hover distance', function() {
                 })
                 .then(done, done.fail);
         });
+
+        it('correctly format the epoch timestamp in a given hover format', function(done) {
+            var x = ['1970-01-01 00:00:00'];
+            var mock = {
+                data: [{type: 'scatter', x: x, y: [1]}],
+                layout: {width: 400, height: 400, xaxis: {hoverformat: '%H:%M:%S'}}
+            };
+
+            Plotly.newPlot(gd, mock)
+                .then(function(gd) {
+                    Fx.hover(gd, {xpx: 120, ypx: 110});
+                    assertHoverLabelContent({nums: '(00:00:00, 1)'});
+                })
+                .then(done, done.fail);
+        });
     });
 });
 


### PR DESCRIPTION
Previously, I fixed issue #6751 with help from @archmoj. I didn't have time to add tests to the original PR before it was merged so I am proposing a new test case with this PR.

Did my best to follow existing patterns from other tests but its my first one in this project so please let me know if I can improve it somehow :)