### PR TITLE
refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ where X.Y.Z is the semver of most recent plotly.js release.
  with thanks to @my-tien for the contribution!
 
 ### Changed
- - Switch to United Nations (coastlines, countries, land, ocean) + Natural Earth (lakes, rivers, subunits) geodata for building topojson used in geo plot
+ - Switch to United Nations (coastlines, countries, land, ocean) + Natural Earth (lakes, rivers, subunits) geodata for building topojson used in geo plot [[#7393](https://github.com/plotly/plotly.js/pull/7393)]
  - Make 'png' all caps [[#7400](https://github.com/plotly/plotly.js/pull/7400)]
 
 ### Fixed

--- a/src/assets/geo_assets.js
+++ b/src/assets/geo_assets.js
@@ -1,22 +1,21 @@
 'use strict';
 
-// TODO: Remove comments from Antarctica, Oceania during new maps release PR
 const topojson = {
   africa_110m: require('../../dist/topojson/africa_110m.json'),
-  // antarctica_110m: require('../../dist/topojson/antarctica_110m.json'),
+  antarctica_110m: require('../../dist/topojson/antarctica_110m.json'),
   asia_110m: require('../../dist/topojson/asia_110m.json'),
   europe_110m: require('../../dist/topojson/europe_110m.json'),
   'north-america_110m': require('../../dist/topojson/north-america_110m.json'),
-  // oceania_110m: require('../../dist/topojson/oceania_110m.json'),
+  oceania_110m: require('../../dist/topojson/oceania_110m.json'),
   'south-america_110m': require('../../dist/topojson/south-america_110m.json'),
   usa_110m: require('../../dist/topojson/usa_110m.json'),
   world_110m: require('../../dist/topojson/world_110m.json'),
   africa_50m: require('../../dist/topojson/africa_50m.json'),
-  // antarctica_50m: require('../../dist/topojson/antarctica_50m.json'),
+  antarctica_50m: require('../../dist/topojson/antarctica_50m.json'),
   asia_50m: require('../../dist/topojson/asia_50m.json'),
   europe_50m: require('../../dist/topojson/europe_50m.json'),
   'north-america_50m': require('../../dist/topojson/north-america_50m.json'),
-  // oceania_50m: require('../../dist/topojson/oceania_50m.json'),
+  oceania_50m: require('../../dist/topojson/oceania_50m.json'),
   'south-america_50m': require('../../dist/topojson/south-america_50m.json'),
   usa_50m: require('../../dist/topojson/usa_50m.json'),
   world_50m: require('../../dist/topojson/world_50m.json'),

--- a/tasks/cdn_publish.sh
+++ b/tasks/cdn_publish.sh
@@ -29,13 +29,11 @@ for path in `ls $dist/plotly*`; do
 done
 
 # copy topojson files over to the sync folder
-# NOTE: Temporarily adding the suffix '_un' to avoid overwriting the old topojson
-# which some old plots might depend on
-for filepath in $dist/topojson/*.json; do
-    f=${filepath##*/}
-    f=${f%.*}
-    cp $filepath "$sync/${f%.*}_un.json"
-done
+# NOTE: Temporarily syncing topojson to 'un' folder to avoid overwriting the old topojson
+# which some old plots might depend on. These can be accessed by setting 'topojsonURL' to
+# 'https://cdn.plot.ly/un/' in the Plotly config.
+mkdir $sync/un
+cp $dist/topojson/* $sync/un
 
 # list folder and files
 echo $sync

--- a/topojson/bin/process_geodata.mjs
+++ b/topojson/bin/process_geodata.mjs
@@ -242,7 +242,6 @@ async function convertLayersToTopojson({ name, resolution }) {
 
 // Get required polygon features from UN GeoJSON
 const inputFilePathUNGeojson = `${inputDir}/${unFilename}.geojson`;
-// await mapshaper.runCommands(`${inputFilePathUNGeojson} -filter 'stscod !== undefined' target=1 -clean target=1 -o force ${inputFilePathUNGeojson}`)
 const outputFilePathAntarctica50m = `${outputDirGeojson}/${unFilename}_50m/antarctica.geojson`;
 const outputFilePathFiji50m = `${outputDirGeojson}/${unFilename}_50m/fiji.geojson`;
 const outputFilePathFijiAntimeridian50m = `${outputDirGeojson}/${unFilename}_50m/fiji_antimeridian.geojson`;


### PR DESCRIPTION
### Description

Cleans up some files related to the recent topojson update.

### Changes

- Uncomments code to add new maps to geo assets script
- Adds missing link to topojson PR in changelog
- Removes commented code from geodata process script
- Updates CDN publish script to save topojson in subfolder

### Notes
- Changing the CDN save location for the new topojson allows the new maps to be referenced by setting `topojsonURL` to the following: https://cdn.plot.ly/un/
