### PR TITLE
Fix subtitle does not properly clear/remove from the chart

### DIFF
--- a/src/components/titles/index.js
+++ b/src/components/titles/index.js
@@ -81,7 +81,7 @@ function draw(gd, titleClass, options) {
     var subtitleEnabled = !!subtitleProp;
     var subtitlePlaceholder = options.subtitlePlaceholder;
     var subtitle = (cont.title || {}).subtitle || {text: '', font: {}};
-    var subtitleTxt = subtitle.text.trim();
+    var subtitleTxt = (subtitle.text || '').trim();
     var subtitleIsPlaceholder = false;
     var subtitleOpacity = 1;
 
@@ -160,7 +160,7 @@ function draw(gd, titleClass, options) {
     var subtitleClass = titleClass + '-subtitle';
     var subtitleElShouldExist = subtitleTxt || editable;
 
-    if(subtitleEnabled && subtitleElShouldExist) {
+    if(subtitleEnabled) {
         subtitleEl = group.selectAll('text.' + subtitleClass)
             .data(subtitleElShouldExist ? [0] : []);
         subtitleEl.enter().append('text');
@@ -231,7 +231,7 @@ function draw(gd, titleClass, options) {
         .attr(attributes)
             .call(svgTextUtils.convertToTspans, gd, adjustSubtitlePosition);
 
-        if(subtitleEl) {
+        if(subtitleEl && !subtitleEl.empty()) {
             // Set subtitle y position based on bottom of title
             // We need to check the Mathjax group as well, in case the Mathjax
             // has already rendered
@@ -405,7 +405,7 @@ function draw(gd, titleClass, options) {
     }
 
     el.classed('js-placeholder', titleIsPlaceholder);
-    if(subtitleEl) subtitleEl.classed('js-placeholder', subtitleIsPlaceholder);
+    if(subtitleEl && !subtitleEl.empty()) subtitleEl.classed('js-placeholder', subtitleIsPlaceholder);
 
     return group;
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where `layout.title.subtitle` does not properly clear/remove from the chart when `subtitle` object is not in place, or `subtitle.text` set to `null`, empty string, or whitespace-only values via `Plotly.relayout()`.

## Problem

When users attempted to clear a subtitle using any of these methods:
```javascript
Plotly.relayout(gd, {'title.subtitle.text': null});
Plotly.relayout(gd, {'title.subtitle.text': ''});
Plotly.relayout(gd, {'title.subtitle.text': '   '});
Plotly.relayout(gd, {'title.subtitle': undefined});
```

The subtitle would remain visible on the chart. The only workaround was to set it to transparent:
```javascript
Plotly.relayout(gd, {
    'title.subtitle.text': 'no text',
    'title.subtitle.font.color': 'transparent'
});
```

## Root Cause

In `src/components/titles/index.js` - **Line 163**: The condition `if(subtitleEnabled && subtitleElShouldExist)` prevented D3's `.exit().remove()` from running when the subtitle needed to be cleared.

### Additional changes

- **Line 84**: Handle null/undefined `subtitle.text`
- **Lines 244 & 408**: Add checks for empty D3 selections to prevent operations on selections with 0 elements

## Notes

This follows the same D3 enter/exit pattern already used for the main title element (lines 147-157 in the same file).
