### PR TITLE
feat: add `colorbar.title.text` alignment support

### DIFF
--- a/draftlogs/7509_add.md
+++ b/draftlogs/7509_add.md
@@ -1,0 +1,1 @@
+Add `align` attribute to `colorbar.title` to control the alignment of the title [[#7509](https://github.com/plotly/plotly.js/pull/7509)]

--- a/src/components/colorbar/attributes.js
+++ b/src/components/colorbar/attributes.js
@@ -226,6 +226,15 @@ module.exports = overrideAll({
                 'Defaults to *top* when `orientation` if *v* and ',
                 'defaults to *right* when `orientation` if *h*.',
             ].join(' ')
+        },
+        align: {
+            valType: 'enumerated',
+            values: ['start', 'middle', 'end'],
+            description: [
+                'Sets the alignment of the color bar\'s title.',
+                'Defaults to *start* when `orientation` if *v*.',
+                'Note: This only takes affect when `orientation` is *v*.'
+            ].join(' ')
         }
     },
 }, 'colorbars', 'from-root');

--- a/src/components/colorbar/defaults.js
+++ b/src/components/colorbar/defaults.js
@@ -133,4 +133,5 @@ module.exports = function colorbarDefaults(containerIn, containerOut, layout) {
     });
     Lib.coerceFont(coerce, 'title.font', dfltTitleFont);
     coerce('title.side', isVertical ? 'top' : 'right');
+    coerce('title.align', isVertical ? 'start' : 'middle');
 };

--- a/src/components/colorbar/draw.js
+++ b/src/components/colorbar/draw.js
@@ -373,7 +373,7 @@ function drawColorBar(g, opts, gd) {
             }
 
             drawTitle(ax._id + 'title', {
-                attributes: {x: x, y: y, 'text-anchor': isVertical ? 'start' : 'middle'}
+                attributes: {x: x, y: y, 'text-anchor': isVertical ? title.align : 'middle'}
             });
         }
     }

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -1652,6 +1652,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -17600,6 +17610,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -19650,6 +19670,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -24743,6 +24773,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -26036,6 +26076,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -27319,6 +27369,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -28641,6 +28701,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -29992,6 +30062,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -31815,6 +31895,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -33041,6 +33131,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -34262,6 +34362,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -36151,6 +36261,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -38781,6 +38901,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -41135,6 +41265,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -42592,6 +42732,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -44096,6 +44246,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -46469,6 +46629,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -49840,6 +50010,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "calc",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "calc",
       "font": {
        "color": {
@@ -51366,6 +51546,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -53974,6 +54164,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -55257,6 +55457,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -60012,6 +60222,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -62648,6 +62868,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "calc",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "calc",
        "font": {
         "color": {
@@ -63357,6 +63587,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "calc",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "calc",
        "font": {
         "color": {
@@ -65190,6 +65430,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -67483,6 +67733,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "calc",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "calc",
        "font": {
         "color": {
@@ -69891,6 +70151,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "calc",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "calc",
        "font": {
         "color": {
@@ -72219,6 +72489,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "calc",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "calc",
        "font": {
         "color": {
@@ -73762,6 +74042,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "calc",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "calc",
        "font": {
         "color": {
@@ -75288,6 +75578,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -77554,6 +77854,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "calc",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "calc",
        "font": {
         "color": {
@@ -79764,6 +80074,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -82069,6 +82389,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -84305,6 +84635,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -85826,6 +86166,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "colorbars",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "colorbars",
       "font": {
        "color": {
@@ -87883,6 +88233,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -89164,6 +89524,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "calc",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "calc",
       "font": {
        "color": {
@@ -92508,6 +92878,16 @@
        "valType": "number"
       },
       "title": {
+       "align": {
+        "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+        "editType": "colorbars",
+        "valType": "enumerated",
+        "values": [
+         "start",
+         "middle",
+         "end"
+        ]
+       },
        "editType": "colorbars",
        "font": {
         "color": {
@@ -95553,6 +95933,16 @@
       "valType": "number"
      },
      "title": {
+      "align": {
+       "description": "Sets the alignment of the color bar's title. Defaults to *start* when `orientation` if *v*. Note: This only takes affect when `orientation` is *v*.",
+       "editType": "calc",
+       "valType": "enumerated",
+       "values": [
+        "start",
+        "middle",
+        "end"
+       ]
+      },
       "editType": "calc",
       "font": {
        "color": {


### PR DESCRIPTION
This PR fixes https://github.com/plotly/plotly.js/issues/7508.

## Description
There is currently no option to configure the `colorbar.title.text` alignment. It is always left-aligned.

This PR proposes a new option `align` within `title`, e.g.,

json format:
```diff
                "colorbar": {
                    "orientation": "v",
                    "title": {
+                        "align": "end",
                        "text": "This is a colorbar title based on Year values"
                    }
                }
``` 

The accepted value for `align` is one of : `start` | `middle` | `end`.



## Changes

Add a new option to configure the `colorbar.title.text` alignment.

## Usages (screenshots were taken from the same position)

### Left-aligned ("orientation": "v") (The default)

with "align": "start", same as default (current)

<img width="1251" height="650" alt="image" src="https://github.com/user-attachments/assets/886df7af-6648-49a1-8d7b-085e818cbae7" />

### Center-aligned ("orientation": "v")

with "align": "middle"

<img width="1251" height="650" alt="image" src="https://github.com/user-attachments/assets/cd62ca78-7ea2-4c13-ad31-51a58b334b31" />

### Right-aligned ("orientation": "v")

with "align": "end"

<img width="1251" height="650" alt="image" src="https://github.com/user-attachments/assets/bb3b91b4-73cb-40cb-a1c1-416dd71e1a6f" />

## Note

As for "orientation": "h" (horizontal), I didn't consider this `align` option, but feel free to comment on it. The implementation is a bit tricky and requires more code. By default, it is positioned in the middle of the colorbar. I think that looks good enough.

## Improvement for "align": "end"

IMHO, it would be nice to align the title text (currently in green line) to the side of the tick value (blue line).

<img width="473" height="538" alt="image" src="https://github.com/user-attachments/assets/789f1e18-1ea5-4935-ad0e-6004b0a56bda" />

What do you think? However, since the fill, background, outline, and tick of colorbar are not grouped, it is trivial to move the colorbar (except the title text) to the left so that they are aligned with the title text. (I want to move the bar to left because it can save more space)
I'm thinking maybe we can group the colorbar compoents into a container and move together? 
Maybe there is other briliant simple way to fulfil this?

Suggestions from the Plotly team are appreciated! 

