### PR TITLE
Simplify drawing font args

### DIFF
--- a/src/components/drawing/index.js
+++ b/src/components/drawing/index.js
@@ -27,16 +27,14 @@ var drawing = module.exports = {};
 // styling functions for plot elements
 // -----------------------------------------------------
 
-drawing.font = function(s, family, size, color, weight, style, variant) {
-    // also allow the form font(s, {family, size, color, weight, style, variant})
-    if(Lib.isPlainObject(family)) {
-        variant = family.variant;
-        style = family.style;
-        weight = family.weight;
-        color = family.color;
-        size = family.size;
-        family = family.family;
-    }
+drawing.font = function(s, font) {
+    var variant = font.variant;
+    var style = font.style;
+    var weight = font.weight;
+    var color = font.color;
+    var size = font.size;
+    var family = font.family;
+
     if(family) s.style('font-family', family);
     if(size + 1) s.style('font-size', size + 'px');
     if(color) s.call(Color.fill, color);

--- a/test/jasmine/tests/drawing_test.js
+++ b/test/jasmine/tests/drawing_test.js
@@ -422,7 +422,10 @@ describe('Drawing', function() {
         it('works with dummy nodes created in Drawing.tester', function() {
             var node = Drawing.tester.append('text')
                 .text('bananas')
-                .call(Drawing.font, '"Open Sans", verdana, arial, sans-serif', 19)
+                .call(Drawing.font, {
+                    family: '"Open Sans", verdana, arial, sans-serif',
+                    size: 19
+                })
                 .call(svgTextUtils.convertToTspans).node();
 
             expect(node.parentNode).toBe(Drawing.tester.node());


### PR DESCRIPTION
This form of calling `drawing.font` is no longer used after #6956.
This PR simplifies the function and make it readable, maintainable and expandable.

cc: @plotly/plotly_js 