### PR TITLE
Only show locationmode warning if locationmode is 'country names'

### DIFF
--- a/src/traces/choropleth/defaults.js
+++ b/src/traces/choropleth/defaults.js
@@ -4,6 +4,12 @@ var Lib = require('../../lib');
 var colorscaleDefaults = require('../../components/colorscale/defaults');
 var attributes = require('./attributes');
 
+const locationmodeBreakingChangeWarning = [
+    'The library used by the *country names* `locationmode` option is changing in the next major version.',
+    'Some country names in existing plots may not work in the new version.',
+    'To ensure consistent behavior, consider setting `locationmode` to *ISO-3*.',
+].join(' ');
+
 module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
     function coerce(attr, dflt) {
         return Lib.coerce(traceIn, traceOut, attributes, attr, dflt);
@@ -27,6 +33,10 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     }
 
     var locationMode = coerce('locationmode', locationmodeDflt);
+
+    if(locationMode === 'country names') {
+        Lib.warn(locationmodeBreakingChangeWarning);
+    }
 
     if(locationMode === 'geojson-id') {
         coerce('featureidkey');

--- a/src/traces/choropleth/plot.js
+++ b/src/traces/choropleth/plot.js
@@ -9,18 +9,7 @@ var findExtremes = require('../../plots/cartesian/autorange').findExtremes;
 
 var style = require('./style').style;
 
-const breakingChangeWarning = [
-    'The library used by the *country names* `locationmode` option is changing in an upcoming version.',
-    'Country names in existing plots may not work in the new version.'
-].join(' ');
-let firstPlot = true;
-
 function plot(gd, geo, calcData) {
-    if(firstPlot) {
-        firstPlot = false;
-        Lib.warn(breakingChangeWarning);
-    }
-
     var choroplethLayer = geo.layers.backplot.select('.choroplethlayer');
 
     Lib.makeTraceGroups(choroplethLayer, calcData, 'trace choropleth').each(function(calcTrace) {

--- a/src/traces/scattergeo/defaults.js
+++ b/src/traces/scattergeo/defaults.js
@@ -10,6 +10,12 @@ var handleFillColorDefaults = require('../scatter/fillcolor_defaults');
 
 var attributes = require('./attributes');
 
+const locationmodeBreakingChangeWarning = [
+    'The library used by the *country names* `locationmode` option is changing in the next major version.',
+    'Some country names in existing plots may not work in the new version.',
+    'To ensure consistent behavior, consider setting `locationmode` to *ISO-3*.',
+].join(' ');
+
 module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout) {
     function coerce(attr, dflt) {
         return Lib.coerce(traceIn, traceOut, attributes, attr, dflt);
@@ -26,6 +32,10 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
         }
 
         var locationMode = coerce('locationmode', locationmodeDflt);
+
+        if(locationMode === 'country names') {
+            Lib.warn(locationmodeBreakingChangeWarning);
+        }
 
         if(locationMode === 'geojson-id') {
             coerce('featureidkey');

--- a/src/traces/scattergeo/plot.js
+++ b/src/traces/scattergeo/plot.js
@@ -13,18 +13,7 @@ var calcMarkerSize = require('../scatter/calc').calcMarkerSize;
 var subTypes = require('../scatter/subtypes');
 var style = require('./style');
 
-const breakingChangeWarning = [
-    'The library used by the *country names* `locationmode` option is changing in an upcoming version.',
-    'Country names in existing plots may not work in the new version.'
-].join(' ');
-let firstPlot = true;
-
 function plot(gd, geo, calcData) {
-    if(firstPlot) {
-        firstPlot = false;
-        Lib.warn(breakingChangeWarning);
-    }
-
     var scatterLayer = geo.layers.frontplot.select('.scatterlayer');
     var gTraces = Lib.makeTraceGroups(scatterLayer, calcData, 'trace scattergeo');
 


### PR DESCRIPTION
While working on #7517 I noticed that the `locationmode: 'country names'` warning is shown for all choropleth and scattergeo charts regardless of their `locationmode` value. This PR modifies the warning such that it is only shown if `locationmode` is set to `'country names'`.