### PR TITLE
Bug Fix: Add <meta charset="utf-8"> to <head> to appease d3.js in test dashboard

### DIFF
--- a/devtools/test_dashboard/index-mathjax3.html
+++ b/devtools/test_dashboard/index-mathjax3.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Plotly.js Devtools - MathJax v3 loaded with svg output</title>
+  <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>

--- a/devtools/test_dashboard/index-mathjax3chtml.html
+++ b/devtools/test_dashboard/index-mathjax3chtml.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Plotly.js Devtools - MathJax v3 loaded with chtml output</title>
+  <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>

--- a/devtools/test_dashboard/index-strict.html
+++ b/devtools/test_dashboard/index-strict.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="Content-Security-Policy" content="script-src 'self'; worker-src blob:; ">
   <title>Plotly.js "strict" Devtools</title>
-
+  <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>

--- a/devtools/test_dashboard/index.html
+++ b/devtools/test_dashboard/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Plotly.js Devtools</title>
+  <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>

--- a/draftlogs/6826_fix.md
+++ b/draftlogs/6826_fix.md
@@ -1,0 +1,1 @@
+- Add charset meta to `<head>`s in test dashboard: helps D3.js [[#6826](https://github.com/plotly/plotly.js/pull/6826)]


### PR DESCRIPTION
Issue: https://github.com/plotly/plotly.js/issues/6825

Error and solution: https://stackoverflow.com/questions/29325566/unexpected-token-error-when-using-d3-js

Trivially simple, adds character encoding directive to <head> tag of plotly test dashboard.