### PR TITLE
fix: escaping angle bracket in documentation

### DIFF
--- a/src/traces/image/attributes.js
+++ b/src/traces/image/attributes.js
@@ -21,7 +21,7 @@ module.exports = extendFlat({
         editType: 'calc',
         description: [
             'Specifies the data URI of the image to be visualized.',
-            'The URI consists of "data:image/[<media subtype>][;base64],<data>"'
+            'The URI consists of "data:image/[<media subtype\\\\>][;base64\\\\],<data\\\\>"'
         ].join(' ')
     },
     z: {

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -47932,7 +47932,7 @@
      "valType": "number"
     },
     "source": {
-     "description": "Specifies the data URI of the image to be visualized. The URI consists of \"data:image/[<media subtype>][;base64],<data>\"",
+     "description": "Specifies the data URI of the image to be visualized. The URI consists of \"data:image/[<media subtype\\\\>][;base64\\\\],<data\\\\>\"",
      "editType": "calc",
      "valType": "string"
     },


### PR DESCRIPTION
The unescaped `<` was causing problems downstream in the Python docs. It may now cause problems in the JS docs, but we need this fix urgently for the Python, so we'll tidy up the JS docs later.