### PR TITLE
Fix #7387: Specify buffers in regl.clear() to avoid performance warning

### DIFF
--- a/src/traces/scattergl/plot.js
+++ b/src/traces/scattergl/plot.js
@@ -60,12 +60,12 @@ var exports = module.exports = function plot(gd, subplot, cdata) {
     linkTraces(gd, subplot, cdata);
 
     if(scene.dirty) {
-        if(
+        if (
             (scene.line2d || scene.error2d) &&
             !(scene.scatter2d || scene.fill2d || scene.glText)
         ) {
             // Fixes shared WebGL context drawing lines only case
-            regl.clear({});
+            regl.clear({ color: true, depth: true });
         }
 
         // make sure scenes are created


### PR DESCRIPTION
This PR fixes issue #7387 by specifying the `color` and `depth` buffers in the `regl.clear()` call in `src/traces/scattergl/plot.js`. This prevents the "Performance warning: clear() called with no buffers in bitmask" warning.

Changes:
- Modified `regl.clear({})` to `regl.clear({ color: true, depth: true })`.

