### PR TITLE
Set key function for layout images

### DIFF
--- a/draftlogs/7277_fix.md
+++ b/draftlogs/7277_fix.md
@@ -1,0 +1,1 @@
+- Maintain layout images element identity based on coordinates, for smoother updates when you add or remove images early in the list. [[#7277](https://github.com/plotly/plotly.js/pull/7277)]

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -242,7 +242,7 @@ module.exports = function draw(gd) {
         var imagesOnSubplot = subplotObj.imagelayer.selectAll('image')
             // even if there are no images on this subplot, we need to run
             // enter and exit in case there were previously
-            .data(imageDataSubplot[subplot] || []);
+            .data(imageDataSubplot[subplot] || [], imgDataFunc);
 
         imagesOnSubplot.enter().append('image');
         imagesOnSubplot.exit().remove();
@@ -251,5 +251,6 @@ module.exports = function draw(gd) {
             setImage.bind(this)(d);
             applyAttributes.bind(this)(d);
         });
+        imagesOnSubplot.sort(imgSort);
     }
 };

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -203,10 +203,14 @@ module.exports = function draw(gd) {
         );
     }
 
+    function imgDataFunc(d) {
+        return [d.xref, d.x, d.sizex, d.yref, d.y, d.sizey].join('_');
+    }
+
     var imagesBelow = fullLayout._imageLowerLayer.selectAll('image')
-        .data(imageDataBelow);
+        .data(imageDataBelow, imgDataFunc);
     var imagesAbove = fullLayout._imageUpperLayer.selectAll('image')
-        .data(imageDataAbove);
+        .data(imageDataAbove, imgDataFunc);
 
     imagesBelow.enter().append('image');
     imagesAbove.enter().append('image');

--- a/src/components/images/draw.js
+++ b/src/components/images/draw.js
@@ -207,6 +207,8 @@ module.exports = function draw(gd) {
         return [d.xref, d.x, d.sizex, d.yref, d.y, d.sizey].join('_');
     }
 
+    function imgSort(a, b) { return a._index - b._index; }
+
     var imagesBelow = fullLayout._imageLowerLayer.selectAll('image')
         .data(imageDataBelow, imgDataFunc);
     var imagesAbove = fullLayout._imageUpperLayer.selectAll('image')
@@ -226,6 +228,8 @@ module.exports = function draw(gd) {
         setImage.bind(this)(d);
         applyAttributes.bind(this)(d);
     });
+    imagesBelow.sort(imgSort);
+    imagesAbove.sort(imgSort);
 
     var allSubplots = Object.keys(fullLayout._plots);
     for(i = 0; i < allSubplots.length; i++) {

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -199,6 +199,7 @@ function assertFileNames() {
                 base === 'SECURITY.md' ||
                 base === 'BUILDING.md' ||
                 base === 'CUSTOM_BUNDLE.md' ||
+                base === 'CITATION.cff' ||
                 file.indexOf('mathjax') !== -1
             ) return;
 

--- a/test/jasmine/tests/transition_test.js
+++ b/test/jasmine/tests/transition_test.js
@@ -106,7 +106,7 @@ describe('Plots.transition', function() {
             var pythonLogo = 'https://images.plot.ly/language-icons/api-home/python-logo.png';
 
             function imageel() {
-                return gd._fullLayout._imageUpperLayer.select('image').node();
+                return gd._fullLayout._imageUpperLayer.node().querySelector('image');
             }
             function imagesrc() {
                 return imageel().getAttribute('href');


### PR DESCRIPTION
Continuing my quest to make `layout.images` work well for a custom tile server - panning around is currently glitchy, because when new tiles are added at or removed from the beginning of the array, we first shift the existing images to where the new start is, then update the URLs.

This PR changes it so if there's an image at the same data or paper coordinates we'll leave the same element there, create new elements at new coordinates, and delete elements at coordinates where there is no longer an image. Two caveats to be aware of, but I think these are reasonable:
1. If your intent is just to move an existing image to new data or paper coordinates, it'll actually delete and recreate that image. Assuming you didn't change the URL, this update typically happens within one render frame so the practical effect should be minimal. If we wanted we could add a new attribute to these images like `id` and have that override this coordinate-based key. That would likely be necessary if we wanted to enable image animation, but we don't have that today.
2. If you ever provided two images at precisely the same coordinates (x/yref, x/y, sizex/y all need to be the same) the update behavior will be undefined so there could still be a glitch in this case. I guess I could imagine this happening for example if you wanted a background and a variable-opacity overlay. The solution again would be to add an `id` attribute.
