### PR TITLE
Skip `restyle radial axis title` Jasmine test in CI (test is not reliable)

### DIFF
--- a/test/jasmine/tests/polar_test.js
+++ b/test/jasmine/tests/polar_test.js
@@ -447,7 +447,7 @@ describe('Test relayout on polar subplots:', function() {
         .then(done, done.fail);
     });
 
-    it('should be able to restyle radial axis title', function(done) {
+    it('@noCI should be able to restyle radial axis title', function(done) {
         var gd = createGraphDiv();
         var lastBBox;
 


### PR DESCRIPTION
Closes #7028 

Remove `restyle radial axis title` test from CI because it is failing when it is not expected to fail. See linked issue for context.

Issue added for fixing this test: #7029 