### PR TITLE
Use `node.js v18` and `npm v10` in development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
   install-and-cibuild: # main cibuild using node 16 & npm 7
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
   timezone-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:18.20.4-browsers
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
@@ -84,7 +84,7 @@ jobs:
   no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:18.20.4-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -103,7 +103,7 @@ jobs:
   webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:18.20.4-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -122,7 +122,7 @@ jobs:
   virtual-webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:18.20.4-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -141,7 +141,7 @@ jobs:
   flaky-no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:18.20.4-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -159,7 +159,7 @@ jobs:
   bundle-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:18.20.4-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -177,7 +177,7 @@ jobs:
   mathjax-firefoxLatest:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:18.20.4-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -269,7 +269,7 @@ jobs:
 
   test-baselines:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -283,7 +283,7 @@ jobs:
 
   test-baselines-virtual-webgl:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -297,7 +297,7 @@ jobs:
 
   test-baselines-b64:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -311,7 +311,7 @@ jobs:
 
   test-baselines-mathjax3:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -348,7 +348,7 @@ jobs:
 
   test-exports:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -362,7 +362,7 @@ jobs:
 
   mock-validation:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -376,7 +376,7 @@ jobs:
 
   source-syntax:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -387,7 +387,7 @@ jobs:
 
   publish-dist:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -457,7 +457,7 @@ jobs:
 
   test-stackgl-bundle:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           name: CI-Build
           command: npm run cibuild
 
-  install-and-cibuild: # main cibuild using node 16 & npm 7
+  install-and-cibuild: 
     docker:
       - image: cimg/node:18.20.4
     working_directory: ~/plotly.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           name: CI-Build
           command: npm run cibuild
 
-  install-and-cibuild: 
+  install-and-cibuild:
     docker:
       - image: cimg/node:18.20.4
     working_directory: ~/plotly.js
@@ -336,8 +336,8 @@ jobs:
       - run:
           name: Install poppler-utils to have pdftops for exporting eps
           command: |
-              sudo apt-get update --allow-releaseinfo-change
-              sudo apt-get install poppler-utils
+            sudo apt-get update --allow-releaseinfo-change
+            sudo apt-get install poppler-utils
       - run:
           name: Create svg, jpg, jpeg, webp, pdf and eps files
           command: python3 test/image/make_exports.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,10 +77,10 @@ We use the following [labels](https://github.com/plotly/plotly.js/labels) to tra
 #### Prerequisites
 
 - git
-- [node.js](https://nodejs.org/en/). We recommend using node.js v16.x.
+- [node.js](https://nodejs.org/en/). We recommend using node.js v18.x.
   Upgrading and managing node versions can be easily done using
   [`nvm`](https://github.com/creationix/nvm) or its Windows alternatives.
-- [`npm`](https://www.npmjs.com/) v7.x and up to ensure that the
+- [`npm`](https://www.npmjs.com/) v10.x and up to ensure that the
   [`package-lock.json`](https://docs.npmjs.com/files/package-lock.json) file is
   used and updated correctly.
 

--- a/draftlogs/7078_change.md
+++ b/draftlogs/7078_change.md
@@ -1,0 +1,2 @@
+ - Use `Node.js v18` and `npm v10` in development [[#5922](https://github.com/plotly/plotly.js/pull/5922), [#7078](https://github.com/plotly/plotly.js/pull/7078)]
+ 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "start": "node devtools/test_dashboard/server.js",
     "baseline": "node test/image/make_baseline.js",
     "noci-baseline": "npm run cibuild && ./tasks/noci_test.sh image && git checkout dist && echo 'Please do not commit unless the change was expected!'",
-    "preversion": "check-node-version --node 16 --npm 8 && npm-link-check && npm ls --prod --all",
+    "preversion": "check-node-version --node 18 --npm 10 && npm-link-check && npm ls --prod --all",
     "version": "npm run build && npm run no-bad-char && git add -A lib dist build src/version.js",
     "postversion": "node -e \"console.log('Version bumped and committed. If ok, run: git push && git push --tags')\"",
     "postpublish": "node tasks/sync_packages.js",


### PR DESCRIPTION
This PR updates to Node 18, which is in maintenance mode until April 30th 2025.

Overview here: https://endoflife.date/nodejs

Closes #7081 