### PR TITLE
Add UID as a classname to bar trace #7328

### DIFF
--- a/draftlogs/7328_add.md
+++ b/draftlogs/7328_add.md
@@ -1,0 +1,1 @@
+- Add `trace{UID}` to bar traces as for scatter ones [[#7328](https://github.com/plotly/plotly.js/issues/7328)]

--- a/src/traces/bar/plot.js
+++ b/src/traces/bar/plot.js
@@ -122,6 +122,8 @@ function plot(gd, plotinfo, cdModule, traceLayer, opts, makeOnCompleteCallback) 
         var keyFunc = getKeyFunc(trace);
         var bars = pointGroup.selectAll('g.point').data(Lib.identity, keyFunc);
 
+        plotGroup.classed('trace' + trace.uid, true);
+
         bars.enter().append('g')
             .classed('point', true);
 


### PR DESCRIPTION
### Feature

Scatter traces have always 3 classnames: `trace scatter trace{UID}` where `UID` is the trace unique ID (`trace.uid`).
Now bar traces can have it too: `trace bars trace{UID}`.