### PR TITLE
Bump target from es5 to es2016

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ jobs:
           command: npm run test-requirejs
       - run:
           name: Test plotly bundles against es6
-          command: npm run no-es6-dist
+          command: npm run no-es2017-dist
       - run:
           name: Display function constructors in all bundles
           command: npm run no-new-func

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "eslint:recommended"
   ],
   "parserOptions": {
-    "ecmaVersion": 5
+    "ecmaVersion": 2016
   },
   "env": {
     "commonjs": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ To see all merged commits on the master branch that will be part of the next plo
 
 where X.Y.Z is the semver of most recent plotly.js release.
 
+## [next-major]
+
+### Breaking
+ - Bump build target to 2016, and drop IE support [[#7017](https://github.com/plotly/plotly.js/pull/7017)]
+
 ## [2.33.0] -- 2024-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ where X.Y.Z is the semver of most recent plotly.js release.
 ## [next-major]
 
 ### Breaking
- - Bump build target to 2016, and drop IE support [[#7017](https://github.com/plotly/plotly.js/pull/7017)]
+ - Bump build target from ES5 to ES2016, and drop IE support [[#7017](https://github.com/plotly/plotly.js/pull/7017)]
 
 ## [2.33.0] -- 2024-05-29
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "no-new-func": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-new-func: warn}' $(find dist -type f -iname '*.js')",
     "no-bad-char": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-misleading-character-class: error}' $(find dist -type f -iname '*.js' | grep plotly)",
     "no-dup-keys": "eslint --no-ignore --no-eslintrc --no-inline-config --rule '{no-dupe-keys: error}' $(find dist -type f -iname '*.js' | grep plotly)",
-    "no-es6-dist": "node tasks/no_es6_dist.js",
+    "no-es2017-dist": "node tasks/no_es2017_dist.js",
     "pretest": "node tasks/pretest.js",
     "test-jasmine": "karma start test/jasmine/karma.conf.js",
     "test-mock": "node tasks/test_mock.js",

--- a/stackgl_modules/webpack.config.js
+++ b/stackgl_modules/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 module.exports = {
-    target: ['web', 'es5'],
+    target: ['web', 'es2016'],
     entry: './main.js',
     output: {
         path: path.resolve('.'),

--- a/tasks/no_es2017_dist.js
+++ b/tasks/no_es2017_dist.js
@@ -16,7 +16,7 @@ function assertES5() {
         ignore: false,
         overrideConfig: {
             parserOptions: {
-                ecmaVersion: 5
+                ecmaVersion: 2016
             }
         }
     });

--- a/test/jasmine/karma.conf.js
+++ b/test/jasmine/karma.conf.js
@@ -263,7 +263,7 @@ func.defaultConfig = {
     },
 
     webpack: {
-        target: ['web', 'es5'],
+        target: ['web', 'es2016'],
         module: {
             rules: webpackConfig.module.rules
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path');
 var NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
 module.exports = {
-    target: ['web', 'es5'],
+    target: ['web', 'es2016'],
     entry: './lib/index.js',
     output: {
         path: path.resolve('./build'),


### PR DESCRIPTION
es2016 is a relative uncontroversial target, in that it's very widely supported ([all but internet explorer](https://caniuse.com/?search=ES2016)). es2017 introduces await/async, and for projects that needs high percentages of support that's generally where issue start to arise due to e.g. angular's zone.js

This unblocks
- #7015 

Closes #6366 
- #6366 