### PR TITLE
fix regl_codegen

### DIFF
--- a/devtools/regl_codegen/server.mjs
+++ b/devtools/regl_codegen/server.mjs
@@ -58,13 +58,6 @@ var server = http.createServer(function(req, res) {
     }
 });
 
-
-// Start the server up!
-server.listen(PORT);
-
-// open up browser window
-open('http://localhost:' + PORT + '/devtools/regl_codegen/index' + (strict ? '-strict' : '') + '.html');
-
 // Build and bundle all the things!
 await getMockFiles()
     .then(readFiles)
@@ -72,6 +65,11 @@ await getMockFiles()
     .then(saveMockListToFile)
     .then(saveReglTracesToFile.bind(null, reglTraceList));
 
+// Start the server up!
+server.listen(PORT);
+
+// open up browser window
+open('http://localhost:' + PORT + '/devtools/regl_codegen/index' + (strict ? '-strict' : '') + '.html');
 
 var devtoolsPath = path.join(constants.pathToRoot, 'devtools/regl_codegen');
 config.entryPoints = [path.join(devtoolsPath, 'devtools.js')];

--- a/devtools/regl_codegen/server.mjs
+++ b/devtools/regl_codegen/server.mjs
@@ -20,12 +20,7 @@ var reglTraceList = [
     'splom'
 ];
 
-var devtoolsPath = path.join(constants.pathToRoot, 'devtools/regl_codegen');
-config.entryPoints = [path.join(devtoolsPath, 'devtools.js')];
-config.outfile = './build/regl_codegen-bundle.js';
-config.sourcemap = false;
-config.minify = false;
-await build(config);
+
 
 // Create server
 var _static = ecstatic({
@@ -71,11 +66,19 @@ server.listen(PORT);
 open('http://localhost:' + PORT + '/devtools/regl_codegen/index' + (strict ? '-strict' : '') + '.html');
 
 // Build and bundle all the things!
-getMockFiles()
+await getMockFiles()
     .then(readFiles)
     .then(createMocksList)
     .then(saveMockListToFile)
     .then(saveReglTracesToFile.bind(null, reglTraceList));
+
+
+var devtoolsPath = path.join(constants.pathToRoot, 'devtools/regl_codegen');
+config.entryPoints = [path.join(devtoolsPath, 'devtools.js')];
+config.outfile = './build/regl_codegen-bundle.js';
+config.sourcemap = false;
+config.minify = false;
+await build(config);
 
 function getMockFiles() {
     return new Promise(function(resolve, reject) {


### PR DESCRIPTION
This fixes the regl_codegen, by making sure the files first are generated, and then the server and devtools are launched after - not the other way around