### PR TITLE
Fix broken styling of map attributions 

### DIFF
--- a/esbuild-config.js
+++ b/esbuild-config.js
@@ -1,6 +1,6 @@
 var glsl = require('esbuild-plugin-glsl').glsl;
 var environmentPlugin = require('esbuild-plugin-environment').environmentPlugin;
-const stylePlugin = require('esbuild-style-plugin');
+const InlineCSSPlugin = require('esbuild-plugin-inline-css');
 
 module.exports = {
     entryPoints: ['./lib/index.js'],
@@ -10,7 +10,7 @@ module.exports = {
     minify: false,
     sourcemap: false,
     plugins: [
-        stylePlugin(),
+        InlineCSSPlugin(),
         glsl({
             minify: true,
         }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "esbuild-plugin-browserify-adapter": "^0.1.4",
         "esbuild-plugin-environment": "^0.4.0",
         "esbuild-plugin-glsl": "^1.2.2",
-        "esbuild-style-plugin": "^1.6.3",
+        "esbuild-plugin-inline-css": "^0.0.1",
         "extra-iterable": "^2.5.22",
         "falafel": "^2.2.5",
         "fs-extra": "^10.1.0",
@@ -1476,12 +1476,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/less": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/less/-/less-3.0.6.tgz",
-      "integrity": "sha512-PecSzorDGdabF57OBeQO/xFbAkYWo88g4Xvnsx7LRwqLC17I7OoKtA3bQB9uXkY6UkMWCOsA8HSVpaoitscdXw==",
-      "dev": true
-    },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
@@ -1507,25 +1501,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA=="
-    },
-    "node_modules/@types/sass": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-      "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-      "deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "sass": "*"
-      }
-    },
-    "node_modules/@types/stylus": {
-      "version": "0.48.42",
-      "resolved": "https://registry.npmjs.org/@types/stylus/-/stylus-0.48.42.tgz",
-      "integrity": "sha512-CPGlr5teL4sqdap+EOowMifLuNGeIoLwc0VQ7u/BPxo+ocqiNa5jeVt0H0IVBblEh6ZwX1sGpIQIFnSSr8NBQA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
@@ -2945,10 +2920,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-hex": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/convert-hex/-/convert-hex-0.1.0.tgz",
+      "integrity": "sha512-w20BOb1PiR/sEJdS6wNrUjF5CSfscZFUp7R9NSlXH8h2wynzXVEPFPJECAnkNylZ+cvf3p7TyRUHggDmrwXT9A==",
+      "dev": true
+    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
+    },
+    "node_modules/convert-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/convert-string/-/convert-string-0.1.0.tgz",
+      "integrity": "sha512-1KX9ESmtl8xpT2LN2tFnKSbV4NiarbVi8DVb39ZriijvtTklyrT+4dT1wsGMHKD3CJUjXgvJzstm9qL9ICojGA==",
       "dev": true
     },
     "node_modules/cookie": {
@@ -4166,18 +4153,15 @@
         "esbuild": "0.x.x"
       }
     },
-    "node_modules/esbuild-style-plugin": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/esbuild-style-plugin/-/esbuild-style-plugin-1.6.3.tgz",
-      "integrity": "sha512-XPEKf4FjLjEVLv/dJH4UxDzXCrFHYpD93DBO8B+izdZARW5b7nNKQbnKv3J+7VDWJbgCU+hzfgIh2AuIZzlmXQ==",
+    "node_modules/esbuild-plugin-inline-css": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-inline-css/-/esbuild-plugin-inline-css-0.0.1.tgz",
+      "integrity": "sha512-CF2NPh3RbSdS6n3KgDmi67MhiBjjYJ+x+xi6Ha3ikMrO4owoS0Oj3+QQpIgwAOfTinLyNLbwhMOlht4QE/iqlQ==",
       "dev": true,
       "dependencies": {
-        "@types/less": "^3.0.3",
-        "@types/sass": "^1.43.1",
-        "@types/stylus": "^0.48.38",
-        "glob": "^10.2.2",
-        "postcss": "^8.4.31",
-        "postcss-modules": "^6.0.0"
+        "fs-extra": "^10.0.0",
+        "path": "^0.12.7",
+        "sha256": "^0.2.0"
       }
     },
     "node_modules/escalade": {
@@ -4785,24 +4769,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/generic-names": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-4.0.0.tgz",
-      "integrity": "sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^3.2.0"
-      }
-    },
-    "node_modules/generic-names/node_modules/loader-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
-      "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12.13.0"
       }
     },
     "node_modules/geojson-vt": {
@@ -6675,12 +6641,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7985,6 +7945,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dev": true,
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8040,6 +8010,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true
+    },
+    "node_modules/path/node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.3"
       }
     },
     "node_modules/pbf": {
@@ -8148,25 +8133,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-modules": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-6.0.0.tgz",
-      "integrity": "sha512-7DGfnlyi/ju82BRzTIjWS5C4Tafmzl3R79YP/PASiocj+aa6yYphHhhKUOEoXQToId5rgyFgJ88+ccOUydjBXQ==",
-      "dev": true,
-      "dependencies": {
-        "generic-names": "^4.0.0",
-        "icss-utils": "^5.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "string-hash": "^1.1.1"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -8383,6 +8349,15 @@
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
         "stream-parser": "~0.3.1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -9143,6 +9118,16 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
     },
+    "node_modules/sha256": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sha256/-/sha256-0.2.0.tgz",
+      "integrity": "sha512-kTWMJUaez5iiT9CcMv8jSq6kMhw3ST0uRdcIWl3D77s6AsLXNXRp3heeqqfu5+Dyfu4hwpQnMzhqHh8iNQxw0w==",
+      "dev": true,
+      "dependencies": {
+        "convert-hex": "~0.1.0",
+        "convert-string": "~0.1.0"
+      }
+    },
     "node_modules/shallow-copy": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
@@ -9550,12 +9535,6 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "node_modules/string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
-      "dev": true
     },
     "node_modules/string-split-by": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "esbuild-plugin-browserify-adapter": "^0.1.4",
     "esbuild-plugin-environment": "^0.4.0",
     "esbuild-plugin-glsl": "^1.2.2",
-    "esbuild-style-plugin": "^1.6.3",
+    "esbuild-plugin-inline-css": "^0.0.1",
     "extra-iterable": "^2.5.22",
     "falafel": "^2.2.5",
     "fs-extra": "^10.1.0",

--- a/tasks/util/bundle_wrapper.mjs
+++ b/tasks/util/bundle_wrapper.mjs
@@ -46,16 +46,6 @@ export default async function _bundle(pathToIndex, pathToBundle, opts, cb) {
 
     addWrapper(pathToBundle);
 
-    if(pathToBundle.endsWith('.js')) {
-        var len = pathToBundle.length;
-        var cssOutput = pathToBundle.slice(0, len - 3) + '.css';
-
-        // remove unwanted css file
-        if (fs.existsSync(cssOutput)) {
-            fs.unlinkSync(cssOutput);
-        }
-    }
-
     if(cb) cb();
 }
 


### PR DESCRIPTION
Closes https://github.com/plotly/plotly-studio/issues/1175

Map attributions were styled incorrectly for plots using MapLibre (`scattermap`, `densitymap`, `scattermap` traces).

This was because a MapLibre stylesheet was missing due to being incorrectly handled in the bundling process.

The bug was introduced by the migration to esbuild (https://github.com/plotly/plotly.js/pull/6909) and present as of Plotly.js 3.0.0.

This PR fixes that issue by using a different tool to inline the missing CSS directly into the JS bundle.

Before fix:
<img width="419" height="314" alt="Screenshot 2025-08-18 at 12 39 25 PM" src="https://github.com/user-attachments/assets/e81fb94c-d36c-4b8c-8a97-19f7f19ad4fb" />

After fix:
<img width="421" height="271" alt="Screenshot 2025-08-18 at 12 39 09 PM" src="https://github.com/user-attachments/assets/351c67fc-9f5f-4dc5-9f66-a26741cc9a0b" />



---

[This commit](https://github.com/plotly/plotly.js/commit/e57335bf94d36988bb9dc25fcfb2fed031436439) demonstrates the resulting difference in the `dist/plotly.js` file (not included in this PR since we only update `dist/` during the release process).

---

As an aside, this was not caught by the image tests because the `Plotly.toImage()` function for MapLibre plots calls `map.getCanvas()` which [does not include the attribution](https://github.com/maplibre/maplibre-gl-js/issues/337), so [Plotly.js manually adds the attribution to the generated image](https://github.com/plotly/plotly.js/blob/04441f95aae7a232fe98a2f72c064661605fc8fe/src/plots/map/index.js#L108). 