### PR TITLE
fix: preserve z-indexed subplots during `relayout` for correct pan/zoom

### DIFF
--- a/draftlogs/7659_fix.md
+++ b/draftlogs/7659_fix.md
@@ -1,0 +1,1 @@
+ - Fix pan/zoom failing on first interaction when traces have different `zorder` values [[#7659](https://github.com/plotly/plotly.js/pull/7659)]

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -872,8 +872,17 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
     function updateSubplots(viewBox) {
         var fullLayout = gd._fullLayout;
         var plotinfos = fullLayout._plots;
-        var subplots = fullLayout._subplots.cartesian;
+        var subplots = fullLayout._subplots.cartesian.slice();
         var i, sp, xa, ya;
+
+        // Include z-indexed subplots from _plots that may not be in _subplots.cartesian
+        // (e.g., after a relayout that resets _subplots.cartesian but preserves _plots)
+        var zindexSeparator = constants.zindexSeparator;
+        for(var plotId in plotinfos) {
+            if(plotId.indexOf(zindexSeparator) !== -1 && subplots.indexOf(plotId) === -1) {
+                subplots.push(plotId);
+            }
+        }
 
         if(hasSplom) {
             Registry.subplotsRegistry.splom.drag(gd);

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -14,6 +14,7 @@ var Color = require('../components/color');
 var BADNUM = require('../constants/numerical').BADNUM;
 
 var axisIDs = require('./cartesian/axis_ids');
+var cartesianConstants = require('./cartesian/constants');
 var clearOutline = require('../components/shapes/handle_outline').clearOutline;
 var scatterAttrs = require('../traces/scatter/layout_attributes');
 
@@ -892,6 +893,19 @@ plots.linkSubplots = function(newFullData, newFullLayout, oldFullData, oldFullLa
                 plotinfo._hasClipOnAxisFalse = true;
                 break;
             }
+        }
+    }
+
+    // Preserve z-indexed subplots (e.g. 'xyz2', 'xyz3') from oldSubplots to _plots only.
+    // These are created by drawFramework when traces have different zorder values.
+    // We preserve them to _plots (not _subplots.cartesian) so that drag/pan operations
+    // in dragbox.js can still transform them during relayout operations that don't
+    // trigger a full redraw (e.g., resize). If drawFramework runs later, it will
+    // properly update/remove these subplots as needed.
+    var zindexSeparator = cartesianConstants.zindexSeparator;
+    for(var oldId in oldSubplots) {
+        if(oldId.indexOf(zindexSeparator) !== -1 && !newSubplots[oldId]) {
+            newSubplots[oldId] = oldSubplots[oldId];
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where pan/zoom fails on the **first** interaction when traces have different `zorder` values. On first drag, **one trace moves with the grid while the other stays frozen** in place. The **second** pan (and all subsequent pans) work correctly — both traces move together as expected. This is particularly noticeable in react-plotly.js, which calls `Plotly.Plots.resize()` after mount.

**Root cause:** When `relayout` is called (e.g., during resize), `supplyDefaults` resets `_plots` via `linkSubplots`, losing z-indexed subplots (e.g., `xyz2`, `xyz3`). Since `relayout` doesn't trigger `drawFramework`, they aren't recreated, causing `updateSubplots` in `dragbox.js` to miss them during pan/zoom.

**Fix:**
- In `linkSubplots` (`plots.js`): preserve z-indexed subplots from `oldSubplots`
- In `updateSubplots` (`dragbox.js`): include z-indexed subplots from `_plots`

## Demo

https://github.com/user-attachments/assets/f7f523f9-709b-4351-b79e-6a74894766ce

**Live before/after comparison:** https://runsascoded.github.io/plotly.js/

To reproduce the bug:
1. Open the [Before Fix](https://runsascoded.github.io/plotly.js/before/) demo
2. Drag the chart to pan horizontally
3. **First drag:** one trace (blue) moves with the grid, but the other trace (red) stays frozen
4. Release and drag again
5. **Second drag:** both traces move correctly together
6. Compare with [After Fix](https://runsascoded.github.io/plotly.js/after/) — first drag works correctly

## Test plan

- [x] Existing `cartesian_interact` tests pass
- [x] Manual testing with react-plotly.js confirms fix
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[plotly/plotly.js#7659]: https://github.com/plotly/plotly.js/pull/7659

<!-- Synced with https://gist.github.com/e9f78b2d6c7426120081a17b77993c56/b953417d2dcd197bea7523d3584928d0f6a3c24b via [ghpr](https://github.com/runsascoded/ghpr) -->