### PR TITLE
Add eventData handler to heatmap for proper click event data

### DIFF
--- a/draftlogs/7686_fix.md
+++ b/draftlogs/7686_fix.md
@@ -1,0 +1,2 @@
+ - Fix `heatmap` click events to include proper `x`, `y`, and `z` values in event data [[#7686](https://github.com/plotly/plotly.js/pull/7686)]
+ - Fix `heatmap` category axis labels returning numeric values instead of category labels [[#7686](https://github.com/plotly/plotly.js/pull/7686)]

--- a/src/traces/heatmap/event_data.js
+++ b/src/traces/heatmap/event_data.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function eventData(out, pt) {
+    // Standard cartesian event data
+    if('xLabelVal' in pt) out.x = pt.xLabelVal;
+    if('yLabelVal' in pt) out.y = pt.yLabelVal;
+    if(pt.xa) out.xaxis = pt.xa;
+    if(pt.ya) out.yaxis = pt.ya;
+    if(pt.zLabelVal !== undefined) out.z = pt.zLabelVal;
+    return out;
+};

--- a/src/traces/heatmap/hover.js
+++ b/src/traces/heatmap/hover.js
@@ -82,8 +82,8 @@ module.exports = function hoverPoints(pointData, xval, yval, hovermode, opts) {
         xl = xc ? _x[nx] : ((_x[nx] + _x[nx + 1]) / 2);
         yl = yc ? _y[ny] : ((_y[ny] + _y[ny + 1]) / 2);
 
-        if(xa && xa.type === 'category') xl = x[nx];
-        if(ya && ya.type === 'category') yl = y[ny];
+        if(xa && xa.type === 'category') xl = xa._categories[nx];
+        if(ya && ya.type === 'category') yl = ya._categories[ny];
 
         if(trace.zsmooth) {
             x0 = x1 = xa.c2p(xl);

--- a/src/traces/heatmap/index.js
+++ b/src/traces/heatmap/index.js
@@ -8,6 +8,7 @@ module.exports = {
     colorbar: require('./colorbar'),
     style: require('./style'),
     hoverPoints: require('./hover'),
+    eventData: require('./event_data'),
 
     moduleType: 'trace',
     name: 'heatmap',


### PR DESCRIPTION
Fixes #7685

This PR adds an `eventData` handler to the heatmap trace module, enabling proper `plotly_click` event data with `x`, `y`, and `z` values.

Also fixes a bug in `hover.js` where category axis labels were incorrectly returning numeric boundary values instead of the actual category labels.

**Changes:**
- `src/traces/heatmap/index.js` - Register the eventData handler
- `src/traces/heatmap/event_data.js` - New file implementing the event data extraction
- `src/traces/heatmap/hover.js` - Fix category axis label lookup to use `xa._categories[nx]


