### PR TITLE
Unified hover: use `legend.tracegroupgap` in mock legend

### DIFF
--- a/draftlogs/6875_change.md
+++ b/draftlogs/6875_change.md
@@ -1,0 +1,1 @@
+- Unified hover: use `legend.tracegroupgap` in mock legend instead of setting a hardcoded value [[#6864](https://github.com/plotly/plotly.js/pull/6864)]

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1139,7 +1139,7 @@ function createHoverText(hoverData, opts) {
                 bgcolor: hoverlabel.bgcolor,
                 bordercolor: hoverlabel.bordercolor,
                 borderwidth: 1,
-                tracegroupgap: 7,
+                tracegroupgap: fullLayout.legend ? fullLayout.legend.tracegroupgap : undefined,
                 traceorder: fullLayout.legend ? fullLayout.legend.traceorder : undefined,
                 orientation: 'v'
             }


### PR DESCRIPTION
When using a mock legend in the `unified` hover label, read the user-provided `legend.tracegroupgap` parameter instead of hardcoding `tracegroupgap: 7`. To make the tooltip match the legend.