### PR TITLE
fix require path to resource in node_modules

### DIFF
--- a/draftlogs/7146_fix.md
+++ b/draftlogs/7146_fix.md
@@ -1,0 +1,1 @@
+- Fix require path to maplibre-gl.css [[#7146](https://github.com/plotly/plotly.js/pull/7146)]

--- a/src/registry.js
+++ b/src/registry.js
@@ -274,7 +274,7 @@ function registerTraceModule(_module) {
 
     // add maplibre-gl CSS here to avoid console warning on instantiation
     if(bpmName === 'map') {
-        require('../node_modules/maplibre-gl/dist/maplibre-gl.css');
+        require('maplibre-gl/dist/maplibre-gl.css');
     }
 
     // if `plotly-geo-assets.js` is not included,


### PR DESCRIPTION
Fix #7145 

Instead of providing the relative path to the node_modules, let the runtime resolve it.

It's a bit speculative, but it's easy to imagine setups (different package managers, monorepos) that doesn't have the maplibre-gl node module located exactly in the location specified:
- pnpm e.g. nests below a node_modules/.pnpm/maplibre-gl
- monorepos often have node_modules at root but not in each package

@archmoj  I don't have a repro of the error, and thus haven't been able to validate the patch. Also, I'm trying to wrap my head around why it's at all necessary for the users of a plotly.js distribution to resolve this path, because I expected webpack to have done so already when the plotly.js bundles are created.