### PR TITLE
chore: Update tar-fs, tmp subdependencies to address vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9747,9 +9747,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10041,15 +10041,13 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-fast-properties": {


### PR DESCRIPTION
### Description

Update tar-fs, tmp subdependencies to address vulnerabilities surfaced by `npm audit`.

### Changes

- Update tar-fs to v2.1.4
- Update tmp to v0.2.5


### Testing

CI passing should be a good enough check.

### Notes

The audit report showed the following. The MathJax vulnerability is a known issue that we've chosen to not to address for now.

```sh
# npm audit report

mathjax  <=2.7.9
Severity: high
MathJax Regular expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-v638-q856-grg8
fix available via `npm audit fix --force`
Will install mathjax@4.0.0, which is a breaking change
node_modules/@plotly/mathjax-v2

tar-fs  2.0.0 - 2.1.3
Severity: high
tar-fs has a symlink validation bypass if destination directory is predictable with a specific tarball - https://github.com/advisories/GHSA-vj76-c3g6-qr5v
fix available via `npm audit fix`
node_modules/tar-fs

tmp  <=0.2.3
tmp allows arbitrary temporary file / directory write via symbolic link `dir` parameter - https://github.com/advisories/GHSA-52f5-9888-hmc6
fix available via `npm audit fix`
node_modules/tmp

3 vulnerabilities (1 low, 2 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```