### PR TITLE
Add ECMA version to Falafel/Acorn.js config

### DIFF
--- a/tasks/find_locale_strings.js
+++ b/tasks/find_locale_strings.js
@@ -28,7 +28,7 @@ function findLocaleStrings() {
             var code = fs.readFileSync(file, 'utf-8');
             var filePartialPath = file.substr(constants.pathToSrc.length);
 
-            falafel(code, {locations: true}, function(node) {
+            falafel(code, { ecmaVersion: 'latest', locations: true }, function(node) {
                 if(node.type === 'CallExpression' &&
                     (node.callee.name === '_' || node.callee.source() === 'Lib._')
                 ) {

--- a/tasks/shard_jasmine_tests.js
+++ b/tasks/shard_jasmine_tests.js
@@ -29,7 +29,7 @@ glob(path.join(pathToJasmineTests, '*.js')).then((files) => {
         var code = fs.readFileSync(file, 'utf-8');
         var bn = path.basename(file);
 
-        falafel(code, function(node) {
+        falafel(code, { ecmaVersion: 'latest' }, function(node) {
             if(isJasmineTestIt(node, tag)) {
                 if(file2cnt[bn]) {
                     file2cnt[bn]++;

--- a/tasks/test_syntax.js
+++ b/tasks/test_syntax.js
@@ -42,7 +42,7 @@ function assertJasmineSuites() {
             var code = fs.readFileSync(file, 'utf-8');
             var bn = path.basename(file);
 
-            falafel(code, {locations: true}, function(node) {
+            falafel(code, { ecmaVersion: 'latest', locations: true }, function(node) {
                 var lineInfo = '[line ' + node.loc.start.line + '] :';
 
                 if(node.type === 'Identifier' && BLACK_LIST.indexOf(node.name) !== -1) {
@@ -108,7 +108,7 @@ function assertSrcContents() {
 
             // parse through code string while keeping track of comments
             var comments = [];
-            falafel(code, {onComment: comments, locations: true}, function(node) {
+            falafel(code, { ecmaVersion: 'latest', locations: true, onComment: comments }, function(node) {
                 // look for .classList
                 if(node.type === 'MemberExpression') {
                     var source = node.source();

--- a/tasks/util/update_version.js
+++ b/tasks/util/update_version.js
@@ -7,7 +7,7 @@ var pkg = require('../../package.json');
 
 module.exports = function updateVersion(pathToFile) {
     fs.readFile(pathToFile, 'utf-8', function(err, code) {
-        var out = falafel(code, function(node) {
+        var out = falafel(code, { ecmaVersion: 'latest' }, function(node) {
             if(isVersionNode(node)) node.update('\'' + pkg.version + '\'');
         });
 


### PR DESCRIPTION
### Description

Add config option to Falafel calls (which gets passed to Acorn) to allow for parsing of the newest ECMAScript syntax.

### Changes

- Updates (or adds) Falafel config to specify the latest ECMAScript version

### Testing

If CI passes, that should be proof enough that this change didn't break anything.

### Notes

- We recently [specified](https://github.com/plotly/plotly.js/pull/7478) an updated version of Acorn.js to be used as a dependency of the Falafel library
- The newer version of Acorn.js includes a warning message that specifying `ecmaVersion` is now required:
  > Since Acorn 8.0.0, options.ecmaVersion is required. Defaulting to 2020, but this will stop working in the future.
- Modern ECMAScript syntax can sometimes cause Acorn.js to fail because it's not parsing the proper version of ECMAScript (I saw it with the logical OR operator: `||=1`)
- By using an [`ecmaScript`](https://github.com/acornjs/acorn/tree/master/acorn/#interface) value of `"latest"` with Acorn.js, we should be covered now and in the future if we start using other modern syntax
