### PR TITLE
docs: remove mention of Chart Studio Cloud and enumeration of font names

### DIFF
--- a/src/plots/font_attributes.js
+++ b/src/plots/font_attributes.js
@@ -49,15 +49,9 @@ module.exports = function(opts) {
             editType: editType,
             description: [
                 'HTML font family - the typeface that will be applied by the web browser.',
-                'The web browser will only be able to apply a font if it is available on the system',
-                'which it operates. Provide multiple font families, separated by commas, to indicate',
-                'the preference in which to apply fonts if they aren\'t available on the system.',
-                'The Chart Studio Cloud (at https://chart-studio.plotly.com or on-premise) generates images on a server,',
-                'where only a select number of',
-                'fonts are installed and supported.',
-                'These include *Arial*, *Balto*, *Courier New*, *Droid Sans*, *Droid Serif*,',
-                '*Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*,',
-                '*PT Sans Narrow*, *Raleway*, *Times New Roman*.'
+                'The web browser can only apply a font if it is available on the system where',
+                'it runs. Provide multiple font families, separated by commas, to indicate',
+                'the order in which to apply fonts if they aren\'t available.',
             ].join(' ')
         },
         size: {


### PR DESCRIPTION
Removing this text here means that it won't be duplicated multiple times in the plotly.py docs.