### PR TITLE
Fix `isosurface` maximum value calculation when `isomax` is set to null

### DIFF
--- a/draftlogs/7002_fix.md
+++ b/draftlogs/7002_fix.md
@@ -1,0 +1,1 @@
+ - Fix isosurface maximum value calculation when `isomax` is set to null [[#7002](https://github.com/plotly/plotly.js/pull/7002)]

--- a/src/traces/isosurface/calc.js
+++ b/src/traces/isosurface/calc.js
@@ -35,7 +35,7 @@ module.exports = function calc(gd, trace) {
     trace._minValues = min;
     trace._maxValues = max;
     trace._vMin = (trace.isomin === undefined || trace.isomin === null) ? min : trace.isomin;
-    trace._vMax = (trace.isomax === undefined || trace.isomin === null) ? max : trace.isomax;
+    trace._vMax = (trace.isomax === undefined || trace.isomax === null) ? max : trace.isomax;
 
     colorscaleCalc(gd, trace, {
         vals: [trace._vMin, trace._vMax],


### PR DESCRIPTION
cc: @plotly/plotly_js 