### PR TITLE
fix getFullTransformMatrix in shadow DOM

### DIFF
--- a/draftlogs/6996_fix.md
+++ b/draftlogs/6996_fix.md
@@ -1,0 +1,2 @@
+- Fix `getFullTransformMatrix` in shadow DOM [[#6996](https://github.com/plotly/plotly.js/pull/6996)],
+  with thanks to @OpportunityLiu for the contribution!

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -134,7 +134,7 @@ function getElementAndAncestors(element) {
     while(isTransformableElement(element)) {
         allElements.push(element);
         element = element.parentNode;
-        if(typeof ShadowRoot === 'function' && typeof element instanceof ShadowRoot) {
+        if(typeof ShadowRoot === 'function' && element instanceof ShadowRoot) {
             element = element.host;
         }
     }

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -134,6 +134,9 @@ function getElementAndAncestors(element) {
     while(isTransformableElement(element)) {
         allElements.push(element);
         element = element.parentNode;
+        if(typeof ShadowRoot === 'function' && typeof element instanceof ShadowRoot) {
+            element = element.host;
+        }
     }
     return allElements;
 }


### PR DESCRIPTION
This PR add ShadowRoot detection in `getElementAndAncestors`, get a full list of dom ancestors, cross shadow dom.

Fix #5760
