### PR TITLE
Add dependabot.yml to reduce manual work

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,14 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+  directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     versioning-strategy: increase
   - package-ecosystem: "npm"
     directory: "/stackgl_modules"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-  directory: "/"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+  - package-ecosystem: "npm"
+    directory: "/stackgl_modules"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ npm-debug.log*
 tags
 
 .*
+!.github
 !.circleci
 !.gitignore
 !.npmignore


### PR DESCRIPTION
I noticed these recent commits:
- https://github.com/plotly/plotly.js/pull/7096
- https://github.com/plotly/plotly.js/pull/7097
- https://github.com/plotly/plotly.js/pull/7098

This PR adds a dependabot that'll automate the bumping of minor/patch versions to keep them up to date, with release notes etc. (example [here](https://github.com/maplibre/maplibre-gl-js/pull/4530)), so that the only work left for maintainers is to merge.

It'll not bump major versions of deps, which could lead to breaking changes.

There will be at most 1 open pr. per lockfile (so two, root+stackgl) with current settings.

It'll not auto merge unless [this](https://github.com/maplibre/maplibre-gl-js/blob/main/.github/workflows/auto-merge-dependabot.yml) github workflow is also added. We actually do auto merge in maplibre, because the CI is the bar it has to meet anyway, and it's honestly quite a relief to be able to focus on the areas that needs attention.