### PR TITLE
Fix scatterternary with ids attribute

### DIFF
--- a/draftlogs/7167_fix.md
+++ b/draftlogs/7167_fix.md
@@ -1,0 +1,1 @@
+- Render scatterternary traces correctly if they have the `ids` attribute [[#7164](https://github.com/plotly/plotly.js/pull/7164)]

--- a/src/traces/scatterternary/calc.js
+++ b/src/traces/scatterternary/calc.js
@@ -15,6 +15,7 @@ module.exports = function calc(gd, trace) {
     var displaySum = ternary.sum;
     var normSum = trace.sum || displaySum;
     var arrays = {a: trace.a, b: trace.b, c: trace.c};
+    var ids = trace.ids;
 
     var i, j, dataArray, newArray, fillArray1, fillArray2;
 
@@ -58,6 +59,9 @@ module.exports = function calc(gd, trace) {
             y = a;
             x = c - b;
             cd[i] = {x: x, y: y, a: a, b: b, c: c};
+            if (ids) {
+                cd[i].id = ids[i];
+            }
         } else cd[i] = {x: false, y: false};
     }
 

--- a/test/image/mocks/ternary_simple.json
+++ b/test/image/mocks/ternary_simple.json
@@ -4,6 +4,7 @@
    "a": [2, 1, 1],
    "b": [1, 2, 1],
    "c": [1, 1, 2.12345],
+   "ids": ["first ID", "second ID", "third ID"],
    "type": "scatterternary"
   }
  ],

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -2061,7 +2061,7 @@ describe('Test select box and lasso per trace:', function() {
     }
 
     [false, true].forEach(function(hasCssTransform) {
-        it('should work on scatterternary traces, hasCssTransform: ' + hasCssTransform, function(done) {
+        fit('should work on scatterternary traces, hasCssTransform: ' + hasCssTransform, function(done) {
             var assertPoints = makeAssertPoints(['a', 'b', 'c']);
             var assertSelectedPoints = makeAssertSelectedPoints();
 
@@ -2079,6 +2079,7 @@ describe('Test select box and lasso per trace:', function() {
                     function() {
                         assertPoints([[0.5, 0.25, 0.25]]);
                         assertSelectedPoints({0: [0]});
+                        expect(selectedData.points[0].id).toBe("first ID")
                     },
                     [380, 180],
                     BOXEVENTS, 'scatterternary select'

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -2061,7 +2061,7 @@ describe('Test select box and lasso per trace:', function() {
     }
 
     [false, true].forEach(function(hasCssTransform) {
-        fit('should work on scatterternary traces, hasCssTransform: ' + hasCssTransform, function(done) {
+        it('should work on scatterternary traces, hasCssTransform: ' + hasCssTransform, function(done) {
             var assertPoints = makeAssertPoints(['a', 'b', 'c']);
             var assertSelectedPoints = makeAssertSelectedPoints();
 

--- a/test/jasmine/tests/ternary_test.js
+++ b/test/jasmine/tests/ternary_test.js
@@ -21,7 +21,7 @@ var assertHoverLabelContent = customAssertions.assertHoverLabelContent;
 
 var SORTED_EVENT_KEYS = [
     'data', 'fullData', 'curveNumber', 'pointNumber', 'pointIndex',
-    'xaxis', 'yaxis', 'a', 'b', 'c',
+    'xaxis', 'yaxis', 'a', 'b', 'c', 'id',
     'bbox'
 ].sort();
 


### PR DESCRIPTION
Fix #7166 

`ids` is part of the `scatterternary` schema, so it shouldn't break things! Anyway I want to use it for selection events, so I can reserve `customdata` for hover labels.