### PR TITLE
Fix resizing `pie` like traces when `textinfo` is set to "none"

### DIFF
--- a/draftlogs/6893_fix.md
+++ b/draftlogs/6893_fix.md
@@ -1,0 +1,1 @@
+- Fix possible NPE when `textinfo: "none"` for pie and funnelarea traces

--- a/src/traces/funnelarea/defaults.js
+++ b/src/traces/funnelarea/defaults.js
@@ -55,7 +55,7 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
             moduleHasTextangle: false,
             moduleHasInsideanchor: false
         });
-    } else if (textInfo === 'none') {
+    } else if(textInfo === 'none') {
         coerce('textposition', 'none');
     }
 

--- a/src/traces/funnelarea/defaults.js
+++ b/src/traces/funnelarea/defaults.js
@@ -55,6 +55,8 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
             moduleHasTextangle: false,
             moduleHasInsideanchor: false
         });
+    } else if (textInfo === 'none') {
+        coerce('textposition', 'none');
     }
 
     handleDomainDefaults(traceOut, layout, coerce);

--- a/src/traces/pie/defaults.js
+++ b/src/traces/pie/defaults.js
@@ -111,6 +111,8 @@ function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
         if(textposition === 'inside' || textposition === 'auto' || Array.isArray(textposition)) {
             coerce('insidetextorientation');
         }
+    } else if (textInfo === 'none') {
+        coerce('textposition', 'none');
     }
 
     handleDomainDefaults(traceOut, layout, coerce);

--- a/src/traces/pie/defaults.js
+++ b/src/traces/pie/defaults.js
@@ -111,7 +111,7 @@ function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
         if(textposition === 'inside' || textposition === 'auto' || Array.isArray(textposition)) {
             coerce('insidetextorientation');
         }
-    } else if (textInfo === 'none') {
+    } else if(textInfo === 'none') {
         coerce('textposition', 'none');
     }
 


### PR DESCRIPTION
If `textinfo==="none"`, the `textposition` coercion is skipped for both funnelarea and pie traces. However, there is a place in the plot render logic that assumes `textposition` is defined and is skipped iff `textposition==="none"` (https://github.com/plotly/plotly.js/blob/master/src/traces/pie/plot.js#L136).

Since the coercion is not enforced and `textposition` is undefined (not `"none"`), related text objects which have not been initialized are attempted to be accessed resulting in a null pointer exception (https://github.com/plotly/plotly.js/blob/master/src/traces/pie/plot.js#L511).

I am open to alternative solutions that may include a `textinfo==="none"` check in the plot render logic, but this approach seemed to be the most comprehensive.

Reproduction example: https://github.com/robbtraister/plotly-npe