### PR TITLE
Remove propagation of original _inputDomain

### DIFF
--- a/src/plots/cartesian/constraints.js
+++ b/src/plots/cartesian/constraints.js
@@ -473,8 +473,7 @@ exports.enforce = function enforce(gd) {
             axisID = axisIDs[j];
             axes[axisID] = ax = fullLayout[id2name(axisID)];
 
-            if(ax._inputDomain) ax.domain = ax._inputDomain.slice();
-            else ax._inputDomain = ax.domain.slice();
+            ax._inputDomain = ax.domain.slice();
 
             if(!ax._inputRange) ax._inputRange = ax.range.slice();
 


### PR DESCRIPTION
Fixes plotly/plotly.py#4794. @alexcjohnson wrote up some of the original reasoning behind the lines I'm changing here in [this PR comment](https://github.com/plotly/plotly.js/pull/1767#issuecomment-307142892). The code I removed prevented the domain from updating when the layout domain changes. 