### PR TITLE
Fix interacting with selection on subplots with overlaid axes

### DIFF
--- a/draftlogs/6870_change.md
+++ b/draftlogs/6870_change.md
@@ -1,0 +1,1 @@
+- Fix bug where extending an existing box/lasso selection on traces with overlaying axes didn't update the selection [[#6870](https://github.com/plotly/plotly.js/pull/6870)].

--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -809,7 +809,8 @@ function determineSearchTraces(gd, xAxes, yAxes, subplot) {
             var sankeyInfo = createSearchInfo(trace._module, cd, xAxes[0], yAxes[0]);
             searchTraces.push(sankeyInfo);
         } else {
-            if(!trace.xaxis || !trace.yaxis) continue;
+            if(xAxisIds.indexOf(trace.xaxis) === -1 && !trace._xA) continue;
+            if(yAxisIds.indexOf(trace.yaxis) === -1 && !trace._yA) continue;
 
             searchTraces.push(createSearchInfo(trace._module, cd,
               getFromId(gd, trace.xaxis), getFromId(gd, trace.yaxis)));

--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -809,8 +809,7 @@ function determineSearchTraces(gd, xAxes, yAxes, subplot) {
             var sankeyInfo = createSearchInfo(trace._module, cd, xAxes[0], yAxes[0]);
             searchTraces.push(sankeyInfo);
         } else {
-            if(xAxisIds.indexOf(trace.xaxis) === -1) continue;
-            if(yAxisIds.indexOf(trace.yaxis) === -1) continue;
+            if(!trace.xaxis || !trace.yaxis) continue;
 
             searchTraces.push(createSearchInfo(trace._module, cd,
               getFromId(gd, trace.xaxis), getFromId(gd, trace.yaxis)));

--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -809,8 +809,8 @@ function determineSearchTraces(gd, xAxes, yAxes, subplot) {
             var sankeyInfo = createSearchInfo(trace._module, cd, xAxes[0], yAxes[0]);
             searchTraces.push(sankeyInfo);
         } else {
-            if(xAxisIds.indexOf(trace.xaxis) === -1 && !trace._xA) continue;
-            if(yAxisIds.indexOf(trace.yaxis) === -1 && !trace._yA) continue;
+            if(xAxisIds.indexOf(trace.xaxis) === -1 && (!trace._xA || !trace._xA.overlaying)) continue;
+            if(yAxisIds.indexOf(trace.yaxis) === -1 && (!trace._yA || !trace._yA.overlaying)) continue;
 
             searchTraces.push(createSearchInfo(trace._module, cd,
               getFromId(gd, trace.xaxis), getFromId(gd, trace.yaxis)));


### PR DESCRIPTION
Fixes #6530 

### Description 
Extending an existing box/lasso selection on traces that overlay axes don't update selection. Only the first trace (which doesn't have `overlay` is updated). See video below:
https://github.com/plotly/plotly.js/assets/35932204/91f75734-f47d-47b6-81b0-806413b2cf45


This was happening because the `yAxisIds` is equal to `'y'` and `trace.yaxis` to y + the index of the trace (e.g `y4`), so  `yAxisIds.indexOf(trace.yaxis)` is `-1` for all the overlaying traces.