### PR TITLE
Fix typos in source comments and treemap attribute description

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -499,7 +499,7 @@ function setPlotContext(gd, config) {
         context.setBackground = setBackground;
     }
 
-    // Check if gd has a specified widht/height to begin with
+    // Check if gd has a specified width/height to begin with
     context._hasZeroHeight = context._hasZeroHeight || gd.clientHeight === 0;
     context._hasZeroWidth = context._hasZeroWidth || gd.clientWidth === 0;
 

--- a/src/plots/cartesian/layout_defaults.js
+++ b/src/plots/cartesian/layout_defaults.js
@@ -267,7 +267,7 @@ module.exports = function supplyLayoutDefaults(layoutIn, layoutOut, fullData) {
             delete axLayoutOut.spikesnap;
         }
 
-        // If it exists, the the domain of the axis for the anchor of the overlaying axis
+        // If it exists, the domain of the axis for the anchor of the overlaying axis
         var overlayingAxis = id2name(axLayoutIn.overlaying);
         var overlayingAnchorDomain = [0, 1];
 

--- a/src/traces/treemap/attributes.js
+++ b/src/traces/treemap/attributes.js
@@ -155,7 +155,7 @@ module.exports = {
             values: ['top', 'bottom'],
             dflt: 'top',
             editType: 'plot',
-            description: ['Determines on which side of the the treemap the', '`pathbar` should be presented.'].join(' ')
+            description: ['Determines on which side of the treemap the', '`pathbar` should be presented.'].join(' ')
         },
 
         edgeshape: {


### PR DESCRIPTION

**Repo:** plotly/plotly.js (⭐ 17000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Corrects three small typos in the `src/` tree: a duplicated "the the" in a treemap `pathbar.side` attribute description (which is user-visible — it ships in the auto-generated plot schema/docs), a duplicated "the the" in a comment in `layout_defaults.js`, and "widht" → "width" in a comment in `plot_api.js`.

## Why
The treemap `pathbar.side` description is exposed to end users via the plot schema and the online attribute reference, so the duplicated word appears in published documentation. The other two are internal comments but were caught while scanning for the same typo class. All changes are comment/string-only and have no runtime impact.

## Testing
No behavioral change. The treemap attribute description is a plain string consumed by the schema generator; no tests assert on its exact wording. A grep for `the the ` in `src/` returns no remaining hits after the change.

## Risk
Low — comment and description string edits only, no code paths affected.
