### PR TITLE
Ensure AMD headers of dependencies aren't kept in bundle

### DIFF
--- a/draftlogs/7367_fix.md
+++ b/draftlogs/7367_fix.md
@@ -1,0 +1,1 @@
+- Fix importing plotly.js via require on pages with [AMD](https://en.wikipedia.org/wiki/Asynchronous_module_definition) [[#7367](https://github.com/plotly/plotly.js/pull/7367)]

--- a/esbuild-config.js
+++ b/esbuild-config.js
@@ -23,6 +23,7 @@ module.exports = {
     },
     define: {
         global: 'window',
+        'define.amd': 'false',
     },
     target: 'es2016',
     logLevel: 'info',


### PR DESCRIPTION
Hi!

Recently an issue with using Plotly to render visualizations in our framework, [solara](https://github.com/widgetti/solara) was brought to our attention. Because we use some architecture from old jupyter notebook versions together with require.js, plotly.js fails to load. This turns out to be because, despite support for AMD headers in ~~the plotly.js bundle~~ plotly.js itself being removed in https://github.com/plotly/plotly.js/pull/7229, checks of the form

```js
if (typeof define == "function" && define.amd) {
    define(function $AMD$() {
        return context[name2];
    });
}
```

are still ~~added to~~ included in the plotly.js bundle by esbuild from plotly's dependencies (as can be seen in the files in `dist/`). For example, in `dist/plotly.js`, these checks are present through 24 different dependencies.

~~I think the ultimate cause of the headers still being present is esbuild not properly handling commonJS modules (see https://github.com/evanw/esbuild/issues/1348). The solution here comes from https://github.com/manzt/anywidget/issues/369#issuecomment-1792376003.~~ For a better explanation take a look at the comment below (https://github.com/plotly/plotly.js/pull/7367#issuecomment-2657141673).
A potentially better solution might be to migrate from esbuild to rollup, which does handle commonJS modules properly, however that could prove to be more laborious. If that is your preferred solution, let me know - I'm more than happy to lend a hand!

cc: @maartenbreddels, @manzt

Keeping these here as a reminder to myself:

After opening a pull request, developer:
 - should create a new small markdown log file using the PR number e.g. `1010_fix.md` or `1010_add.md` inside `draftlogs` folder as described in this [README](https://github.com/plotly/plotly.js/blob/master/draftlogs/README.md), commit it and push.
 - should **not** force push (i.e. `git push -f`) to remote branches associated with opened pull requests. Force pushes make it hard for maintainers to keep track of updates. Therefore, if required, please fetch `upstream/master` and "merge" with master instead of "rebase".