### PR TITLE
fix: tidying up some Markdown documentation

### DIFF
--- a/src/plots/map/layout_attributes.js
+++ b/src/plots/map/layout_attributes.js
@@ -168,7 +168,7 @@ var attrs = module.exports = overrideAll({
                 'GeoJSON geometries.',
                 'With `sourcetype` set to *vector*, the following values are allowed:',
                 ' *circle*, *line*, *fill* and *symbol*.',
-                'With `sourcetype` set to *raster* or `*image*`, only the *raster* value is allowed.'
+                'With `sourcetype` set to *raster* or *image*, only the *raster* value is allowed.'
             ].join(' ')
         },
 

--- a/src/plots/mapbox/layout_attributes.js
+++ b/src/plots/mapbox/layout_attributes.js
@@ -189,7 +189,7 @@ var attrs = module.exports = overrideAll({
                 'GeoJSON geometries.',
                 'With `sourcetype` set to *vector*, the following values are allowed:',
                 ' *circle*, *line*, *fill* and *symbol*.',
-                'With `sourcetype` set to *raster* or `*image*`, only the *raster* value is allowed.'
+                'With `sourcetype` set to *raster* or *image*, only the *raster* value is allowed.'
             ].join(' ')
         },
 

--- a/src/traces/parcats/attributes.js
+++ b/src/traces/parcats/attributes.js
@@ -65,8 +65,8 @@ module.exports = {
         ],
         description: [
             'This value here applies when hovering over dimensions.',
-            'Note that `*categorycount`, *colorcount* and *bandcolorcount*',
-            'are only available when `hoveron` contains the *color* flag'
+            'Note that *categorycount*, *colorcount* and *bandcolorcount*',
+            'are only available when `hoveron` contains the *color* flag. '
         ].join(' ')
     }),
 


### PR DESCRIPTION
Removing some stray back-ticks that were causing documentation formatting glitches downstream.