### PR TITLE
Fix issue where scattergl traces disappear while zooming or panning

### DIFF
--- a/draftlogs/7018_fix.md
+++ b/draftlogs/7018_fix.md
@@ -1,0 +1,1 @@
+ - Fix disappearing traces when using `scattergl` and `xaxis.type: 'date'` [[#7018](https://github.com/plotly/plotly.js/pull/7018)]

--- a/draftlogs/7018_fix.md
+++ b/draftlogs/7018_fix.md
@@ -1,1 +1,2 @@
- - Fix disappearing traces when using `scattergl` and `xaxis.type: 'date'` [[#7018](https://github.com/plotly/plotly.js/pull/7018)]
+ - Fix displaying scattergl traces while zooming or panning (regression introduced in 2.26.0) [[#7018](https://github.com/plotly/plotly.js/pull/7018)], 
+   with thanks to @eiriklv for the contribution!

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -886,14 +886,11 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
                 ya = sp.yaxis;
 
                 if(sp._scene) {
-                    var xrng = Lib.simpleMap(xa.range, xa.r2l);
-                    var yrng = Lib.simpleMap(ya.range, ya.r2l);
-
                     if(xa.limitRange) xa.limitRange();
                     if(ya.limitRange) ya.limitRange();
 
-                    xrng = xa.range;
-                    yrng = ya.range;
+                    var xrng = Lib.simpleMap(xa.range, xa.r2l);
+                    var yrng = Lib.simpleMap(ya.range, ya.r2l);
 
                     sp._scene.update({range: [xrng[0], yrng[0], xrng[1], yrng[1]]});
                 }


### PR DESCRIPTION
Fixes #6814.

The existing code overwrites the converted range so that you end up passing a string into the scene update when using `xaxis.type: 'date'`. This PR makes sure that the range limiting happens before the conversion/mapping and scene update.

Before:

![2024-06-06 16 14 47](https://github.com/plotly/plotly.js/assets/3486317/e998771a-f208-4a68-8d05-c7024ed890ac)

After:

![2024-06-06 16 13 23](https://github.com/plotly/plotly.js/assets/3486317/9dce1f0a-dc4f-4095-bf5b-f56661447b82)
