### PR TITLE
chore: Fix dashboard 

### DIFF
--- a/devtools/regl_codegen/devtools.js
+++ b/devtools/regl_codegen/devtools.js
@@ -158,5 +158,3 @@ function handleOnLoad() {
         window.close();
     });
 }
-
-module.exports = Tabs;

--- a/devtools/test_dashboard/devtools.js
+++ b/devtools/test_dashboard/devtools.js
@@ -269,4 +269,3 @@ function handleOnLoad() {
     plotFromHash();
 }
 
-module.exports = Tabs;


### PR DESCRIPTION
Avoid the following console error: `Uncaught ReferenceError: module is not defined`.