### PR TITLE
fix wrong scrollBoxY value for legend scroll

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -337,7 +337,7 @@ function drawOne(gd, opts) {
                 legend.on('wheel', function() {
                     scrollBoxY = Lib.constrain(
                         legendObj._scrollY +
-                            ((d3.event.deltaY / scrollBarYMax) * scrollBoxYMax),
+                            ((d3.event.deltaY / scrollBoxYMax) * scrollBarYMax),
                         0, scrollBoxYMax);
                     scrollHandler(scrollBoxY, scrollBarHeight, scrollRatio);
                     if(scrollBoxY !== 0 && scrollBoxY !== scrollBoxYMax) {


### PR DESCRIPTION
Fix #7066

I would also prefer to disable scrolling for the parent, i.e. not detect whether it reaches the top or bottom, but simply call `d3.event.preventDefault();` at the end.

https://github.com/plotly/plotly.js/blob/55d8f983d45fe533596cd52a8526c78efda41e6b/src/components/legend/draw.js#L343-L345

But that is not related to the bug, so I'll leave it for discussion.