### PR TITLE
Fix hover bug

### DIFF
--- a/src/components/modebar/modebar.js
+++ b/src/components/modebar/modebar.js
@@ -60,9 +60,6 @@ proto.update = function(graphInfo, buttons) {
     document.querySelectorAll(groupSelector).forEach(function(group) {
         group.style.backgroundColor = style.bgcolor;
     });
-    // set styles on hover using event listeners instead of inline CSS that's not allowed by strict CSP's
-    Lib.setStyleOnHover('#' + modeBarId + ' .modebar-btn', '.active', '.icon path', 'fill: ' + style.activecolor, 'fill: ' + style.color);
-
     // if buttons or logo have changed, redraw modebar interior
     var needsNewButtons = !this.hasButtons(buttons);
     var needsNewLogo = (this.hasLogo !== context.displaylogo);
@@ -92,6 +89,10 @@ proto.update = function(graphInfo, buttons) {
     }
 
     this.updateActiveButton();
+
+    // set styles on hover using event listeners instead of inline CSS that's not allowed by strict CSP's
+    Lib.setStyleOnHover('#' + modeBarId + ' .modebar-btn', '.active', '.icon path', 'fill: ' + style.activecolor, 'fill: ' + style.color, this.element);
+
 };
 
 proto.updateButtons = function(buttons) {

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -101,12 +101,14 @@ function deleteRelatedStyleRule(uid) {
  * @param {string} activeStyle    style that has to be applied when 'hovered' or 'active'
  * @param {string} inactiveStyle    style that has to be applied when not 'hovered' nor 'active'
  */
-function setStyleOnHover(selector, activeSelector, childSelector, activeStyle, inactiveStyle) {
+function setStyleOnHover(selector, activeSelector, childSelector, activeStyle, inactiveStyle, element) {
     var activeStyleParts = activeStyle.split(':');
     var inactiveStyleParts = inactiveStyle.split(':');
     var eventAddedAttrName = 'data-btn-style-event-added';
-
-    document.querySelectorAll(selector).forEach(function(el) {
+    if (!element) {
+        element = document;
+    }
+    element.querySelectorAll(selector).forEach(function(el) {
         if(!el.getAttribute(eventAddedAttrName)) {
             // Emulate ":hover" CSS style using JS event handlers to set the
             // style in a strict CSP-compliant manner.


### PR DESCRIPTION
Fixes #7335. The issue was happening because the `setStyleOnHover` function was:
1. Being called before the creation of the modebar button elements
2. Being called before the modebar element was attached to the DOM. So as @Lexachoc noted, `document.querySelectorAll('#' + modeBarId + ' .modebar-btn')` was returning an empty list, because while the elements were _created_, they weren't part of the `document`. 

To solve #1, I moved the call to `setStyleOnHover` to after the button elements were created, and to solve #2, I passed the `ModeBar.element` as an optional parameter to `setStyleOnHover`. When the `element` parameter is present, `querySelectorAll` is called on `element` rather than `document`, so that it doesn't need to be attached to the DOM yet. 