### PR TITLE
Add switch to specify major/minor in `axes.arrayTicks()`

### DIFF
--- a/draftlogs/6829_fix.md
+++ b/draftlogs/6829_fix.md
@@ -1,0 +1,1 @@
+- Add argument to `arrayTicks()` to render major OR minor [[#6829](https://github.com/plotly/plotly.js/pull/6829)]

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -949,10 +949,10 @@ axes.calcTicks = function calcTicks(ax, opts) {
         if(mockAx.tickmode === 'array') {
             if(major) {
                 tickVals = [];
-                ticksOut = arrayTicks(ax, major);
+                ticksOut = arrayTicks(ax, !isMinor);
             } else {
                 minorTickVals = [];
-                minorTicks = arrayTicks(ax, false);
+                minorTicks = arrayTicks(ax, !isMinor);
             }
             continue;
         }
@@ -1261,8 +1261,7 @@ function syncTicks(ax) {
     return ticksOut;
 }
 
-function arrayTicks(ax, major) {
-    if(major === undefined) throw new Error('arrayTicks must specify ticktype');
+function arrayTicks(ax, majorOnly) {
     var rng = Lib.simpleMap(ax.range, ax.r2l);
     var exRng = expandRange(rng);
     var tickMin = Math.min(exRng[0], exRng[1]);
@@ -1280,11 +1279,10 @@ function arrayTicks(ax, major) {
 
     var ticksOut = [];
     for(var isMinor = 0; isMinor <= 1; isMinor++) {
-        if(!isMinor && !major) continue;
-        if(isMinor && (!ax.minor || major)) continue;
+        if((majorOnly !== undefined) && ((majorOnly && isMinor) || (majorOnly === false && !isMinor))) continue;
+        if(isMinor && !ax.minor) continue;
         var vals = !isMinor ? ax.tickvals : ax.minor.tickvals;
         var text = !isMinor ? ax.ticktext : [];
-
         if(!vals) continue;
 
 

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -949,10 +949,10 @@ axes.calcTicks = function calcTicks(ax, opts) {
         if(mockAx.tickmode === 'array') {
             if(major) {
                 tickVals = [];
-                ticksOut = arrayTicks(ax);
+                ticksOut = arrayTicks(ax, major);
             } else {
                 minorTickVals = [];
-                minorTicks = arrayTicks(ax);
+                minorTicks = arrayTicks(ax, false);
             }
             continue;
         }
@@ -1261,7 +1261,7 @@ function syncTicks(ax) {
     return ticksOut;
 }
 
-function arrayTicks(ax) {
+function arrayTicks(ax, major) {
     var rng = Lib.simpleMap(ax.range, ax.r2l);
     var exRng = expandRange(rng);
     var tickMin = Math.min(exRng[0], exRng[1]);
@@ -1279,7 +1279,8 @@ function arrayTicks(ax) {
 
     var ticksOut = [];
     for(var isMinor = 0; isMinor <= 1; isMinor++) {
-        if(isMinor && !ax.minor) continue;
+        if(!isMinor && !major) continue;
+        if(isMinor && (!ax.minor || major)) continue;
         var vals = !isMinor ? ax.tickvals : ax.minor.tickvals;
         var text = !isMinor ? ax.ticktext : [];
 

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1262,7 +1262,7 @@ function syncTicks(ax) {
 }
 
 function arrayTicks(ax, major) {
-    if (major === undefined) throw new Error("arrayTicks must specify ticktype")
+    if(major === undefined) throw new Error('arrayTicks must specify ticktype');
     var rng = Lib.simpleMap(ax.range, ax.r2l);
     var exRng = expandRange(rng);
     var tickMin = Math.min(exRng[0], exRng[1]);

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1262,6 +1262,7 @@ function syncTicks(ax) {
 }
 
 function arrayTicks(ax, major) {
+    if (major === undefined) throw new Error("arrayTicks must specify ticktype")
     var rng = Lib.simpleMap(ax.range, ax.r2l);
     var exRng = expandRange(rng);
     var tickMin = Math.min(exRng[0], exRng[1]);

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -8253,50 +8253,48 @@ fdescribe('test tickmode calculator', function() {
     }
 
     describe('arrayTicks', function() {
-        for(let i = 0; i < 4; i++) {
-            (function(i) {
-                it('should return the specified correct number of major ticks and minor ticks', function(done) {
-                  const BOTH = 0;
-                  const MAJOR = 1;
-                  const MINOR = 2;
-                  const NEITHER = 3;
-                  var xMajorConfig = ticksOff;
-                  var xMinorConfig = ticksOff;
-                  if(i == BOTH) {
-                    xMajorConfig = generateTickConfig();
-                    xMinorConfig = generateTickConfig();
-                  } else if(i == MAJOR) {
-                    xMajorConfig = generateTickConfig();
-                  } else if(i==MINOR) {
-                    xMinorConfig = generateTickConfig();
-                  } else if(i == NEITHER) {
-                    // Do nothing, all ticks off
+        it('should return the specified correct number of major ticks and minor ticks', function(done) {
+          for(let i = 0; i < 4; i++) {
+              const BOTH = 0;
+              const MAJOR = 1;
+              const MINOR = 2;
+              const NEITHER = 3;
+              var xMajorConfig = ticksOff;
+              var xMinorConfig = ticksOff;
+              if(i == BOTH) {
+                xMajorConfig = generateTickConfig();
+                xMinorConfig = generateTickConfig();
+              } else if(i == MAJOR) {
+                xMajorConfig = generateTickConfig();
+              } else if(i==MINOR) {
+                xMinorConfig = generateTickConfig();
+              } else if(i == NEITHER) {
+                // Do nothing, all ticks off
+              }
+              Plotly.newPlot(gd, {
+                  data: [{
+                      x: [0, 1],
+                      y: [0, 1]
+                  }],
+                  layout: {
+                      width: 400,
+                      height: 400,
+                      margin: {
+                          t: 40,
+                          b: 40,
+                          l: 40,
+                          r: 40
+                      },
+                      xaxis: {
+                        range: [0, 1000],
+                        ...xMajorConfig,
+                        minor: xMinorConfig,
+                      },
                   }
-                  Plotly.newPlot(gd, {
-                      data: [{
-                          x: [0, 1],
-                          y: [0, 1]
-                      }],
-                      layout: {
-                          width: 400,
-                          height: 400,
-                          margin: {
-                              t: 40,
-                              b: 40,
-                              l: 40,
-                              r: 40
-                          },
-                          xaxis: {
-                            range: [0, 1000],
-                            ...xMajorConfig,
-                            minor: xMinorConfig,
-                          },
-                      }
-                  }).then(function() {
-                      _assert(xMajorConfig.tickvals.length + xMinorConfig.tickvals.length);
-                  }).then(done, done.fail);
-                });
-            })(i);
-        }
+              }).then(function() {
+                  _assert(xMajorConfig.tickvals.length + xMinorConfig.tickvals.length);
+              }).then(done, done.fail);
+          } 
+        });
     });
 });

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -8229,7 +8229,8 @@ fdescribe('test tickmode calculator', function() {
       standardConfig = {tickmode: 'array', ticks: 'inside', ticklen: 1, showticklabels: false};
 
       // Number of ticks will be random
-      var n = Math.floor(Math.random() * 99) + 1;
+      Lib.seedPseudoRandom();
+      var n = (Lib.pseudoRandom() * 99) + 1;
       tickVals = [];
       for(let i = 0; i <= n; i++) {
         tickVals.push(i);

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -8216,7 +8216,7 @@ describe('shift tests', function() {
         });
     });
 });
-fdescribe('test tickmode calculator', function() {
+describe('test tickmode calculator', function() {
     var gd;
 
     beforeEach(function() {
@@ -8225,21 +8225,21 @@ fdescribe('test tickmode calculator', function() {
 
     afterEach(destroyGraphDiv);
 
-    function generateTickConfig(){
-      standardConfig = {tickmode: 'array', ticks: 'inside', ticklen: 1, showticklabels: false};
+    function generateTickConfig() {
+        var standardConfig = {tickmode: 'array', ticks: 'inside', ticklen: 1, showticklabels: false};
 
-      // Number of ticks will be random
-      Lib.seedPseudoRandom();
-      var n = (Lib.pseudoRandom() * 99) + 1;
-      tickVals = [];
-      for(let i = 0; i <= n; i++) {
-        tickVals.push(i);
-      }
-      standardConfig['tickvals'] = tickVals;
-      standardConfig['ticktext'] = tickVals;
-      return standardConfig;
+        // Number of ticks will be random
+        Lib.seedPseudoRandom();
+        var n = (Lib.pseudoRandom() * 99) + 1;
+        var tickVals = [];
+        for(var i = 0; i <= n; i++) {
+            tickVals.push(i);
+        }
+        standardConfig.tickvals = tickVals;
+        standardConfig.ticktext = tickVals;
+        return standardConfig;
     }
-    var ticksOff = {tickmode:"array", ticks: '', tickvals:[], ticktext:[], ticklen: 0, showticklabels: false};
+    var ticksOff = {tickmode: 'array', ticks: '', tickvals: [], ticktext: [], ticklen: 0, showticklabels: false};
 
     function _assert(expLength) {
         var ax = gd._fullLayout.xaxis;
@@ -8255,47 +8255,31 @@ fdescribe('test tickmode calculator', function() {
 
     describe('arrayTicks', function() {
         it('should return the specified correct number of major ticks and minor ticks', function(done) {
-          for(let i = 0; i < 4; i++) {
-              const BOTH = 0;
-              const MAJOR = 1;
-              const MINOR = 2;
-              const NEITHER = 3;
-              var xMajorConfig = ticksOff;
-              var xMinorConfig = ticksOff;
-              if(i == BOTH) {
-                xMajorConfig = generateTickConfig();
-                xMinorConfig = generateTickConfig();
-              } else if(i == MAJOR) {
-                xMajorConfig = generateTickConfig();
-              } else if(i==MINOR) {
-                xMinorConfig = generateTickConfig();
-              } else if(i == NEITHER) {
-                // Do nothing, all ticks off
-              }
-              Plotly.newPlot(gd, {
-                  data: [{
-                      x: [0, 1],
-                      y: [0, 1]
-                  }],
-                  layout: {
-                      width: 400,
-                      height: 400,
-                      margin: {
-                          t: 40,
-                          b: 40,
-                          l: 40,
-                          r: 40
-                      },
-                      xaxis: {
-                        range: [0, 1000],
-                        ...xMajorConfig,
-                        minor: xMinorConfig,
-                      },
-                  }
-              }).then(function() {
-                  _assert(xMajorConfig.tickvals.length + xMinorConfig.tickvals.length);
-              }).then(done, done.fail);
-          } 
+            var xMajorConfig = ticksOff;
+            var xMinorConfig = ticksOff;
+            xMajorConfig = generateTickConfig();
+            xMinorConfig = generateTickConfig();
+            xMajorConfig.range = [0, 1000];
+            xMajorConfig.minor = xMinorConfig;
+            Plotly.newPlot(gd, {
+                data: [{
+                    x: [0, 1],
+                    y: [0, 1]
+                }],
+                layout: {
+                    width: 400,
+                    height: 400,
+                    margin: {
+                        t: 40,
+                        b: 40,
+                        l: 40,
+                        r: 40
+                    },
+                    xaxis: xMajorConfig,
+                }
+            }).then(function() {
+                _assert(xMajorConfig.tickvals.length + xMinorConfig.tickvals.length);
+            }).then(done, done.fail);
         });
     });
 });


### PR DESCRIPTION
Long explanation in: https://github.com/plotly/plotly.js/issues/6828: but basically `calcTicks()` tries and thinks its differentiating between major and minor ticks when doing some adjustments, but it is not actually. It ends up creating a `ticksOut` that contains each tick duplicated once instead.

Actual changes simple. If this function is used outside of `axes.js`, should probably make default behavior same as original behavior.

I will do the draft log tomorrow.

Fixing this hidden error would solve all problems in my [other draft pull request](https://github.com/plotly/plotly.js/pull/6827) and allow `proportional` tickmode for minor ticks. 
