### PR TITLE
fix wheel event handler Violation in Chromium by setting passive: true

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -59,9 +59,20 @@ var Events = {
             internalEv.emit(event, data);
         };
 
-        // Add a dummy event handler for 'wheel' event for Safari
-        // to enable mouse wheel zoom.
-        addDummyScrollEventListener(plotObj);
+        /*
+        * Add a dummy event handler for 'wheel' event for Safari
+        * to enable mouse wheel zoom.
+        * https://github.com/d3/d3/issues/3035
+        * https://github.com/plotly/plotly.js/issues/7452
+        *
+        * We set {passive: true} for better performance
+        * and to avoid a Violation warning in Chromium.
+        * https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
+        * https://github.com/plotly/plotly.js/issues/7516
+        */
+        if(typeof plotObj.addEventListener === 'function') {
+            plotObj.addEventListener("wheel", () => {}, { passive: true });
+        }
 
         return plotObj;
     },
@@ -133,36 +144,5 @@ var Events = {
     }
 
 };
-
-function addDummyScrollEventListener(plotObj) {
-    /*
-     * Add a dummy event handler for 'wheel' event for Safari
-     * to enable mouse wheel zoom.
-     * https://github.com/d3/d3/issues/3035
-     * https://github.com/plotly/plotly.js/issues/7452
-     *
-     * We set {passive: true} for better performance
-     * and to avoid a Violation warning in Chromium.
-     * https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
-     * https://github.com/plotly/plotly.js/issues/7516
-     */
-
-    // Test whether the passive property is accessed (for compatibility with older browsers)
-    var supportsPassive = false;
-    try {
-        var opts = Object.defineProperty({}, 'passive', {
-            get: function() {
-                supportsPassive = true;
-            }
-        });
-        window.addEventListener("testPassive", null, opts);
-        window.removeEventListener("testPassive", null, opts);
-    } catch (e) {}
-
-    if(typeof plotObj.addEventListener === 'function') {
-        plotObj.addEventListener("wheel", () => {}, supportsPassive ? { passive: true } : false);
-    }
-
-}
 
 module.exports = Events;


### PR DESCRIPTION
Closes #7516 

Fixes regression caused by #7474  which caused a `Violation` console message in Chrome regarding scroll wheel event handling.

Note: This change resolves one of the `Violation` messages, but there seem to be two others generated by other parts of the code.