### PR TITLE
bump plotly/d3 v3.8.2

### DIFF
--- a/draftlogs/6992_fix.md
+++ b/draftlogs/6992_fix.md
@@ -1,0 +1,3 @@
+ - Fix unicode variable names in @plotly/d3 [[#6992](https://github.com/plotly/plotly.js/pull/6992)],
+   with thanks to @GeorchW for the contribution!
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.32.0",
       "license": "MIT",
       "dependencies": {
-        "@plotly/d3": "3.8.1",
+        "@plotly/d3": "3.8.2",
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
         "@plotly/mapbox-gl": "1.13.4",
@@ -2276,9 +2276,9 @@
       }
     },
     "node_modules/@plotly/d3": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.1.tgz",
-      "integrity": "sha512-x49ThEu1FRA00kTso4Jdfyf2byaCPLBGmLjAYQz5OzaPyLUhHesX3/Nfv2OHEhynhdy2UB39DLXq6thYe2L2kg=="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.2.tgz",
+      "integrity": "sha512-wvsNmh1GYjyJfyEBPKJLTMzgf2c2bEbSIL50lmqVUi+o1NHaLPi1Lb4v7VxXXJn043BhNyrxUrWI85Q+zmjOVA=="
     },
     "node_modules/@plotly/d3-sankey": {
       "version": "0.7.2",
@@ -14737,9 +14737,9 @@
       }
     },
     "@plotly/d3": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.1.tgz",
-      "integrity": "sha512-x49ThEu1FRA00kTso4Jdfyf2byaCPLBGmLjAYQz5OzaPyLUhHesX3/Nfv2OHEhynhdy2UB39DLXq6thYe2L2kg=="
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.2.tgz",
+      "integrity": "sha512-wvsNmh1GYjyJfyEBPKJLTMzgf2c2bEbSIL50lmqVUi+o1NHaLPi1Lb4v7VxXXJn043BhNyrxUrWI85Q+zmjOVA=="
     },
     "@plotly/d3-sankey": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     ]
   },
   "dependencies": {
-    "@plotly/d3": "3.8.1",
+    "@plotly/d3": "3.8.2",
     "@plotly/d3-sankey": "0.7.2",
     "@plotly/d3-sankey-circular": "0.33.1",
     "@plotly/mapbox-gl": "1.13.4",


### PR DESCRIPTION
No more unicode variable names in `@plotly/d3` thanks to @GeorchW.

cc: @plotly/plotly_js 
