### PR TITLE
fix: Omit ISO country codes list when copying topojson to dist folder

### DIFF
--- a/tasks/preprocess.js
+++ b/tasks/preprocess.js
@@ -76,5 +76,14 @@ function writeLibFiles(obj) {
 }
 
 function copyTopojsonFiles() {
-    fs.copy(constants.pathToTopojsonSrc, constants.pathToTopojsonDist, { clobber: true }, common.throwOnError);
+    const FILES_TO_EXCLUDE = ['country_names_iso_codes.json'];
+    fs.copy(
+        constants.pathToTopojsonSrc,
+        constants.pathToTopojsonDist,
+        {
+            clobber: true,
+            filter: (filePath) => !FILES_TO_EXCLUDE.includes(path.basename(filePath))
+        },
+        common.throwOnError
+    );
 }


### PR DESCRIPTION
### Description

Omit the ISO country codes list when copying the topojson during build preprocessing.

Closes #7636.

### Changes

- Linting/formatting
- Update preprocess build step

### Testing

- Be on master
- Run `npm run preprocess`
- Note that the list has been copied into the dist folder
- Discard changes
- Switch to this branch
- Run `npm run preprocess`
- Note that the list has NOT been copied into the dist folder