### PR TITLE
Fix `mablibre` source map

### DIFF
--- a/draftlogs/7204_fix.md
+++ b/draftlogs/7204_fix.md
@@ -1,0 +1,1 @@
+ - Fix mablibre source map [[#7204](https://github.com/plotly/plotly.js/pull/7204)]

--- a/src/plots/map/map.js
+++ b/src/plots/map/map.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var maplibregl = require('maplibre-gl/dist/maplibre-gl-unminified');
+var maplibregl = require('maplibre-gl');
 
 var Lib = require('../../lib');
 var geoUtils = require('../../lib/geo_location_utils');


### PR DESCRIPTION
Fixes #7161.
@plotly/plotly_js 
cc: @birkskyum 