### PR TITLE
Fix hover count info label in `createHoverLabelForColorHovermode`

### DIFF
--- a/draftlogs/6944_change.md
+++ b/draftlogs/6944_change.md
@@ -1,3 +1,3 @@
-- Fix hover count info label in `createHoverLabelForColorHovermode`[[#6944](https://github.com/plotly/plotly.js/pull/6944)]
-
+- Fix hover count in parcats trace [[#6944](https://github.com/plotly/plotly.js/pull/6944)],
+   with thanks to @weiweikee for the contribution!
 

--- a/draftlogs/6944_change.md
+++ b/draftlogs/6944_change.md
@@ -1,0 +1,1 @@
+- Fix hover count info label in `createHoverLabelForColorHovermode`[[#6944](https://github.com/plotly/plotly.js/pull/6944)]

--- a/src/traces/parcats/parcats.js
+++ b/src/traces/parcats/parcats.js
@@ -921,7 +921,7 @@ function createHoverLabelForColorHovermode(gd, rootBBox, bandElement) {
     var pColorGivenCat = bandColorCount / catCount;
 
     var labels = {
-        countLabel: totalCount,
+        countLabel: bandColorCount,
         categoryLabel: catLabel,
         probabilityLabel: pColorAndCat.toFixed(3)
     };

--- a/test/image/mocks/parcats_hoveron_color.json
+++ b/test/image/mocks/parcats_hoveron_color.json
@@ -3,7 +3,7 @@
     {"type": "parcats",
       "domain": {"x": [0.125, 0.625],"y": [0.25, 0.75]},
       "hoveron": "color",
-      "hoverinfo": "probability",
+      "hoverinfo": "count+probability",
       "dimensions":[
         {"label": "One", "values": [1, 1, 2, 1, 2, 1, 1, 2, 1]},
         {"label": "Two", "values": ["A", "B", "A", "B", "C", "C", "A", "B", "C"]},


### PR DESCRIPTION
# Pull Request Summary 
Fixes incorrect hover labels in Parallel Categories Diagrams with `'hoveron: color', 'hoverinfo: count'`. Labels now accurately reflect counts for the specific color segment hovered over. Below are screenshots of the changes in effect.

## Before the changes
### Hovering on Gray
![03_27_24_15_53_screenshot](https://github.com/plotly/plotly.js/assets/22086519/f5f9a391-3440-4c22-bc33-7e08f37b1853)
### Hovering on Red
![03_27_24_15_53_screenshot (2)](https://github.com/plotly/plotly.js/assets/22086519/41eded78-47a9-4c3c-a676-7922186277db)

## After the changes
### Hovering on Gray
![03_27_24_15_56_screenshot](https://github.com/plotly/plotly.js/assets/22086519/a87e9b41-902e-48aa-8d94-d8cfe1469334)
### Hovering on Red
![03_27_24_15_56_screenshot (2)](https://github.com/plotly/plotly.js/assets/22086519/643abcaf-2cba-4c60-acff-2f56c730c877)
