### PR TITLE
Add `layout.subplots` to enable (x|y) hover effects across multiple cartesian and splom suplots sharing one axis

### DIFF
--- a/draftlogs/6947_add.md
+++ b/draftlogs/6947_add.md
@@ -1,1 +1,1 @@
- - Add `layout.hoversameaxis` to enable hover effects across multiple cartesian suplots sharing one axis [[#6947](https://github.com/plotly/plotly.js/pull/6947)]
+ - Add `layout.hoverthrough` to enable hover effects across multiple cartesian suplots sharing one axis [[#6947](https://github.com/plotly/plotly.js/pull/6947)]

--- a/draftlogs/6947_add.md
+++ b/draftlogs/6947_add.md
@@ -1,0 +1,1 @@
+ - Add `layout.hoversameaxis` to enable hover effects across multiple cartesian suplots sharing one axis [[#6947](https://github.com/plotly/plotly.js/pull/6947)]

--- a/draftlogs/6947_add.md
+++ b/draftlogs/6947_add.md
@@ -1,1 +1,1 @@
- - Add `layout.hoverthrough` to enable hover effects across multiple cartesian suplots sharing one axis [[#6947](https://github.com/plotly/plotly.js/pull/6947)]
+ - Add `layout.hoversubplots` to enable hover effects across multiple cartesian suplots sharing one axis [[#6947](https://github.com/plotly/plotly.js/pull/6947)]

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -261,7 +261,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     var spId;
 
     var fullLayout = gd._fullLayout;
-    var hoverthrough = fullLayout.hoverthrough;
+    var hoversubplots = fullLayout.hoversubplots;
     var plots = fullLayout._plots || [];
     var plotinfo = plots[subplot];
     var hasCartesian = fullLayout._has('cartesian');
@@ -270,7 +270,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     var hovermodeHasX = (hovermode || '').charAt(0) === 'x';
     var hovermodeHasY = (hovermode || '').charAt(0) === 'y';
 
-    if(hasCartesian && (hovermodeHasX || hovermodeHasY) && hoverthrough === 'axis') {
+    if(hasCartesian && (hovermodeHasX || hovermodeHasY) && hoversubplots === 'axis') {
         var subplotsLength = subplots.length;
         for(var p = 0; p < subplotsLength; p++) {
             spId = subplots[p];
@@ -570,7 +570,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
                         hoverLayer: fullLayout._hoverlayer,
 
                         // options for splom when hovering on same axis
-                        hoverthrough: hoverthrough,
+                        hoversubplots: hoversubplots,
                         gd: gd
                     });
 
@@ -692,7 +692,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     gd._spikepoints = newspikepoints;
 
     var sortHoverData = function() {
-        if(!hoverthrough) {
+        if(!hoversubplots) {
             hoverData.sort(function(d1, d2) { return d1.distance - d2.distance; });
         }
 

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -270,7 +270,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     var hovermodeHasX = (hovermode || '').charAt(0) === 'x';
     var hovermodeHasY = (hovermode || '').charAt(0) === 'y';
 
-    if(hoverthrough && hasCartesian && (hovermodeHasX || hovermodeHasY)) {
+    if(hasCartesian && (hovermodeHasX || hovermodeHasY) && hoverthrough === 'axis') {
         var subplotsLength = subplots.length;
         for(var p = 0; p < subplotsLength; p++) {
             spId = subplots[p];

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -466,6 +466,12 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
             // the rest of this function from running and failing
             if(['carpet', 'contourcarpet'].indexOf(trace._module.name) !== -1) continue;
 
+            // within one trace mode can sometimes be overridden
+            _mode = hovermode;
+            if(helpers.isUnifiedHover(_mode)) {
+                _mode = _mode.charAt(0);
+            }
+
             if(trace.type === 'splom') {
                 // splom traces do not generate overlay subplots,
                 // it is safe to assume here splom traces correspond to the 0th subplot
@@ -474,12 +480,6 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
             } else {
                 subplotId = helpers.getSubplot(trace);
                 subploti = subplots.indexOf(subplotId);
-            }
-
-            // within one trace mode can sometimes be overridden
-            _mode = hovermode;
-            if(helpers.isUnifiedHover(_mode)) {
-                _mode = _mode.charAt(0);
             }
 
             // container for new point, also used to pass info into module.hoverPoints

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -566,7 +566,11 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
                 if(trace._module && trace._module.hoverPoints) {
                     var newPoints = trace._module.hoverPoints(pointData, xval, yval, _mode, {
                         finiteRange: true,
-                        hoverLayer: fullLayout._hoverlayer
+                        hoverLayer: fullLayout._hoverlayer,
+
+                        // options for splom when hovering on same axis
+                        hoversameaxis: hoversameaxis,
+                        gd: gd
                     });
 
                     if(newPoints) {

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -291,7 +291,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     }
 
     // list of all overlaid subplots to look at
-    if(plotinfo) {
+    if(plotinfo && hoversubplots !== 'single') {
         var overlayedSubplots = plotinfo.overlays.map(function(pi) {
             return pi.id;
         });

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -533,8 +533,6 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
                 pointData.scene = fullLayout._splomScenes[trace.uid];
             }
 
-            closedataPreviousLength = hoverData.length;
-
             // for a highlighting array, figure out what
             // we're searching for with this element
             if(_mode === 'array') {
@@ -560,6 +558,8 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
                 xval = xvalArray[subploti];
                 yval = yvalArray[subploti];
             }
+
+            closedataPreviousLength = hoverData.length;
 
             // Now if there is range to look in, find the points to hover.
             if(hoverdistance !== 0) {

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -271,7 +271,8 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     var hovermodeHasY = (hovermode || '').charAt(0) === 'y';
 
     if(hoversameaxis && hasCartesian && (hovermodeHasX || hovermodeHasY)) {
-        for(var p = 0; p < subplots.length; p++) {
+        var subplotsLength = subplots.length;
+        for(var p = 0; p < subplotsLength; p++) {
             spId = subplots[p];
             if(plots[spId]) {
                 // 'cartesian' case

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -692,7 +692,9 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     gd._spikepoints = newspikepoints;
 
     var sortHoverData = function() {
-        hoverData.sort(function(d1, d2) { return d1.distance - d2.distance; });
+        if(!hoverthrough) {
+            hoverData.sort(function(d1, d2) { return d1.distance - d2.distance; });
+        }
 
         // move period positioned points and box/bar-like traces to the end of the list
         hoverData = orderRangePoints(hoverData, hovermode);

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -261,7 +261,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     var spId;
 
     var fullLayout = gd._fullLayout;
-    var hoversameaxis = fullLayout.hoversameaxis;
+    var hoverthrough = fullLayout.hoverthrough;
     var plots = fullLayout._plots || [];
     var plotinfo = plots[subplot];
     var hasCartesian = fullLayout._has('cartesian');
@@ -270,7 +270,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     var hovermodeHasX = (hovermode || '').charAt(0) === 'x';
     var hovermodeHasY = (hovermode || '').charAt(0) === 'y';
 
-    if(hoversameaxis && hasCartesian && (hovermodeHasX || hovermodeHasY)) {
+    if(hoverthrough && hasCartesian && (hovermodeHasX || hovermodeHasY)) {
         var subplotsLength = subplots.length;
         for(var p = 0; p < subplotsLength; p++) {
             spId = subplots[p];
@@ -570,7 +570,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
                         hoverLayer: fullLayout._hoverlayer,
 
                         // options for splom when hovering on same axis
-                        hoversameaxis: hoversameaxis,
+                        hoverthrough: hoverthrough,
                         gd: gd
                     });
 

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -692,7 +692,7 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     gd._spikepoints = newspikepoints;
 
     var sortHoverData = function() {
-        if(!hoversubplots) {
+        if(hoversubplots !== 'axis') {
             hoverData.sort(function(d1, d2) { return d1.distance - d2.distance; });
         }
 

--- a/src/components/fx/hovermode_defaults.js
+++ b/src/components/fx/hovermode_defaults.js
@@ -12,6 +12,6 @@ module.exports = function handleHoverModeDefaults(layoutIn, layoutOut) {
     }
 
     coerce('clickmode');
-    coerce('hoverthrough');
+    coerce('hoversubplots');
     return coerce('hovermode');
 };

--- a/src/components/fx/hovermode_defaults.js
+++ b/src/components/fx/hovermode_defaults.js
@@ -12,6 +12,6 @@ module.exports = function handleHoverModeDefaults(layoutIn, layoutOut) {
     }
 
     coerce('clickmode');
-    coerce('hoversameaxis');
+    coerce('hoverthrough');
     return coerce('hovermode');
 };

--- a/src/components/fx/hovermode_defaults.js
+++ b/src/components/fx/hovermode_defaults.js
@@ -12,5 +12,6 @@ module.exports = function handleHoverModeDefaults(layoutIn, layoutOut) {
     }
 
     coerce('clickmode');
+    coerce('hoversameaxis');
     return coerce('hovermode');
 };

--- a/src/components/fx/layout_attributes.js
+++ b/src/components/fx/layout_attributes.js
@@ -78,7 +78,7 @@ module.exports = {
             'If false, hover interactions are disabled.'
         ].join(' ')
     },
-    hoversameaxis: {
+    hoverthrough: {
         valType: 'boolean',
         dflt: false,
         editType: 'none',

--- a/src/components/fx/layout_attributes.js
+++ b/src/components/fx/layout_attributes.js
@@ -79,11 +79,13 @@ module.exports = {
         ].join(' ')
     },
     hoverthrough: {
-        valType: 'boolean',
+        valType: 'enumerated',
+        values: ['axis', false],
         dflt: false,
         editType: 'none',
         description: [
-            'Determines expansion of hover effects to other subplots in case of sharing an axis.',
+            'Determines expansion of hover effects to other subplots',
+            'If *axis*, points from subplots linked to the axis of hovered subplot are included.',
             'Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.',
         ].join(' ')
     },

--- a/src/components/fx/layout_attributes.js
+++ b/src/components/fx/layout_attributes.js
@@ -78,7 +78,7 @@ module.exports = {
             'If false, hover interactions are disabled.'
         ].join(' ')
     },
-    hoverthrough: {
+    hoversubplots: {
         valType: 'enumerated',
         values: ['axis', false],
         dflt: false,

--- a/src/components/fx/layout_attributes.js
+++ b/src/components/fx/layout_attributes.js
@@ -80,11 +80,12 @@ module.exports = {
     },
     hoversubplots: {
         valType: 'enumerated',
-        values: ['overlaying', 'axis'],
+        values: ['single', 'overlaying', 'axis'],
         dflt: 'overlaying',
         editType: 'none',
         description: [
             'Determines expansion of hover effects to other subplots',
+            'If *single* just the axis pair of the primary point is included without overlaying subplots.',
             'If *overlaying* all subplots using the main axis and occupying the same space are included.',
             'If *axis*, also include stacked subplots using the same axis',
             'when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.',

--- a/src/components/fx/layout_attributes.js
+++ b/src/components/fx/layout_attributes.js
@@ -78,6 +78,15 @@ module.exports = {
             'If false, hover interactions are disabled.'
         ].join(' ')
     },
+    hoversameaxis: {
+        valType: 'boolean',
+        dflt: false,
+        editType: 'none',
+        description: [
+            'Determines expansion of hover effects to other subplots in case of sharing an axis.',
+            'Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.',
+        ].join(' ')
+    },
     hoverdistance: {
         valType: 'integer',
         min: -1,

--- a/src/components/fx/layout_attributes.js
+++ b/src/components/fx/layout_attributes.js
@@ -80,13 +80,14 @@ module.exports = {
     },
     hoversubplots: {
         valType: 'enumerated',
-        values: ['axis', false],
-        dflt: false,
+        values: ['overlaying', 'axis'],
+        dflt: 'overlaying',
         editType: 'none',
         description: [
             'Determines expansion of hover effects to other subplots',
-            'If *axis*, points from subplots linked to the axis of hovered subplot are included.',
-            'Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.',
+            'If *overlaying* all subplots using the main axis and occupying the same space are included.',
+            'If *axis*, also include stacked subplots using the same axis',
+            'when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.',
         ].join(' ')
     },
     hoverdistance: {

--- a/src/traces/splom/hover.js
+++ b/src/traces/splom/hover.js
@@ -73,6 +73,8 @@ function _hoverPoints(pointData, xpx, ypx, hoversubplotsX, hoversubplotsY) {
     var minDist = maxDistance;
 
     for(var i = 0; i < x.length; i++) {
+        if((hoversubplotsX || hoversubplotsY) && i !== pointData.index) continue;
+
         var ptx = x[i];
         var pty = y[i];
         var thisXpx = xa.c2p(ptx);

--- a/src/traces/splom/hover.js
+++ b/src/traces/splom/hover.js
@@ -2,16 +2,64 @@
 
 var helpers = require('./helpers');
 var calcHover = require('../scattergl/hover').calcHover;
+var getFromId = require('../../plots/cartesian/axes').getFromId;
+var extendFlat = require('../../lib/extend').extendFlat;
 
-function hoverPoints(pointData, xval, yval) {
+function hoverPoints(pointData, xval, yval, hovermode, opts) {
+    if(!opts) opts = {};
+
+    var hovermodeHasX = (hovermode || '').charAt(0) === 'x';
+    var hovermodeHasY = (hovermode || '').charAt(0) === 'y';
+
+    var xpx = pointData.xa.c2p(xval);
+    var ypx = pointData.ya.c2p(yval);
+
+    var points = _hoverPoints(pointData, xpx, ypx);
+
+    if(opts.hoversameaxis && (hovermodeHasX || hovermodeHasY)) {
+        var _xpx = points[0]._xpx;
+        var _ypx = points[0]._ypx;
+
+        if(
+            (hovermodeHasX && _xpx !== undefined) ||
+            (hovermodeHasY && _ypx !== undefined)
+        ) {
+            var subplotsWith = (
+                hovermodeHasX ?
+                pointData.xa :
+                pointData.ya
+            )._subplotsWith;
+
+            var gd = opts.gd;
+
+            var _pointData = extendFlat({}, pointData);
+
+            for(var i = 0; i < subplotsWith.length; i++) {
+                var spId = subplotsWith[i];
+
+                if(hovermodeHasY) {
+                    _pointData.xa = getFromId(gd, spId, 'x');
+                } else { // hovermodeHasX
+                    _pointData.ya = getFromId(gd, spId, 'y');
+                }
+
+                var newPoints = _hoverPoints(_pointData, _xpx, _ypx, hovermodeHasX, hovermodeHasY);
+
+                points = points.concat(newPoints);
+            }
+        }
+    }
+
+    return points;
+}
+
+function _hoverPoints(pointData, xpx, ypx, hoversameaxisX, hoversameaxisY) {
     var cd = pointData.cd;
     var trace = cd[0].trace;
     var scene = pointData.scene;
     var cdata = scene.matrixOptions.cdata;
     var xa = pointData.xa;
     var ya = pointData.ya;
-    var xpx = xa.c2p(xval);
-    var ypx = ya.c2p(yval);
     var maxDistance = pointData.distance;
 
     var xi = helpers.getDimIndex(trace, xa);
@@ -21,19 +69,34 @@ function hoverPoints(pointData, xval, yval) {
     var x = cdata[xi];
     var y = cdata[yi];
 
-    var id, dxy;
+    var id, dxy, _xpx, _ypx;
     var minDist = maxDistance;
 
     for(var i = 0; i < x.length; i++) {
         var ptx = x[i];
         var pty = y[i];
-        var dx = xa.c2p(ptx) - xpx;
-        var dy = ya.c2p(pty) - ypx;
-        var dist = Math.sqrt(dx * dx + dy * dy);
+        var thisXpx = xa.c2p(ptx);
+        var thisYpx = ya.c2p(pty);
 
-        if(dist < minDist) {
+        var dx = thisXpx - xpx;
+        var dy = thisYpx - ypx;
+        var dist = 0;
+
+        var pick = false;
+        if(hoversameaxisX) {
+            if(dx === 0) pick = true;
+        } else if(hoversameaxisY) {
+            if(dy === 0) pick = true;
+        } else {
+            dist = Math.sqrt(dx * dx + dy * dy);
+            if(dist < minDist) pick = true;
+        }
+
+        if(pick) {
             minDist = dxy = dist;
             id = i;
+            _xpx = thisXpx;
+            _ypx = thisYpx;
         }
     }
 
@@ -43,7 +106,10 @@ function hoverPoints(pointData, xval, yval) {
 
     if(id === undefined) return [pointData];
 
-    return [calcHover(pointData, x, y, trace)];
+    var out = calcHover(pointData, x, y, trace);
+    out._xpx = _xpx;
+    out._ypx = _ypx;
+    return [out];
 }
 
 module.exports = {

--- a/src/traces/splom/hover.js
+++ b/src/traces/splom/hover.js
@@ -16,7 +16,7 @@ function hoverPoints(pointData, xval, yval, hovermode, opts) {
 
     var points = _hoverPoints(pointData, xpx, ypx);
 
-    if((hovermodeHasX || hovermodeHasY) && opts.hoverthrough === 'axis') {
+    if((hovermodeHasX || hovermodeHasY) && opts.hoversubplots === 'axis') {
         var _xpx = points[0]._xpx;
         var _ypx = points[0]._ypx;
 
@@ -53,7 +53,7 @@ function hoverPoints(pointData, xval, yval, hovermode, opts) {
     return points;
 }
 
-function _hoverPoints(pointData, xpx, ypx, hoverthroughX, hoverthroughY) {
+function _hoverPoints(pointData, xpx, ypx, hoversubplotsX, hoversubplotsY) {
     var cd = pointData.cd;
     var trace = cd[0].trace;
     var scene = pointData.scene;
@@ -83,9 +83,9 @@ function _hoverPoints(pointData, xpx, ypx, hoverthroughX, hoverthroughY) {
         var dist = 0;
 
         var pick = false;
-        if(hoverthroughX) {
+        if(hoversubplotsX) {
             if(dx === 0) pick = true;
-        } else if(hoverthroughY) {
+        } else if(hoversubplotsY) {
             if(dy === 0) pick = true;
         } else {
             dist = Math.sqrt(dx * dx + dy * dy);

--- a/src/traces/splom/hover.js
+++ b/src/traces/splom/hover.js
@@ -16,7 +16,7 @@ function hoverPoints(pointData, xval, yval, hovermode, opts) {
 
     var points = _hoverPoints(pointData, xpx, ypx);
 
-    if(opts.hoversameaxis && (hovermodeHasX || hovermodeHasY)) {
+    if(opts.hoverthrough && (hovermodeHasX || hovermodeHasY)) {
         var _xpx = points[0]._xpx;
         var _ypx = points[0]._ypx;
 
@@ -53,7 +53,7 @@ function hoverPoints(pointData, xval, yval, hovermode, opts) {
     return points;
 }
 
-function _hoverPoints(pointData, xpx, ypx, hoversameaxisX, hoversameaxisY) {
+function _hoverPoints(pointData, xpx, ypx, hoverthroughX, hoverthroughY) {
     var cd = pointData.cd;
     var trace = cd[0].trace;
     var scene = pointData.scene;
@@ -83,9 +83,9 @@ function _hoverPoints(pointData, xpx, ypx, hoversameaxisX, hoversameaxisY) {
         var dist = 0;
 
         var pick = false;
-        if(hoversameaxisX) {
+        if(hoverthroughX) {
             if(dx === 0) pick = true;
-        } else if(hoversameaxisY) {
+        } else if(hoverthroughY) {
             if(dy === 0) pick = true;
         } else {
             dist = Math.sqrt(dx * dx + dy * dy);

--- a/src/traces/splom/hover.js
+++ b/src/traces/splom/hover.js
@@ -16,7 +16,7 @@ function hoverPoints(pointData, xval, yval, hovermode, opts) {
 
     var points = _hoverPoints(pointData, xpx, ypx);
 
-    if(opts.hoverthrough && (hovermodeHasX || hovermodeHasY)) {
+    if((hovermodeHasX || hovermodeHasY) && opts.hoverthrough === 'axis') {
         var _xpx = points[0]._xpx;
         var _ypx = points[0]._ypx;
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2380,12 +2380,12 @@ describe('hover info on stacked subplots', function() {
     });
 });
 
-describe('hover on subplots when hoverthrough is set to *axis* and x hovermodes', function() {
+describe('hover on subplots when hoversubplots is set to *axis* and x hovermodes', function() {
     'use strict';
 
     var mock = {
         layout: {
-            hoverthrough: 'axis',
+            hoversubplots: 'axis',
             hovermode: 'x',
             grid: {
                 rows: 3,
@@ -2423,7 +2423,7 @@ describe('hover on subplots when hoverthrough is set to *axis* and x hovermodes'
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: *x* | *x unified* with hoverthrough: *axis*', function() {
+    it('hovermode: *x* | *x unified* with hoversubplots: *axis*', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2468,12 +2468,12 @@ describe('hover on subplots when hoverthrough is set to *axis* and x hovermodes'
     });
 });
 
-describe('hover on subplots when hoverthrough is set to *axis* and y hovermodes', function() {
+describe('hover on subplots when hoversubplots is set to *axis* and y hovermodes', function() {
     'use strict';
 
     var mock = {
         layout: {
-            hoverthrough: 'axis',
+            hoversubplots: 'axis',
             hovermode: 'y',
             grid: {
                 rows: 2,
@@ -2511,7 +2511,7 @@ describe('hover on subplots when hoverthrough is set to *axis* and y hovermodes'
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: *y* | *y unified* with hoverthrough: *axis*', function() {
+    it('hovermode: *y* | *y unified* with hoversubplots: *axis*', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2556,12 +2556,12 @@ describe('hover on subplots when hoverthrough is set to *axis* and y hovermodes'
     });
 });
 
-describe('splom hover on subplots when hoverthrough is set to *axis* and (x|y) hovermodes', function() {
+describe('splom hover on subplots when hoversubplots is set to *axis* and (x|y) hovermodes', function() {
     'use strict';
 
     var mock = Lib.extendDeep({}, splomLogMock);
     mock.layout.hovermode = 'x';
-    mock.layout.hoverthrough = 'axis';
+    mock.layout.hoversubplots = 'axis';
 
     var gd;
 
@@ -2572,7 +2572,7 @@ describe('splom hover on subplots when hoverthrough is set to *axis* and (x|y) h
 
     afterEach(destroyGraphDiv);
 
-    it('splom hoverthrough: *axis*', function() {
+    it('splom hoversubplots: *axis*', function() {
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
         expect(gd._hoverdata.length).toBe(3);

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -28,6 +28,8 @@ var assertElemInside = customAssertions.assertElemInside;
 
 var groupTitlesMock = require('../../image/mocks/legendgroup-titles');
 
+var splomLogMock = require('../../image/mocks/splom_log');
+
 function touch(path, options) {
     var len = path.length;
     Lib.clearThrottle();
@@ -2550,6 +2552,45 @@ describe('hover on subplots when hoversameaxis is set to true and y hovermodes',
         subplot = 'xy';
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {yval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(3);
+    });
+});
+
+describe('splom hover on subplots when hoversameaxis is set to true and (x|y) hovermodes', function() {
+    'use strict';
+
+    var mock = Lib.extendDeep({}, splomLogMock);
+    mock.layout.hovermode = 'x';
+    mock.layout.hoversameaxis = true;
+
+    var gd;
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+        Plotly.newPlot(gd, mock).then(done);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('splom hoversameaxis: true', function() {
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
+        expect(gd._hoverdata.length).toBe(3);
+        assertHoverLabelContent({
+            nums: ['100', '100k'],
+            name: ['', ''],
+            axis: '100'
+        });
+
+        Plotly.relayout(gd, 'hovermode', 'x unified');
+
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
+        expect(gd._hoverdata.length).toBe(3);
+
+        Plotly.relayout(gd, 'hovermode', 'y unified');
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
         expect(gd._hoverdata.length).toBe(3);
     });
 });

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2378,6 +2378,168 @@ describe('hover info on stacked subplots', function() {
     });
 });
 
+describe('hover on subplots when hoversameaxis is set to true and x hovermode', function() {
+    'use strict';
+
+    var mock = {
+        layout: {
+            hoversameaxis: true,
+            hovermode: 'x',
+            grid: {
+                rows: 3,
+                columns: 2,
+                pattern: 'coupled'
+            }
+        },
+
+        data: [
+            {
+                y: [1, 2, 3]
+            },
+            {
+                y: [10, 20, 30],
+                yaxis: 'y2'
+            },
+            {
+                y: [100, 200, 300],
+                yaxis: 'y3'
+            },
+            {
+                y: [10, 20, 30],
+                xaxis: 'x2',
+                yaxis: 'y2'
+            }
+        ],
+    };
+
+    var gd;
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+        Plotly.newPlot(gd, mock).then(done);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('hovermode: x with hoversameaxis: true', function() {
+        var pos = 0;
+        var subplot = 'xy';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {xval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(3);
+        assertHoverLabelContent({
+            nums: ['1', '10', '100'],
+            name: ['trace 0', 'trace 1', 'trace 2'],
+            axis: String([pos])
+        });
+
+        pos = 1;
+        subplot = 'xy2';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {xval: pos}, subplot);
+
+        expect(gd._hoverdata.length).toBe(3);
+        assertHoverLabelContent({
+            nums: ['2', '20', '200'],
+            name: ['trace 0', 'trace 1', 'trace 2'],
+            axis: String(pos)
+        });
+
+        pos = 2;
+        subplot = 'xy3';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {xval: pos}, subplot);
+
+        expect(gd._hoverdata.length).toBe(3);
+        assertHoverLabelContent({
+            nums: ['3', '30', '300'],
+            name: ['trace 0', 'trace 1', 'trace 2'],
+            axis: String(pos)
+        });
+    });
+});
+
+describe('hover on subplots when hoversameaxis is set to true and y hovermode', function() {
+    'use strict';
+
+    var mock = {
+        layout: {
+            hoversameaxis: true,
+            hovermode: 'y',
+            grid: {
+                rows: 2,
+                columns: 3,
+                pattern: 'coupled'
+            }
+        },
+
+        data: [
+            {
+                x: [1, 2, 3]
+            },
+            {
+                x: [10, 20, 30],
+                xaxis: 'x2'
+            },
+            {
+                x: [100, 200, 300],
+                xaxis: 'x3'
+            },
+            {
+                x: [10, 20, 30],
+                xaxis: 'x2',
+                yaxis: 'y2'
+            }
+        ],
+    };
+
+    var gd;
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+        Plotly.newPlot(gd, mock).then(done);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('hovermode: y with hoversameaxis: true', function() {
+        var pos = 0;
+        var subplot = 'xy';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {yval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(3);
+        assertHoverLabelContent({
+            nums: ['1', '10', '100'],
+            name: ['trace 0', 'trace 1', 'trace 2'],
+            axis: String([pos])
+        });
+
+        pos = 1;
+        subplot = 'x2y';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {yval: pos}, subplot);
+
+        expect(gd._hoverdata.length).toBe(3);
+        assertHoverLabelContent({
+            nums: ['2', '20', '200'],
+            name: ['trace 0', 'trace 1', 'trace 2'],
+            axis: String(pos)
+        });
+
+        pos = 2;
+        subplot = 'x3y';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {yval: pos}, subplot);
+
+        expect(gd._hoverdata.length).toBe(3);
+        assertHoverLabelContent({
+            nums: ['3', '30', '300'],
+            name: ['trace 0', 'trace 1', 'trace 2'],
+            axis: String(pos)
+        });
+    });
+});
+
 describe('hover on many lines+bars', function() {
     'use strict';
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2380,6 +2380,71 @@ describe('hover info on stacked subplots', function() {
     });
 });
 
+describe('hover on subplots when hoversubplots is set to *single* and x hovermodes', function() {
+    'use strict';
+
+    var mock = {
+        layout: {
+            hoversubplots: 'single',
+            hovermode: 'x',
+            yaxis2: {
+                anchor: 'x',
+                overlaying: 'y'
+            }
+        },
+
+        data: [
+            {
+                y: [1, 2, 3]
+            },
+            {
+                y: [1, 3, 2],
+                yaxis: 'y2'
+            }
+        ],
+    };
+
+    var gd;
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+        Plotly.newPlot(gd, mock).then(done);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('hovermode: *x* | *x unified* with hoversubplots: *axis*', function() {
+        var pos = 0;
+        var subplot = 'xy';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {xval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(1);
+        assertHoverLabelContent({
+            nums: '1',
+            name: 'trace 0',
+            axis: String(pos)
+        });
+
+        pos = 0;
+        subplot = 'xy2';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {xval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(1);
+        assertHoverLabelContent({
+            nums: '1',
+            name: 'trace 1',
+            axis: String(pos)
+        });
+
+        Plotly.relayout(gd, 'hovermode', 'x unified');
+        pos = 0;
+        subplot = 'xy';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {xval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(1);
+    });
+});
+
 describe('hover on subplots when hoversubplots is set to *axis* and x hovermodes', function() {
     'use strict';
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2378,7 +2378,7 @@ describe('hover info on stacked subplots', function() {
     });
 });
 
-describe('hover on subplots when hoversameaxis is set to true and x hovermode', function() {
+describe('hover on subplots when hoversameaxis is set to true and x hovermodes', function() {
     'use strict';
 
     var mock = {
@@ -2421,7 +2421,7 @@ describe('hover on subplots when hoversameaxis is set to true and x hovermode', 
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: x with hoversameaxis: true', function() {
+    it('hovermode: *x* | *x unified* with hoversameaxis: true', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2456,10 +2456,17 @@ describe('hover on subplots when hoversameaxis is set to true and x hovermode', 
             name: ['trace 0', 'trace 1', 'trace 2'],
             axis: String(pos)
         });
+
+        Plotly.relayout(gd, 'hovermode', 'x unified');
+        pos = 0;
+        subplot = 'xy';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {xval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(3);
     });
 });
 
-describe('hover on subplots when hoversameaxis is set to true and y hovermode', function() {
+describe('hover on subplots when hoversameaxis is set to true and y hovermodes', function() {
     'use strict';
 
     var mock = {
@@ -2502,7 +2509,7 @@ describe('hover on subplots when hoversameaxis is set to true and y hovermode', 
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: y with hoversameaxis: true', function() {
+    it('hovermode: *y* | *y unified* with hoversameaxis: true', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2537,6 +2544,13 @@ describe('hover on subplots when hoversameaxis is set to true and y hovermode', 
             name: ['trace 0', 'trace 1', 'trace 2'],
             axis: String(pos)
         });
+
+        Plotly.relayout(gd, 'hovermode', 'y unified');
+        pos = 0;
+        subplot = 'xy';
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {yval: pos}, subplot);
+        expect(gd._hoverdata.length).toBe(3);
     });
 });
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2380,12 +2380,12 @@ describe('hover info on stacked subplots', function() {
     });
 });
 
-describe('hover on subplots when hoversameaxis is set to true and x hovermodes', function() {
+describe('hover on subplots when hoverthrough is set to true and x hovermodes', function() {
     'use strict';
 
     var mock = {
         layout: {
-            hoversameaxis: true,
+            hoverthrough: true,
             hovermode: 'x',
             grid: {
                 rows: 3,
@@ -2423,7 +2423,7 @@ describe('hover on subplots when hoversameaxis is set to true and x hovermodes',
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: *x* | *x unified* with hoversameaxis: true', function() {
+    it('hovermode: *x* | *x unified* with hoverthrough: true', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2468,12 +2468,12 @@ describe('hover on subplots when hoversameaxis is set to true and x hovermodes',
     });
 });
 
-describe('hover on subplots when hoversameaxis is set to true and y hovermodes', function() {
+describe('hover on subplots when hoverthrough is set to true and y hovermodes', function() {
     'use strict';
 
     var mock = {
         layout: {
-            hoversameaxis: true,
+            hoverthrough: true,
             hovermode: 'y',
             grid: {
                 rows: 2,
@@ -2511,7 +2511,7 @@ describe('hover on subplots when hoversameaxis is set to true and y hovermodes',
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: *y* | *y unified* with hoversameaxis: true', function() {
+    it('hovermode: *y* | *y unified* with hoverthrough: true', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2556,12 +2556,12 @@ describe('hover on subplots when hoversameaxis is set to true and y hovermodes',
     });
 });
 
-describe('splom hover on subplots when hoversameaxis is set to true and (x|y) hovermodes', function() {
+describe('splom hover on subplots when hoverthrough is set to true and (x|y) hovermodes', function() {
     'use strict';
 
     var mock = Lib.extendDeep({}, splomLogMock);
     mock.layout.hovermode = 'x';
-    mock.layout.hoversameaxis = true;
+    mock.layout.hoverthrough = true;
 
     var gd;
 
@@ -2572,7 +2572,7 @@ describe('splom hover on subplots when hoversameaxis is set to true and (x|y) ho
 
     afterEach(destroyGraphDiv);
 
-    it('splom hoversameaxis: true', function() {
+    it('splom hoverthrough: true', function() {
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
         expect(gd._hoverdata.length).toBe(3);

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2380,12 +2380,12 @@ describe('hover info on stacked subplots', function() {
     });
 });
 
-describe('hover on subplots when hoverthrough is set to true and x hovermodes', function() {
+describe('hover on subplots when hoverthrough is set to *axis* and x hovermodes', function() {
     'use strict';
 
     var mock = {
         layout: {
-            hoverthrough: true,
+            hoverthrough: 'axis',
             hovermode: 'x',
             grid: {
                 rows: 3,
@@ -2423,7 +2423,7 @@ describe('hover on subplots when hoverthrough is set to true and x hovermodes', 
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: *x* | *x unified* with hoverthrough: true', function() {
+    it('hovermode: *x* | *x unified* with hoverthrough: *axis*', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2468,12 +2468,12 @@ describe('hover on subplots when hoverthrough is set to true and x hovermodes', 
     });
 });
 
-describe('hover on subplots when hoverthrough is set to true and y hovermodes', function() {
+describe('hover on subplots when hoverthrough is set to *axis* and y hovermodes', function() {
     'use strict';
 
     var mock = {
         layout: {
-            hoverthrough: true,
+            hoverthrough: 'axis',
             hovermode: 'y',
             grid: {
                 rows: 2,
@@ -2511,7 +2511,7 @@ describe('hover on subplots when hoverthrough is set to true and y hovermodes', 
 
     afterEach(destroyGraphDiv);
 
-    it('hovermode: *y* | *y unified* with hoverthrough: true', function() {
+    it('hovermode: *y* | *y unified* with hoverthrough: *axis*', function() {
         var pos = 0;
         var subplot = 'xy';
         Lib.clearThrottle();
@@ -2556,12 +2556,12 @@ describe('hover on subplots when hoverthrough is set to true and y hovermodes', 
     });
 });
 
-describe('splom hover on subplots when hoverthrough is set to true and (x|y) hovermodes', function() {
+describe('splom hover on subplots when hoverthrough is set to *axis* and (x|y) hovermodes', function() {
     'use strict';
 
     var mock = Lib.extendDeep({}, splomLogMock);
     mock.layout.hovermode = 'x';
-    mock.layout.hoverthrough = true;
+    mock.layout.hoverthrough = 'axis';
 
     var gd;
 
@@ -2572,7 +2572,7 @@ describe('splom hover on subplots when hoverthrough is set to true and (x|y) hov
 
     afterEach(destroyGraphDiv);
 
-    it('splom hoverthrough: true', function() {
+    it('splom hoverthrough: *axis*', function() {
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
         expect(gd._hoverdata.length).toBe(3);

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2660,6 +2660,106 @@ describe('splom hover on subplots when hoversubplots is set to *axis* and (x|y) 
     });
 });
 
+describe('splom hover *axis* hoversubplots splom points on same position should pick points with same index', function() {
+    'use strict';
+
+    var mock = {
+        data: [{
+            type: 'splom',
+            dimensions: [{
+                values: [1, 1, 1, 1]
+            }, {
+                values: [1, 2, 3, 4]
+            }, {
+                values: [1, 2, 3, 4]
+            }, {
+                values: [1, null, 3, 4]
+            }
+            ]}],
+        layout: {
+            hoversubplots: 'axis',
+            hovermode: 'x',
+            width: 600,
+            height: 600
+        }
+    };
+
+    var gd;
+
+    beforeEach(function(done) {
+        gd = createGraphDiv();
+        Plotly.newPlot(gd, mock).then(done);
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('splom *axis* hoversubplots', function() {
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {}, 'xy');
+        expect(gd._hoverdata.length).toBe(5);
+        assertHoverLabelContent({
+            nums: ['1', '1', '1', '1'],
+            name: ['', '', '', ''],
+            axis: '1'
+        });
+
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {}, 'xy2');
+        expect(gd._hoverdata.length).toBe(4);
+        assertHoverLabelContent({
+            nums: ['1', '2', '2'],
+            name: ['', '', ''],
+            axis: '1'
+        });
+
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {}, 'xy3');
+        expect(gd._hoverdata.length).toBe(4);
+        assertHoverLabelContent({
+            nums: ['1', '2', '2'],
+            name: ['', '', ''],
+            axis: '1'
+        });
+
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {}, 'xy4');
+        expect(gd._hoverdata.length).toBe(5);
+        assertHoverLabelContent({
+            nums: ['1', '3', '3', '3'],
+            name: ['', '', '', ''],
+            axis: '1'
+        });
+
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {}, 'x2y');
+        expect(gd._hoverdata.length).toBe(5);
+        assertHoverLabelContent({
+            nums: ['1', '3', '3', '3'],
+            name: ['', '', '', ''],
+            axis: '3'
+        });
+
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {}, 'x3y');
+        expect(gd._hoverdata.length).toBe(5);
+        assertHoverLabelContent({
+            nums: ['1', '3', '3', '3'],
+            name: ['', '', '', ''],
+            axis: '3'
+        });
+
+        Lib.clearThrottle();
+        Plotly.Fx.hover(gd, {}, 'x4y');
+        expect(gd._hoverdata.length).toBe(5);
+        assertHoverLabelContent({
+            nums: ['1', '3', '3', '3'],
+            name: ['', '', '', ''],
+            axis: '3'
+        });
+    });
+});
+
+
 describe('hover on many lines+bars', function() {
     'use strict';
 

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -2634,7 +2634,7 @@
      "y unified"
     ]
    },
-   "hoverthrough": {
+   "hoversubplots": {
     "description": "Determines expansion of hover effects to other subplots If *axis*, points from subplots linked to the axis of hovered subplot are included. Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
     "dflt": false,
     "editType": "none",

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -2635,13 +2635,13 @@
     ]
    },
    "hoversubplots": {
-    "description": "Determines expansion of hover effects to other subplots If *axis*, points from subplots linked to the axis of hovered subplot are included. Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
-    "dflt": false,
+    "description": "Determines expansion of hover effects to other subplots If *overlaying* all subplots using the main axis and occupying the same space are included. If *axis*, also include stacked subplots using the same axis when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
+    "dflt": "overlaying",
     "editType": "none",
     "valType": "enumerated",
     "values": [
-     "axis",
-     false
+     "overlaying",
+     "axis"
     ]
    },
    "images": {

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -2635,10 +2635,14 @@
     ]
    },
    "hoverthrough": {
-    "description": "Determines expansion of hover effects to other subplots in case of sharing an axis. Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
+    "description": "Determines expansion of hover effects to other subplots If *axis*, points from subplots linked to the axis of hovered subplot are included. Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
     "dflt": false,
     "editType": "none",
-    "valType": "boolean"
+    "valType": "enumerated",
+    "values": [
+     "axis",
+     false
+    ]
    },
    "images": {
     "items": {

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -2635,11 +2635,12 @@
     ]
    },
    "hoversubplots": {
-    "description": "Determines expansion of hover effects to other subplots If *overlaying* all subplots using the main axis and occupying the same space are included. If *axis*, also include stacked subplots using the same axis when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
+    "description": "Determines expansion of hover effects to other subplots If *single* just the axis pair of the primary point is included without overlaying subplots. If *overlaying* all subplots using the main axis and occupying the same space are included. If *axis*, also include stacked subplots using the same axis when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
     "dflt": "overlaying",
     "editType": "none",
     "valType": "enumerated",
     "values": [
+     "single",
      "overlaying",
      "axis"
     ]

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -2634,7 +2634,7 @@
      "y unified"
     ]
    },
-   "hoversameaxis": {
+   "hoverthrough": {
     "description": "Determines expansion of hover effects to other subplots in case of sharing an axis. Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
     "dflt": false,
     "editType": "none",

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -2634,6 +2634,12 @@
      "y unified"
     ]
    },
+   "hoversameaxis": {
+    "description": "Determines expansion of hover effects to other subplots in case of sharing an axis. Has an effect only when `hovermode` is set to *x*, *x unified*, *y* or *y unified*.",
+    "dflt": false,
+    "editType": "none",
+    "valType": "boolean"
+   },
    "images": {
     "items": {
      "image": {


### PR DESCRIPTION
Resolves #4755 and resolves #2114.

@plotly/plotly_js 


TODO: 
- [x] Handle splom
- [x] Should it be new `hovermode` options e.g. `'x all'`, `x all unified`, `y all` and `y all unified` instead? --> No.
- [x] Improve positioning of unified hover to be closer to initial hovered subplot 