### PR TITLE
axis.categoryanchor property

### DIFF
--- a/draftlogs/7001_add.md
+++ b/draftlogs/7001_add.md
@@ -1,0 +1,1 @@
+ - Add property `categoryanchor` to axis [[#7001](https://github.com/plotly/plotly.js/pull/7001)]

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -96,6 +96,8 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
 
     handleCategoryOrderDefaults(containerIn, containerOut, coerce, options);
 
+    containerOut.categoryanchor = containerIn.categoryanchor || 'center';
+
     if(axType !== 'category' && !options.noHover) coerce('hoverformat');
 
     var dfltColor = coerce('color');

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -1190,6 +1190,20 @@ module.exports = {
             'Used with `categoryorder`.'
         ].join(' ')
     },
+    categoryanchor: {
+        valType: 'enumerated',
+        dflt: 'center',
+        values: [
+            'center', 'start', 'end'
+        ],
+        editType: 'calc',
+        description: [
+            'Defines if references to a category are anchored to the center, start or end of the',
+            'category. I.e. when specifying a shape or annotation and using category names as',
+            'coordinates, these can refer to the start, center or end of the category.',
+            'Defaults to center. Only has an effect on category axes.'
+        ].join(' ')
+    },
     uirevision: {
         valType: 'any',
         editType: 'none',

--- a/src/plots/cartesian/set_convert.js
+++ b/src/plots/cartesian/set_convert.js
@@ -179,7 +179,12 @@ module.exports = function setConvert(ax, fullLayout) {
     }
 
     function getRangePosition(v) {
-        return isNumeric(v) ? +v : getCategoryIndex(v);
+        if(isNumeric(v)) {
+            return +v;
+        }
+        var shift = (ax.categoryanchor === 'start') ? -0.5 :
+                    (ax.categoryanchor === 'end') ? 0.5 : 0;
+        return getCategoryIndex(v) + shift;
     }
 
     // include 2 fractional digits on pixel, for PDF zooming etc

--- a/test/image/mocks/zzz_categoryanchor.json
+++ b/test/image/mocks/zzz_categoryanchor.json
@@ -1,0 +1,56 @@
+{
+    "data": [
+        {
+            "x": [
+                "A", "B", "C", "D"
+            ],
+            "y": [
+                1, 2, 3, 4
+            ],
+            "type": "bar"
+        }
+    ],
+    "layout": {
+        "shapes": [
+            {
+                "layer": "above",
+                "name": "divider",
+                "line": {
+                  "color": "yellow",
+                  "width": 3.0
+                },
+                "x0": "C",
+                "x1": "C",
+                "y0": 0,
+                "y1": 1,
+                "yref": "paper"
+            },
+            {
+                "layer": "above",
+                "name": "centered",
+                "line": {
+                  "color": "pink",
+                  "width": 3.0
+                },
+                "x0": 2,
+                "x1": 2,
+                "y0": 0,
+                "y1": 1,
+                "yref": "paper"
+            }
+        ],
+        "annotations": [
+            {
+                "text": "hi",
+                "xref": "xaxis",
+                "yref": "yaxis",
+                "x": "B",
+                "y": 2
+            }
+        ],
+        "xaxis": {
+            "categoryanchor": "end"
+        }
+        
+    }
+}

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -14000,6 +14000,17 @@
       "ummalqura"
      ]
     },
+    "categoryanchor": {
+     "description": "Defines if references to a category are anchored to the center, start or end of the category. I.e. when specifying a shape or annotation and using category names as coordinates, these can refer to the start, center or end of the category. Defaults to center. Only has an effect on category axes.",
+     "dflt": "center",
+     "editType": "calc",
+     "valType": "enumerated",
+     "values": [
+      "center",
+      "start",
+      "end"
+     ]
+    },
     "categoryarray": {
      "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
      "editType": "calc",
@@ -15624,6 +15635,17 @@
       "taiwan",
       "thai",
       "ummalqura"
+     ]
+    },
+    "categoryanchor": {
+     "description": "Defines if references to a category are anchored to the center, start or end of the category. I.e. when specifying a shape or annotation and using category names as coordinates, these can refer to the start, center or end of the category. Defaults to center. Only has an effect on category axes.",
+     "dflt": "center",
+     "editType": "calc",
+     "valType": "enumerated",
+     "values": [
+      "center",
+      "start",
+      "end"
      ]
     },
     "categoryarray": {


### PR DESCRIPTION
Defines if references to a category are anchored to the center, start or end of the category. I.e. when specifying a shape or annotation and using category names as coordinates, these can refer to the start, center or end of the category.

This is e.g. a chart with
- xaxis.categoryanchor = "end"
- annotation x = "B"
- shape x0/x1 = "C"
![image](https://github.com/plotly/plotly.js/assets/3898364/9b9ea46f-b8e6-4641-86b6-6b451634a33b)


<details>
<summary>Disclaimer</summary>
I am required to add that…

the software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. in no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the software or the use or other dealings in the software.
</details >