### PR TITLE
CI: upload-dev-build: Require manual approval for forks, and exit if PR number is empty

### DIFF
--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -39,14 +39,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUM: ${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          GH_REPO: ${{ github.repository }}
         run: |
           # Get SHA from triggering workflow, or from manual input
-          if [ "${{ github.event_name }}" == "workflow_run" ]; then
-            SHA="${{ github.event.workflow_run.head_sha }}"
+          if [ "${GH_EVENT_NAME}" == "workflow_run" ]; then
+            SHA="${GH_HEAD_SHA}"
           else
             echo "Fetching latest SHA for PR #${PR_NUM}..."
             if [ -n "${PR_NUM}" ]; then
-              SHA=$(gh pr view "${PR_NUM}" --repo "${{ github.repository }}" --json headRefOid --template '{{.headRefOid}}')
+              SHA=$(gh pr view "${PR_NUM}" --repo "${GH_REPO}" --json headRefOid --template '{{.headRefOid}}')
             fi
           fi
 
@@ -61,8 +64,8 @@ jobs:
             PR_NUM=$(gh pr list --search "sha:${SHA}" --state open --json number --jq '.[0].number')
           fi
 
-          # Validate that we have a PR number and that it is less than 5 characters
-          if [ -z "${PR_NUM}" ] || [ ${#PR_NUM} -gt 5 ]; then
+          # Validate that we have a valid PR number
+          if [ -z "${PR_NUM}" ] || [[ "${PR_NUM}" =~ ^[1-9][0-9]{0,4}$ ]]; then
             echo "Failed to get PR number, exiting (PR_NUM=${PR_NUM})"
             exit 1
           fi
@@ -108,32 +111,42 @@ jobs:
 
       - name: Commit and push files
         id: commit-and-push
+        env:
+          PR_NUM: ${{ steps.setup-metadata.outputs.PR_NUM }}
+          SHORT_SHA: ${{ steps.setup-metadata.outputs.SHORT_SHA }}
         run: |
-          # 1. Move 'upload' directory into repo folder and cd into repo root
-          mkdir -p plotly.js-dev-builds/upload/
-          cp -r upload/ plotly.js-dev-builds/
+          # Move 'upload/pr-NNNN/' directory into repo folder and cd into repo root
+          TARGET_DIR="upload/pr-${PR_NUM}"
+          mkdir -p plotly.js-dev-builds/${TARGET_DIR}
+          cp -r ${TARGET_DIR} plotly.js-dev-builds/
           cd plotly.js-dev-builds
 
-          # 2. Configure git
+          # Configure git
           git config user.name "plotly.js-pr-upload"
           git config user.email "<>"
 
-          # 3. add, commit, and push
-          git add upload/
+          # Add files
+          git add ${TARGET_DIR}/
+
+          # Ensure that only files in upload/pr-NNNN/ are staged
+          if git diff --name-only --cached | grep -qv "^${TARGET_DIR}/"; then
+            echo "Error: Changes detected outside ${TARGET_DIR}/"
+            exit 1
+          fi
 
           # Only commit if there are changes
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Deploy build for PR #${{ steps.setup-metadata.outputs.PR_NUM }} (commit ${{ steps.setup-metadata.outputs.SHORT_SHA }})"
+            git commit -m "Deploy build for PR #${PR_NUM} (commit ${SHORT_SHA})"
             git push origin main
           fi
 
       - name: Generate summary
         run: |
-          BASE="https://plotly.github.io/plotly.js-dev-builds/upload/pr-${{ steps.setup-metadata.outputs.PR_NUM }}"
+          BASE="https://plotly.github.io/plotly.js-dev-builds/upload/pr-${PR_NUM}"
           echo "### PR Build Uploaded" >> $GITHUB_STEP_SUMMARY
-          echo "Builds for PR #${{ steps.setup-metadata.outputs.PR_NUM }} can be accessed at:" >> $GITHUB_STEP_SUMMARY
-          echo "- Latest build for this PR: [$BASE/latest/plotly.min.js]($BASE/latest/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
-          echo "- Build for this commit: [$BASE/${{ steps.setup-metadata.outputs.SHA }}/plotly.min.js]($BASE/${{ steps.setup-metadata.outputs.SHORT_SHA }}/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
+          echo "Builds for PR #${PR_NUM} can be accessed at:" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest build for this PR: [${BASE}/latest/plotly.min.js](${BASE}/latest/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
+          echo "- Build for this commit: [${BASE}/${SHORT_SHA}/plotly.min.js](${BASE}/${SHORT_SHA}/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
           echo "The above links should start working a minute or two after this job completes." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -10,9 +10,10 @@ on:
       pr_number:
         description: 'PR Number to deploy'
         required: false
-      run_id:
-        description: 'The Run ID of the CI workflow that has the artifact'
-        required: true
+
+env:
+  ARTIFACT_UPLOAD_WORKFLOW_NAME: "Publish Dist"
+  UPLOAD_DIR_NAME: "upload"
 
 jobs:
   upload:
@@ -25,35 +26,24 @@ jobs:
             github.event.workflow_run.conclusion == 'success'
           )
     steps:
-      - name: Download build artifact
-        id: download-artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: dist  # uploaded by publish-dist.yml > publish-dist
-          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: temp-dist
-
-      - name: Setup metadata and prepare folders
-        id: setup-metadata
+      - name: Get required metadata (PR number, commit SHA, workflow run ID containing artifacts)
+        id: get-metadata
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUM: ${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number }}
           GH_EVENT_NAME: ${{ github.event_name }}
-          GH_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GH_REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          PR_NUM: ${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number }}
         run: |
-          # Get SHA from triggering workflow, or from manual input
-          if [ "${GH_EVENT_NAME}" == "workflow_run" ]; then
-            SHA="${GH_HEAD_SHA}"
-          else
-            echo "Fetching latest SHA for PR #${PR_NUM}..."
+          # Get SHA from manually-provided PR number if triggered by workflow_dispatch
+          if [ "${GH_EVENT_NAME}" == "workflow_dispatch" ]; then
             if [ -n "${PR_NUM}" ]; then
               SHA=$(gh pr view "${PR_NUM}" --repo "${GH_REPO}" --json headRefOid --template '{{.headRefOid}}')
             fi
           fi
 
-          # Validate that we have a SHA
+          # At this point, SHA should be defined. If not, fail the workflow
           if [ -z "${SHA}" ]; then
             echo "Failed to get commit SHA, exiting"
             exit 1
@@ -65,14 +55,50 @@ jobs:
           fi
 
           # Validate that we have a valid PR number
-          if [ -z "${PR_NUM}" ] || [[ "${PR_NUM}" =~ ^[1-9][0-9]{0,4}$ ]]; then
+          if [ -z "${PR_NUM}" ] || [[ ! "${PR_NUM}" =~ ^[1-9][0-9]{0,4}$ ]]; then
             echo "Failed to get PR number, exiting (PR_NUM=${PR_NUM})"
             exit 1
           fi
 
-          SHORT_SHA=${SHA::7}
-          UPLOAD_DIR_NAME="upload"
+          # If RUN_ID is empty, use the gh CLI to get the most recent run ID for SHA
+          if [ -z "${RUN_ID}" ]; then
+            RUN_ID=$(gh run list \
+              --workflow "${ARTIFACT_UPLOAD_WORKFLOW_NAME}" \
+              --commit "${SHA}" \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+          fi
 
+          # At this point, RUN_ID should be defined. If not, fail the workflow
+          if [ -z "${RUN_ID}" ]; then
+            echo "Failed to get workflow run ID, exiting"
+            exit 1
+          fi
+
+          # Save PR number, commit SHA, short SHA, and run ID to output
+          echo "PR_NUM=${PR_NUM}" >> $GITHUB_OUTPUT
+          echo "SHA=${SHA}" >> $GITHUB_OUTPUT
+          echo "SHORT_SHA=${SHA:0:7}" >> $GITHUB_OUTPUT
+          echo "RUN_ID=${RUN_ID}" >> $GITHUB_OUTPUT
+
+      - name: Download build artifact
+        id: download-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: dist  # uploaded by publish-dist.yml > publish-dist
+          run-id: ${{ steps.get-metadata.outputs.RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: temp-dist
+
+      - name: Prepare folders
+        id: setup-metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ steps.get-metadata.outputs.PR_NUM }}
+          SHA: ${{ steps.get-metadata.outputs.SHA }}
+          SHORT_SHA: ${{ steps.get-metadata.outputs.SHORT_SHA }}
+        run: |
           echo "SHA: ${SHA}"
           echo "Short SHA: ${SHORT_SHA}"
           echo "PR number: ${PR_NUM}"
@@ -88,10 +114,6 @@ jobs:
           UPLOAD_DIR_FULL_PATH=$(pwd)/${UPLOAD_DIR_NAME}/
           echo "Created directory ${UPLOAD_DIR_FULL_PATH} with the following contents:"
           echo "$(ls -lR ${UPLOAD_DIR_FULL_PATH})"
-
-          echo "PR_NUM=${PR_NUM}" >> $GITHUB_OUTPUT
-          echo "SHA=${SHA}" >> $GITHUB_OUTPUT
-          echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Generate GitHub App token
         id: generate-token
@@ -112,12 +134,11 @@ jobs:
       - name: Commit and push files
         id: commit-and-push
         env:
-          PR_NUM: ${{ steps.setup-metadata.outputs.PR_NUM }}
-          SHORT_SHA: ${{ steps.setup-metadata.outputs.SHORT_SHA }}
+          PR_NUM: ${{ steps.get-metadata.outputs.PR_NUM }}
+          SHORT_SHA: ${{ steps.get-metadata.outputs.SHORT_SHA }}
         run: |
-          # Move 'upload/pr-NNNN/' directory into repo folder and cd into repo root
-          TARGET_DIR="upload/pr-${PR_NUM}"
-          mkdir -p plotly.js-dev-builds/${TARGET_DIR}
+          # Move 'pr-NNNN/' directory into upload directory inside repo and cd into repo root
+          TARGET_DIR="${UPLOAD_DIR_NAME}/pr-${PR_NUM}"
           cp -r ${TARGET_DIR} plotly.js-dev-builds/
           cd plotly.js-dev-builds
 
@@ -143,10 +164,13 @@ jobs:
           fi
 
       - name: Generate summary
+        env:
+          PR_NUM: ${{ steps.get-metadata.outputs.PR_NUM }}
+          SHORT_SHA: ${{ steps.get-metadata.outputs.SHORT_SHA }}
         run: |
-          BASE="https://plotly.github.io/plotly.js-dev-builds/upload/pr-${PR_NUM}"
+          BASE_URL="https://plotly.github.io/plotly.js-dev-builds/${UPLOAD_DIR_NAME}/pr-${PR_NUM}"
           echo "### PR Build Uploaded" >> $GITHUB_STEP_SUMMARY
           echo "Builds for PR #${PR_NUM} can be accessed at:" >> $GITHUB_STEP_SUMMARY
-          echo "- Latest build for this PR: [${BASE}/latest/plotly.min.js](${BASE}/latest/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
-          echo "- Build for this commit: [${BASE}/${SHORT_SHA}/plotly.min.js](${BASE}/${SHORT_SHA}/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest build for this PR: [${BASE_URL}/latest/plotly.min.js](${BASE_URL}/latest/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
+          echo "- Build for this commit: [${BASE_URL}/${SHORT_SHA}/plotly.min.js](${BASE_URL}/${SHORT_SHA}/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
           echo "The above links should start working a minute or two after this job completes." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -18,12 +18,16 @@ env:
 jobs:
   upload:
     runs-on: ubuntu-latest
+    # Only run on manual dispatch, 
+    # OR if the parent run succeeded and was triggered by a PR from
+    # a branch in the main repo (not a fork)
     if: |
           github.event_name == 'workflow_dispatch' ||
           (
             github.event_name == 'workflow_run' && 
             github.event.workflow_run.event == 'pull_request' &&
-            github.event.workflow_run.conclusion == 'success'
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.head_repository.full_name == github.repository
           )
     steps:
       - name: Get required metadata (PR number, commit SHA, workflow run ID containing artifacts)
@@ -49,7 +53,7 @@ jobs:
             exit 1
           fi
 
-          # If PR_NUM is empty (this is the case for forks) get PR number using SHA
+          # If PR_NUM is empty, get PR number using SHA
           if [ -z "${PR_NUM}" ]; then
             PR_NUM=$(gh pr list --search "sha:${SHA}" --state open --json number --jq '.[0].number')
           fi
@@ -139,7 +143,8 @@ jobs:
         run: |
           # Move 'pr-NNNN/' directory into upload directory inside repo and cd into repo root
           TARGET_DIR="${UPLOAD_DIR_NAME}/pr-${PR_NUM}"
-          cp -r ${TARGET_DIR} plotly.js-dev-builds/
+          mkdir -p "plotly.js-dev-builds/${UPLOAD_DIR_NAME}"
+          cp -r "${TARGET_DIR}" "plotly.js-dev-builds/${UPLOAD_DIR_NAME}"
           cd plotly.js-dev-builds
 
           # Configure git
@@ -147,7 +152,7 @@ jobs:
           git config user.email "<>"
 
           # Add files
-          git add ${TARGET_DIR}/
+          git add "${TARGET_DIR}/"
 
           # Ensure that only files in upload/pr-NNNN/ are staged
           if git diff --name-only --cached | grep -qv "^${TARGET_DIR}/"; then

--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -1,5 +1,8 @@
 name: Upload dev build from PR
 
+# See https://github.com/plotly/plotly.js/blob/master/CONTRIBUTING.md#live-links-to-dev-builds
+# for documentation on the usage of this workflow.
+
 on:
   workflow_run:
     workflows: ["Publish Dist"]  # publish-dist.yml

--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       pr_number:
         description: 'PR Number to deploy'
-        required: true
+        required: false
       run_id:
         description: 'The Run ID of the CI workflow that has the artifact'
         required: true
@@ -44,14 +44,35 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_run" ]; then
             SHA="${{ github.event.workflow_run.head_sha }}"
           else
-            echo "Fetching latest SHA for PR #$PR_NUM..."
-            SHA=$(gh pr view "$PR_NUM" --repo ${{ github.repository }} --json headRefOid --template '{{.headRefOid}}')
+            echo "Fetching latest SHA for PR #${PR_NUM}..."
+            if [ -n "${PR_NUM}" ]; then
+              SHA=$(gh pr view "${PR_NUM}" --repo "${{ github.repository }}" --json headRefOid --template '{{.headRefOid}}')
+            fi
           fi
+
+          # Validate that we have a SHA
+          if [ -z "${SHA}" ]; then
+            echo "Failed to get commit SHA, exiting"
+            exit 1
+          fi
+
+          # If PR_NUM is empty (this is the case for forks) get PR number using SHA
+          if [ -z "${PR_NUM}" ]; then
+            PR_NUM=$(gh pr list --search "sha:${SHA}" --state open --json number --jq '.[0].number')
+          fi
+
+          # Validate that we have a PR number and that it is less than 5 characters
+          if [ -z "${PR_NUM}" ] || [ ${#PR_NUM} -gt 5 ]; then
+            echo "Failed to get PR number, exiting (PR_NUM=${PR_NUM})"
+            exit 1
+          fi
+
           SHORT_SHA=${SHA::7}
           UPLOAD_DIR_NAME="upload"
 
-          echo "Using SHA: ${SHA}"
+          echo "SHA: ${SHA}"
           echo "Short SHA: ${SHORT_SHA}"
+          echo "PR number: ${PR_NUM}"
           mkdir -p "${UPLOAD_DIR_NAME}/pr-${PR_NUM}/latest"
           mkdir -p "${UPLOAD_DIR_NAME}/pr-${PR_NUM}/${SHORT_SHA}"
           # Copy all 3 artifacts (plotly.js, plotly.min.js, plot-schema.json) to /latest/
@@ -114,5 +135,5 @@ jobs:
           echo "### PR Build Uploaded" >> $GITHUB_STEP_SUMMARY
           echo "Builds for PR #${{ steps.setup-metadata.outputs.PR_NUM }} can be accessed at:" >> $GITHUB_STEP_SUMMARY
           echo "- Latest build for this PR: [$BASE/latest/plotly.min.js]($BASE/latest/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
-          echo "- Build for this commit: [$BASE/${{ steps.setup-metadata.outputs.SHA }}/plotly.min.js]($BASE/${{ steps.setup-metadata.outputs.SHA }}/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
+          echo "- Build for this commit: [$BASE/${{ steps.setup-metadata.outputs.SHA }}/plotly.min.js]($BASE/${{ steps.setup-metadata.outputs.SHORT_SHA }}/plotly.min.js)" >> $GITHUB_STEP_SUMMARY
           echo "The above links should start working a minute or two after this job completes." >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,6 +326,17 @@ This will produce the following plot, and say you want to simulate a selection p
 
 <img src="https://user-images.githubusercontent.com/31989842/38890553-0bc6190c-4282-11e8-8efc-077bf05ca565.png">
 
+### Live links to dev builds
+
+The [Upload dev build from PR](.github/workflows/upload-dev-build.yml) workflow can be used to upload a dev build for a PR to the plotly.js-dev-builds repo, creating a live link to the plotly.js dev build which can be used in online coding environments to test and demo the PR.
+
+It is triggered in one of two ways:
+- Automatically on completion of the Publish Dist workflow, if triggered by a PR from a branch in the main repo (not a fork).
+- Manually via the Actions tab in the GitHub UI, by entering a PR number in the workflow inputs
+  - Only users with write access to the plotly.js repo can trigger workflows manually
+
+If you would like a link to the dev build for your PR but don't have permission to trigger the workflow, tag a maintainer to request a run for your PR.
+
 ## Repo organization
 
 - Distributed files are in `dist/`


### PR DESCRIPTION
Closes #7805 

- Update `upload-dev-build` workflow:
  -  Exit workflow if PR number is empty, rather than proceeding
  - Modify workflow such that it will _not_ run automatically if the source branch of a PR is part of a fork
  - Modify manual trigger such that _only_ PR number is required (not Run ID)

This adds additional security by ensuring the workflow can only be triggered by users with write permissions for the repository. It also makes manually triggering the workflow much easier, since only the PR number is needed.

### Steps for testing

The `workflow_run` trigger scenario (normal case) can't be directly tested until on `master` due to GitHub Actions security measures. However, the `workflow_dispatch` (manual trigger) can be tested:

<img width="333" height="310" alt="Screenshot 2026-05-25 at 11 26 38 AM" src="https://github.com/user-attachments/assets/ff128fca-f6d9-406e-8fdf-c4c82a10556c" />

**Verify that the workflow fails when PR number is not available**
- Manually trigger the workflow using the "Run workflow" button [on this page](https://github.com/plotly/plotly.js/actions/workflows/upload-dev-build.yml), making sure to select this branch (`fail-if-no-pr-number` from the dropdown)
- Enter nothing for the PR number
- Confirm that the workflow fails
  - Note: When run via manual dispatch, the missing PR number also causes the "get SHA" command to fail, which is why the error message reads "Failed to get commit SHA, exiting" 

**Verify that the workflow can be dispatched for PRs from forks**
- Manually trigger the workflow using the "Run workflow" button [on this page](https://github.com/plotly/plotly.js/actions/workflows/upload-dev-build.yml), making sure to select this branch (`fail-if-no-pr-number` from the dropdown)
- Enter [7804](https://github.com/plotly/plotly.js/pull/7804) for the PR number
- Confirm that the workflow succeeds

**Verify that the workflow can be dispatched for PRs within the repo**
- Manually trigger the workflow using the "Run workflow" button [on this page](https://github.com/plotly/plotly.js/actions/workflows/upload-dev-build.yml), making sure to select this branch (`fail-if-no-pr-number` from the dropdown)
- Enter [7806](https://github.com/plotly/plotly.js/pull/7806) for the PR number
- Confirm that the workflow succeeds