### PR TITLE
Fix: Prevent loss of domain information when template field is present in layout

### DIFF
--- a/draftlogs/7283_fix.md
+++ b/draftlogs/7283_fix.md
@@ -1,0 +1,1 @@
+- Fix handling of new domain values given in the Plotly.react function to prevent loss of new domain values. [[#7283](https://github.com/plotly/plotly.js/pull/7283)]

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2831,6 +2831,9 @@ function diffLayout(gd, oldFullLayout, newFullLayout, immutable, transition) {
                 // what you're asking for HAS changed, so clear _inputDomain and let us start from scratch
                 newFullLayout[key]._inputDomain = null;
             }
+            // We skip the else case (newDomain !== oldInputDomain && newDomain === oldDomain)
+            // because it's likely that if the newDomain and oldDomain are the same, the user
+            // passed in the same layout object and we should keep the _inputDomain.
         }
     }
 

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2811,6 +2811,29 @@ function diffLayout(gd, oldFullLayout, newFullLayout, immutable, transition) {
         return PlotSchema.getLayoutValObject(newFullLayout, parts);
     }
 
+    // Clear out any _inputDomain that's no longer valid
+    for (var key in newFullLayout) {
+        if (!key.startsWith('xaxis') && !key.startsWith('yaxis')) {
+            continue;
+        }
+        if (!oldFullLayout[key]) {
+            continue;
+        }
+        var newDomain = newFullLayout[key].domain;
+        var oldDomain = oldFullLayout[key].domain;
+        var oldInputDomain = oldFullLayout[key]._inputDomain;
+        if (oldFullLayout[key]._inputDomain) {
+            if (newDomain[0] === oldInputDomain[0] && newDomain[1] === oldInputDomain[1]) {
+                // what you're asking for hasn't changed, so let plotly.js start with what it
+                // concluded last time and iterate from there
+                newFullLayout[key].domain = oldFullLayout[key].domain;
+            } else if (newDomain[0] !== oldDomain[0] || newDomain[1] !== oldDomain[1]) {
+                // what you're asking for HAS changed, so clear _inputDomain and let us start from scratch
+                newFullLayout[key]._inputDomain = null;
+            }
+        }
+    }
+
     var diffOpts = {
         getValObject: getLayoutValObject,
         flags: flags,
@@ -2861,11 +2884,6 @@ function getDiffFlags(oldContainer, newContainer, outerparts, opts) {
         // track cartesian axes with altered ranges
         if(AX_RANGE_RE.test(astr) || AX_AUTORANGE_RE.test(astr)) {
             flags.rangesAltered[outerparts[0]] = 1;
-        }
-
-        // clear _inputDomain on cartesian axes with altered domains
-        if(AX_DOMAIN_RE.test(astr)) {
-            nestedProperty(newContainer, '_inputDomain').set(null);
         }
 
         // track datarevision changes

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1800,9 +1800,7 @@ describe('Test axes', function() {
             Plotly.newPlot(gd,
                 [{z: [[0, 1], [2, 3]], type: 'heatmap'}],
                 { template: {}, xaxis: { domain: [0,1], scaleanchor: 'y' } }
-            ).then(function() {
-                assertRangeDomain('xaxis', [-1.451851851851852,2.4518518518518517], [0, 1], [0, 1]);
-            })
+            )
             .then(function() {
                 return Plotly.react(gd, 
                     [{z: [[0, 1], [2, 3]], type: 'heatmap'}],

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1796,7 +1796,7 @@ describe('Test axes', function() {
                 'input range, ' + msg + ': ' + ax.range);
         }
 
-        it('can change _inputDomain on call to react when template is present', function(done) {
+        it('can change axis domain on call to react when template is present', function(done) {
             Plotly.newPlot(gd,
                 [{z: [[0, 1], [2, 3]], type: 'heatmap'}],
                 { template: {}, xaxis: { domain: [0,1], scaleanchor: 'y' } }

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -1796,6 +1796,25 @@ describe('Test axes', function() {
                 'input range, ' + msg + ': ' + ax.range);
         }
 
+        it('can change _inputDomain on call to react when template is present', function(done) {
+            Plotly.newPlot(gd,
+                [{z: [[0, 1], [2, 3]], type: 'heatmap'}],
+                { template: {}, xaxis: { domain: [0,1], scaleanchor: 'y' } }
+            ).then(function() {
+                assertRangeDomain('xaxis', [-1.451851851851852,2.4518518518518517], [0, 1], [0, 1]);
+            })
+            .then(function() {
+                return Plotly.react(gd, 
+                    [{z: [[0, 1], [2, 3]], type: 'heatmap'}],
+                    { template: {}, xaxis: { domain: [0.1, 0.9] } }
+                );
+            })
+            .then(function() {
+                assertRangeDomain('xaxis', [-0.5,1.5], [0.1, 0.9], [0.1, 0.9]);
+            })
+            .then(done, done.fail);
+        });
+
         it('can change per-axis constrain:domain/range and constraintoward', function(done) {
             Plotly.newPlot(gd,
                 // start with a heatmap as it has no padding so calculations are easy


### PR DESCRIPTION
Alternative fix to plotly/plotly.py#4794. Other fix is #7282. 

Context:
* @alexcjohnson noted that #7282 didn't seem like the right fix because changing `editType` from `'calc'` to `'plot'` is more of a _downgrade_ than something that should _fix_ this issue. 
* I pointed out [this particular line](https://github.com/plotly/plotly.js/blob/ca6a8868c22968afff2f8bd7d26f839df23b9d15/src/plot_api/plot_api.js#L2868) should be resetting the `_inputDomain`, but that [this line](https://github.com/plotly/plotly.js/blob/ca6a8868c22968afff2f8bd7d26f839df23b9d15/src/plot_api/plot_api.js#L2883) was returning in `diffFlags` before it reached the yaxis to reset it
* Alex said that the fact that we're resetting `_inputDomain` in the `changed` function was actually incorrect. It should be reset in its own separate crawl of the layout. 
* We decided to put the reset of `_inputDomain` into the `diffLayout` function because it has access to both the old layout and the new layout. 