### PR TITLE
remove duplicated keys from mocks

### DIFF
--- a/test/image/mocks/11.json
+++ b/test/image/mocks/11.json
@@ -213,9 +213,7 @@
     "yanchor": "auto",
     "xatype": "category",
     "yatype": "linear",
-    "tag": "",
-    "xref": "paper",
-    "yref": "paper"
+    "tag": ""
    }
   ],
   "margin": {

--- a/test/image/mocks/14.json
+++ b/test/image/mocks/14.json
@@ -166,9 +166,7 @@
     "yanchor": "auto",
     "xatype": "log",
     "yatype": "log",
-    "tag": "",
-    "xref": "plot",
-    "yref": "plot"
+    "tag": ""
    },
    {
     "x": 0.15585471975544452,
@@ -198,9 +196,7 @@
     "yanchor": "auto",
     "xatype": "log",
     "yatype": "log",
-    "tag": "",
-    "xref": "plot",
-    "yref": "plot"
+    "tag": ""
    },
    {
     "x": 1.8420351138192386,
@@ -230,9 +226,7 @@
     "yanchor": "auto",
     "xatype": "log",
     "yatype": "log",
-    "tag": "",
-    "xref": "plot",
-    "yref": "plot"
+    "tag": ""
    },
    {
     "x": -0.5537301200821234,
@@ -262,9 +256,7 @@
     "yanchor": "auto",
     "xatype": "log",
     "yatype": "log",
-    "tag": "",
-    "xref": "plot",
-    "yref": "plot"
+    "tag": ""
    },
    {
     "x": -2.701204903100102,
@@ -294,9 +286,7 @@
     "yanchor": "auto",
     "xatype": "log",
     "yatype": "log",
-    "tag": "",
-    "xref": "plot",
-    "yref": "plot"
+    "tag": ""
    },
    {
     "x": -1.6961577824283882,
@@ -326,9 +316,7 @@
     "yanchor": "auto",
     "xatype": "log",
     "yatype": "log",
-    "tag": "",
-    "xref": "plot",
-    "yref": "plot"
+    "tag": ""
    }
   ],
   "margin": {

--- a/test/image/mocks/17.json
+++ b/test/image/mocks/17.json
@@ -611,9 +611,7 @@
     "yanchor": "auto",
     "xatype": "linear",
     "yatype": "linear",
-    "tag": "",
-    "xref": "plot",
-    "yref": "plot"
+    "tag": ""
    }
   ],
   "margin": {

--- a/test/image/mocks/29.json
+++ b/test/image/mocks/29.json
@@ -2255,9 +2255,7 @@
     "opacity": 1,
     "xanchor": "auto",
     "yanchor": "auto",
-    "tag": "",
-    "xref": "paper",
-    "yref": "paper"
+    "tag": ""
    }
   ],
   "margin": {


### PR DESCRIPTION
@emilykl While running tests as part of [releasing plotly.js](https://github.com/plotly/dev-docs/blob/master/advanced/plotly.js.md), I noticed some error messages related to the duplicated keys added in https://github.com/plotly/plotly.js/commit/ec3aa9f939f506326a3ab8ec1bd91626289cf5cf.

In some of these cases the values are different between the first and second occurrence of the key.

cc @plotly/plotly_js 

