### PR TITLE
plot schema should not show `line.shape` options for `scatterpolargl` trace 

### DIFF
--- a/draftlogs/6781_fix.md
+++ b/draftlogs/6781_fix.md
@@ -1,0 +1,1 @@
+ - Fix plot schema not to show `line.shape` options for `scatterpolargl` trace [[#6781](https://github.com/plotly/plotly.js/pull/6781)]

--- a/src/traces/scatterpolargl/attributes.js
+++ b/src/traces/scatterpolargl/attributes.js
@@ -21,7 +21,13 @@ module.exports = {
     hovertext: scatterPolarAttrs.hovertext,
     hovertemplate: scatterPolarAttrs.hovertemplate,
 
-    line: scatterGlAttrs.line,
+    line: {
+        color: scatterGlAttrs.line.color,
+        width: scatterGlAttrs.line.width,
+        dash: scatterGlAttrs.line.dash,
+        editType: 'calc'
+    },
+
     connectgaps: scatterGlAttrs.connectgaps,
 
     marker: scatterGlAttrs.marker,

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -58874,19 +58874,6 @@
      },
      "editType": "calc",
      "role": "object",
-     "shape": {
-      "description": "Determines the line shape. The values correspond to step-wise line shapes.",
-      "dflt": "linear",
-      "editType": "calc",
-      "valType": "enumerated",
-      "values": [
-       "linear",
-       "hv",
-       "vh",
-       "hvh",
-       "vhv"
-      ]
-     },
      "width": {
       "description": "Sets the line width (in px).",
       "dflt": 2,


### PR DESCRIPTION
Fixes #6774.
