### PR TITLE
fix hover event not triggered on consecutive empty bins (count=0) with `hovermode:'x'` for histogram

### DIFF
--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -2283,7 +2283,8 @@ function hoverChanged(gd, evt, oldhoverdata) {
 
         if(oldPt.curveNumber !== newPt.curveNumber ||
             String(oldPt.pointNumber) !== String(newPt.pointNumber) ||
-            String(oldPt.pointNumbers) !== String(newPt.pointNumbers)
+            String(oldPt.pointNumbers) !== String(newPt.pointNumbers) ||
+            String(oldPt.binNumber) !== String(newPt.binNumber)
         ) {
             return true;
         }


### PR DESCRIPTION
This PR fix #7502 