### PR TITLE
Update and organize .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,18 +1,16 @@
+# Exclude all hidden files and folders
+.*
+
+# Exclude all files in build/, except for plotcss.js and README.md
 build/*
 !build/plotcss.js
 !build/README.md
 
-stackgl_modules/node_modules
-
+# Exclude these directories
 devtools
-test
-draftlogs
 dist/extras
-
-circle.yml
-bower.json
-
-.ackrc
-.agignore
-
-npm-debug.log
+draftlogs
+stackgl_modules/node_modules
+tasks
+test
+topojson


### PR DESCRIPTION
Closes #7593 

- Ignore all hidden files and folders (starting with `.`)
- Ignore `build/`, `tasks/`, and `topojson/` dirs
- Remove `circle.yml` and `bower.json` as I don't think they're relevant anymore
- Remove `npm-debug.log` since [according to the docs](https://docs.npmjs.com/generating-and-locating-npm-debug.log-files) that file will be created inside `.npm` which is already ignored
- Reorganize for clarity

Before:
```
npm notice package size: 29.4 MB
npm notice unpacked size: 117.6 MB
```

After:
```
npm notice package size: 21.1 MB
npm notice unpacked size: 98.0 MB
```