### PR TITLE
Use cimg/node instead of circleci/node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: 81.0
+          firefox-version: "81.0"
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:
@@ -203,7 +203,7 @@ jobs:
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: 82.0
+          firefox-version: "82.0"
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,7 @@ jobs:
 
   test-baselines:
     docker:
-      - image: circleci/node:16.9.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -321,7 +321,7 @@ jobs:
 
   test-baselines-virtual-webgl:
     docker:
-      - image: circleci/node:16.9.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -335,7 +335,7 @@ jobs:
 
   test-baselines-b64:
     docker:
-      - image: circleci/node:16.9.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -349,7 +349,7 @@ jobs:
 
   test-baselines-mathjax3:
     docker:
-      - image: circleci/node:16.9.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -386,7 +386,7 @@ jobs:
 
   test-exports:
     docker:
-      - image: circleci/node:16.9.0
+      - image: cimg/node:16.17.1
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,44 +174,6 @@ jobs:
           name: Run jasmine tests (part D)
           command: .circleci/test.sh bundle-jasmine
 
-  mathjax-firefox101:
-    docker:
-      # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
-    environment:
-      # Alaska time (arbitrary timezone to test date logic)
-      TZ: "America/Anchorage"
-    working_directory: ~/plotly.js
-    steps:
-      - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: "101.0"
-          install-chrome: false
-          install-chromedriver: false
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Test MathJax on firefox-101
-          command: .circleci/test.sh mathjax-firefox
-
-  mathjax-firefox102:
-    docker:
-      # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.20.2-browsers
-    environment:
-      # Alaska time (arbitrary timezone to test date logic)
-      TZ: "America/Anchorage"
-    working_directory: ~/plotly.js
-    steps:
-      - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: "102.0"
-          install-chrome: false
-          install-chromedriver: false
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Test MathJax on firefox-102
-          command: .circleci/test.sh mathjax-firefox102+
-
   mathjax-firefoxLatest:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
@@ -228,7 +190,7 @@ jobs:
           at: ~/
       - run:
           name: Test MathJax on firefox-latest
-          command: .circleci/test.sh mathjax-firefox102+
+          command: .circleci/test.sh mathjax-firefox
 
   make-baselines-virtual-webgl:
     parallelism: 8
@@ -523,12 +485,6 @@ workflows:
           requires:
             - install-and-cibuild
       - bundle-jasmine:
-          requires:
-            - install-and-cibuild
-      - mathjax-firefox101:
-          requires:
-            - install-and-cibuild
-      - mathjax-firefox102:
           requires:
             - install-and-cibuild
       - mathjax-firefoxLatest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: '81.0'
+          firefox-version: 81.0
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:
@@ -203,7 +203,7 @@ jobs:
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: '82.0'
+          firefox-version: 82.0
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
 
   install-and-cibuild: # main cibuild using node 16 & npm 7
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
   timezone-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
@@ -84,7 +84,7 @@ jobs:
   no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -103,7 +103,7 @@ jobs:
   webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -122,7 +122,7 @@ jobs:
   virtual-webgl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -141,7 +141,7 @@ jobs:
   flaky-no-gl-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -159,7 +159,7 @@ jobs:
   bundle-jasmine:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -177,7 +177,7 @@ jobs:
   mathjax-firefox81:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -196,7 +196,7 @@ jobs:
   mathjax-firefox82:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -215,7 +215,7 @@ jobs:
   mathjax-firefoxLatest:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
-      - image: cimg/node:16.17.1-browsers
+      - image: cimg/node:16.20.2-browsers
     environment:
       # Alaska time (arbitrary timezone to test date logic)
       TZ: "America/Anchorage"
@@ -307,7 +307,7 @@ jobs:
 
   test-baselines:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -321,7 +321,7 @@ jobs:
 
   test-baselines-virtual-webgl:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -335,7 +335,7 @@ jobs:
 
   test-baselines-b64:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -349,7 +349,7 @@ jobs:
 
   test-baselines-mathjax3:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -386,7 +386,7 @@ jobs:
 
   test-exports:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -400,7 +400,7 @@ jobs:
 
   mock-validation:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -414,7 +414,7 @@ jobs:
 
   source-syntax:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - attach_workspace:
@@ -425,7 +425,7 @@ jobs:
 
   publish-dist:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - checkout
@@ -495,7 +495,7 @@ jobs:
 
   test-stackgl-bundle:
     docker:
-      - image: cimg/node:16.17.1
+      - image: cimg/node:16.20.2
     working_directory: ~/plotly.js
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,13 +184,13 @@ jobs:
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: "81.0"
+          firefox-version: "101.0"
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:
           at: ~/
       - run:
-          name: Test MathJax on firefox-81
+          name: Test MathJax on firefox-101
           command: .circleci/test.sh mathjax-firefox
 
   mathjax-firefox82:
@@ -203,14 +203,14 @@ jobs:
     working_directory: ~/plotly.js
     steps:
       - browser-tools/install-browser-tools: &browser-versions
-          firefox-version: "82.0"
+          firefox-version: "102.0"
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:
           at: ~/
       - run:
-          name: Test MathJax on firefox-82
-          command: .circleci/test.sh mathjax-firefox82+
+          name: Test MathJax on firefox-102
+          command: .circleci/test.sh mathjax-firefox102+
 
   mathjax-firefoxLatest:
     docker:
@@ -228,7 +228,7 @@ jobs:
           at: ~/
       - run:
           name: Test MathJax on firefox-latest
-          command: .circleci/test.sh mathjax-firefox82+
+          command: .circleci/test.sh mathjax-firefox102+
 
   make-baselines-virtual-webgl:
     parallelism: 8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - image: cimg/node:16.20.2-browsers
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -91,7 +91,7 @@ jobs:
     parallelism: 12
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -110,7 +110,7 @@ jobs:
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -129,7 +129,7 @@ jobs:
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -147,7 +147,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -165,7 +165,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -183,7 +183,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           firefox-version: '81.0'
           install-chrome: false
           install-chromedriver: false
@@ -202,7 +202,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           firefox-version: '82.0'
           install-chrome: false
           install-chromedriver: false
@@ -221,7 +221,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools:
+      - browser-tools/install-browser-tools: &browser-versions
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
           name: Run jasmine tests (part D)
           command: .circleci/test.sh bundle-jasmine
 
-  mathjax-firefox81:
+  mathjax-firefox101:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: cimg/node:16.20.2-browsers
@@ -193,7 +193,7 @@ jobs:
           name: Test MathJax on firefox-101
           command: .circleci/test.sh mathjax-firefox
 
-  mathjax-firefox82:
+  mathjax-firefox102:
     docker:
       # need '-browsers' version to test in real (xvfb-wrapped) browsers
       - image: cimg/node:16.20.2-browsers
@@ -525,10 +525,10 @@ workflows:
       - bundle-jasmine:
           requires:
             - install-and-cibuild
-      - mathjax-firefox81:
+      - mathjax-firefox101:
           requires:
             - install-and-cibuild
-      - mathjax-firefox82:
+      - mathjax-firefox102:
           requires:
             - install-and-cibuild
       - mathjax-firefoxLatest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - image: cimg/node:16.20.2-browsers
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -91,7 +91,7 @@ jobs:
     parallelism: 12
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -110,7 +110,7 @@ jobs:
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -129,7 +129,7 @@ jobs:
     parallelism: 8
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -147,7 +147,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -165,7 +165,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           install-firefox: false
           install-geckodriver: false
       - attach_workspace:
@@ -183,7 +183,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           firefox-version: '81.0'
           install-chrome: false
           install-chromedriver: false
@@ -202,7 +202,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           firefox-version: '82.0'
           install-chrome: false
           install-chromedriver: false
@@ -221,7 +221,7 @@ jobs:
       TZ: "America/Anchorage"
     working_directory: ~/plotly.js
     steps:
-      - browser-tools/install-browser-tools: &browser-versions
+      - browser-tools/install-browser-tools:
           install-chrome: false
           install-chromedriver: false
       - attach_workspace:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -85,8 +85,8 @@ case $1 in
         ;;
 
     mathjax-firefox102+)
-        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --skip-tags=noFF102 --nowatch &&
-        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --mathjax3 --skip-tags=noFF102 --nowatch &&
+        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --nowatch &&
+        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --mathjax3 --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax_config --mathjax3 --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax_config --nowatch || EXIT_STATE=$?
         exit $EXIT_STATE

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -84,7 +84,7 @@ case $1 in
         exit $EXIT_STATE
         ;;
 
-    mathjax-firefox82+)
+    mathjax-firefox102+)
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --skip-tags=noFF82 --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --mathjax3 --skip-tags=noFF82 --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax_config --mathjax3 --nowatch &&

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -85,8 +85,8 @@ case $1 in
         ;;
 
     mathjax-firefox102+)
-        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --skip-tags=noFF82 --nowatch &&
-        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --mathjax3 --skip-tags=noFF82 --nowatch &&
+        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --skip-tags=noFF102 --nowatch &&
+        ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --mathjax3 --skip-tags=noFF102 --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax_config --mathjax3 --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax_config --nowatch || EXIT_STATE=$?
         exit $EXIT_STATE

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -84,7 +84,7 @@ case $1 in
         exit $EXIT_STATE
         ;;
 
-    mathjax-firefox102+)
+    mathjax-firefox)
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax --mathjax3 --nowatch &&
         ./node_modules/karma/bin/karma start test/jasmine/karma.conf.js --FF --bundleTest=mathjax_config --mathjax3 --nowatch &&

--- a/draftlogs/7080_change.md
+++ b/draftlogs/7080_change.md
@@ -1,1 +1,2 @@
  - Use cimg/node instead of circleci/node in CI [[#7080](https://github.com/plotly/plotly.js/pull/7080)]
+ 

--- a/draftlogs/7080_change.md
+++ b/draftlogs/7080_change.md
@@ -1,0 +1,1 @@
+ - Use cimg/node instead of circleci/node in CI [[#7080](https://github.com/plotly/plotly.js/pull/7080)]

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -31,7 +31,7 @@ assertCircularDeps();
 // check for for focus and exclude jasmine blocks
 function assertJasmineSuites() {
     var BLACK_LIST = ['fdescribe', 'fit', 'xdescribe', 'xit'];
-    var TAGS = ['noCI', 'noCIdep', 'noFF102', 'gl', 'flaky'];
+    var TAGS = ['noCI', 'noCIdep', 'gl', 'flaky'];
     var IT_ONLY_TAGS = ['gl', 'flaky'];
     var logs = [];
 

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -31,7 +31,7 @@ assertCircularDeps();
 // check for for focus and exclude jasmine blocks
 function assertJasmineSuites() {
     var BLACK_LIST = ['fdescribe', 'fit', 'xdescribe', 'xit'];
-    var TAGS = ['noCI', 'noCIdep', 'noFF82', 'gl', 'flaky'];
+    var TAGS = ['noCI', 'noCIdep', 'noFF102', 'gl', 'flaky'];
     var IT_ONLY_TAGS = ['gl', 'flaky'];
     var logs = [];
 

--- a/test/jasmine/bundle_tests/mathjax_test.js
+++ b/test/jasmine/bundle_tests/mathjax_test.js
@@ -95,6 +95,25 @@ describe('Test MathJax v' + mathjaxVersion + ':', function() {
             .then(done, done.fail);
         });
 
+        it('should scoot x-axis title (with MathJax) below x-axis ticks', function(done) {
+            expect(window.MathJax).toBeDefined();
+
+            testTitleScoot({
+                data: [{
+                    y: [1, 2, 1]
+                }],
+                layout: {
+                    xaxis: {title: texTitle},
+                    width: 500,
+                    height: 500,
+                    margin: {t: 100, b: 100, l: 100, r: 100}
+                }
+            }, {
+                xCategories: longCats
+            })
+            .then(done, done.fail);
+        });
+
         it('should scoot x-axis title below x-axis ticks (with MathJax)', function(done) {
             expect(window.MathJax).toBeDefined();
 

--- a/test/jasmine/bundle_tests/mathjax_test.js
+++ b/test/jasmine/bundle_tests/mathjax_test.js
@@ -95,24 +95,26 @@ describe('Test MathJax v' + mathjaxVersion + ':', function() {
             .then(done, done.fail);
         });
 
-        it('should scoot x-axis title (with MathJax) below x-axis ticks', function(done) {
-            expect(window.MathJax).toBeDefined();
 
-            testTitleScoot({
-                data: [{
-                    y: [1, 2, 1]
-                }],
-                layout: {
-                    xaxis: {title: texTitle},
-                    width: 500,
-                    height: 500,
-                    margin: {t: 100, b: 100, l: 100, r: 100}
-                }
-            }, {
-                xCategories: longCats
-            })
-            .then(done, done.fail);
-        });
+        // Firefox bug - see https://bugzilla.mozilla.org/show_bug.cgi?id=1350755
+        // it('should scoot x-axis title (with MathJax) below x-axis ticks', function(done) {
+        //     expect(window.MathJax).toBeDefined();
+
+        //     testTitleScoot({
+        //         data: [{
+        //             y: [1, 2, 1]
+        //         }],
+        //         layout: {
+        //             xaxis: {title: texTitle},
+        //             width: 500,
+        //             height: 500,
+        //             margin: {t: 100, b: 100, l: 100, r: 100}
+        //         }
+        //     }, {
+        //         xCategories: longCats
+        //     })
+        //     .then(done, done.fail);
+        // });
 
         it('should scoot x-axis title below x-axis ticks (with MathJax)', function(done) {
             expect(window.MathJax).toBeDefined();

--- a/test/jasmine/bundle_tests/mathjax_test.js
+++ b/test/jasmine/bundle_tests/mathjax_test.js
@@ -95,25 +95,6 @@ describe('Test MathJax v' + mathjaxVersion + ':', function() {
             .then(done, done.fail);
         });
 
-        it('@noFF102 should scoot x-axis title (with MathJax) below x-axis ticks', function(done) {
-            expect(window.MathJax).toBeDefined();
-
-            testTitleScoot({
-                data: [{
-                    y: [1, 2, 1]
-                }],
-                layout: {
-                    xaxis: {title: texTitle},
-                    width: 500,
-                    height: 500,
-                    margin: {t: 100, b: 100, l: 100, r: 100}
-                }
-            }, {
-                xCategories: longCats
-            })
-            .then(done, done.fail);
-        });
-
         it('should scoot x-axis title below x-axis ticks (with MathJax)', function(done) {
             expect(window.MathJax).toBeDefined();
 

--- a/test/jasmine/bundle_tests/mathjax_test.js
+++ b/test/jasmine/bundle_tests/mathjax_test.js
@@ -95,7 +95,7 @@ describe('Test MathJax v' + mathjaxVersion + ':', function() {
             .then(done, done.fail);
         });
 
-        it('@noFF82 should scoot x-axis title (with MathJax) below x-axis ticks', function(done) {
+        it('@noFF102 should scoot x-axis title (with MathJax) below x-axis ticks', function(done) {
             expect(window.MathJax).toBeDefined();
 
             testTitleScoot({


### PR DESCRIPTION
As mentioned [here](https://circleci.com/developer/images/image/cimg/node):

> cimg/node is designed to supercede the legacy CircleCI Node.js image, circleci/node

This is still Node 16, but using the cimg/node as a step towards:
- #7078 

Related to
- https://github.com/plotly/plotly.js/issues/7081