### PR TITLE
Fix `scattergl` rendering bug on M1 mac devices

### DIFF
--- a/draftlogs/6830_fix.md
+++ b/draftlogs/6830_fix.md
@@ -1,0 +1,2 @@
+ - Fix scattergl rendering bug on M1 mac devices [[#6830](https://github.com/plotly/plotly.js/pull/6830)],
+   with thanks to @justinjhendrick for the contribution!

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "regl": "npm:@plotly/regl@^2.1.2",
         "regl-error2d": "^2.0.12",
         "regl-line2d": "^3.1.2",
-        "regl-scatter2d": "^3.2.9",
+        "regl-scatter2d": "^3.3.1",
         "regl-splom": "^1.0.14",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
@@ -10835,9 +10835,9 @@
       }
     },
     "node_modules/regl-scatter2d": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
-      "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
+      "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "dependencies": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",
@@ -21359,9 +21359,9 @@
       }
     },
     "regl-scatter2d": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
-      "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
+      "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "requires": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "regl": "npm:@plotly/regl@^2.1.2",
     "regl-error2d": "^2.0.12",
     "regl-line2d": "^3.1.2",
-    "regl-scatter2d": "^3.2.9",
+    "regl-scatter2d": "^3.3.1",
     "regl-splom": "^1.0.14",
     "strongly-connected-components": "^1.0.1",
     "superscript-text": "^1.0.0",


### PR DESCRIPTION
Fix #6820 by bump `regl-scatter2d` to v3.3.1.
Thanks to @justinjhendrick's https://github.com/gl-vis/regl-scatter2d/pull/36.
@plotly/plotly_js 