### PR TITLE
Re-add support for passing `title` as string

### DIFF
--- a/src/components/colorbar/attributes.js
+++ b/src/components/colorbar/attributes.js
@@ -228,4 +228,10 @@ module.exports = overrideAll({
             ].join(' ')
         }
     },
+    _deprecated: {
+        title: {
+            valType: 'string',
+            description: 'It is recommended to use the color bar\'s `title.text` attribute instead.'
+        }
+    }
 }, 'colorbars', 'from-root');

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -90,6 +90,29 @@ exports.cleanLayout = function(layout) {
                 delete ax.autotick;
             }
 
+            cleanTitle(ax);
+        } else if(polarAttrRegex && polarAttrRegex.test(key)) {
+            // modifications for polar
+
+            var polar = layout[key];
+            cleanTitle(polar.radialaxis);
+        } else if(ternaryAttrRegex && ternaryAttrRegex.test(key)) {
+            // modifications for ternary
+
+            var ternary = layout[key];
+            cleanTitle(ternary.aaxis);
+            cleanTitle(ternary.baxis);
+            cleanTitle(ternary.caxis);
+        } else if(sceneAttrRegex && sceneAttrRegex.test(key)) {
+            // modifications for 3D scenes
+
+            var scene = layout[key];
+
+            // clean axis titles
+            cleanTitle(scene.xaxis);
+            cleanTitle(scene.yaxis);
+            cleanTitle(scene.zaxis);
+
         }
     }
 
@@ -143,6 +166,9 @@ exports.cleanLayout = function(layout) {
         }
     }
 
+    // clean plot title
+    cleanTitle(layout);
+
     /*
      * Moved from rotate -> orbit for dragmode
      */
@@ -165,6 +191,25 @@ function cleanAxRef(container, attr) {
     var axLetter = attr.charAt(0);
     if(valIn && valIn !== 'paper') {
         container[attr] = cleanId(valIn, axLetter, true);
+    }
+}
+
+/**
+  * Cleans up old title-as-string attribute by moving a string passed as `title` to `title.text`.
+  *
+  * @param {Object} titleContainer - an object potentially including a `title` attribute
+  *     which may be a string
+  */
+function cleanTitle(titleContainer) {
+    if(titleContainer) {
+        // title -> title.text
+        // (although title used to be a string attribute,
+        // numbers are accepted as well)
+        if(typeof titleContainer.title === 'string' || typeof titleContainer.title === 'number') {
+            titleContainer.title = {
+                text: titleContainer.title
+            };
+        }
     }
 }
 
@@ -347,6 +392,13 @@ exports.cleanData = function(data) {
             delete trace.autobiny;
             delete trace.ybins;
         }
+
+        cleanTitle(trace);
+        if(trace.colorbar) cleanTitle(trace.colorbar);
+        if(trace.marker && trace.marker.colorbar) cleanTitle(trace.marker.colorbar);
+        if(trace.line && trace.line.colorbar) cleanTitle(trace.line.colorbar);
+        if(trace.aaxis) cleanTitle(trace.aaxis);
+        if(trace.baxis) cleanTitle(trace.baxis);
     }
 };
 

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -1241,5 +1241,10 @@ module.exports = {
                 'Set `tickmode` to *linear* for `autotick` *false*.'
             ].join(' ')
         },
+        title: {
+            valType: 'string',
+            editType: 'ticks',
+            description: 'It is recommended to use the layout\'s `title.text` attribute instead.'
+        },
     }
 };

--- a/src/plots/gl3d/layout/axis_attributes.js
+++ b/src/plots/gl3d/layout/axis_attributes.js
@@ -121,4 +121,7 @@ module.exports = overrideAll({
     zeroline: axesAttrs.zeroline,
     zerolinecolor: axesAttrs.zerolinecolor,
     zerolinewidth: axesAttrs.zerolinewidth,
+    _deprecated: {
+        title: axesAttrs._deprecated.title
+    }
 }, 'plot', 'from-root');

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -451,4 +451,11 @@ module.exports = {
         ].join(' '),
         editType: 'none'
     }),
+    _deprecated: {
+        title: {
+            valType: 'string',
+            editType: 'layoutstyle',
+            description: 'It is recommended to use the layout\'s `title.text` attribute instead.'
+        }
+    }
 };

--- a/src/plots/polar/layout_attributes.js
+++ b/src/plots/polar/layout_attributes.js
@@ -146,6 +146,10 @@ var radialAxisAttrs = {
     },
 
     editType: 'calc',
+
+    _deprecated: {
+        title: axesAttrs._deprecated.title
+    }
 };
 
 extendFlat(

--- a/src/plots/ternary/layout_attributes.js
+++ b/src/plots/ternary/layout_attributes.js
@@ -62,6 +62,9 @@ var ternaryAxesAttrs = {
             'all the minima set to zero.'
         ].join(' ')
     },
+    _deprecated: {
+        title: axesAttrs._deprecated.title
+    }
 };
 
 var attrs = module.exports = overrideAll({

--- a/src/traces/carpet/axis_attributes.js
+++ b/src/traces/carpet/axis_attributes.js
@@ -451,5 +451,15 @@ module.exports = {
         editType: 'calc',
         description: 'The stride between grid lines along the axis'
     },
-    editType: 'calc'
+
+
+    _deprecated: {
+        title: {
+            valType: 'string',
+            editType: 'calc',
+            description: 'It is recommended to use the axis\'s `title.text` attribute instead.'
+        }
+    },
+
+    editType: 'calc',
 };

--- a/src/traces/pie/attributes.js
+++ b/src/traces/pie/attributes.js
@@ -292,4 +292,13 @@ module.exports = {
             'or an array to highlight one or more slices.'
         ].join(' ')
     },
+
+    _deprecated: {
+        title: {
+            valType: 'string',
+            dflt: '',
+            editType: 'calc',
+            description: 'It is recommended to use the pie\'s `title.text` attribute instead.'
+        }
+    }
 };

--- a/test/jasmine/tests/funnelarea_test.js
+++ b/test/jasmine/tests/funnelarea_test.js
@@ -568,6 +568,24 @@ describe('Funnelarea traces', function() {
         .then(done, done.fail);
     });
 
+    it('should be able to restyle title despite using deprecated title-as-string', function(done) {
+        Plotly.newPlot(gd, [{
+            type: 'funnelarea',
+            values: [1, 2, 3],
+            title: 'yo',
+        }])
+        .then(function() {
+            _assertTitle('base', 'yo', 'rgb(0, 0, 0)');
+            return Plotly.restyle(gd, {
+                title: 'oy',
+            });
+        })
+        .then(function() {
+            _assertTitle('base', 'oy', 'rgb(0, 0, 0)');
+        })
+        .then(done, done.fail);
+    });
+
     it('should be able to react with new text colors', function(done) {
         Plotly.newPlot(gd, [{
             type: 'funnelarea',

--- a/test/jasmine/tests/funnelarea_test.js
+++ b/test/jasmine/tests/funnelarea_test.js
@@ -575,13 +575,13 @@ describe('Funnelarea traces', function() {
             title: 'yo',
         }])
         .then(function() {
-            _assertTitle('base', 'yo', 'rgb(0, 0, 0)');
+            _assertTitle('base', 'yo', 'rgb(68, 68, 68)');
             return Plotly.restyle(gd, {
                 title: 'oy',
             });
         })
         .then(function() {
-            _assertTitle('base', 'oy', 'rgb(0, 0, 0)');
+            _assertTitle('base', 'oy', 'rgb(68, 68, 68)');
         })
         .then(done, done.fail);
     });

--- a/test/jasmine/tests/pie_test.js
+++ b/test/jasmine/tests/pie_test.js
@@ -786,6 +786,24 @@ describe('Pie traces', function() {
         .then(done, done.fail);
     });
 
+    it('should be able to restyle title despite using deprecated title-as-string', function(done) {
+        Plotly.newPlot(gd, [{
+            type: 'funnelarea',
+            values: [1, 2, 3],
+            title: 'yo',
+        }])
+        .then(function() {
+            _assertTitle('base', 'yo', 'rgb(0, 0, 0)');
+            return Plotly.restyle(gd, {
+                title: 'oy',
+            });
+        })
+        .then(function() {
+            _assertTitle('base', 'oy', 'rgb(0, 0, 0)');
+        })
+        .then(done, done.fail);
+    });
+
     it('should be able to react with new text colors', function(done) {
         Plotly.newPlot(gd, [{
             type: 'pie',

--- a/test/jasmine/tests/pie_test.js
+++ b/test/jasmine/tests/pie_test.js
@@ -793,13 +793,13 @@ describe('Pie traces', function() {
             title: 'yo',
         }])
         .then(function() {
-            _assertTitle('base', 'yo', 'rgb(0, 0, 0)');
+            _assertTitle('base', 'yo', 'rgb(68, 68, 68)');
             return Plotly.restyle(gd, {
                 title: 'oy',
             });
         })
         .then(function() {
-            _assertTitle('base', 'oy', 'rgb(0, 0, 0)');
+            _assertTitle('base', 'oy', 'rgb(68, 68, 68)');
         })
         .then(done, done.fail);
     });

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -526,6 +526,30 @@ describe('Test plot api', function() {
             .then(assertSizeAndThen(543, 432, true, 'final back to autosize'))
             .then(done, done.fail);
         });
+
+        it('passes update data back to plotly_relayout unmodified ' +
+            'even if deprecated title-as-string has been used', function(done) {
+                Plotly.newPlot(gd, [{y: [1, 3, 2]}])
+                .then(function() {
+                    gd.on('plotly_relayout', function(eventData) {
+                        expect(eventData).toEqual({
+                            title: 'Plotly chart',
+                            'xaxis.title': 'X',
+                            'yaxis.title': 'Y',
+                            'polar.radialaxis.title': 'Radial'
+                        });
+                        done();
+                    });
+    
+                    return Plotly.relayout(gd, {
+                        title: 'Plotly chart',
+                        'xaxis.title': 'X',
+                        'yaxis.title': 'Y',
+                        'polar.radialaxis.title': 'Radial'
+                    });
+                })
+                .then(done, done.fail);
+        });
     });
 
     describe('Plotly.relayout subroutines switchboard', function() {

--- a/test/jasmine/tests/titles_test.js
+++ b/test/jasmine/tests/titles_test.js
@@ -52,6 +52,15 @@ describe('Plot title', function() {
         .then(done, done.fail);
     });
 
+    it('can still be defined as `layout.title` to ensure backwards-compatibility', function(done) {
+        Plotly.newPlot(gd, data, {title: 'Plotly line chart'})
+        .then(function() {
+            expectTitle('Plotly line chart');
+            expectDefaultCenteredPosition(gd);
+        })
+        .then(done, done.fail);
+    });
+
     it('can be updated via `relayout`', function(done) {
         Plotly.newPlot(gd, data, { title: { text: 'Plotly line chart' } })
           .then(expectTitleFn('Plotly line chart'))
@@ -619,6 +628,23 @@ describe('Titles can be updated', function() {
                 'xaxis.title.text': NEW_XTITLE,
                 'yaxis.title.text': NEW_YTITLE
             }
+        },
+        {
+            desc: 'despite passing title only as a string (backwards-compatibility)',
+            update: {
+                title: NEW_TITLE,
+                xaxis: {title: NEW_XTITLE},
+                yaxis: {title: NEW_YTITLE}
+            }
+        },
+        {
+            desc: 'despite passing title only as a string using string attributes ' +
+            '(backwards-compatibility)',
+            update: {
+                title: NEW_TITLE,
+                'xaxis.title': NEW_XTITLE,
+                'yaxis.title': NEW_YTITLE
+            }
         }
     ].forEach(function(testCase) {
         it('via `Plotly.relayout` ' + testCase.desc, function(done) {
@@ -867,6 +893,60 @@ describe('Title fonts can be updated', function() {
         expectXAxisTitleFont(NEW_XTITLE_FONT.color, NEW_XTITLE_FONT.family, NEW_XTITLE_FONT.size);
         expectYAxisTitleFont(NEW_YTITLE_FONT.color, NEW_YTITLE_FONT.family, NEW_YTITLE_FONT.size);
     }
+});
+
+describe('Titles for multiple axes', function() {
+    'use strict';
+
+    var data = [
+      {x: [1, 2, 3], y: [1, 2, 3], xaxis: 'x', yaxis: 'y'},
+      {x: [1, 2, 3], y: [3, 2, 1], xaxis: 'x2', yaxis: 'y2'}
+    ];
+    var multiAxesLayout = {
+        xaxis: { title: 'X-Axis 1' },
+        xaxis2: {
+            title: 'X-Axis 2',
+            side: 'top'
+        },
+        yaxis: { title: 'Y-Axis 1' },
+        yaxis2: {
+            title: 'Y-Axis 2',
+            side: 'right'
+        }
+    };
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    it('still supports deprecated title-as-string (backwards-compatibility)', function(done) {
+        Plotly.newPlot(gd, data, multiAxesLayout)
+        .then(function() {
+            expect(xTitleSel(1).text()).toBe('X-Axis 1');
+            expect(xTitleSel(2).text()).toBe('X-Axis 2');
+            expect(yTitleSel(1).text()).toBe('Y-Axis 1');
+            expect(yTitleSel(2).text()).toBe('Y-Axis 2');
+        })
+        .then(done, done.fail);
+    });
+
+    it('can be updated using deprecated title-as-string (backwards-compatibility)', function(done) {
+        Plotly.newPlot(gd, data, multiAxesLayout)
+        .then(function() {
+            return Plotly.relayout(gd, {
+                'xaxis2.title': '2nd X-Axis',
+                'yaxis2.title': '2nd Y-Axis',
+            });
+        })
+        .then(function() {
+            expect(xTitleSel(2).text()).toBe('2nd X-Axis');
+            expect(yTitleSel(2).text()).toBe('2nd Y-Axis');
+        })
+        .then(done, done.fail);
+    });
 });
 
 // TODO: Add in tests for interactions with other automargined elements

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -596,6 +596,13 @@
  },
  "layout": {
   "layoutAttributes": {
+   "_deprecated": {
+    "title": {
+     "description": "It is recommended to use the layout's `title.text` attribute instead.",
+     "editType": "layoutstyle",
+     "valType": "string"
+    }
+   },
    "activeselection": {
     "editType": "none",
     "fillcolor": {
@@ -1224,6 +1231,13 @@
      "valType": "number"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -5632,6 +5646,13 @@
      "valType": "number"
     },
     "radialaxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the layout's `title.text` attribute instead.",
+       "editType": "ticks",
+       "valType": "string"
+      }
+     },
      "angle": {
       "description": "Sets the angle (in degrees) from which the radial axis is drawn. Note that by default, radial axis line on the theta=0 line corresponds to a line pointing right (like what mathematicians prefer). Defaults to the first `polar.sector` angle.",
       "editType": "plot",
@@ -7062,6 +7083,13 @@
      "valType": "any"
     },
     "xaxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the layout's `title.text` attribute instead.",
+       "editType": "plot",
+       "valType": "string"
+      }
+     },
      "autorange": {
       "description": "Determines whether or not the range of this axis is computed in relation to the input data. See `rangemode` for more info. If `range` is provided and it has a value for both the lower and upper bound, `autorange` is set to *false*. Using *min* applies autorange only to set the minimum. Using *max* applies autorange only to set the maximum. Using *min reversed* applies autorange only to set the minimum on a reversed axis. Using *max reversed* applies autorange only to set the maximum on a reversed axis. Using *reversed* applies autorange on both ends and reverses the axis direction.",
       "dflt": true,
@@ -7801,6 +7829,13 @@
      }
     },
     "yaxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the layout's `title.text` attribute instead.",
+       "editType": "plot",
+       "valType": "string"
+      }
+     },
      "autorange": {
       "description": "Determines whether or not the range of this axis is computed in relation to the input data. See `rangemode` for more info. If `range` is provided and it has a value for both the lower and upper bound, `autorange` is set to *false*. Using *min* applies autorange only to set the minimum. Using *max* applies autorange only to set the maximum. Using *min reversed* applies autorange only to set the minimum on a reversed axis. Using *max reversed* applies autorange only to set the maximum on a reversed axis. Using *reversed* applies autorange on both ends and reverses the axis direction.",
       "dflt": true,
@@ -8540,6 +8575,13 @@
      }
     },
     "zaxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the layout's `title.text` attribute instead.",
+       "editType": "plot",
+       "valType": "string"
+      }
+     },
      "autorange": {
       "description": "Determines whether or not the range of this axis is computed in relation to the input data. See `rangemode` for more info. If `range` is provided and it has a value for both the lower and upper bound, `autorange` is set to *false*. Using *min* applies autorange only to set the minimum. Using *max* applies autorange only to set the maximum. Using *min reversed* applies autorange only to set the minimum on a reversed axis. Using *max reversed* applies autorange only to set the maximum on a reversed axis. Using *reversed* applies autorange on both ends and reverses the axis direction.",
       "dflt": true,
@@ -11085,6 +11127,13 @@
    "ternary": {
     "_isSubplotObj": true,
     "aaxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the layout's `title.text` attribute instead.",
+       "editType": "plot",
+       "valType": "string"
+      }
+     },
      "color": {
       "description": "Sets default for all colors associated with this axis all at once: line, font, tick, and grid colors. Grid color is lightened by blending this with the plot background Individual pieces can override this.",
       "dflt": "#444",
@@ -11598,6 +11647,13 @@
      }
     },
     "baxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the layout's `title.text` attribute instead.",
+       "editType": "plot",
+       "valType": "string"
+      }
+     },
      "color": {
       "description": "Sets default for all colors associated with this axis all at once: line, font, tick, and grid colors. Grid color is lightened by blending this with the plot background Individual pieces can override this.",
       "dflt": "#444",
@@ -12117,6 +12173,13 @@
      "valType": "color"
     },
     "caxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the layout's `title.text` attribute instead.",
+       "editType": "plot",
+       "valType": "string"
+      }
+     },
      "color": {
       "description": "Sets default for all colors associated with this axis all at once: line, font, tick, and grid colors. Grid color is lightened by blending this with the plot background Individual pieces can override this.",
       "dflt": "#444",
@@ -13432,6 +13495,11 @@
       "description": "Obsolete. Set `tickmode` to *auto* for old `autotick` *true* behavior. Set `tickmode` to *linear* for `autotick` *false*.",
       "editType": "ticks",
       "valType": "boolean"
+     },
+     "title": {
+      "description": "It is recommended to use the layout's `title.text` attribute instead.",
+      "editType": "ticks",
+      "valType": "string"
      }
     },
     "_isSubplotObj": true,
@@ -14984,6 +15052,11 @@
       "description": "Obsolete. Set `tickmode` to *auto* for old `autotick` *true* behavior. Set `tickmode` to *linear* for `autotick` *false*.",
       "editType": "ticks",
       "valType": "boolean"
+     },
+     "title": {
+      "description": "It is recommended to use the layout's `title.text` attribute instead.",
+      "editType": "ticks",
+      "valType": "string"
      }
     },
     "_isSubplotObj": true,
@@ -17056,6 +17129,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -19099,6 +19179,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -22472,6 +22559,13 @@
      "valType": "number"
     },
     "aaxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the axis's `title.text` attribute instead.",
+       "editType": "calc",
+       "valType": "string"
+      }
+     },
      "arraydtick": {
       "description": "The stride between grid lines along the axis",
       "dflt": 1,
@@ -23143,6 +23237,13 @@
      "valType": "number"
     },
     "baxis": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the axis's `title.text` attribute instead.",
+       "editType": "calc",
+       "valType": "string"
+      }
+     },
      "arraydtick": {
       "description": "The stride between grid lines along the axis",
       "dflt": 1,
@@ -24199,6 +24300,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -25496,6 +25604,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -26783,6 +26898,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -28109,6 +28231,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -29454,6 +29583,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -31281,6 +31417,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -32507,6 +32650,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -33732,6 +33882,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -35619,6 +35776,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -38252,6 +38416,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -40604,6 +40775,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -42060,6 +42238,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -43568,6 +43753,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -45939,6 +46131,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -49313,6 +49512,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "calc",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -50833,6 +51039,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -53439,6 +53652,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -54732,6 +54952,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -55717,6 +55944,14 @@
   "pie": {
    "animatable": false,
    "attributes": {
+    "_deprecated": {
+     "title": {
+      "description": "It is recommended to use the pie's `title.text` attribute instead.",
+      "dflt": "",
+      "editType": "calc",
+      "valType": "string"
+     }
+    },
     "automargin": {
      "description": "Determines whether outside text labels can push the margins.",
      "dflt": false,
@@ -59455,6 +59690,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -62095,6 +62337,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "calc",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -62804,6 +63053,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "calc",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -64641,6 +64897,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -66938,6 +67201,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "calc",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -69350,6 +69620,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "calc",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -71682,6 +71959,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "calc",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -73229,6 +73513,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "calc",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -74759,6 +75050,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -77029,6 +77327,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "calc",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -79243,6 +79548,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -81552,6 +81864,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -83792,6 +84111,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -85323,6 +85649,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "colorbars",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -87368,6 +87701,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -88662,6 +89002,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "calc",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",
@@ -91988,6 +92335,13 @@
       "valType": "subplotid"
      },
      "colorbar": {
+      "_deprecated": {
+       "title": {
+        "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+        "editType": "colorbars",
+        "valType": "string"
+       }
+      },
       "bgcolor": {
        "description": "Sets the color of padded area.",
        "dflt": "rgba(0,0,0,0)",
@@ -95036,6 +95390,13 @@
      "valType": "subplotid"
     },
     "colorbar": {
+     "_deprecated": {
+      "title": {
+       "description": "It is recommended to use the color bar's `title.text` attribute instead.",
+       "editType": "calc",
+       "valType": "string"
+      }
+     },
      "bgcolor": {
       "description": "Sets the color of padded area.",
       "dflt": "rgba(0,0,0,0)",


### PR DESCRIPTION
- Re-add support for passing a string to `title` property (removed in #7212)
  - Other properties removed in that PR (e.g. `titlefont`, `titleoffset`) remain removed
- Re-add functions for moving title string to `title.text` internally
- Re-add Jasmine tests for passing title as string