### PR TITLE
Drop deprecated `zauto`, `zmin` and `zmax` from the surface trace

### DIFF
--- a/draftlogs/7234_remove.md
+++ b/draftlogs/7234_remove.md
@@ -1,0 +1,1 @@
+ - Drop deprecated zauto, zmin and zmax from the surface trace [[#7234](https://github.com/plotly/plotly.js/pull/7234)]

--- a/src/traces/surface/attributes.js
+++ b/src/traces/surface/attributes.js
@@ -288,18 +288,6 @@ colorScaleAttrs('', {
         ].join(' ')
     },
 
-    _deprecated: {
-        zauto: extendFlat({}, colorScaleAttrs.zauto, {
-            description: 'Obsolete. Use `cauto` instead.'
-        }),
-        zmin: extendFlat({}, colorScaleAttrs.zmin, {
-            description: 'Obsolete. Use `cmin` instead.'
-        }),
-        zmax: extendFlat({}, colorScaleAttrs.zmax, {
-            description: 'Obsolete. Use `cmax` instead.'
-        })
-    },
-
     hoverinfo: extendFlat({}, baseAttrs.hoverinfo),
     showlegend: extendFlat({}, baseAttrs.showlegend, {dflt: false}),
 }), 'calc', 'nested');

--- a/src/traces/surface/defaults.js
+++ b/src/traces/surface/defaults.js
@@ -121,13 +121,6 @@ function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
         coerce(contourDim + '.size');
     }
 
-    // backward compatibility block
-    if(!surfaceColor) {
-        mapLegacy(traceIn, 'zmin', 'cmin');
-        mapLegacy(traceIn, 'zmax', 'cmax');
-        mapLegacy(traceIn, 'zauto', 'cauto');
-    }
-
     // TODO if contours.?.usecolormap are false and hidesurface is true
     // the colorbar shouldn't be shown by default
 
@@ -152,12 +145,6 @@ function opacityscaleDefaults(traceIn, traceOut, layout, coerce) {
         traceOut.opacityscale = createWave(1, MIN);
     } else if(!isValidScaleArray(opacityscale)) {
         traceOut.opacityscale = undefined;
-    }
-}
-
-function mapLegacy(traceIn, oldAttr, newAttr) {
-    if(oldAttr in traceIn && !(newAttr in traceIn)) {
-        traceIn[newAttr] = traceIn[oldAttr];
     }
 }
 

--- a/tasks/test_mock.mjs
+++ b/tasks/test_mock.mjs
@@ -177,7 +177,6 @@ function notBlackListed(name) {
         'gl2d_text_chart_single-string',
         'gl2d_text_chart_styling',
         'gl2d_texttemplate',
-        'gl3d_autocolorscale',
         'gl3d_bunny',
         'gl3d_bunny-hull',
         'gl3d_coloraxes',

--- a/test/image/mocks/gl3d_autocolorscale.json
+++ b/test/image/mocks/gl3d_autocolorscale.json
@@ -9,8 +9,8 @@
     ["zero two", "one two", "two two"]
    ],
    "autocolorscale": true,
-   "zmin": 0,
-   "zmax": "50"
+   "cmin": 0,
+   "cmax": "50"
   }
  ],
  "layout": {

--- a/test/jasmine/tests/surface_test.js
+++ b/test/jasmine/tests/surface_test.js
@@ -107,35 +107,6 @@ describe('Test surface', function() {
             expect(traceOut.colorbar).toBeDefined();
         });
 
-        it('should coerce \'c\' attributes with \'z\' if \'c\' isn\'t present', function() {
-            traceIn = {
-                z: [[1, 2, 3], [2, 1, 2]],
-                zauto: false,
-                zmin: 0,
-                zmax: 10
-            };
-
-            supplyDefaults(traceIn, traceOut, defaultColor, layout);
-            expect(traceOut.cauto).toEqual(false);
-            expect(traceOut.cmin).toEqual(0);
-            expect(traceOut.cmax).toEqual(10);
-        });
-
-        it('should coerce \'c\' attributes with \'c\' values regardless of `\'z\' if \'c\' is present', function() {
-            traceIn = {
-                z: [[1, 2, 3], [2, 1, 2]],
-                zmin: 0,
-                zmax: 10,
-                cmin: -10,
-                cmax: 20
-            };
-
-            supplyDefaults(traceIn, traceOut, defaultColor, layout);
-            expect(traceOut.cauto).toEqual(false);
-            expect(traceOut.cmin).toEqual(-10);
-            expect(traceOut.cmax).toEqual(20);
-        });
-
         it('should default \'c\' attributes with if \'surfacecolor\' is present', function() {
             traceIn = {
                 z: [[1, 2, 3], [2, 1, 2]],

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -88601,20 +88601,6 @@
   "surface": {
    "animatable": false,
    "attributes": {
-    "_deprecated": {
-     "zauto": {
-      "description": "Obsolete. Use `cauto` instead.",
-      "editType": "calc"
-     },
-     "zmax": {
-      "description": "Obsolete. Use `cmax` instead.",
-      "editType": "calc"
-     },
-     "zmin": {
-      "description": "Obsolete. Use `cmin` instead.",
-      "editType": "calc"
-     }
-    },
     "autocolorscale": {
      "description": "Determines whether the colorscale is a default palette (`autocolorscale: true`) or the palette determined by `colorscale`. In case `colorscale` is unspecified or `autocolorscale` is true, the default palette will be chosen according to whether numbers in the `color` array are all positive, all negative or mixed.",
      "dflt": false,


### PR DESCRIPTION
Closes #7187.