### PR TITLE
simplify splom hover

### DIFF
--- a/draftlogs/6947_add.md
+++ b/draftlogs/6947_add.md
@@ -1,1 +1,1 @@
- - Add `layout.hoversubplots` to enable hover effects across multiple cartesian suplots sharing one axis [[#6947](https://github.com/plotly/plotly.js/pull/6947)]
+ - Add `layout.hoversubplots` to enable hover effects across multiple cartesian suplots sharing one axis [[#6947](https://github.com/plotly/plotly.js/pull/6947), [#6950](https://github.com/plotly/plotly.js/pull/6950)]


### PR DESCRIPTION
Revert some of unnecessary changes made in #6947 to simplify splom hover.
For reference before #6947 the file used to like this: https://raw.githubusercontent.com/plotly/plotly.js/v2.30.1/src/traces/splom/hover.js

cc: @plotly/plotly_js 