### PR TITLE
 Feature: Sankey Link Hover Styling

### DIFF
--- a/draftlogs/6839_change.md
+++ b/draftlogs/6839_change.md
@@ -1,0 +1,1 @@
+- Update Sankey trace to allow user-defined link hover style override [[#6839](https://github.com/plotly/plotly.js/pull/6839)]

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -68,7 +68,7 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
         // Figure out whether the user has provided their own sankey-link-hover style.
         var styleExists = false;
         for (var i=0; i<document.styleSheets.length; i++) {
-            const rules = document.styleSheets[i].cssRules;
+            var rules = document.styleSheets[i].cssRules;
             for (var j=0; j < rules.length; j++) {
                 if (rules[j].selectorText === '.sankey-link-hover') {
                     styleExists = true;
@@ -85,7 +85,7 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
                 style = document.createElement('style');
                 document.head.appendChild(style);
             }
-            const sheet = style.sheet;
+            var sheet = style.sheet;
             // If these are not flagged as !important chrome won't render the change
             sheet.insertRule('.sankey-link-hover { fill-opacity: 0.4 !important; }', 0);
         }

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -64,24 +64,24 @@ function nodeNonHoveredStyle(sankeyNode, d, sankey) {
 }
 
 function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
-    if (!linkStyleInitialized) {
+    if(!linkStyleInitialized) {
         // Figure out whether the user has provided their own sankey-link-hover style.
         var styleExists = false;
-        for (var i=0; i<document.styleSheets.length; i++) {
+        for(var i = 0; i < document.styleSheets.length; i++) {
             var rules = document.styleSheets[i].cssRules;
-            for (var j=0; j < rules.length; j++) {
-                if (rules[j].selectorText === '.sankey-link-hover') {
+            for(var j = 0; j < rules.length; j++) {
+                if(rules[j].selectorText === '.sankey-link-hover') {
                     styleExists = true;
                     break;
                 }
             }
-            if (styleExists) break;
+            if(styleExists) break;
         }
-        
+
         // If not, insert a default one
-        if (!styleExists) {
+        if(!styleExists) {
             var style = document.querySelector('style');
-            if (!style) {
+            if(!style) {
                 style = document.createElement('style');
                 document.head.appendChild(style);
             }

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -66,10 +66,10 @@ function nodeNonHoveredStyle(sankeyNode, d, sankey) {
 function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
     if (!linkStyleInitialized) {
         // Figure out whether the user has provided their own sankey-link-hover style.
-        let styleExists = false;
-        for (let i=0; i<document.styleSheets.length; i++) {
+        var styleExists = false;
+        for (var i=0; i<document.styleSheets.length; i++) {
             const rules = document.styleSheets[i].cssRules;
-            for (let j=0; j < rules.length; j++) {
+            for (var j=0; j < rules.length; j++) {
                 if (rules[j].selectorText === '.sankey-link-hover') {
                     styleExists = true;
                     break;

--- a/src/traces/sankey/plot.js
+++ b/src/traces/sankey/plot.js
@@ -68,14 +68,18 @@ function linkHoveredStyle(d, sankey, visitNodes, sankeyLink) {
         // Figure out whether the user has provided their own sankey-link-hover style.
         var styleExists = false;
         for(var i = 0; i < document.styleSheets.length; i++) {
-            var rules = document.styleSheets[i].cssRules;
-            for(var j = 0; j < rules.length; j++) {
-                if(rules[j].selectorText === '.sankey-link-hover') {
-                    styleExists = true;
-                    break;
+            try {
+                var rules = document.styleSheets[i].cssRules;
+                for(var j = 0; j < rules.length; j++) {
+                    if(rules[j].selectorText === '.sankey-link-hover') {
+                        styleExists = true;
+                        break;
+                    }
                 }
+                if(styleExists) break;
+            } catch(e) {
+                // This particular style sheet cannot be accessed (due to CORS policy)
             }
-            if(styleExists) break;
         }
 
         // If not, insert a default one

--- a/test/jasmine/tests/sankey_test.js
+++ b/test/jasmine/tests/sankey_test.js
@@ -1087,7 +1087,7 @@ describe('sankey tests', function() {
                         .filter(function(obj) {
                             return obj.link.label === 'stream 1';
                         })[0].forEach(function(l) {
-                            expect(l.style.fillOpacity).toEqual('0.4');
+                            expect(l.classList.contains('sankey-link-hover')).toBe(true);
                         });
                 }).then(function() {
                     mouseEvent('mouseout', 200, 250);
@@ -1096,7 +1096,7 @@ describe('sankey tests', function() {
                         .filter(function(obj) {
                             return obj.link.label === 'stream 1';
                         })[0].forEach(function(l) {
-                            expect(l.style.fillOpacity).toEqual('0.2');
+                            expect(l.classList.contains('sankey-link-hover')).toBe(false);
                         });
                 })
                 .then(done, done.fail);


### PR DESCRIPTION
**Existing Behavior:**
When a user hovers over a link in a Sankey diagram, the diagram changes the style of all of the links with the same title. This is useful for tracking what path a particular thing took while it travelled through the diagram. This style change leaves the color the same, but sets the link opacity to 0.4. 

**Problem:**
The current behavior works well when there are only a small number of links, but when dealing with hundreds or thousands of links it becomes impossible to track where an individual link came from. Users have requested a solution to this several times over the past several years:

- https://community.plotly.com/t/feature-request-hover-link-color-in-sankey-graphs/52868
- https://community.plotly.com/t/sankey-link-hover-color/26912
- https://community.plotly.com/t/changing-trace-colors-in-sankey/10691

**Proposed Change:**
Allow end users to override the sankey link hover style by providing their own css styling. With this PR users can build apps which include css like the following:

```css
.sankey-link-hover {
    fill: black !important;
    fill-opacity: 1 !important;
  }
```

This makes it feasible to track individual instances across complex diagrams even when there are hundreds of links at once.

### Translations:

No user-faces changes to translate.

### Features, Bug fixes, and others:

Before opening a pull request, developer should:

- [x] make sure they are not on the `master` branch of their fork as using `master` for a pull request would make it difficult to fetch `upstream` changes.
- [x] fetch latest changes from `upstream/master` into your fork i.e. `origin/master` then pull `origin/master` from you local `master`.
- [x] then `git rebase master` their local dev branch off the latest `master` which should be sync with `upstream/master` at this time.
- [x] make sure to **not** `git add` the `dist/` folder (the `dist/` is updated only on version bumps).
- [x] make sure to commit changes to the `package-lock.json` file (if any new dependency required).
- [x] provide a title and write an overview of what the PR attempts to do with a link to the issue they are trying to address.
- [x] select the _Allow edits from maintainers_ option (see this [article](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for more details).

After opening a pull request, developer:
 - [x] should create a new small markdown log file using the PR number e.g. `1010_fix.md` or `1010_add.md` inside `draftlogs` folder as described in this [README](https://github.com/plotly/plotly.js/blob/master/draftlogs/README.md), commit it and push.
 - [x] should **not** force push (i.e. `git push -f`) to remote branches associated with opened pull requests. Force pushes make it hard for maintainers to keep track of updates. Therefore, if required, please fetch `upstream/master` and "merge" with master instead of "rebase".
