### PR TITLE
fix: do not ovelap hoverlabels for different tracetypes

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -1757,7 +1757,7 @@ function hoverAvoidOverlaps(hoverLabels, rotateLabels, fullLayout, commonLabelBo
             topOverlap = p0.pos + p0.dp + p0.size - p1.pos - p1.dp + p1.size;
 
             // Only group points that lie on the same axes
-            if(topOverlap > 0.01 && (p0.pmin === p1.pmin) && (p0.pmax === p1.pmax)) {
+            if(topOverlap > 0.01 && p0.crossAxKey === p1.crossAxKey) {
                 // push the new point(s) added to this group out of the way
                 for(j = g1.length - 1; j >= 0; j--) g1[j].dp += topOverlap;
 

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -1668,6 +1668,10 @@ describe('hover info', function() {
             return Math.max(0, overlap);
         }
 
+        function labelCount() {
+            return d3Select(gd).selectAll('g.hovertext').size();
+        }
+
         it('centered-aligned, should render labels inside boxes', function(done) {
             var trace1 = {
                 x: ['giraffes'],
@@ -1787,6 +1791,59 @@ describe('hover info', function() {
             })
             .then(done, done.fail);
         });
+
+        it("does not overlap lebels for different trace types", function (done) {
+            function trace(name, type, delta) {
+              return {
+                name: name,
+                type: type,
+                y: [0 + delta, 1 + delta, 2 + delta],
+                x: ["CAT 1", "CAT 2", "CAT 3"],
+              };
+            }
+      
+            var scatterName = "scatter_";
+            var barName = "bar_";
+            var data = [];
+            for(let i = 0; i<3; i++) {
+                data.push(trace(barName + i, "bar", 0.0));
+                data.push(trace(scatterName + i, "scatter", 0.1));
+            }
+            var layout = {
+              width: 600,
+              height: 400,
+              hovermode: "x",
+            };
+      
+            Plotly.newPlot(gd, data, layout)
+              .then(function () {
+                _hoverNatural(gd, 200, 200);
+              })
+              .then(function () {
+                expect(labelCount()).toBe(6);
+              })
+              .then(function () {
+
+                var nodes = [];
+                for(let i = 0; i<3; i++) {
+                    nodes.push(hoverInfoNodes(barName + i).secondaryBox.getBoundingClientRect());
+                    nodes.push(hoverInfoNodes(scatterName + i).secondaryBox.getBoundingClientRect());
+                }
+                nodes.sort(function(a,b) { return a.top - b.top; } );
+                
+                for(let i = 0; i<5; i++) {
+                        expect(
+                            calcLineOverlap(
+                                nodes[i].top,
+                                nodes[i].bottom,
+                                nodes[i+1].top,
+                                nodes[i+1].bottom,
+                            )
+                        ).toBeWithin(2, 1);
+                    }
+              })
+              .then(done, done.fail);
+          });
     });
 
     describe('constraints info graph viewport', function() {


### PR DESCRIPTION
This PR attempts a fix for https://github.com/plotly/plotly.js/issues/6917 which reported excessive hoverlabel removal and overlap for plots with both scatter and bar traces.

Behaviour before the fix:

<img width="595" alt="Screenshot 2024-04-10 at 21 54 14" src="https://github.com/plotly/plotly.js/assets/42407285/18089631-805d-49c4-9f6d-db03858eecb5">

or even 

<img width="590" alt="Screenshot 2024-04-10 at 21 56 01" src="https://github.com/plotly/plotly.js/assets/42407285/b97eba39-eaac-4fa9-8886-096fe63137e6">

Behaviour after the fix:

<img width="603" alt="Screenshot 2024-04-10 at 21 51 35" src="https://github.com/plotly/plotly.js/assets/42407285/28d35bfd-526d-4fe1-b01c-26acfd709de4">


<details>
  <summary>JSON file used for the example</summary>

```json
{
  "data": [
    {
      "name": "scatter_1",
      "type": "scatter",
      "y": [0, 1, 2],
      "x": ["CAT 1", "CAT 2", "CAT 3"]
    },
    {
      "name": "bar_1",
      "type": "bar",
      "y": [0, 1, 2],
      "x": ["CAT 1", "CAT 2", "CAT 3"]
    },
    {
      "name": "scatter_2",
      "type": "scatter",
      "x": ["CAT 1", "CAT 2", "CAT 3"],
      "y": [0, 1, 2]
    },
    {
      "name": "bar_2",
      "type": "bar",
      "y": [0, 1, 2],
      "x": ["CAT 1", "CAT 2", "CAT 3"]
    },
    {
      "name": "scatter_3",
      "type": "scatter",
      "x": ["CAT 1", "CAT 2", "CAT 3"],
      "y": [0, 1, 2]
    },
    {
      "name": "bar_3",
      "type": "bar",
      "y": [0, 1, 2],
      "x": ["CAT 1", "CAT 2", "CAT 3"]
    }
  ],
  "layout": {
    "width": 600,
    "height": 400,
    "hovermode": "x"
  }
}
```
</details>