### PR TITLE
Fix for openmaptiles open sans extrabold

### DIFF
--- a/draftlogs/7020_fix.md
+++ b/draftlogs/7020_fix.md
@@ -1,0 +1,1 @@
+- fix for Open Sans Extrabold [#7020](https://github.com/plotly/plotly.js/pull/7020).

--- a/src/traces/scattermapbox/convert.js
+++ b/src/traces/scattermapbox/convert.js
@@ -417,6 +417,10 @@ function getTextFont(trace) {
     else if(str === 'Open Sans Regular Bold Italic') str = 'Open Sans Bold Italic';
     else if(str === 'Klokantech Noto Sans Regular Italic') str = 'Klokantech Noto Sans Italic';
 
+    // Openmaptiles called it Extra Bold, instead of Extrabold - https://github.com/openmaptiles/fonts/issues/24
+    else if(str === 'Open Sans Extrabold') str = 'Open Sans Extra Bold';
+    else if(str === 'Open Sans Extrabold Italic') str = 'Open Sans Extra Bold Italic';
+
     // Ensure the result is a supported font
     if(!isSupportedFont(str)) {
         str = family;


### PR DESCRIPTION
Openmaptiles call the Open Sans Extrabold for Open Sans Extra Bold
- https://github.com/openmaptiles/fonts/issues/24

Affecting the scattermapbox trace