### PR TITLE
fix: Calculate colorscale properly for histogram

### DIFF
--- a/src/traces/histogram/calc.js
+++ b/src/traces/histogram/calc.js
@@ -5,6 +5,9 @@ var isNumeric = require('fast-isnumeric');
 var Lib = require('../../lib');
 var Registry = require('../../registry');
 var Axes = require('../../plots/cartesian/axes');
+const { hasColorscale } = require('../../components/colorscale/helpers');
+const colorscaleCalc = require('../../components/colorscale/calc');
+
 
 var arraysToCalcdata = require('../bar/arrays_to_calcdata');
 var binFunctions = require('./bin_functions');
@@ -200,6 +203,22 @@ function calc(gd, trace) {
         // when we collapse to a single bin, calcdata no longer describes bin size
         // so we need to explicitly specify it
         cd[0].width1 = Axes.tickIncrement(cd[0].p, binSpec.size, false, calendar) - cd[0].p;
+    }
+
+    // auto-z and autocolorscale if applicable
+    if(hasColorscale(trace, 'marker')) {
+        colorscaleCalc(gd, trace, {
+            vals: trace.marker.color,
+            containerStr: 'marker',
+            cLetter: 'c'
+        });
+    }
+    if(hasColorscale(trace, 'marker.line')) {
+        colorscaleCalc(gd, trace, {
+            vals: trace.marker.line.color,
+            containerStr: 'marker.line',
+            cLetter: 'c'
+        });
     }
 
     arraysToCalcdata(cd, trace);


### PR DESCRIPTION
### Description

Calculate the colorscale properties for the histrogram trace when they are undefined.

### Testing

- Be on master
- Add a log statement for the domain [here](https://github.com/plotly/plotly.js/blob/cam/7523/switch-color-library/src/components/colorscale/helpers.js#L133): `console.log({ domain })`
- Run [this](https://github.com/plotly/plotly.js/blob/cam/7523/switch-color-library/test/jasmine/tests/colorbar_test.js#L263) test: `npm run test-jasmine colorbar`
- Note that the log statement shows a domain of `NaN` values
  `LOG: Object{domain: [NaN, NaN, NaN, NaN, NaN, NaN]}`
- Switch to this branch and log/test the same way
- Note that the log statement shows a domain of numeric values:
  `LOG: Object{domain: [1, 2, 3, 6]}`

### Notes

- I'm skipping adding a test because issues should surface after the color processing has been updated in #7523