### PR TITLE
Drop support for deprecated `annotation.ref` attribute (use `annotation.xref` and `annotation.yref` instead)

### DIFF
--- a/draftlogs/7215_remove.md
+++ b/draftlogs/7215_remove.md
@@ -1,0 +1,1 @@
+Drop support for deprecated `annotation.ref` attribute (use `annotation.xref` and `annotation.yref` instead) [[#7215](https://github.com/plotly/plotly.js/pull/7215)]

--- a/src/components/annotations/attributes.js
+++ b/src/components/annotations/attributes.js
@@ -487,14 +487,4 @@ module.exports = templatedArray('annotation', {
         ].join(' ')
     },
     editType: 'calc',
-
-    _deprecated: {
-        ref: {
-            valType: 'string',
-            editType: 'calc',
-            description: [
-                'Obsolete. Set `xref` and `yref` separately instead.'
-            ].join(' ')
-        }
-    }
 });

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -144,17 +144,6 @@ exports.cleanLayout = function(layout) {
 
         if(!Lib.isPlainObject(ann)) continue;
 
-        if(ann.ref) {
-            if(ann.ref === 'paper') {
-                ann.xref = 'paper';
-                ann.yref = 'paper';
-            } else if(ann.ref === 'data') {
-                ann.xref = 'x';
-                ann.yref = 'y';
-            }
-            delete ann.ref;
-        }
-
         cleanAxRef(ann, 'xref');
         cleanAxRef(ann, 'yref');
     }

--- a/test/image/mocks/11.json
+++ b/test/image/mocks/11.json
@@ -214,7 +214,8 @@
     "xatype": "category",
     "yatype": "linear",
     "tag": "",
-    "ref": "paper"
+    "xref": "paper",
+    "yref": "paper"
    }
   ],
   "margin": {

--- a/test/image/mocks/14.json
+++ b/test/image/mocks/14.json
@@ -167,7 +167,8 @@
     "xatype": "log",
     "yatype": "log",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    },
    {
     "x": 0.15585471975544452,
@@ -198,7 +199,8 @@
     "xatype": "log",
     "yatype": "log",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    },
    {
     "x": 1.8420351138192386,
@@ -229,7 +231,8 @@
     "xatype": "log",
     "yatype": "log",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    },
    {
     "x": -0.5537301200821234,
@@ -260,7 +263,8 @@
     "xatype": "log",
     "yatype": "log",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    },
    {
     "x": -2.701204903100102,
@@ -291,7 +295,8 @@
     "xatype": "log",
     "yatype": "log",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    },
    {
     "x": -1.6961577824283882,
@@ -322,7 +327,8 @@
     "xatype": "log",
     "yatype": "log",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    }
   ],
   "margin": {

--- a/test/image/mocks/17.json
+++ b/test/image/mocks/17.json
@@ -612,7 +612,8 @@
     "xatype": "linear",
     "yatype": "linear",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    }
   ],
   "margin": {

--- a/test/image/mocks/27.json
+++ b/test/image/mocks/27.json
@@ -329,7 +329,8 @@
     "xatype": "linear",
     "yatype": "linear",
     "tag": "",
-    "ref": "plot"
+    "xref": "plot",
+    "yref": "plot"
    }
   ],
   "margin": {

--- a/test/image/mocks/29.json
+++ b/test/image/mocks/29.json
@@ -2256,7 +2256,8 @@
     "xanchor": "auto",
     "yanchor": "auto",
     "tag": "",
-    "ref": "paper"
+    "xref": "paper",
+    "yref": "paper"
    }
   ],
   "margin": {

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -2540,7 +2540,6 @@ describe('Test plot api', function() {
 
             var layout = {
                 annotations: [
-                    { ref: 'paper' },
                     null,
                     { xref: 'x02', yref: 'y1' }
                 ],
@@ -2553,9 +2552,8 @@ describe('Test plot api', function() {
 
             Plotly.newPlot(gd, data, layout);
 
-            expect(gd.layout.annotations[0]).toEqual({ xref: 'paper', yref: 'paper' });
-            expect(gd.layout.annotations[1]).toEqual(null);
-            expect(gd.layout.annotations[2]).toEqual({ xref: 'x2', yref: 'y' });
+            expect(gd.layout.annotations[0]).toEqual(null);
+            expect(gd.layout.annotations[1]).toEqual({ xref: 'x2', yref: 'y' });
 
             expect(gd.layout.shapes[0].xref).toBeUndefined();
             expect(gd.layout.shapes[0].yref).toBeUndefined();

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -730,13 +730,6 @@
    "annotations": {
     "items": {
      "annotation": {
-      "_deprecated": {
-       "ref": {
-        "description": "Obsolete. Set `xref` and `yref` separately instead.",
-        "editType": "calc",
-        "valType": "string"
-       }
-      },
       "align": {
        "description": "Sets the horizontal alignment of the `text` within the box. Has an effect only if `text` spans two or more lines (i.e. `text` contains one or more <br> HTML tags) or if an explicit width is set to override the text width.",
        "dflt": "center",


### PR DESCRIPTION
Closes #7191 

- Drop support for deprecated `annotation.ref` attribute (use `annotation.xref` and `annotation.yref` instead)