### PR TITLE
Avoid duplicate points in splom hover

### DIFF
--- a/draftlogs/6965_fix.md
+++ b/draftlogs/6965_fix.md
@@ -1,0 +1,1 @@
+ - Fix duplicated points in splom hover when `hoversubplots` is set to "axis" [[#6965](https://github.com/plotly/plotly.js/pull/6965)]

--- a/src/traces/splom/hover.js
+++ b/src/traces/splom/hover.js
@@ -27,6 +27,9 @@ function hoverPoints(pointData, xval, yval, hovermode, opts) {
         for(var i = 0; i < subplotsWith.length; i++) {
             var spId = subplotsWith[i];
 
+            // do not reselect on the initial subplot
+            if(spId === (pointData.xa._id + pointData.ya._id)) continue;
+
             if(hovermodeHasY) {
                 _pointData.xa = getFromId(gd, spId, 'x');
             } else { // hovermodeHasX

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -2640,7 +2640,7 @@ describe('splom hover on subplots when hoversubplots is set to *axis* and (x|y) 
     it('splom hoversubplots: *axis*', function() {
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
-        expect(gd._hoverdata.length).toBe(3);
+        expect(gd._hoverdata.length).toBe(2);
         assertHoverLabelContent({
             nums: ['100', '100k'],
             name: ['', ''],
@@ -2651,12 +2651,12 @@ describe('splom hover on subplots when hoversubplots is set to *axis* and (x|y) 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
-        expect(gd._hoverdata.length).toBe(3);
+        expect(gd._hoverdata.length).toBe(2);
 
         Plotly.relayout(gd, 'hovermode', 'y unified');
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {x: 200, y: 200}, 'xy');
-        expect(gd._hoverdata.length).toBe(3);
+        expect(gd._hoverdata.length).toBe(2);
     });
 });
 
@@ -2696,7 +2696,7 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
     it('splom *axis* hoversubplots', function() {
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy');
-        expect(gd._hoverdata.length).toBe(5);
+        expect(gd._hoverdata.length).toBe(4);
         assertHoverLabelContent({
             nums: ['1', '1', '1', '1'],
             name: ['', '', '', ''],
@@ -2705,7 +2705,7 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy2');
-        expect(gd._hoverdata.length).toBe(4);
+        expect(gd._hoverdata.length).toBe(3);
         assertHoverLabelContent({
             nums: ['1', '2', '2'],
             name: ['', '', ''],
@@ -2714,7 +2714,7 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy3');
-        expect(gd._hoverdata.length).toBe(4);
+        expect(gd._hoverdata.length).toBe(3);
         assertHoverLabelContent({
             nums: ['1', '2', '2'],
             name: ['', '', ''],
@@ -2723,7 +2723,7 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'xy4');
-        expect(gd._hoverdata.length).toBe(5);
+        expect(gd._hoverdata.length).toBe(4);
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],
@@ -2732,7 +2732,7 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'x2y');
-        expect(gd._hoverdata.length).toBe(5);
+        expect(gd._hoverdata.length).toBe(4);
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],
@@ -2741,7 +2741,7 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'x3y');
-        expect(gd._hoverdata.length).toBe(5);
+        expect(gd._hoverdata.length).toBe(4);
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],
@@ -2750,7 +2750,7 @@ describe('splom hover *axis* hoversubplots splom points on same position should 
 
         Lib.clearThrottle();
         Plotly.Fx.hover(gd, {}, 'x4y');
-        expect(gd._hoverdata.length).toBe(5);
+        expect(gd._hoverdata.length).toBe(4);
         assertHoverLabelContent({
             nums: ['1', '3', '3', '3'],
             name: ['', '', '', ''],


### PR DESCRIPTION
Fixes #6959.

@plotly/plotly_js 