### PR TITLE
fix: snap tick values to grid before applying custom tickformat

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -2189,7 +2189,18 @@ function numFormat(v, ax, fmtoverride, hover) {
         if(ax.hoverformat) tickformat = ax.hoverformat;
     }
 
-    if(tickformat) return ax._numFormat(tickformat)(v).replace(/-/g, MINUS_SIGN);
+    if(tickformat) {
+        // Snap v to the nearest ideal tick position before applying a custom tickformat.
+        // Floating-point arithmetic can leave tick values slightly off their true position
+        // (e.g. -8.88e-16 instead of 0). The default formatter is immune because it adds
+        // a rounding epsilon, but custom d3 formats like '~r' expose the raw number.
+        // Only snap for linear-style numeric ticks (dtick and tick0 are both numbers).
+        if(!hover && isNumeric(ax.dtick) && isNumeric(ax.tick0) && ax.dtick) {
+            var ideal = ax.tick0 + Math.round((v - ax.tick0) / ax.dtick) * ax.dtick;
+            if(Math.abs(v - ideal) < Math.abs(ax.dtick) * 1e-9) v = ideal;
+        }
+        return ax._numFormat(tickformat)(v).replace(/-/g, MINUS_SIGN);
+    }
 
     // 'epsilon' - rounding increment
     var e = Math.pow(10, -tickRound) / 2;

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -18,6 +18,7 @@ var numerical = require('../../../src/constants/numerical');
 var BADNUM = numerical.BADNUM;
 var ONEDAY = numerical.ONEDAY;
 var ONEWEEK = numerical.ONEWEEK;
+var MINUS_SIGN = numerical.MINUS_SIGN;
 
 var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
@@ -3886,6 +3887,31 @@ describe('Test axes', function() {
                 ax.range = rng;
                 expect(mockCalc(ax).length).toBe(0, rng);
             });
+        });
+
+        it('should not show floating-point artefacts with custom tickformat', function() {
+            // Floating-point arithmetic can leave tick values slightly off their true
+            // position (e.g. -8.88e-16 instead of 0). The default formatter is immune
+            // because it adds an internal rounding epsilon, but custom d3 formats like
+            // '~r' expose the raw number. Ticks should be snapped to their ideal
+            // position (tick0 + n*dtick) before formatting. See gh#7765.
+            var ax = {
+                type: 'linear',
+                tickmode: 'linear',
+                tick0: 0,
+                dtick: 0.5,
+                tickformat: '~r',
+                range: [-0.75, 0.75]
+            };
+            var textOut = mockCalc(ax);
+            // Without the fix the middle tick renders as '−0.0000000000000000888178'
+            expect(textOut).toEqual([MINUS_SIGN + '0.5', '0', '0.5']);
+
+            // Also check with a dtick that itself introduces floating-point error.
+            ax.dtick = 0.1;
+            ax.range = [-0.25, 0.25];
+            textOut = mockCalc(ax);
+            expect(textOut).toEqual([MINUS_SIGN + '0.2', MINUS_SIGN + '0.1', '0', '0.1', '0.2']);
         });
 
         it('should always start at year for date axis hover', function() {


### PR DESCRIPTION
Fixes #7765

## What's wrong

When floating-point arithmetic leaves a tick value slightly off its true grid position — for example `-8.88e-16` instead of `0` — the result depends on which formatter is used. The built-in formatter is safe because it adds an internal rounding epsilon and then rounds to the computed number of significant digits. But when a user sets `tickformat` (e.g. `'~r'`, `'.4f'`) the value is passed straight to d3-format, which faithfully renders the raw float:

```
−0.0000000000000000888178   ← tick that should be 0, rendered with tickformat: '~r'
```

## The fix

Before delegating to the user's formatter, snap `v` to the nearest ideal tick position `tick0 + n * dtick`. The tolerance is `1e-9 × dtick`, which is well below any deliberate non-zero tick value but comfortably above the floating-point noise that accumulates over a handful of `dtick` additions.

The snap is only applied to non-hover labels (hover already independently recalculates its own rounding) and only when both `tick0` and `dtick` are numeric (so date and log axes are unaffected).

## Changes

- `src/plots/cartesian/axes.js` — snap inside `numFormat` before the `tickformat` early-return
- `test/jasmine/tests/axes_test.js` — two cases: `dtick: 0.5` (the exact scenario from the issue) and `dtick: 0.1` (a dtick that itself accumulates FP error over several steps)