### PR TITLE
update custom bundle instruction to clone

### DIFF
--- a/CUSTOM_BUNDLE.md
+++ b/CUSTOM_BUNDLE.md
@@ -1,9 +1,9 @@
 # Custom bundle
 You can simply make custom bundles yourself, if none of the [distributed packages](https://github.com/plotly/plotly.js/blob/master/dist/README.md) meet your needs, or you want to make a more optimized bundle file with/without specific traces and transforms.
 
-Install plotly.js, move to plotly.js folder then install plotly.js dependencies:
+Clone plotly.js, move to plotly.js folder then install plotly.js dependencies:
 ```sh
-npm i plotly.js
+git clone https://github.com/plotly/plotly.js.git
 cd node_modules/plotly.js
 npm i
 ```


### PR DESCRIPTION
It's more flexible to clone the repo, than to npm install it and go to the node_modules/plotly.js.

I.e. the lockfile doesn't follow when just npm installing, so the user trying to make a custom build will end up with a set of  dependency versions that haven't passed CI.