### PR TITLE
Add placeholder workflow file

### DIFF
--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -1,0 +1,17 @@
+name: Upload dev build from PR (placeholder, not yet implemented)
+
+on:
+  workflow_run:
+    workflows: ["CI"]  # ci.yml
+    types:
+      - completed
+  workflow_dispatch:
+
+
+jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hello World
+        run: |
+          echo "Hello World"


### PR DESCRIPTION
Related to https://github.com/plotly/plotly.js/issues/7759

I am testing workflows for uploading plotly.js dev build artifacts. The flow I am testing uses the `workflow_run` trigger to activate when the `"CI"` workflow completes.

Per GitHub docs, [the `workflow_run` event can only trigger a workflow if the workflow file exists on the default branch](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run). Therefore in order to test the flow, we need to add a placeholder workflow file to `main` in order to be able to test the implementation on a feature branch.