### PR TITLE
Enhance `hole` property in Pie Chart for variable slice radii

### DIFF
--- a/draftlogs/6769_add.md
+++ b/draftlogs/6769_add.md
@@ -1,0 +1,1 @@
+ - Enhance `hole` property in Pie Chart for variable slice radii [[#6769](https://github.com/plotly/plotly.js/pull/6769)]

--- a/src/traces/pie/attributes.js
+++ b/src/traces/pie/attributes.js
@@ -244,6 +244,7 @@ module.exports = {
         max: 1,
         dflt: 0,
         editType: 'calc',
+        arrayOk: true,
         description: [
             'Sets the fraction of the radius to cut out of the pie.',
             'Use this to make a donut chart.'

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -764,7 +764,7 @@ function positionTitleInside(cd0) {
     return {
         x: cd0.cx,
         y: cd0.cy,
-        scale: (cd0.trace.hole[0] || cd0.trace.hole) * cd0.r * 2 / textDiameter,
+        scale: (Lib.isArrayOrTypedArray(cd0.trace.hole) ? Math.min.apply(null, cd0.trace.hole) : cd0.trace.hole) * cd0.r * 2 / textDiameter,
         tx: 0,
         ty: - cd0.titleBox.height / 2 + cd0.trace.title.font.size
     };
@@ -1092,7 +1092,7 @@ function setCoords(cd) {
         cdi.largeArc = (cdi.v > cd0.vTotal / 2) ? 1 : 0;
 
         cdi.halfangle = Math.PI * Math.min(cdi.v / cd0.vTotal, 0.5);
-        cdi.ring = 1 - (trace.hole[i] || trace.hole);
+        cdi.ring = 1 - (Lib.isArrayOrTypedArray(cd0.trace.hole) ? trace.hole[i] : trace.hole);
         cdi.rInscribed = getInscribedRadiusFraction(cdi, cd0);
     }
 }

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -734,7 +734,7 @@ function calcMaxHalfSize(a, halfAngle, r, ring) {
 }
 
 function getInscribedRadiusFraction(pt, cd0) {
-    if(pt.v === cd0.vTotal && !(cd0.trace.hole[0] || cd0.trace.hole)) return 1;// special case of 100% with no hole
+    if(pt.v === cd0.vTotal && !(Lib.isArrayOrTypedArray(cd0.trace.hole) ? [pt.i] : cd0.trace.hole)) return 1;// special case of 100% with no hole
 
     return Math.min(1 / (1 + 1 / Math.sin(pt.halfangle)), pt.ring / 2);
 }

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -97,7 +97,10 @@ function plot(gd, cdModule) {
                         pt.largeArc + (cw ? ' 1 ' : ' 0 ') + dx + ',' + dy;
                 }
 
-                var hole = trace.hole[i] || trace.hole;
+                var hole = trace.hole;
+                if(hole) {
+                    hole = +helpers.castOption(trace.hole, pt.pts) || 0;
+                }
                 if(pt.v === cd0.vTotal) { // 100% fails bcs arc start and end are identical
                     var outerCircle = 'M' + (cx + pt.px0[0]) + ',' + (cy + pt.px0[1]) +
                         arc(pt.px0, pt.pxmid, true, 1) +

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -731,7 +731,7 @@ function calcMaxHalfSize(a, halfAngle, r, ring) {
 }
 
 function getInscribedRadiusFraction(pt, cd0) {
-    if(pt.v === cd0.vTotal && !cd0.trace.hole) return 1;// special case of 100% with no hole
+    if(pt.v === cd0.vTotal && !(cd0.trace.hole[0] || cd0.trace.hole)) return 1;// special case of 100% with no hole
 
     return Math.min(1 / (1 + 1 / Math.sin(pt.halfangle)), pt.ring / 2);
 }
@@ -761,7 +761,7 @@ function positionTitleInside(cd0) {
     return {
         x: cd0.cx,
         y: cd0.cy,
-        scale: cd0.trace.hole * cd0.r * 2 / textDiameter,
+        scale: (cd0.trace.hole[0] || cd0.trace.hole) * cd0.r * 2 / textDiameter,
         tx: 0,
         ty: - cd0.titleBox.height / 2 + cd0.trace.title.font.size
     };
@@ -1089,7 +1089,7 @@ function setCoords(cd) {
         cdi.largeArc = (cdi.v > cd0.vTotal / 2) ? 1 : 0;
 
         cdi.halfangle = Math.PI * Math.min(cdi.v / cd0.vTotal, 0.5);
-        cdi.ring = 1 - trace.hole;
+        cdi.ring = 1 - (trace.hole[i] || trace.hole);
         cdi.rInscribed = getInscribedRadiusFraction(cdi, cd0);
     }
 }

--- a/src/traces/pie/plot.js
+++ b/src/traces/pie/plot.js
@@ -97,7 +97,7 @@ function plot(gd, cdModule) {
                         pt.largeArc + (cw ? ' 1 ' : ' 0 ') + dx + ',' + dy;
                 }
 
-                var hole = trace.hole;
+                var hole = trace.hole[i] || trace.hole;
                 if(pt.v === cd0.vTotal) { // 100% fails bcs arc start and end are identical
                     var outerCircle = 'M' + (cx + pt.px0[0]) + ',' + (cy + pt.px0[1]) +
                         arc(pt.px0, pt.pxmid, true, 1) +

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -4368,7 +4368,6 @@
      ]
     },
     "hole": {
-     "arrayOk": true,
      "description": "Sets the fraction of the radius to cut out of the polar subplot.",
      "dflt": 0,
      "editType": "plot",
@@ -42616,6 +42615,7 @@
      }
     },
     "hole": {
+     "arrayOk": true,
      "description": "Sets the fraction of the radius to cut out of the pie. Use this to make a donut chart.",
      "dflt": 0,
      "editType": "calc",

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -4368,6 +4368,7 @@
      ]
     },
     "hole": {
+     "arrayOk": true,
      "description": "Sets the fraction of the radius to cut out of the polar subplot.",
      "dflt": 0,
      "editType": "plot",

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -42623,6 +42623,11 @@
      "min": 0,
      "valType": "number"
     },
+    "holesrc": {
+     "description": "Sets the source reference on Chart Studio Cloud for `hole`.",
+     "editType": "none",
+     "valType": "string"
+    },
     "hoverinfo": {
      "arrayOk": true,
      "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",


### PR DESCRIPTION
Refined the Pie Chart to permit the hole property to accept both numbers and arrays. This enhancement facilitates setting individual radii for each pie slice, offering greater customization in visual representation.

Addresses: https://github.com/plotly/plotly.js/issues/6768