### PR TITLE
drop deprecated `bardir` attribute (use `orientation` instead)

### DIFF
--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -295,17 +295,6 @@ exports.cleanData = function(data) {
             delete trace.error_y.opacity;
         }
 
-        // convert bardir to orientation, and put the data into
-        // the axes it's eventually going to be used with
-        if('bardir' in trace) {
-            if(trace.bardir === 'h' && (traceIs(trace, 'bar') ||
-                trace.type.substr(0, 9) === 'histogram')) {
-                trace.orientation = 'h';
-                exports.swapXYData(trace);
-            }
-            delete trace.bardir;
-        }
-
         // now we have only one 1D histogram type, and whether
         // it uses x or y data depends on trace.orientation
         if(trace.type === 'histogramy') exports.swapXYData(trace);

--- a/src/traces/bar/attributes.js
+++ b/src/traces/bar/attributes.js
@@ -227,13 +227,4 @@ module.exports = {
         editType: 'style'
     },
     zorder: scatterAttrs.zorder,
-
-    _deprecated: {
-        bardir: {
-            valType: 'enumerated',
-            editType: 'calc',
-            values: ['v', 'h'],
-            description: 'Renamed to `orientation`.'
-        }
-    }
 };

--- a/src/traces/histogram/attributes.js
+++ b/src/traces/histogram/attributes.js
@@ -246,9 +246,5 @@ module.exports = {
     selected: barAttrs.selected,
     unselected: barAttrs.unselected,
 
-    _deprecated: {
-        bardir: barAttrs._deprecated.bardir
-    },
-
     zorder: barAttrs.zorder
 };

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -17291,17 +17291,6 @@
   "bar": {
    "animatable": true,
    "attributes": {
-    "_deprecated": {
-     "bardir": {
-      "description": "Renamed to `orientation`.",
-      "editType": "calc",
-      "valType": "enumerated",
-      "values": [
-       "v",
-       "h"
-      ]
-     }
-    },
     "alignmentgroup": {
      "description": "Set several traces linked to the same position axis or matching axes to the same alignmentgroup. This controls whether bars compute their positional range dependently or independently.",
      "dflt": "",
@@ -43700,17 +43689,6 @@
   "histogram": {
    "animatable": false,
    "attributes": {
-    "_deprecated": {
-     "bardir": {
-      "description": "Renamed to `orientation`.",
-      "editType": "calc",
-      "valType": "enumerated",
-      "values": [
-       "v",
-       "h"
-      ]
-     }
-    },
     "alignmentgroup": {
      "description": "Set several traces linked to the same position axis or matching axes to the same alignmentgroup. This controls whether bars compute their positional range dependently or independently.",
      "dflt": "",


### PR DESCRIPTION
Closes #7186 

- Drop support for deprecated `bardir` attribute (use `orientation` instead)
