### PR TITLE
ci: Enable auto rerun for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,6 +518,7 @@ jobs:
 workflows:
   version: 2
   build-and-test:
+    max_auto_reruns: 1
     jobs:
       - install-and-cibuild
       - timezone-jasmine:


### PR DESCRIPTION
### Description

Enable auto rerun for CircleCI build-and-test workflow.

### Notes

- This change will cause CircleCI test runs to rerun for failed jobs automatically 1 time
- You can see that it worked for the initial commit on this branch [here](https://app.circleci.com/pipelines/github/plotly/plotly.js?branch=cam%2Fenable-circleci-auto-rerun)
- This should catch most flaky test runs. I'm reluctant to bump the number of any more because that could result in a lot of wasted runs.
- Documentation about this feature is available [here](https://circleci.com/docs/guides/orchestrate/automatic-reruns/)