### PR TITLE
chore: Update devtools scripts to avoid opening browser window

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,10 +169,9 @@ making changes that affect the usage of regl shaders, you would need to run
 npm run regl-codegen
 ```
 
-to regenerate the regl code. This opens a browser window, runs through all
-traces with 'regl' in the tags, and stores the captured code into 
-[src/generated/regl-codegen](https://github.com/plotly/plotly.js/blob/master/src/generated/regl-codegen). If no updates are necessary, it would be a no-op, but
-if there are changes, you would need to commit them.
+to regenerate the regl code. This will prompt you to open a browser window. This will then run through all
+traces with 'regl' in the tags, and store the captured code into 
+[src/generated/regl-codegen](https://github.com/plotly/plotly.js/blob/master/src/generated/regl-codegen). If no updates are necessary, it will be a no-op, but if there are changes, you will need to commit them.
 
 This is needed because regl performs codegen in runtime which breaks CSP
 compliance, and so for strict builds we pre-generate regl shader code here.

--- a/devtools/regl_codegen/index.html
+++ b/devtools/regl_codegen/index.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-  <title>REGL Codegen</title>
-  <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>
+  <title>Plotly.js Devtools- REGL Codegen</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css"
+    href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT" />
   <link rel="stylesheet" type="text/css" href="../test_dashboard/style.css">
 </head>
+
 <body>
   <section id="mocks-list"></section>
   <div id="plots">
@@ -13,7 +17,8 @@
   <div id="snapshot"></div>
 
   <script src="../../node_modules/mathjax/MathJax.js?config=TeX-AMS-MML_SVG"></script>
-  <script charset="utf-8" id="source"  type="module">import "../../build/plotly.js"</script>
+  <script charset="utf-8" id="source" src="../../build/plotly.js"></script>
   <script charset="utf-8" src="../../build/regl_codegen-bundle.js"></script>
 </body>
+
 </html>

--- a/devtools/regl_codegen/server.mjs
+++ b/devtools/regl_codegen/server.mjs
@@ -3,7 +3,6 @@ import { build } from 'esbuild';
 import fs from 'fs';
 import http from 'http';
 import minimist from 'minimist';
-import open from 'open';
 import path from 'path';
 import { localDevReglCodegenConfig as config } from '../../esbuild-config.js';
 import constants from '../../tasks/util/constants.js';
@@ -17,7 +16,6 @@ import {
 
 var args = minimist(process.argv.slice(2), {});
 var PORT = args.port || 3000;
-var strict = args.strict;
 
 var reglTraceList = ['parcoords', 'scattergl', 'scatterpolargl', 'splom'];
 
@@ -68,7 +66,10 @@ await getMockFiles()
 server.listen(PORT);
 
 // open up browser window
-open('http://localhost:' + PORT + '/devtools/regl_codegen/index' + (strict ? '-strict' : '') + '.html');
+const serverUrl = `http://localhost:${PORT}/devtools/regl_codegen/index.html`;
+console.log('\x1b[31mOpen the following link to launch a browser window and precompile the regl shaders.');
+console.log('This can be processor and memory intensive.\x1b[0m\n');
+console.log(`  \x1b[1m\x1b[32m➜\x1b[0m  \x1b[1mLocal:\x1b[0m   \x1b[1m\x1b[36m${serverUrl}\x1b[0m\n`);
 
 await build(config);
 

--- a/devtools/test_dashboard/index.html
+++ b/devtools/test_dashboard/index.html
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <title>Plotly.js Devtools</title>
   <meta charset="utf-8">
-  <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT"/>
+  <link rel="stylesheet" type="text/css"
+    href="//fonts.googleapis.com/css?family=Open+Sans:600,400,300,200|Droid+Sans|PT+Sans+Narrow|Gravitas+One|Droid+Sans+Mono|Droid+Serif|Raleway|Old+Standard+TT" />
   <link rel="stylesheet" type="text/css" href="./style.css">
 </head>
+
 <body>
   <header>
     <img src="http://images.plot.ly/logo/plotlyjs-logo@2x.png" onClick="Tabs.reload();" />
@@ -23,9 +26,10 @@
 
   <!-- Update UI elements if strict mode is enabled -->
   <script src="./strict.js"></script>
-  
+
   <script src="../../node_modules/@plotly/mathjax-v2/MathJax.js?config=TeX-AMS-MML_SVG"></script>
   <script charset="utf-8" id="source" src="../../build/plotly.js"></script>
   <script charset="utf-8" src="../../build/test_dashboard-bundle.js"></script>
 </body>
+
 </html>

--- a/devtools/test_dashboard/server.mjs
+++ b/devtools/test_dashboard/server.mjs
@@ -2,7 +2,6 @@ import ecstatic from 'ecstatic';
 import { build, context } from 'esbuild';
 import http from 'http';
 import minimist from 'minimist';
-import open from 'open';
 import { devtoolsConfig, localDevConfig } from '../../esbuild-config.js';
 import constants from '../../tasks/util/constants.js';
 import { createMocksList, getMockFiles, readFiles, saveMockListToFile } from '../dashboard_utilities.mjs';
@@ -64,5 +63,6 @@ function devServer() {
     indexName += '.html';
 
     // open up browser window
-    open(`http://localhost:${PORT}/devtools/test_dashboard/${indexName}${strict ? '?strict=true' : ''}`);
+    const serverUrl = `http://localhost:${PORT}/devtools/test_dashboard/${indexName}${strict ? '?strict=true' : ''}`;
+    console.log(`  \x1b[1m\x1b[32m➜\x1b[0m  \x1b[1mLocal:\x1b[0m   \x1b[1m\x1b[36m${serverUrl}\x1b[0m\n`);
 }

--- a/esbuild-config.js
+++ b/esbuild-config.js
@@ -47,11 +47,9 @@ const localDevConfig = {
 
 // Config used when building bundle to serve regl
 const localDevReglCodegenConfig = {
-    ...esbuildConfig,
+    ...devtoolsConfig,
     entryPoints: [path.join(constants.pathToRoot, 'devtools/regl_codegen', 'devtools.js')],
-    outfile: './build/regl_codegen-bundle.js',
-    sourcemap: false,
-    minify: false
+    outfile: './build/regl_codegen-bundle.js'
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,6 @@
         "madge": "^8.0.0",
         "minify-stream": "^2.1.0",
         "npm-link-check": "^5.0.1",
-        "open": "^8.4.2",
         "pixelmatch": "^7.1.0",
         "prepend-file": "^2.0.1",
         "prettysize": "^2.0.0",
@@ -3502,15 +3501,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -7831,23 +7821,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dev": true,
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "madge": "^8.0.0",
     "minify-stream": "^2.1.0",
     "npm-link-check": "^5.0.1",
-    "open": "^8.4.2",
     "pixelmatch": "^7.1.0",
     "prepend-file": "^2.0.1",
     "prettysize": "^2.0.0",


### PR DESCRIPTION
### Description

Print a URL to open the dev server when running `npm start` or `npm run regl-codegen` instead of opening a browser window directly.

Closes #7776.

### Changes

- Update devtools server scripts
- Fix issue with loading plotly.js in regl codegen
- Fix issue with esbuild config for regl codegen
- Remove unused dependency
- Update docs per above changes

### Testing

- Run `npm start` or `npm run regl-codegen`
- Note that no browser window opens
- Note that the server URL is printed in the terminal

### Notes

- regl codegen has been broken for a while
- In a future PR, this will run in CI if the proper files have been changed
