### PR TITLE
Bump `mapbox-gl` dependency from `v1.10.1` to `v1.13.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
         "is-mobile": "^4.0.0",
-        "mapbox-gl": "1.10.1",
+        "mapbox-gl": "1.13.1",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
         "mouse-wheel": "^1.2.0",
@@ -8637,9 +8637,9 @@
       "dev": true
     },
     "node_modules/mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
+      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -8661,7 +8661,7 @@
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
+        "supercluster": "^7.1.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       },
@@ -11686,9 +11686,9 @@
       }
     },
     "node_modules/supercluster": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.0.0.tgz",
-      "integrity": "sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
       "dependencies": {
         "kdbush": "^3.0.0"
       }
@@ -19631,9 +19631,9 @@
       "dev": true
     },
     "mapbox-gl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
-      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.1.tgz",
+      "integrity": "sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -19655,7 +19655,7 @@
         "potpack": "^1.0.1",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
+        "supercluster": "^7.1.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.1"
       }
@@ -22020,9 +22020,9 @@
       }
     },
     "supercluster": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.0.0.tgz",
-      "integrity": "sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
       "requires": {
         "kdbush": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "has-hover": "^1.0.1",
     "has-passive-events": "^1.0.0",
     "is-mobile": "^4.0.0",
-    "mapbox-gl": "1.10.1",
+    "mapbox-gl": "1.13.1",
     "mouse-change": "^1.4.0",
     "mouse-event-offset": "^3.0.2",
     "mouse-wheel": "^1.2.0",

--- a/src/plots/mapbox/constants.js
+++ b/src/plots/mapbox/constants.js
@@ -2,7 +2,7 @@
 
 var sortObjectKeys = require('../../lib/sort_object_keys');
 
-var requiredVersion = '1.10.1';
+var requiredVersion = '1.13.1';
 
 var OSM = '© <a target="_blank" href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 var carto = [

--- a/test/jasmine/tests/mapbox_test.js
+++ b/test/jasmine/tests/mapbox_test.js
@@ -1693,7 +1693,9 @@ describe('mapbox plots', function() {
 
     function _mouseEvent(type, pos, cb) {
         return new Promise(function(resolve) {
-            mouseEvent(type, pos[0], pos[1]);
+            mouseEvent(type, pos[0], pos[1], {
+                buttons: 1 // left button
+            });
 
             setTimeout(function() {
                 cb();

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -2303,7 +2303,9 @@ describe('Test Plotly.react + interactions under uirevision:', function() {
         // see mapbox_test.js for rationale
         function _mouseEvent(type, pos) {
             return new Promise(function(resolve) {
-                mouseEvent(type, pos[0], pos[1]);
+                mouseEvent(type, pos[0], pos[1], {
+                    buttons: 1 // left button
+                });
                 setTimeout(resolve, 100);
             });
         }


### PR DESCRIPTION
Supersedes #5123.
Fixed various bugs between two versions. See [`mapbox-gl` CHANGELOG](https://github.com/mapbox/mapbox-gl-js/compare/v1.10.1...v1.11.0).

@plotly/plotly_js 