### PR TITLE
Update CI to build with Node 22 only

### DIFF
--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -25,41 +25,6 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: '18'
-          cache: 'npm'
-
-      - name: Set up build environment
-        run: .github/scripts/env_build.sh
-
-      - name: Set draft version in package.json
-        run: |
-          node --eval "var fs = require('fs'); var inOut = './package.json'; var data = JSON.parse(fs.readFileSync(inOut)); var a = process.argv; data.version = a[a.length - 1].replace('v', ''); fs.writeFileSync(inOut, JSON.stringify(data, null, 2) + '\n');" $(git describe)
-          # View package.json diff from last release (should show that the version has been changed to the draft version)
-          git --no-pager diff --color-words tags/$(git describe --tags --abbrev=0) package.json || true
-
-      - name: Build dist/
-        run: npm run build
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        name: Upload Node 18 archive of plotly.js build folder
-        with:
-          name: dist-node18
-          retention-days: 7
-          path: dist/
-
-      - name: Test plot-schema.json diff
-        run: diff --unified --color dist/plot-schema.json test/plot-schema.json
-
-  publish-dist-node-v22:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
           node-version: '22.14.0'
           cache: 'npm'
 
@@ -76,9 +41,9 @@ jobs:
         run: npm run build
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        name: Upload Node 22 archive of plotly.js build folder
+        name: Upload archive of plotly.js build artifacts (contents of dist/)
         with:
-          name: dist-node22
+          name: dist
           retention-days: 7
           path: dist/
 

--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -29,7 +29,7 @@ jobs:
         id: download-artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: dist-node22  # uploaded by publish-dist.yml > publish-dist-node-v22
+          name: dist  # uploaded by publish-dist.yml > publish-dist
           run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: temp-dist


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/issues/7796

Node 18 build job is no longer needed