### PR TITLE
Change translations according to taaladvies guidelines

### DIFF
--- a/lib/locales/nl-be.js
+++ b/lib/locales/nl-be.js
@@ -9,13 +9,13 @@ module.exports = {
             'zondag', 'maandag', 'dinsdag', 'woensdag',
             'donderdag', 'vrijdag', 'zaterdag'
         ],
-        shortDays: ['zon', 'maa', 'din', 'woe', 'don', 'vri', 'zat'],
+        shortDays: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
         months: [
             'januari', 'februari', 'maart', 'april', 'mei', 'juni',
             'juli', 'augustus', 'september', 'oktober', 'november', 'december'
         ],
         shortMonths: [
-            'jan', 'feb', 'maa', 'apr', 'mei', 'jun',
+            'jan', 'feb', 'mrt', 'apr', 'mei', 'jun',
             'jul', 'aug', 'sep', 'okt', 'nov', 'dec'
         ],
         date: '%d/%m/%Y'

--- a/lib/locales/nl.js
+++ b/lib/locales/nl.js
@@ -43,13 +43,13 @@ module.exports = {
             'zondag', 'maandag', 'dinsdag', 'woensdag',
             'donderdag', 'vrijdag', 'zaterdag'
         ],
-        shortDays: ['zon', 'maa', 'din', 'woe', 'don', 'vri', 'zat'],
+        shortDays: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
         months: [
             'januari', 'februari', 'maart', 'april', 'mei', 'juni',
             'juli', 'augustus', 'september', 'oktober', 'november', 'december'
         ],
         shortMonths: [
-            'jan', 'feb', 'maa', 'apr', 'mei', 'jun',
+            'jan', 'feb', 'mrt', 'apr', 'mei', 'jun',
             'jul', 'aug', 'sep', 'okt', 'nov', 'dec'
         ],
         date: '%d-%m-%Y',


### PR DESCRIPTION
Changed the dutch abbreviations of the months and days to be in line with the guidelines according to [Genootschap onze taal](https://onzetaal.nl/taalloket/afkortingen-dagen-en-maanden) and [Taal unie](https://taaladvies.net/afkortingen-van-de-namen-van-de-maanden/).