### PR TITLE
Pin Chrome 127 in Jasmine CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
       - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
+          install-chrome: true
+          chrome-version: 127
       - attach_workspace:
           at: ~/
       - run:
@@ -78,6 +80,8 @@ jobs:
       - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
+          install-chrome: true
+          chrome-version: 127
       - attach_workspace:
           at: ~/
       - run:
@@ -97,6 +101,8 @@ jobs:
       - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
+          install-chrome: true
+          chrome-version: 127
       - attach_workspace:
           at: ~/
       - run:
@@ -116,6 +122,8 @@ jobs:
       - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
+          install-chrome: true
+          chrome-version: 127
       - attach_workspace:
           at: ~/
       - run:
@@ -134,6 +142,8 @@ jobs:
       - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
+          install-chrome: true
+          chrome-version: 127
       - attach_workspace:
           at: ~/
       - run:
@@ -152,6 +162,8 @@ jobs:
       - browser-tools/install-browser-tools: &browser-versions
           install-firefox: false
           install-geckodriver: false
+          install-chrome: true
+          chrome-version: 127
       - attach_workspace:
           at: ~/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: 127
+          chrome-version: "127"
       - attach_workspace:
           at: ~/
       - run:
@@ -81,7 +81,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: 127
+          chrome-version: "127"
       - attach_workspace:
           at: ~/
       - run:
@@ -102,7 +102,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: 127
+          chrome-version: "127"
       - attach_workspace:
           at: ~/
       - run:
@@ -123,7 +123,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: 127
+          chrome-version: "127"
       - attach_workspace:
           at: ~/
       - run:
@@ -143,7 +143,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: 127
+          chrome-version: "127"
       - attach_workspace:
           at: ~/
       - run:
@@ -163,7 +163,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: 127
+          chrome-version: "127"
       - attach_workspace:
           at: ~/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127"
+          chrome-version: "127.0.6533.132"
       - attach_workspace:
           at: ~/
       - run:
@@ -81,7 +81,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127"
+          chrome-version: "127.0.6533.132"
       - attach_workspace:
           at: ~/
       - run:
@@ -102,7 +102,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127"
+          chrome-version: "127.0.6533.132"
       - attach_workspace:
           at: ~/
       - run:
@@ -123,7 +123,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127"
+          chrome-version: "127.0.6533.132"
       - attach_workspace:
           at: ~/
       - run:
@@ -143,7 +143,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127"
+          chrome-version: "127.0.6533.132"
       - attach_workspace:
           at: ~/
       - run:
@@ -163,7 +163,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127"
+          chrome-version: "127.0.6533.132"
       - attach_workspace:
           at: ~/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127.0.6533.132"
+          chrome-version: "127.0.6533.119"
       - attach_workspace:
           at: ~/
       - run:
@@ -81,7 +81,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127.0.6533.132"
+          chrome-version: "127.0.6533.119"
       - attach_workspace:
           at: ~/
       - run:
@@ -102,7 +102,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127.0.6533.132"
+          chrome-version: "127.0.6533.119"
       - attach_workspace:
           at: ~/
       - run:
@@ -123,7 +123,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127.0.6533.132"
+          chrome-version: "127.0.6533.119"
       - attach_workspace:
           at: ~/
       - run:
@@ -143,7 +143,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127.0.6533.132"
+          chrome-version: "127.0.6533.119"
       - attach_workspace:
           at: ~/
       - run:
@@ -163,7 +163,7 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chrome: true
-          chrome-version: "127.0.6533.132"
+          chrome-version: "127.0.6533.119"
       - attach_workspace:
           at: ~/
       - run:


### PR DESCRIPTION
There is a regression in Chrome 128, this pins chrome  [127.0.6533.119](https://chromereleases.googleblog.com/2024/08/stable-channel-update-for-desktop_13.html)  in CI. 

Closes #7126 
- #7126 