### PR TITLE
Apply styles to SVG text elements directly as allowed by strict CSPs

### DIFF
--- a/draftlogs/7256_fix.md
+++ b/draftlogs/7256_fix.md
@@ -1,1 +1,2 @@
-Remove inline styles in SVG text elements generated from pseudo-HTML configurations, which break with strict CSP setups [[#7256](https://github.com/plotly/plotly.js/pull/7256)]
+ - Remove inline styles in SVG text elements generated from pseudo-HTML configurations, which break with strict CSP setups [[#7256](https://github.com/plotly/plotly.js/pull/7256)],
+   with thanks to @martian111 for the contribution!

--- a/draftlogs/7256_fix.md
+++ b/draftlogs/7256_fix.md
@@ -1,0 +1,1 @@
+Remove inline styles in SVG text elements generated from pseudo-HTML configurations, which break with strict CSP setups [[#7256](https://github.com/plotly/plotly.js/pull/7256)]

--- a/test/image/mocks/pseudo_html.json
+++ b/test/image/mocks/pseudo_html.json
@@ -3,7 +3,7 @@
   {
    "x": ["<b>b</b>   <i>i</i>", "line <em>1</em><br>line <b>2</b>"],
    "y": ["sub<sub>1</sub>", "sup<sup>2</sup>"],
-   "name": "<b>test</b> <i>pseudo</i>HTML<br><sup>3</sup>H<sub>2</sub>O is <em>heavy!</em><br>and <span style=\"color:#f00;font-family:'Times New Roman', Times, serif\">Fonts,</span><br>oh my?"
+   "name": "<b>test</b> <i>pseudo</i>HTML<br><sup>3</sup>H<sub>2</sub>O is <em>heavy!</em><br>and <span style=\"color:#f00;font-family:'Times', serif\">Fonts,</span><br>oh my?"
   }
  ],
  "layout": {

--- a/test/jasmine/tests/hover_label_test.js
+++ b/test/jasmine/tests/hover_label_test.js
@@ -748,7 +748,7 @@ describe('hover info', function() {
 
         it('provides exponents correctly for z data', function(done) {
             function expFmt(val, exp) {
-                return val + '×10\u200b<tspan style="font-size:70%" dy="-0.6em">' +
+                return val + '×10\u200b<tspan dy="-0.6em" style="font-size: 70%;">' +
                     (exp < 0 ? MINUS_SIGN + -exp : exp) +
                     '</tspan><tspan dy="0.42em">\u200b</tspan>';
             }
@@ -2071,7 +2071,7 @@ describe('hover info', function() {
                 expect(hoverTrace.y).toEqual(1);
 
                 assertHoverLabelContent({
-                    nums: '<tspan style="font-weight:bold">$1.00</tspan>\nPV learning curve.txt',
+                    nums: '<tspan style="font-weight: bold;">$1.00</tspan>\nPV learning curve.txt',
                     name: '',
                     axis: '0.388'
                 });
@@ -2120,7 +2120,7 @@ describe('hover info', function() {
                 expect(hoverTrace.y).toEqual(1);
 
                 assertHoverLabelContent({
-                    nums: 'Cost ($/W​<tspan style="font-size:70%" dy="0.3em">P</tspan><tspan dy="-0.21em">​</tspan>):$1.00\nCumulative Production (GW):0.3880',
+                    nums: 'Cost ($/W​<tspan dy="0.3em" style="font-size: 70%;">P</tspan><tspan dy="-0.21em">​</tspan>):$1.00\nCumulative Production (GW):0.3880',
                     name: '',
                     axis: '0.388'
                 });

--- a/test/jasmine/tests/icicle_test.js
+++ b/test/jasmine/tests/icicle_test.js
@@ -635,7 +635,7 @@ describe('Test icicle hover:', function() {
         exp: {
             label: {
                 nums: 'Abel :: 6.00',
-                name: '<tspan style="font-weight:bold">N.B.</tspan>'
+                name: '<tspan style="font-weight: bold;">N.B.</tspan>'
             },
             ptData: {
                 curveNumber: 0,

--- a/test/jasmine/tests/sunburst_test.js
+++ b/test/jasmine/tests/sunburst_test.js
@@ -648,7 +648,7 @@ describe('Test sunburst hover:', function() {
         exp: {
             label: {
                 nums: 'Abel :: 6.00',
-                name: '<tspan style="font-weight:bold">N.B.</tspan>'
+                name: '<tspan style="font-weight: bold;">N.B.</tspan>'
             },
             ptData: {
                 curveNumber: 0,

--- a/test/jasmine/tests/svg_text_utils_test.js
+++ b/test/jasmine/tests/svg_text_utils_test.js
@@ -64,8 +64,8 @@ describe('svg+text utils', function() {
 
             var style = expectedAttrs.style || '';
             var fullStyle = style || '';
-            if(style) fullStyle += ';';
-            fullStyle += 'cursor:pointer';
+            if(style) fullStyle += '; ';
+            fullStyle += 'cursor: pointer;';
 
             expect(a.attr('style')).toBe(fullStyle, msg);
 
@@ -167,27 +167,27 @@ describe('svg+text utils', function() {
                 var node = mockTextSVGElement(textCase);
 
                 expect(node.text()).toEqual('Subtitle');
-                assertAnchorAttrs(node, {style: 'font-size:300px'});
+                assertAnchorAttrs(node, {style: 'font-size: 300px'});
                 assertAnchorLink(node, 'XSS');
             });
         });
 
         it('accepts href and style in <a> in any order and tosses other stuff', function() {
             var textCases = [
-                '<a href="x" style="y">z</a>',
-                '<a href=\'x\' style="y">z</a>',
-                '<A HREF="x"StYlE=\'y\'>z</a>',
-                '<a style=\'y\'href=\'x\'>z</A>',
-                '<a \t\r\n href="x" \n\r\t style="y"  \n  \t  \r>z</a>',
-                '<a magic="true" href="x" weather="cloudy" style="y" speed="42">z</a>',
-                '<a href="x" style="y">z</a href="nope" style="for real?">',
+                '<a href="x" style="font-variant: small-caps;">z</a>',
+                '<a href=\'x\' style="font-variant: small-caps">z</a>',
+                '<A HREF="x"StYlE=\'font-variant:small-caps\'>z</a>',
+                '<a style=\'font-variant:small-caps;\'href=\'x\'>z</A>',
+                '<a \t\r\n href="x" \n\r\t style="font-variant: small-caps;"  \n  \t  \r>z</a>',
+                '<a magic="true" href="x" weather="cloudy" style="font-variant: small-caps;" speed="42">z</a>',
+                '<a href="x" style="font-variant: small-caps;">z</a href="nope" style="for real?">',
             ];
 
             textCases.forEach(function(textCase) {
                 var node = mockTextSVGElement(textCase);
 
                 expect(node.text()).toEqual('z');
-                assertAnchorAttrs(node, {style: 'y'});
+                assertAnchorAttrs(node, {style: 'font-variant: small-caps'});
                 assertAnchorLink(node, 'x');
             });
         });
@@ -288,29 +288,47 @@ describe('svg+text utils', function() {
 
         it('allows quoted styles in spans', function() {
             var node = mockTextSVGElement(
-                '<span style="quoted: yeah;">text</span>'
+                '<span style="fill: green;">text</span>'
             );
 
             expect(node.text()).toEqual('text');
-            assertTspanStyle(node, 'quoted: yeah;');
+            assertTspanStyle(node, 'fill: green;');
+        });
+
+        it('adjusts quoted styles in spans', function() {
+            var node = mockTextSVGElement(
+                '<span style="color: green;">text</span>'
+            );
+
+            expect(node.text()).toEqual('text');
+            assertTspanStyle(node, 'fill: green;');
         });
 
         it('ignores extra stuff after span styles', function() {
             var node = mockTextSVGElement(
-                '<span style="quoted: yeah;"disallowed: indeed;">text</span>'
+                '<span style="fill: green;"disallowed: indeed;">text</span>'
             );
 
             expect(node.text()).toEqual('text');
-            assertTspanStyle(node, 'quoted: yeah;');
+            assertTspanStyle(node, 'fill: green;');
         });
 
-        it('escapes HTML entities in span styles', function() {
+        it('decodes some HTML entities in span styles', function() {
             var node = mockTextSVGElement(
-                '<span style="quoted: yeah&\';;">text</span>'
+                '<span style="font-family:&quot;Times New Roman&quot;;">text</span>'
             );
 
             expect(node.text()).toEqual('text');
-            assertTspanStyle(node, 'quoted: yeah&\';;');
+            assertTspanStyle(node, "font-family: \"Times New Roman\";");
+        });
+
+        it('ignores invalid HTML entities in span styles', function() {
+            var node = mockTextSVGElement(
+                '<span style="font-family: Times&\';;">text</span>'
+            );
+
+            expect(node.text()).toEqual('text');
+            assertTspanStyle(node, null);
         });
 
         it('decodes some HTML entities in text', function() {
@@ -367,30 +385,30 @@ describe('svg+text utils', function() {
 
             var controlNode = mockTextSVGElement('<b>bold</b>');
             expect(controlNode.html()).toBe(
-                '<tspan style="font-weight:bold">bold</tspan>'
+                '<tspan style="font-weight: bold;">bold</tspan>'
             );
         });
 
         it('supports superscript by itself', function() {
             var node = mockTextSVGElement('<sup>123</sup>');
             expect(node.html()).toBe(
-                '\u200b<tspan style="font-size:70%" dy="-0.6em">123</tspan>' +
+                '\u200b<tspan dy="-0.6em" style="font-size: 70%;">123</tspan>' +
                 '<tspan dy="0.42em">\u200b</tspan>');
         });
 
         it('supports subscript by itself', function() {
             var node = mockTextSVGElement('<sub>123</sub>');
             expect(node.html()).toBe(
-                '\u200b<tspan style="font-size:70%" dy="0.3em">123</tspan>' +
+                '\u200b<tspan dy="0.3em" style="font-size: 70%;">123</tspan>' +
                 '<tspan dy="-0.21em">\u200b</tspan>');
         });
 
         it('supports superscript and subscript together with normal text', function() {
             var node = mockTextSVGElement('SO<sub>4</sub><sup>2-</sup>');
             expect(node.html()).toBe(
-                'SO\u200b<tspan style="font-size:70%" dy="0.3em">4</tspan>' +
+                'SO\u200b<tspan dy="0.3em" style="font-size: 70%;">4</tspan>' +
                 '<tspan dy="-0.21em">\u200b</tspan>\u200b' +
-                '<tspan style="font-size:70%" dy="-0.6em">2-</tspan>' +
+                '<tspan dy="-0.6em" style="font-size: 70%;">2-</tspan>' +
                 '<tspan dy="0.42em">\u200b</tspan>');
         });
 
@@ -398,22 +416,22 @@ describe('svg+text utils', function() {
             var node = mockTextSVGElement('be <b>Bold<br>and<br><i>Strong</i></b>');
             expect(node.html()).toBe(
                 '<tspan class="line" dy="0em" x="0" y="0">be ' +
-                    '<tspan style="font-weight:bold">Bold</tspan></tspan>' +
+                    '<tspan style="font-weight: bold;">Bold</tspan></tspan>' +
                 '<tspan class="line" dy="1.3em" x="0" y="0">' +
-                    '<tspan style="font-weight:bold">and</tspan></tspan>' +
+                    '<tspan style="font-weight: bold;">and</tspan></tspan>' +
                 '<tspan class="line" dy="2.6em" x="0" y="0">' +
-                    '<tspan style="font-weight:bold">' +
-                        '<tspan style="font-style:italic">Strong</tspan></tspan></tspan>');
+                    '<tspan style="font-weight: bold;">' +
+                        '<tspan style="font-style: italic;">Strong</tspan></tspan></tspan>');
         });
 
         it('allows one <sub> to span <br>s', function() {
             var node = mockTextSVGElement('SO<sub>4<br>44</sub>');
             expect(node.html()).toBe(
                 '<tspan class="line" dy="0em" x="0" y="0">SO\u200b' +
-                    '<tspan style="font-size:70%" dy="0.3em">4</tspan>' +
+                    '<tspan dy="0.3em" style="font-size: 70%;">4</tspan>' +
                     '<tspan dy="-0.21em">\u200b</tspan></tspan>' +
                 '<tspan class="line" dy="1.3em" x="0" y="0">\u200b' +
-                    '<tspan style="font-size:70%" dy="0.3em">44</tspan>' +
+                    '<tspan dy="0.3em" style="font-size: 70%;">44</tspan>' +
                     '<tspan dy="-0.21em">\u200b</tspan></tspan>');
         });
 
@@ -428,9 +446,9 @@ describe('svg+text utils', function() {
                 var node = mockTextSVGElement(textCase);
                 function opener(dy) {
                     return '<tspan class="line" dy="' + dy + 'em" x="0" y="0">' +
-                        '<tspan style="font-weight:bold">' +
-                        '<tspan style="font-style:italic">' +
-                        '\u200b<tspan style="font-size:70%" dy="-0.6em">';
+                        '<tspan style="font-weight: bold;">' +
+                        '<tspan style="font-style: italic;">' +
+                        '\u200b<tspan dy="-0.6em" style="font-size: 70%;">';
                 }
                 var closer = '</tspan><tspan dy="0.42em">\u200b</tspan>' +
                     '</tspan></tspan></tspan>';
@@ -589,25 +607,25 @@ describe('sanitizeHTML', function() {
         textCases.forEach(function(textCase) {
             var innerHTML = mockHTML(textCase);
 
-            expect(innerHTML).toEqual('<a style="font-size:300px" href="XSS">Subtitle</a>');
+            expect(innerHTML).toEqual('<a href="XSS" style="font-size: 300px;">Subtitle</a>');
         });
     });
 
     it('accepts href and style in <a> in any order and tosses other stuff', function() {
         var textCases = [
-            '<a href="x" style="y">z</a>',
-            '<a href=\'x\' style="y">z</a>',
-            '<A HREF="x"StYlE=\'y\'>z</a>',
-            '<a style=\'y\'href=\'x\'>z</A>',
-            '<a \t\r\n href="x" \n\r\t style="y"  \n  \t  \r>z</a>',
-            '<a magic="true" href="x" weather="cloudy" style="y" speed="42">z</a>',
-            '<a href="x" style="y">z</a href="nope" style="for real?">',
+            '<a href="x" style="font-variant: small-caps;">z</a>',
+            '<a href=\'x\' style="font-variant: small-caps;">z</a>',
+            '<A HREF="x"StYlE=\'font-variant: small-caps\'>z</a>',
+            '<a style=\'font-variant:small-caps;\'href=\'x\'>z</A>',
+            '<a \t\r\n href="x" \n\r\t style="font-variant:small-caps"  \n  \t  \r>z</a>',
+            '<a magic="true" href="x" weather="cloudy" style="font-variant: small-caps; ;" speed="42">z</a>',
+            '<a href="x" style="font-variant: small-caps;;">z</a href="nope" style="for real?">',
         ];
 
         textCases.forEach(function(textCase) {
             var innerHTML = mockHTML(textCase);
 
-            expect(innerHTML).toEqual('<a style="y" href="x">z</a>');
+            expect(innerHTML).toEqual('<a href="x" style="font-variant: small-caps;">z</a>');
         });
     });
 

--- a/test/jasmine/tests/treemap_test.js
+++ b/test/jasmine/tests/treemap_test.js
@@ -737,7 +737,7 @@ describe('Test treemap hover:', function() {
         exp: {
             label: {
                 nums: 'Abel :: 6.00',
-                name: '<tspan style="font-weight:bold">N.B.</tspan>'
+                name: '<tspan style="font-weight: bold;">N.B.</tspan>'
             },
             ptData: {
                 curveNumber: 0,


### PR DESCRIPTION
This addresses another part of the Plotly code that uses inline CSS (should be related to #2355). This case is less severe than the situation fixed by PR #7109 because it only affects some "advanced" configurations, such as those using "pseudo-HTML" in data set names or in `hovertemplate` settings.  Plots that did not utilize "pseudo-HTML" were not impacted.  Even if it did use "pseudo-HTML", depending on how much text formatting was done, the impact of strict CSPs may not be too noticeable.  For example,  bolded text would have rendered, but without the bold font.

Strict Content Security Policies (those without 'unsafe-inline' keyword) does not permit inline styles (setting the 'style' attribute in code). However, setting individual style properties on an element object is allowed.

Therefore, this fixes the "svg_text_utils.js" by changing the code that retrieves, manipulates, and applies the style attribute strings of the "pseudo-HTML" configuration to instead parse and/or apply styles directly on the element. In other words, instead of using `d3.select(node).attr("style", "some string value")`, use `d3.select(node).style(name, value)` as shown in the D3JS docs: https://d3js.org/d3-selection/selecting#select

With this method, in addition to it being allowed by string CSPs, the D3 JS library and/or the browser seems to do some level of input validation and normalization. As such, unit test cases were updated to account for this differences, which includes:
- Order and format of the attributes were changed. For example, there will be a space after the colon of the CSS style when read back from the browser.
- Invalid style attributes would not be applied. Thus, fixed test cases with actual valid styles.
- Setting the "color" style attribute in SVG text spans actually normalizes to setting the "fill" color attribute.
- Using "Times New Roman" font will cause "make-baseline" test to fail due to "error 525: plotly.js error" when run by the Kaleido Python library. Root cause of that is probably too deep to get into and removing it does not change the substance of that test case (using "Times, serif" achieves the same result).

## Testing
I tested using the `plotly-basic.js` build before and after the fix and configured a basic scatter chart with a `hovertemplate` configuration containing a lot of formatting using the "pseudo-HTML" allowed by this library. When hovering on the data points, it's very obvious when styles are properly applied.

* Before fix:  https://fqr9yv.csb.app/
* After fix:  https://kh7h56.csb.app/

Note:  The "before fix" CSB uses the `plotly-basic.js` built from `master` that is the base of this branch since it needs PR #7109 to work properly.