### PR TITLE
Prevent NaN lonShift from crashing hover

### DIFF
--- a/src/traces/scattermap/hover.js
+++ b/src/traces/scattermap/hover.js
@@ -26,6 +26,8 @@ function hoverPoints(pointData, xval, yval) {
     var winding = (xval >= 0) ?
         Math.floor((xval + 180) / 360) :
         Math.ceil((xval - 180) / 360);
+    // if xval is undefined, so will be winding
+    if(isNaN(winding)) winding = 0;
 
     // shift longitude to [-180, 180] to determine closest point
     var lonShift = winding * 360;


### PR DESCRIPTION
Prevent `NaN` `lonShift` from crashing hover on maps when `xval` is undefined.
Fixes #7702. 
I created this since I saw PR #7709 was abandoned/deleted by its author.
