### PR TITLE
fix: Log error message if malformed JSON file found

### DIFF
--- a/devtools/dashboard_utilities.mjs
+++ b/devtools/dashboard_utilities.mjs
@@ -55,8 +55,12 @@ export function createMocksList(files) {
                 file: filename,
                 keywords: types.join(', ')
             };
-        } catch {
-            console.log(`Couldn't parse ${file.name} as JSON. Excluding from mocks list.`);
+        } catch (error) {
+            if (error instanceof SyntaxError) {
+                console.log(`Couldn't parse ${file.name} as JSON. Excluding from mocks list.`);
+            } else {
+                throw error;
+            }
         }
     });
 


### PR DESCRIPTION
### Description

Add logic to catch errors when mocks are loaded in plotly.js DevTools and log a message.

Closes #7637.

### Changes

- Add error handling logic


### Testing

- Be on master
- Add an empty JSON file to the mocks folder:
  ```sh
  touch test/image/mocks/empty_file.json
  ```
- Run `npm start`
- Note that the process crashes
- Switch to this branch
- Run `npm start`
- Note that the process doesn't crash and an error message is logged