### PR TITLE
ci: Add workflow to check for new UN geodata

### DIFF
--- a/.github/scripts/check-un-geodata.mjs
+++ b/.github/scripts/check-un-geodata.mjs
@@ -1,0 +1,63 @@
+// ArcGIS Portal REST API — Search reference:
+// https://developers.arcgis.com/rest/users-groups-and-items/search-reference.htm
+const API_URL =
+    'https://geoportal.un.org/arcgis/sharing/rest/search?f=json&q=(type:%22geojson%22)%20AND%20(title:%22*geodata*%22)&sortField=modified&sortOrder=desc';
+
+export default async function checkUnGeodata({ github, context, core }) {
+    // Fetch the UN Geodata API
+    const res = await fetch(API_URL);
+    if (!res.ok) throw new Error(`API request failed: ${res.status}`);
+    const data = await res.json();
+    const newest = data.results[0];
+    if (!newest) throw new Error('No results returned from API');
+
+    const marker = `<!-- un-geodata-modified:${newest.modified} -->`;
+
+    // Check if we already created an issue for this modified timestamp
+    const { data: issues } = await github.rest.issues.listForRepo({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        labels: 'topojson',
+        state: 'all',
+        sort: 'created',
+        direction: 'desc',
+        per_page: 100
+    });
+
+    if (issues.some((issue) => issue.body?.includes(marker))) {
+        core.info('No new updates — issue already exists for this timestamp');
+        return;
+    }
+
+    // Build the issue body
+    const summary = data.results
+        .map((r) => {
+            const date = new Date(r.modified).toISOString().slice(0, 10);
+            return `- **${r.title}** (modified: ${date}, id: \`${r.id}\`)`;
+        })
+        .join('\n');
+
+    const body = [
+        marker,
+        '',
+        `The [UN Geoportal geodata API](${API_URL}) has new or updated artifacts.`,
+        '',
+        `### Datasets found (${data.total}):`,
+        summary,
+        '',
+        '### Next steps',
+        '- Review the updated dataset at the [UN Geoportal](https://geoportal.un.org/)',
+        '- Determine if `topojson/` sources need updating',
+        '',
+        '---',
+        `*This issue was created automatically by the [Check UN Geodata Updates](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/workflows/check-un-geodata.yml) workflow.*`
+    ].join('\n');
+
+    await github.rest.issues.create({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        title: `UN Geodata update detected: ${newest.title}`,
+        body,
+        labels: ['topojson']
+    });
+}

--- a/.github/workflows/check-un-geodata.yml
+++ b/.github/workflows/check-un-geodata.yml
@@ -1,0 +1,25 @@
+name: Check UN Geodata Updates
+
+on:
+  schedule:
+    # First day of every month at 09:00 UTC
+    - cron: '0 9 1 * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  check-geodata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github/scripts
+
+      - name: Check for UN Geodata updates
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const { default: checkUnGeodata } = await import('${{ github.workspace }}/.github/scripts/check-un-geodata.mjs');
+            await checkUnGeodata({ github, context, core });


### PR DESCRIPTION
### Description

Add CI workflow to check for new UN geodata.

Closes #7781.

### Changes

- Add new workflow/script for check

### Testing

- Try running the workflow manually


### Notes

- The first time this is run, it will create an issue requesting an update with a hidden timestamp. This can be closed.
- Subsequent runs will find the old issue and the hidden timestamp and check against that
- If the issue timestamp is older than the one from the API check, a new issue will be created. Otherwise it's a no-op.