### PR TITLE
Drop support for deprecated error bar `opacity` attribute (use alpha channel of error bar `color` attribute instead)

### DIFF
--- a/src/components/errorbars/attributes.js
+++ b/src/components/errorbars/attributes.js
@@ -121,15 +121,4 @@ module.exports = {
         ].join(' ')
     },
     editType: 'calc',
-
-    _deprecated: {
-        opacity: {
-            valType: 'number',
-            editType: 'style',
-            description: [
-                'Obsolete.',
-                'Use the alpha channel in error bar `color` to set the opacity.'
-            ].join(' ')
-        }
-    }
 };

--- a/src/components/errorbars/attributes.js
+++ b/src/components/errorbars/attributes.js
@@ -102,7 +102,7 @@ module.exports = {
     color: {
         valType: 'color',
         editType: 'style',
-        description: 'Sets the stoke color of the error bars.'
+        description: 'Sets the stroke color of the error bars.'
     },
     thickness: {
         valType: 'number',

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -283,18 +283,6 @@ exports.cleanData = function(data) {
             delete trace.xbins;
         }
 
-        // error_y.opacity is obsolete - merge into color
-        if(trace.error_y && 'opacity' in trace.error_y) {
-            var dc = Color.defaults;
-            var yeColor = trace.error_y.color || (traceIs(trace, 'bar') ?
-                Color.defaultLine :
-                dc[tracei % dc.length]);
-            trace.error_y.color = Color.addOpacity(
-                Color.rgb(yeColor),
-                Color.opacity(yeColor) * trace.error_y.opacity);
-            delete trace.error_y.opacity;
-        }
-
         // convert bardir to orientation, and put the data into
         // the axes it's eventually going to be used with
         if('bardir' in trace) {

--- a/test/image/mocks/error_bar_style.json
+++ b/test/image/mocks/error_bar_style.json
@@ -72,16 +72,14 @@
     "value": 0.1,
     "color": "#85144B",
     "thickness": 1.5,
-    "width": 3,
-    "opacity": 1
+    "width": 3
    },
    "error_x": {
     "type": "constant",
     "value": 0.2,
     "color": "#85144B",
     "thickness": 1.5,
-    "width": 3,
-    "opacity": 1
+    "width": 3
    },
    "marker": {
     "color": "#85144B",


### PR DESCRIPTION
- Drop support for deprecated error bar `opacity` attribute (use alpha channel of error bar `color` attribute instead)
