### PR TITLE
Fix deprecated dependency notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@plotly/d3": "3.8.1",
     "@plotly/d3-sankey": "0.7.2",
     "@plotly/d3-sankey-circular": "0.33.1",
-    "@plotly/mapbox-gl": "v1.13.4",
+    "@plotly/mapbox-gl": "1.13.4",
     "@turf/area": "^6.4.0",
     "@turf/bbox": "^6.4.0",
     "@turf/centroid": "^6.0.2",


### PR DESCRIPTION
Minor change to replaces a semver v1 notation (with leading `v`) with semver v2.

PS: The npm semver package most likely will deprecate semver v1 support in next major.

