### PR TITLE
Add Plotly.profile() API for performance profiling

### DIFF
--- a/draftlogs/7657_add.md
+++ b/draftlogs/7657_add.md
@@ -1,0 +1,1 @@
+ - Add `Plotly.profile()` API method for performance profiling [[#7657](https://github.com/plotly/plotly.js/pull/7657)]

--- a/draftlogs/XXXX_add.md
+++ b/draftlogs/XXXX_add.md
@@ -1,0 +1,1 @@
+ - Add `Plotly.profile()` API method for performance profiling [[#XXXX](https://github.com/plotly/plotly.js/pull/XXXX)]

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1413,3 +1413,5 @@ lib.getPositionFromD3Event = function () {
         return [d3.event.offsetX, d3.event.offsetY];
     }
 };
+
+lib.Profiler = require('./profiler');

--- a/src/lib/profiler.js
+++ b/src/lib/profiler.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * Profiler utility for collecting render timing data
+ *
+ * Usage:
+ *   var profiler = Profiler.start(gd);
+ *   // ... do work ...
+ *   profiler.mark('phaseName');
+ *   // ... do more work ...
+ *   profiler.end();
+ */
+
+exports.isEnabled = function(gd) {
+    return gd && gd._profileEnabled === true;
+};
+
+exports.start = function(gd) {
+    if(!exports.isEnabled(gd)) {
+        return {
+            mark: function() {},
+            end: function() {}
+        };
+    }
+
+    var startTime = performance.now();
+    var lastMark = startTime;
+    var phases = {};
+
+    return {
+        mark: function(phaseName) {
+            var now = performance.now();
+            phases[phaseName] = {
+                duration: now - lastMark,
+                timestamp: now - startTime
+            };
+            lastMark = now;
+        },
+        end: function() {
+            var endTime = performance.now();
+            return {
+                total: endTime - startTime,
+                phases: phases,
+                timestamp: new Date().toISOString()
+            };
+        }
+    };
+};

--- a/src/plot_api/index.js
+++ b/src/plot_api/index.js
@@ -37,3 +37,5 @@ exports.downloadImage = require('../snapshot/download');
 var templateApi = require('./template_api');
 exports.makeTemplate = templateApi.makeTemplate;
 exports.validateTemplate = templateApi.validateTemplate;
+
+exports.profile = require('./profile');

--- a/src/plot_api/profile.js
+++ b/src/plot_api/profile.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var Lib = require('../lib');
+
+/**
+ * Enable or disable performance profiling on a graph div
+ *
+ * @param {string|HTMLDivElement} gd - Graph div or its id
+ * @param {boolean} [enable=true] - Whether to enable profiling
+ * @returns {Object|null} - Current profile data if available, null otherwise
+ *
+ * Usage:
+ *   Plotly.profile('myDiv');           // Enable profiling
+ *   Plotly.profile('myDiv', true);     // Enable profiling
+ *   Plotly.profile('myDiv', false);    // Disable profiling
+ *
+ * After each render, profile data is available via:
+ *   gd._profileData           // Latest profile result
+ *   gd.on('plotly_profiled', function(data) { ... });  // Event listener
+ */
+function profile(gd, enable) {
+    gd = Lib.getGraphDiv(gd);
+
+    if(!Lib.isPlotDiv(gd)) {
+        Lib.warn('profile() called on non-plot element');
+        return null;
+    }
+
+    // Default to enabling
+    if(enable === undefined) enable = true;
+
+    gd._profileEnabled = !!enable;
+
+    if(!enable) {
+        // Clear profile data when disabling
+        delete gd._profileData;
+    }
+
+    return gd._profileData || null;
+}
+
+module.exports = profile;

--- a/test/jasmine/tests/profile_test.js
+++ b/test/jasmine/tests/profile_test.js
@@ -1,0 +1,222 @@
+'use strict';
+
+var Plotly = require('../../../lib/index');
+var Lib = require('../../../src/lib');
+var createGraphDiv = require('../assets/create_graph_div');
+var destroyGraphDiv = require('../assets/destroy_graph_div');
+
+describe('Plotly.profile', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    describe('API', function() {
+        it('should be a function', function() {
+            expect(typeof Plotly.profile).toBe('function');
+        });
+
+        it('should enable profiling when called with true or no argument', function(done) {
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd);
+                    expect(gd._profileEnabled).toBe(true);
+
+                    Plotly.profile(gd, false);
+                    expect(gd._profileEnabled).toBe(false);
+
+                    Plotly.profile(gd, true);
+                    expect(gd._profileEnabled).toBe(true);
+                })
+                .then(done, done.fail);
+        });
+
+        it('should warn when called on non-plot element', function() {
+            spyOn(Lib, 'warn');
+            var div = document.createElement('div');
+            Plotly.profile(div);
+            expect(Lib.warn).toHaveBeenCalled();
+        });
+
+        it('should return null for non-plot element', function() {
+            var div = document.createElement('div');
+            var result = Plotly.profile(div);
+            expect(result).toBeNull();
+        });
+
+        it('should clear profile data when disabling', function(done) {
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    expect(gd._profileData).toBeDefined();
+                    Plotly.profile(gd, false);
+                    expect(gd._profileData).toBeUndefined();
+                })
+                .then(done, done.fail);
+        });
+    });
+
+    describe('profiling data collection', function() {
+        it('should collect timing data after render when enabled', function(done) {
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    expect(gd._profileData).toBeDefined();
+                    expect(gd._profileData.total).toBeGreaterThan(0);
+                    expect(gd._profileData.phases).toBeDefined();
+                    expect(gd._profileData.timestamp).toBeDefined();
+                })
+                .then(done, done.fail);
+        });
+
+        it('should not collect timing data when disabled', function(done) {
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, false);
+                    delete gd._profileData; // Clear any existing data
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    expect(gd._profileData).toBeUndefined();
+                })
+                .then(done, done.fail);
+        });
+
+        it('should emit plotly_profiled event', function(done) {
+            var eventData = null;
+
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    gd.on('plotly_profiled', function(data) {
+                        eventData = data;
+                    });
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    expect(eventData).not.toBeNull();
+                    expect(eventData.total).toBeGreaterThan(0);
+                    expect(eventData.phases).toBeDefined();
+                })
+                .then(done, done.fail);
+        });
+
+        it('should update profile data on each render', function(done) {
+            var firstProfileData;
+
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    firstProfileData = gd._profileData;
+                    expect(firstProfileData).toBeDefined();
+                    return Plotly.react(gd, [{y: [7, 8, 9]}]);
+                })
+                .then(function() {
+                    expect(gd._profileData).toBeDefined();
+                    // Timestamps should be different
+                    expect(gd._profileData.timestamp).not.toBe(firstProfileData.timestamp);
+                })
+                .then(done, done.fail);
+        });
+    });
+
+    describe('phase timing', function() {
+        it('should include expected phases', function(done) {
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    var phases = gd._profileData.phases;
+                    expect(phases.supplyDefaults).toBeDefined();
+                    expect(phases.doCalcdata).toBeDefined();
+                })
+                .then(done, done.fail);
+        });
+
+        it('should have duration and timestamp for each phase', function(done) {
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    var phases = gd._profileData.phases;
+                    var phaseNames = Object.keys(phases);
+
+                    expect(phaseNames.length).toBeGreaterThan(0);
+
+                    phaseNames.forEach(function(name) {
+                        var phase = phases[name];
+                        expect(typeof phase.duration).toBe('number');
+                        expect(phase.duration).toBeGreaterThanOrEqual(0);
+                        expect(typeof phase.timestamp).toBe('number');
+                        expect(phase.timestamp).toBeGreaterThanOrEqual(0);
+                    });
+                })
+                .then(done, done.fail);
+        });
+
+        it('should include async phases after full render', function(done) {
+            Plotly.newPlot(gd, [{y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [{y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    var phases = gd._profileData.phases;
+                    // These are the async phases added in Phase 4
+                    expect(phases.drawFramework).toBeDefined();
+                    expect(phases.drawData).toBeDefined();
+                })
+                .then(done, done.fail);
+        });
+    });
+
+    describe('different trace types', function() {
+        it('should work with bar traces', function(done) {
+            Plotly.newPlot(gd, [{type: 'bar', y: [1, 2, 3]}])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [{type: 'bar', y: [4, 5, 6]}]);
+                })
+                .then(function() {
+                    expect(gd._profileData).toBeDefined();
+                    expect(gd._profileData.total).toBeGreaterThan(0);
+                })
+                .then(done, done.fail);
+        });
+
+        it('should work with multiple traces', function(done) {
+            Plotly.newPlot(gd, [
+                {y: [1, 2, 3]},
+                {y: [3, 2, 1]}
+            ])
+                .then(function() {
+                    Plotly.profile(gd, true);
+                    return Plotly.react(gd, [
+                        {y: [4, 5, 6]},
+                        {y: [6, 5, 4]}
+                    ]);
+                })
+                .then(function() {
+                    expect(gd._profileData).toBeDefined();
+                    expect(gd._profileData.total).toBeGreaterThan(0);
+                })
+                .then(done, done.fail);
+        });
+    });
+});


### PR DESCRIPTION
## Overview

This PR adds a new `Plotly.profile()` API method that enables users to diagnose 
rendering performance of their Plotly charts by collecting timing data for each 
phase of the rendering pipeline.

## Motivation

Users often ask "why is my chart slow?" but currently have no built-in way to 
diagnose where time is being spent. This profiler provides visibility into the 
rendering lifecycle, helping users understand whether bottlenecks are in data 
processing (`doCalcdata`), DOM manipulation (`drawFramework`), or actual drawing 
(`drawData`).

**Future direction**: This MVP focuses on timing collection. Down the line, this 
could potentially be extended to:
- Provide optimization suggestions based on profile data (e.g., "consider using 
  scattergl for datasets > 10k points")
- Recommend optimal data structures for different trace types
- Help users choose appropriate partial bundles based on their usage

I wanted to get community feedback on the core API before expanding scope.

## What this PR does

- Adds `Plotly.profile(gd, [enable])` to enable/disable profiling on a graph div
- Collects timing for rendering phases: supplyDefaults, doCalcdata, drawFramework, 
  drawData, etc.
- Stores results in `gd._profileData` after each render
- Emits `plotly_profiled` event for reactive integrations
- Zero overhead when profiling is disabled

## Usage

```javascript
// Enable profiling
Plotly.profile(gd);

// Render or update a chart
Plotly.react(gd, [{y: [1, 2, 3]}]);

// Inspect timing breakdown
console.log(gd._profileData);
// { total: 45.2, phases: { supplyDefaults: {...}, doCalcdata: {...}, ... } }

// Listen for profiling events
gd.on('plotly_profiled', data => console.log('Render took', data.total, 'ms'));

// Disable profiling
Plotly.profile(gd, false);
```

## Files changed


- src/lib/profiler.js (NEW) - Core timing utility
- src/plot_api/profile.js (NEW) - Public API method
- src/lib/index.js - Export profiler module
- src/plot_api/index.js - Export profile method
- src/plot_api/plot_api.js - Add timing hooks to rendering pipeline
- test/jasmine/tests/profile_test.js (NEW) - Unit tests

## Checklist


- Working on dev branch, not master
- Merged with latest upstream/master
- Did NOT modify dist/ folder
- `npm run lint` passes
- Tests pass (`npm run test-jasmine -- profile`)


Note: This is my first contribution to plotly.js (working on two PRs for this
project). I've done my best to follow the contribution guidelines and existing
code patterns, but I'm very open to feedback on the API design, implementation
approach, or anything else. Thank you for taking the time to review!
