### PR TITLE
Fix hovering over Sankey node only fully highlights first trace

### DIFF
--- a/draftlogs/6799_fix.md
+++ b/draftlogs/6799_fix.md
@@ -1,1 +1,1 @@
- -  Fix hovering over Sankey node only fully highlights first trace [[#6799](https://github.com/plotly/plotly.js/pull/6799)]
+ -  Fix hovering over Sankey node only fully highlights first trace [[#6799](https://github.com/plotly/plotly.js/pull/6799)], with thanks to @DominicWuest for the contribution!

--- a/draftlogs/6799_fix.md
+++ b/draftlogs/6799_fix.md
@@ -1,0 +1,1 @@
+ -  Fix hovering over Sankey node only fully highlights first trace [[#6799](https://github.com/plotly/plotly.js/pull/6799)]

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -68,7 +68,7 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
         }
     });
 
-    sankeyLink.each((curLink => {
+    sankeyLink.each(function(curLink) {
         var label = curLink.link.label;
         if(label) {
             ownTrace(sankey, d)
@@ -80,7 +80,7 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
                     }
                 });
         }
-    }))
+    });
 
     if(visitNodes) {
         ownTrace(sankey, d)
@@ -93,7 +93,7 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
 function linkNonHoveredStyle(d, sankey, visitNodes, sankeyLink) {
     sankeyLink.style('fill-opacity', function(d) {return d.tinyColorAlpha;});
 
-    sankeyLink.each(curLink => {
+    sankeyLink.each(function(curLink) {
         var label = curLink.link.label;
         if(label) {
             ownTrace(sankey, d)
@@ -101,7 +101,7 @@ function linkNonHoveredStyle(d, sankey, visitNodes, sankeyLink) {
                 .filter(function(l) {return l.link.label === label;})
                 .style('fill-opacity', function(d) {return d.tinyColorAlpha;});
         }
-    })
+    });
 
     if(visitNodes) {
         ownTrace(sankey, d)

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -62,24 +62,25 @@ function nodeNonHoveredStyle(sankeyNode, d, sankey) {
 }
 
 function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
-    var label = sankeyLink.datum().link.label;
-
     sankeyLink.style('fill-opacity', function(l) {
         if(!l.link.concentrationscale) {
             return 0.4;
         }
     });
 
-    if(label) {
-        ownTrace(sankey, d)
-            .selectAll('.' + cn.sankeyLink)
-            .filter(function(l) {return l.link.label === label;})
-            .style('fill-opacity', function(l) {
-                if(!l.link.concentrationscale) {
-                    return 0.4;
-                }
-            });
-    }
+    sankeyLink.each((curLink => {
+        var label = curLink.link.label;
+        if(label) {
+            ownTrace(sankey, d)
+                .selectAll('.' + cn.sankeyLink)
+                .filter(function(l) {return l.link.label === label;})
+                .style('fill-opacity', function(l) {
+                    if(!l.link.concentrationscale) {
+                        return 0.4;
+                    }
+                });
+        }
+    }))
 
     if(visitNodes) {
         ownTrace(sankey, d)
@@ -90,15 +91,17 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
 }
 
 function linkNonHoveredStyle(d, sankey, visitNodes, sankeyLink) {
-    var label = sankeyLink.datum().link.label;
-
     sankeyLink.style('fill-opacity', function(d) {return d.tinyColorAlpha;});
-    if(label) {
-        ownTrace(sankey, d)
-            .selectAll('.' + cn.sankeyLink)
-            .filter(function(l) {return l.link.label === label;})
-            .style('fill-opacity', function(d) {return d.tinyColorAlpha;});
-    }
+
+    sankeyLink.each(curLink => {
+        var label = curLink.link.label;
+        if(label) {
+            ownTrace(sankey, d)
+                .selectAll('.' + cn.sankeyLink)
+                .filter(function(l) {return l.link.label === label;})
+                .style('fill-opacity', function(d) {return d.tinyColorAlpha;});
+        }
+    })
 
     if(visitNodes) {
         ownTrace(sankey, d)

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -70,7 +70,7 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
 
     sankeyLink.each(function(curLink) {
         var label = curLink.link.label;
-        if(label !== undefined) {
+        if(label !== '') {
             ownTrace(sankey, d)
                 .selectAll('.' + cn.sankeyLink)
                 .filter(function(l) {return l.link.label === label;})
@@ -95,7 +95,7 @@ function linkNonHoveredStyle(d, sankey, visitNodes, sankeyLink) {
 
     sankeyLink.each(function(curLink) {
         var label = curLink.link.label;
-        if(label !== undefined) {
+        if(label !== '') {
             ownTrace(sankey, d)
                 .selectAll('.' + cn.sankeyLink)
                 .filter(function(l) {return l.link.label === label;})

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -70,7 +70,7 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
 
     sankeyLink.each(function(curLink) {
         var label = curLink.link.label;
-        if(label) {
+        if(label !== undefined) {
             ownTrace(sankey, d)
                 .selectAll('.' + cn.sankeyLink)
                 .filter(function(l) {return l.link.label === label;})
@@ -95,7 +95,7 @@ function linkNonHoveredStyle(d, sankey, visitNodes, sankeyLink) {
 
     sankeyLink.each(function(curLink) {
         var label = curLink.link.label;
-        if(label) {
+        if(label !== undefined) {
             ownTrace(sankey, d)
                 .selectAll('.' + cn.sankeyLink)
                 .filter(function(l) {return l.link.label === label;})

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -1080,7 +1080,7 @@ describe('sankey tests', function() {
 
             Plotly.newPlot(gd, mockCopy)
                 .then(function() {
-                    _hover(1000, 400);
+                    _hover(200, 250);
                 })
                 .then(function() {
                     d3SelectAll('.sankey-link')
@@ -1090,7 +1090,7 @@ describe('sankey tests', function() {
                             expect(l.style.fillOpacity).toEqual('0.4');
                         });
                 }).then(function() {
-                    mouseEvent('mouseout', 1000, 400);
+                    mouseEvent('mouseout', 200, 250);
                 }).then(function() {
                     d3SelectAll('.sankey-link')
                         .filter(function(obj) {

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -1073,6 +1073,34 @@ describe('sankey tests', function() {
             })
             .then(done, done.fail);
         });
+
+        it('should (un-)highlight all traces ending in a (un-)hovered node', function(done) {
+            var gd = createGraphDiv();
+            var mockCopy = Lib.extendDeep({}, mock);
+
+            Plotly.newPlot(gd, mockCopy)
+                .then(function() {
+                    _hover(1000, 400);
+                })
+                .then(function() {
+                    d3SelectAll('.sankey-link')
+                        .filter(function(obj) {
+                            return obj.link.label === 'stream 1';
+                        })[0].forEach(function(l) {
+                            expect(l.style.fillOpacity).toEqual('0.4');
+                        });
+                }).then(function() {
+                    mouseEvent('mouseout', 1000, 400);
+                }).then(function() {
+                    d3SelectAll('.sankey-link')
+                        .filter(function(obj) {
+                            return obj.link.label === 'stream 1';
+                        })[0].forEach(function(l) {
+                            expect(l.style.fillOpacity).toEqual('0.2');
+                        });
+                })
+                .then(done, done.fail);
+        });
     });
 
     describe('Test hover/click event data:', function() {


### PR DESCRIPTION
Fixes #6328.

The issue was that only the label of the first link was considered when recursively highlighting traces.