### PR TITLE
Update Biome to v2.2.0; migrate config file

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,140 +1,139 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
-	"organizeImports": { "enabled": true },
-	"files": {
-		"maxSize": 10000000,
-		"include": [
-			"src",
-			"lib",
-			"test",
-			"tasks",
-			"devtools"
-		],
-		"ignore": [
-			"test/plot-schema.json",
-			"dist",
-			"stackgl_modules",
-			"node_modules",
-			"build",
-			"tasks/test_amdefine.js",
-			"tasks/test_requirejs.js",
-			"test/jasmine/assets/jquery-1.8.3.min.js"
-		]
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": false,
-			"complexity": {
-				"noExtraBooleanCast": "error",
-				"noMultipleSpacesInRegularExpressionLiterals": "error",
-				"noUselessCatch": "error",
-				"noWith": "error",
-				"useLiteralKeys": "error"
-			},
-			"correctness": {
-				"noConstAssign": "error",
-				"noConstantCondition": "error",
-				"noEmptyCharacterClassInRegex": "error",
-				"noEmptyPattern": "error",
-				"noGlobalObjectCalls": "error",
-				"noInnerDeclarations": "off",
-				"noInvalidConstructorSuper": "error",
-				"noInvalidUseBeforeDeclaration": "error",
-				"noNewSymbol": "error",
-				"noNonoctalDecimalEscape": "error",
-				"noPrecisionLoss": "error",
-				"noSelfAssign": "error",
-				"noSetterReturn": "error",
-				"noSwitchDeclarations": "off",
-				"noUndeclaredVariables": "off",
-				"noUnreachable": "error",
-				"noUnreachableSuper": "error",
-				"noUnsafeFinally": "error",
-				"noUnsafeOptionalChaining": "error",
-				"noUnusedLabels": "error",
-				"noUnusedVariables": "off",
-				"useIsNan": "error",
-				"useValidForDirection": "error",
-				"useYield": "error"
-			},
-			"style": {
-				"useBlockStatements": "off",
-				"useSingleVarDeclarator": "off",
-				"noVar": "off"
-			},
-			"suspicious": {
-				"noAssignInExpressions": "off",
-				"noAsyncPromiseExecutor": "error",
-				"noCatchAssign": "error",
-				"noClassAssign": "error",
-				"noCompareNegZero": "error",
-				"noConsoleLog": "off",
-				"noControlCharactersInRegex": "error",
-				"noDebugger": "error",
-				"noDoubleEquals": "off",
-				"noDuplicateCase": "error",
-				"noDuplicateClassMembers": "error",
-				"noDuplicateObjectKeys": "error",
-				"noDuplicateParameters": "error",
-				"noEmptyBlockStatements": "off",
-				"noFallthroughSwitchClause": "off",
-				"noFunctionAssign": "error",
-				"noGlobalAssign": "error",
-				"noImportAssign": "error",
-				"noMisleadingCharacterClass": "error",
-				"noPrototypeBuiltins": "off",
-				"noRedeclare": "off",
-				"noShadowRestrictedNames": "off",
-				"noUnsafeNegation": "error",
-				"useGetterReturn": "error",
-				"useValidTypeof": "error"
-			}
-		},
-		"ignore": [
-			"**/stackgl_modules",
-			"**/node_modules",
-			"**/dist",
-			"**/build",
-			"tasks/test_amdefine.js",
-			"tasks/test_requirejs.js",
-			"test/jasmine/assets/jquery-1.8.3.min.js"
-		]
-	},
-	"javascript": {
-		"globals": [
-			"Promise",
-			"Float32Array",
-			"Uint8ClampedArray",
-			"Int32Array",
-			"ArrayBuffer",
-			"Uint16Array",
-			"DataView",
-			"Float64Array",
-			"Int16Array",
-			"Uint8Array",
-			"Int8Array",
-			"Uint32Array"
-		],
-		"formatter": {
-			"quoteStyle": "single",
-			"trailingCommas": "none",
-			"indentStyle": "space",
-			"indentWidth": 4,
-			"lineEnding": "lf",
-			"lineWidth": 120
-		}
-	},
-	"json": {
-		"linter": {
-			"enabled": true
-		},
-		"formatter": {
-			"enabled": true,
-			"indentStyle": "space",
-			"indentWidth": 1,
-			"lineEnding": "lf",
-			"lineWidth": 80
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "files": {
+    "maxSize": 10000000,
+    "includes": [
+      "**/src/**",
+      "**/lib/**",
+      "**/test/**",
+      "**/tasks/**",
+      "**/devtools/**",
+      "!**/test/plot-schema.json",
+      "!**/dist",
+      "!**/stackgl_modules",
+      "!**/node_modules",
+      "!**/build",
+      "!**/tasks/test_amdefine.js",
+      "!**/tasks/test_requirejs.js",
+      "!**/test/jasmine/assets/jquery-1.8.3.min.js"
+    ]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "complexity": {
+        "noExtraBooleanCast": "error",
+        "noUselessCatch": "error",
+        "useLiteralKeys": "error",
+        "noAdjacentSpacesInRegex": "error"
+      },
+      "correctness": {
+        "noConstAssign": "error",
+        "noConstantCondition": "error",
+        "noEmptyCharacterClassInRegex": "error",
+        "noEmptyPattern": "error",
+        "noGlobalObjectCalls": "error",
+        "noInnerDeclarations": "off",
+        "noInvalidConstructorSuper": "error",
+        "noInvalidUseBeforeDeclaration": "error",
+        "noNonoctalDecimalEscape": "error",
+        "noPrecisionLoss": "error",
+        "noSelfAssign": "error",
+        "noSetterReturn": "error",
+        "noSwitchDeclarations": "off",
+        "noUndeclaredVariables": "off",
+        "noUnreachable": "error",
+        "noUnreachableSuper": "error",
+        "noUnsafeFinally": "error",
+        "noUnsafeOptionalChaining": "error",
+        "noUnusedLabels": "error",
+        "noUnusedVariables": "off",
+        "useIsNan": "error",
+        "useValidForDirection": "error",
+        "useYield": "error",
+        "noInvalidBuiltinInstantiation": "error",
+        "useValidTypeof": "error"
+      },
+      "style": {
+        "useBlockStatements": "off",
+        "useSingleVarDeclarator": "off"
+      },
+      "suspicious": {
+        "noAssignInExpressions": "off",
+        "noAsyncPromiseExecutor": "error",
+        "noCatchAssign": "error",
+        "noClassAssign": "error",
+        "noCompareNegZero": "error",
+        "noControlCharactersInRegex": "error",
+        "noDebugger": "error",
+        "noDoubleEquals": "off",
+        "noDuplicateCase": "error",
+        "noDuplicateClassMembers": "error",
+        "noDuplicateObjectKeys": "error",
+        "noDuplicateParameters": "error",
+        "noEmptyBlockStatements": "off",
+        "noFallthroughSwitchClause": "off",
+        "noFunctionAssign": "error",
+        "noGlobalAssign": "error",
+        "noImportAssign": "error",
+        "noMisleadingCharacterClass": "error",
+        "noPrototypeBuiltins": "off",
+        "noRedeclare": "off",
+        "noShadowRestrictedNames": "off",
+        "noUnsafeNegation": "error",
+        "useGetterReturn": "error",
+        "noWith": "error",
+        "noVar": "off",
+        "noConsole": { "level": "off", "options": { "allow": ["log"] } }
+      }
+    },
+    "includes": [
+      "**",
+      "!**/stackgl_modules",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/build",
+      "!**/tasks/test_amdefine.js",
+      "!**/tasks/test_requirejs.js",
+      "!**/test/jasmine/assets/jquery-1.8.3.min.js"
+    ]
+  },
+  "javascript": {
+    "globals": [
+      "Promise",
+      "Float32Array",
+      "Uint8ClampedArray",
+      "Int32Array",
+      "ArrayBuffer",
+      "Uint16Array",
+      "DataView",
+      "Float64Array",
+      "Int16Array",
+      "Uint8Array",
+      "Int8Array",
+      "Uint32Array"
+    ],
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "none",
+      "indentStyle": "space",
+      "indentWidth": 4,
+      "lineEnding": "lf",
+      "lineWidth": 120
+    }
+  },
+  "json": {
+    "linter": {
+      "enabled": true
+    },
+    "formatter": {
+      "enabled": true,
+      "indentStyle": "space",
+      "indentWidth": 1,
+      "lineEnding": "lf",
+      "lineWidth": 80
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "world-calendars": "^1.0.4"
       },
       "devDependencies": {
-        "@biomejs/biome": "1.8.3",
+        "@biomejs/biome": "2.2.0",
         "@plotly/mathjax-v2": "npm:mathjax@2.7.5",
         "@plotly/mathjax-v3": "npm:mathjax@^3.2.2",
         "amdefine": "^1.0.1",
@@ -185,11 +185,10 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.8.3.tgz",
-      "integrity": "sha512-/uUV3MV+vyAczO+vKrPdOW0Iaet7UnJMU4bNMinggGJTAnBPjCoLEYcyYtYHNnUNYlv4xZMH6hVIQCAozq8d5w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.0.tgz",
+      "integrity": "sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
         "biome": "bin/biome"
@@ -202,20 +201,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.8.3",
-        "@biomejs/cli-darwin-x64": "1.8.3",
-        "@biomejs/cli-linux-arm64": "1.8.3",
-        "@biomejs/cli-linux-arm64-musl": "1.8.3",
-        "@biomejs/cli-linux-x64": "1.8.3",
-        "@biomejs/cli-linux-x64-musl": "1.8.3",
-        "@biomejs/cli-win32-arm64": "1.8.3",
-        "@biomejs/cli-win32-x64": "1.8.3"
+        "@biomejs/cli-darwin-arm64": "2.2.0",
+        "@biomejs/cli-darwin-x64": "2.2.0",
+        "@biomejs/cli-linux-arm64": "2.2.0",
+        "@biomejs/cli-linux-arm64-musl": "2.2.0",
+        "@biomejs/cli-linux-x64": "2.2.0",
+        "@biomejs/cli-linux-x64-musl": "2.2.0",
+        "@biomejs/cli-win32-arm64": "2.2.0",
+        "@biomejs/cli-win32-x64": "2.2.0"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.8.3.tgz",
-      "integrity": "sha512-9DYOjclFpKrH/m1Oz75SSExR8VKvNSSsLnVIqdnKexj6NwmiMlKk94Wa1kZEdv6MCOHGHgyyoV57Cw8WzL5n3A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==",
       "cpu": [
         "arm64"
       ],
@@ -230,9 +229,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.8.3.tgz",
-      "integrity": "sha512-UeW44L/AtbmOF7KXLCoM+9PSgPo0IDcyEUfIoOXYeANaNXXf9mLUwV1GeF2OWjyic5zj6CnAJ9uzk2LT3v/wAw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==",
       "cpu": [
         "x64"
       ],
@@ -247,9 +246,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.8.3.tgz",
-      "integrity": "sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==",
       "cpu": [
         "arm64"
       ],
@@ -264,9 +263,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.8.3.tgz",
-      "integrity": "sha512-9yjUfOFN7wrYsXt/T/gEWfvVxKlnh3yBpnScw98IF+oOeCYb5/b/+K7YNqKROV2i1DlMjg9g/EcN9wvj+NkMuQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.0.tgz",
+      "integrity": "sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==",
       "cpu": [
         "arm64"
       ],
@@ -281,9 +280,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.8.3.tgz",
-      "integrity": "sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==",
       "cpu": [
         "x64"
       ],
@@ -298,9 +297,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.8.3.tgz",
-      "integrity": "sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.0.tgz",
+      "integrity": "sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==",
       "cpu": [
         "x64"
       ],
@@ -315,9 +314,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.8.3.tgz",
-      "integrity": "sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.0.tgz",
+      "integrity": "sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==",
       "cpu": [
         "arm64"
       ],
@@ -332,9 +331,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.8.3.tgz",
-      "integrity": "sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "world-calendars": "^1.0.4"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.8.3",
+    "@biomejs/biome": "2.2.0",
     "@plotly/mathjax-v2": "npm:mathjax@2.7.5",
     "@plotly/mathjax-v3": "npm:mathjax@^3.2.2",
     "amdefine": "^1.0.1",

--- a/test/image/mocks/27.json
+++ b/test/image/mocks/27.json
@@ -303,8 +303,6 @@
    {
     "x": 1995.4584324515083,
     "y": 0.36681307285082176,
-    "xref": "x",
-    "yref": "y",
     "text": "Note: The Gini index is a commonly used measure of inequality.<br>0 is a perfectly equitable income distribution; 1 is perfectly inequitable.",
     "font": {
      "family": "",


### PR DESCRIPTION
### Description

Update Biome dependency to v2.2.0 and migrate the config file to be compatible with the new version.

### Changes

- Update Biome to v2.2.0 from v1.8.3
- Update Biome config
- Remove duplicated keys in JSON test mock

### Notes

- Users will need to run `npm i` after this merges to get the new Biome binary
- I'm going to start formatting on save. This will result in a number of changes to follow the rules in the Biome config. The philosophy of Biome formatting is to have a limited number of options so that you set it and forget it and don't argue about what set up is better. Let's use that same philosophy!
- FYI, `if(someBoolean)` will get switched to `if (someBoolean)` because there's no way to configure that space in between `if` and `(`
- It would be nice to add a linting/formatting check in CI in the future
- ~~The current rules are being mostly ignored because we don't enforce any check~~ This isn't true. There is a [linting check](https://github.com/plotly/plotly.js/blob/cam/update-biome/.circleci/config.yml#L404), but there's no formatting check.