### PR TITLE
Ensure winning points of hover are listed first when `hoversubplots` is set to "axis" and sorting by distance 

### DIFF
--- a/draftlogs/6963_fix.md
+++ b/draftlogs/6963_fix.md
@@ -1,0 +1,1 @@
+ - Ensure winning points of hover are listed first when hoversubplots is set to "axis" and sorting by distance [[#6963](https://github.com/plotly/plotly.js/pull/6963)]

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -713,6 +713,9 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
     gd._spikepoints = newspikepoints;
 
     var sortHoverData = function() {
+        // When sorting keep the points in the main subplot at the top
+        // then add points in other subplots
+
         var hoverDataInSubplot = hoverData.filter(function(a) {
             return (
                 (firstXaxis && firstXaxis._id === a.xa._id) &&

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2445,6 +2445,12 @@ describe('hover on subplots when hoversubplots is set to *single* and x hovermod
     });
 });
 
+function assertFirstPointOn(gd, xaxisId, yaxisId) {
+    // first point should be on the main subplot
+    expect(gd._hoverdata[0].xaxis._id).toBe(xaxisId);
+    expect(gd._hoverdata[0].yaxis._id).toBe(yaxisId);
+}
+
 describe('hover on subplots when hoversubplots is set to *axis* and x hovermodes', function() {
     'use strict';
 
@@ -2494,6 +2500,9 @@ describe('hover on subplots when hoversubplots is set to *axis* and x hovermodes
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {xval: pos}, subplot);
         expect(gd._hoverdata.length).toBe(3);
+
+        assertFirstPointOn(gd, 'x', 'y');
+
         assertHoverLabelContent({
             nums: ['1', '10', '100'],
             name: ['trace 0', 'trace 1', 'trace 2'],
@@ -2504,6 +2513,8 @@ describe('hover on subplots when hoversubplots is set to *axis* and x hovermodes
         subplot = 'xy2';
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {xval: pos}, subplot);
+
+        assertFirstPointOn(gd, 'x', 'y2');
 
         expect(gd._hoverdata.length).toBe(3);
         assertHoverLabelContent({
@@ -2516,6 +2527,8 @@ describe('hover on subplots when hoversubplots is set to *axis* and x hovermodes
         subplot = 'xy3';
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {xval: pos}, subplot);
+
+        assertFirstPointOn(gd, 'x', 'y3');
 
         expect(gd._hoverdata.length).toBe(3);
         assertHoverLabelContent({
@@ -2530,6 +2543,8 @@ describe('hover on subplots when hoversubplots is set to *axis* and x hovermodes
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {xval: pos}, subplot);
         expect(gd._hoverdata.length).toBe(3);
+
+        assertFirstPointOn(gd, 'x', 'y');
     });
 });
 
@@ -2582,6 +2597,9 @@ describe('hover on subplots when hoversubplots is set to *axis* and y hovermodes
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {yval: pos}, subplot);
         expect(gd._hoverdata.length).toBe(3);
+
+        assertFirstPointOn(gd, 'x', 'y');
+
         assertHoverLabelContent({
             nums: ['1', '10', '100'],
             name: ['trace 0', 'trace 1', 'trace 2'],
@@ -2594,6 +2612,9 @@ describe('hover on subplots when hoversubplots is set to *axis* and y hovermodes
         Plotly.Fx.hover(gd, {yval: pos}, subplot);
 
         expect(gd._hoverdata.length).toBe(3);
+
+        assertFirstPointOn(gd, 'x2', 'y');
+
         assertHoverLabelContent({
             nums: ['2', '20', '200'],
             name: ['trace 0', 'trace 1', 'trace 2'],
@@ -2606,6 +2627,9 @@ describe('hover on subplots when hoversubplots is set to *axis* and y hovermodes
         Plotly.Fx.hover(gd, {yval: pos}, subplot);
 
         expect(gd._hoverdata.length).toBe(3);
+
+        assertFirstPointOn(gd, 'x3', 'y');
+
         assertHoverLabelContent({
             nums: ['3', '30', '300'],
             name: ['trace 0', 'trace 1', 'trace 2'],
@@ -2618,6 +2642,8 @@ describe('hover on subplots when hoversubplots is set to *axis* and y hovermodes
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {yval: pos}, subplot);
         expect(gd._hoverdata.length).toBe(3);
+
+        assertFirstPointOn(gd, 'x', 'y');
     });
 });
 
@@ -2641,6 +2667,9 @@ describe('splom hover on subplots when hoversubplots is set to *axis* and (x|y) 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
         expect(gd._hoverdata.length).toBe(3);
+
+        assertFirstPointOn(gd, 'x', 'y');
+
         assertHoverLabelContent({
             nums: ['100', '100k'],
             name: ['', ''],
@@ -2651,11 +2680,17 @@ describe('splom hover on subplots when hoversubplots is set to *axis* and (x|y) 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
+
+        assertFirstPointOn(gd, 'x', 'y');
+
         expect(gd._hoverdata.length).toBe(3);
 
         Plotly.relayout(gd, 'hovermode', 'y unified');
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
+
+        assertFirstPointOn(gd, 'x', 'y');
+
         expect(gd._hoverdata.length).toBe(3);
     });
 });
@@ -2697,6 +2732,9 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy');
         expect(gd._hoverdata.length).toBe(5);
+
+        assertFirstPointOn(gd, 'x', 'y');
+
         assertHoverLabelContent({
             nums: ['1', '1', '1', '1'],
             name: ['', '', '', ''],
@@ -2706,6 +2744,9 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy2');
         expect(gd._hoverdata.length).toBe(4);
+
+        assertFirstPointOn(gd, 'x', 'y2');
+
         assertHoverLabelContent({
             nums: ['1', '2', '2'],
             name: ['', '', ''],
@@ -2715,6 +2756,9 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy3');
         expect(gd._hoverdata.length).toBe(4);
+
+        assertFirstPointOn(gd, 'x', 'y3');
+
         assertHoverLabelContent({
             nums: ['1', '2', '2'],
             name: ['', '', ''],
@@ -2724,6 +2768,9 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy4');
         expect(gd._hoverdata.length).toBe(5);
+
+        assertFirstPointOn(gd, 'x', 'y4');
+
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],
@@ -2733,6 +2780,9 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'x2y');
         expect(gd._hoverdata.length).toBe(5);
+
+        assertFirstPointOn(gd, 'x2', 'y');
+
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],
@@ -2742,6 +2792,9 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'x3y');
         expect(gd._hoverdata.length).toBe(5);
+
+        assertFirstPointOn(gd, 'x3', 'y');
+
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],
@@ -2751,6 +2804,9 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'x4y');
         expect(gd._hoverdata.length).toBe(5);
+
+        assertFirstPointOn(gd, 'x4', 'y');
+
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],


### PR DESCRIPTION
Fixes #6960.

@plotly/plotly_js 