### PR TITLE
Remove chart studio upload APIs

### DIFF
--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -76,15 +76,6 @@ modeBarButtons.sendDataToCloud = {
     }
 };
 
-modeBarButtons.editInChartStudio = {
-    name: 'editInChartStudio',
-    title: function(gd) { return _(gd, 'Edit in Chart Studio'); },
-    icon: Icons.pencil,
-    click: function(gd) {
-        Plots.sendDataToCloud(gd);
-    }
-};
-
 modeBarButtons.zoom2d = {
     name: 'zoom2d',
     _cat: 'zoom',

--- a/src/components/modebar/manage.js
+++ b/src/components/modebar/manage.js
@@ -145,8 +145,7 @@ function getButtonGroups(gd) {
 
     // buttons common to all plot types
     var commonGroup = ['toImage'];
-    if(context.showEditInChartStudio) commonGroup.push('editInChartStudio');
-    else if(context.showSendToCloud) commonGroup.push('sendDataToCloud');
+    if(context.showSendToCloud) commonGroup.push('sendDataToCloud');
     addGroup(commonGroup);
 
     var zoomGroup = [];

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -373,7 +373,6 @@ function _doPlot(gd, data, layout, config) {
         subroutines.drawData,
         subroutines.finalDraw,
         initInteractions,
-        Plots.addLinks,
         Plots.rehover,
         Plots.redrag,
         Plots.reselect,
@@ -485,7 +484,6 @@ function setPlotContext(gd, config) {
         context.scrollZoom = false;
         context.doubleClick = false;
         context.showTips = false;
-        context.showLink = false;
         context.displayModeBar = false;
     }
 

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -36,7 +36,7 @@ var configAttributes = {
         dflt: '',
         description: [
             'When set it determines base URL for',
-            'the \'Edit in Chart Studio\' `showEditInChartStudio`/`showSendToCloud` mode bar button.',
+            'the \'Edit in Chart Studio\' `showSendToCloud` mode bar button.',
             'To enable sending your data to Chart Studio Cloud, you need to',
             'set both `plotlyServerURL` to \'https://chart-studio.plotly.com\' and',
             'also set `showSendToCloud` to true.'
@@ -249,15 +249,6 @@ var configAttributes = {
             'Note that this button can (depending on `plotlyServerURL` being set) send your data',
             'to an external server. However that server does not persist your data',
             'until you arrive at the Chart Studio and explicitly click "Save".'
-        ].join(' ')
-    },
-    showEditInChartStudio: {
-        valType: 'boolean',
-        dflt: false,
-        description: [
-            'Same as `showSendToCloud`, but use a pencil icon instead of a floppy-disk.',
-            'Note that if both `showSendToCloud` and `showEditInChartStudio` are turned,',
-            'only `showEditInChartStudio` will be honored.'
         ].join(' ')
     },
     modeBarButtonsToRemove: {

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -36,8 +36,7 @@ var configAttributes = {
         dflt: '',
         description: [
             'When set it determines base URL for',
-            'the \'Edit in Chart Studio\' `showEditInChartStudio`/`showSendToCloud` mode bar button',
-            'and the showLink/sendData on-graph link.',
+            'the \'Edit in Chart Studio\' `showEditInChartStudio`/`showSendToCloud` mode bar button.',
             'To enable sending your data to Chart Studio Cloud, you need to',
             'set both `plotlyServerURL` to \'https://chart-studio.plotly.com\' and',
             'also set `showSendToCloud` to true.'
@@ -225,40 +224,6 @@ var configAttributes = {
         valType: 'boolean',
         dflt: true,
         description: 'Determines whether or not notifier is displayed.'
-    },
-
-    showLink: {
-        valType: 'boolean',
-        dflt: false,
-        description: [
-            'Determines whether a link to Chart Studio Cloud is displayed',
-            'at the bottom right corner of resulting graphs.',
-            'Use with `sendData` and `linkText`.'
-        ].join(' ')
-    },
-    linkText: {
-        valType: 'string',
-        dflt: 'Edit chart',
-        noBlank: true,
-        description: [
-            'Sets the text appearing in the `showLink` link.'
-        ].join(' ')
-    },
-    sendData: {
-        valType: 'boolean',
-        dflt: true,
-        description: [
-            'If *showLink* is true, does it contain data',
-            'just link to a Chart Studio Cloud file?'
-        ].join(' ')
-    },
-    showSources: {
-        valType: 'any',
-        dflt: false,
-        description: [
-            'Adds a source-displaying function to show sources on',
-            'the resulting graphs.'
-        ].join(' ')
     },
 
     displayModeBar: {

--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -188,32 +188,6 @@ module.exports = {
         ].join(' ')
     },
     hoverlabel: fxAttrs.hoverlabel,
-    stream: {
-        token: {
-            valType: 'string',
-            noBlank: true,
-            strict: true,
-            editType: 'calc',
-            description: [
-                'The stream id number links a data trace on a plot with a stream.',
-                'See https://chart-studio.plotly.com/settings for more details.'
-            ].join(' ')
-        },
-        maxpoints: {
-            valType: 'number',
-            min: 0,
-            max: 10000,
-            dflt: 500,
-            editType: 'calc',
-            description: [
-                'Sets the maximum number of points to keep on the plots from an',
-                'incoming stream.',
-                'If `maxpoints` is set to *50*, only the newest 50 points will',
-                'be displayed on the plot.'
-            ].join(' ')
-        },
-        editType: 'calc'
-    },
     uirevision: {
         valType: 'any',
         editType: 'none',

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -113,93 +113,6 @@ plots.previousPromises = function(gd) {
     }
 };
 
-/**
- * Adds the 'Edit chart' link.
- * Note that now _doPlot calls this so it can regenerate whenever it replots
- *
- * Add source links to your graph inside the 'showSources' config argument.
- */
-plots.addLinks = function(gd) {
-    // Do not do anything if showLink and showSources are not set to true in config
-    if(!gd._context.showLink && !gd._context.showSources) return;
-
-    var fullLayout = gd._fullLayout;
-
-    var linkContainer = Lib.ensureSingle(fullLayout._paper, 'text', 'js-plot-link-container', function(s) {
-        s.style({
-            'font-family': '"Open Sans", Arial, sans-serif',
-            'font-size': '12px',
-            fill: Color.defaultLine,
-            'pointer-events': 'all'
-        })
-        .each(function() {
-            var links = d3.select(this);
-            links.append('tspan').classed('js-link-to-tool', true);
-            links.append('tspan').classed('js-link-spacer', true);
-            links.append('tspan').classed('js-sourcelinks', true);
-        });
-    });
-
-    // The text node inside svg
-    var text = linkContainer.node();
-    var attrs = {y: fullLayout._paper.attr('height') - 9};
-
-    // If text's width is bigger than the layout
-    // Check that text is a child node or document.body
-    // because otherwise Edge might throw an exception
-    // when calling getComputedTextLength().
-    // Apparently offsetParent is null for invisibles.
-    if(document.body.contains(text) && text.getComputedTextLength() >= (fullLayout.width - 20)) {
-        // Align the text at the left
-        attrs['text-anchor'] = 'start';
-        attrs.x = 5;
-    } else {
-        // Align the text at the right
-        attrs['text-anchor'] = 'end';
-        attrs.x = fullLayout._paper.attr('width') - 7;
-    }
-
-    linkContainer.attr(attrs);
-
-    var toolspan = linkContainer.select('.js-link-to-tool');
-    var spacespan = linkContainer.select('.js-link-spacer');
-    var sourcespan = linkContainer.select('.js-sourcelinks');
-
-    if(gd._context.showSources) gd._context.showSources(gd);
-
-    // 'view in plotly' link for embedded plots
-    if(gd._context.showLink) positionPlayWithData(gd, toolspan);
-
-    // separator if we have both sources and tool link
-    spacespan.text((toolspan.text() && sourcespan.text()) ? ' - ' : '');
-};
-
-// note that now this function is only adding the brand in
-// iframes and 3rd-party apps
-function positionPlayWithData(gd, container) {
-    container.text('');
-    var link = container.append('a')
-        .attr({
-            'xlink:xlink:href': '#',
-            class: 'link--impt link--embedview',
-            'font-weight': 'bold'
-        })
-        .text(gd._context.linkText + ' ' + String.fromCharCode(187));
-
-    if(gd._context.sendData) {
-        link.on('click', function() {
-            plots.sendDataToCloud(gd);
-        });
-    } else {
-        var path = window.location.pathname.split('/');
-        var query = window.location.search;
-        link.attr({
-            'xlink:xlink:show': 'new',
-            'xlink:xlink:href': '/' + path[2].split('.')[0] + '/' + path[1] + query
-        });
-    }
-}
-
 plots.sendDataToCloud = function(gd) {
     var baseUrl = (window.PLOTLYENV || {}).BASE_URL || gd._context.plotlyServerURL;
     if(!baseUrl) return;
@@ -2105,16 +2018,6 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults, includeConfi
                     // keepdata: remove all ...src tags
                     if(v.slice(-3) === 'src') {
                         return;
-                    }
-                } else if(mode === 'keepstream') {
-                    // keep sourced data if it's being streamed.
-                    // similar to keepref, but if the 'stream' object exists
-                    // in a trace, we will keep the data array.
-                    src = d[v + 'src'];
-                    if(typeof src === 'string' && src.indexOf(':') > 0) {
-                        if(!Lib.isPlainObject(d.stream)) {
-                            return;
-                        }
                     }
                 } else if(mode !== 'keepall') {
                     // keepref: remove sourced data but only

--- a/src/snapshot/cloneplot.js
+++ b/src/snapshot/cloneplot.js
@@ -141,7 +141,6 @@ module.exports = function clonePlot(graphObj, options) {
                 2 :
                 options.plotGlPixelRatio,
             displaylogo: options.displaylogo || false,
-            showLink: options.showLink || false,
             showTips: options.showTips || false,
             mapboxAccessToken: context.mapboxAccessToken
         }

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -219,41 +219,6 @@ describe('config argument', function() {
         });
     });
 
-    describe('showLink attribute', function() {
-        var gd;
-
-        beforeEach(function() {
-            gd = createGraphDiv();
-        });
-
-        afterEach(destroyGraphDiv);
-
-        it('should not display the edit link by default', function(done) {
-            Plotly.newPlot(gd, [], {})
-            .then(function() {
-                var link = document.getElementsByClassName('js-plot-link-container')[0];
-
-                expect(link).toBeUndefined();
-            })
-            .then(done, done.fail);
-        });
-
-        it('should display a link when true', function(done) {
-            Plotly.newPlot(gd, [], {}, { showLink: true })
-            .then(function() {
-                var link = document.getElementsByClassName('js-plot-link-container')[0];
-
-                expect(link.textContent).toBe('Edit chart »');
-
-                var bBox = link.getBoundingClientRect();
-                expect(bBox.width).toBeGreaterThan(0);
-                expect(bBox.height).toBeGreaterThan(0);
-            })
-            .then(done, done.fail);
-        });
-    });
-
-
     describe('editable attribute', function() {
         var gd;
 

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -54,7 +54,6 @@ describe('ModeBar', function() {
             _context: {
                 displaylogo: true,
                 showSendToCloud: false,
-                showEditInChartStudio: false,
                 displayModeBar: true,
                 modeBarButtonsToRemove: [],
                 modeBarButtonsToAdd: [],
@@ -810,7 +809,7 @@ describe('ModeBar', function() {
             expect(countLogo(gd._fullLayout._modeBar)).toEqual(0);
         });
 
-        it('displays/hides cloud link according to showSendToCloud and/or showEditInChartStudio config arg', function() {
+        it('displays/hides cloud link according to showSendToCloud config arg', function() {
             var gd = getMockGraphInfo();
             gd._fullLayout._basePlotModules = [{ name: 'pie' }];
             gd._fullData = [{type: 'pie'}];
@@ -820,24 +819,15 @@ describe('ModeBar', function() {
             ]), 1);
 
             gd._context.showSendToCloud = true;
-            gd._context.showEditInChartStudio = false;
             manageModeBar(gd);
             checkButtons(gd._fullLayout._modeBar, getButtons([
                 ['toImage', 'sendDataToCloud']
             ]), 1);
 
             gd._context.showSendToCloud = false;
-            gd._context.showEditInChartStudio = true;
             manageModeBar(gd);
             checkButtons(gd._fullLayout._modeBar, getButtons([
-                ['toImage', 'editInChartStudio']
-            ]), 1);
-
-            gd._context.showSendToCloud = true;
-            gd._context.showEditInChartStudio = true;
-            manageModeBar(gd);
-            checkButtons(gd._fullLayout._modeBar, getButtons([
-                ['toImage', 'editInChartStudio']
+                ['toImage']
             ]), 1);
         });
 

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -80,7 +80,6 @@ describe('Plotly.Snapshot', function() {
                 staticPlot: true,
                 plotGlPixelRatio: 2,
                 displaylogo: false,
-                showLink: false,
                 showTips: false,
                 setBackground: 'opaque',
                 mapboxAccessToken: undefined


### PR DESCRIPTION
## Summary
Removes the APIs that are related to chart studio with the exception of a couple (`Plots.sendDataToCloud`, `plotlyServerURL`, the `sendDataToCloud` modebar button, and the `plotly_beforeexport`/`plotly_afterexport` events) in anticipation of adding similar behavior for Plotly Cloud soon. 

## Removed
  Legacy on-graph "Edit chart" link
  - Config options: showLink, linkText, sendData, showSources
  - Plots.addLinks and its positionPlayWithData helper (and the call site in the plot sequence)
  - The showLink = false static-plot override and the showLink passthrough in Snapshot.clone

  Legacy streaming
  - The stream trace attribute (stream.token / stream.maxpoints) — vestigial; plotly.js has no streaming client. This was attached to every trace type, hence the bulk of the schema diff.
  - The now-unreachable keepstream branch in Plots.graphJson

  "Edit in Chart Studio" pencil button
  - The editInChartStudio modebar button and its showEditInChartStudio config option
  - Simplified manage.js so the cloud button group is driven solely by showSendToCloud

 
 ## Kept (reusable upload pipeline)

  Intentionally left intact for the upcoming Plotly Cloud project:
  - Plots.sendDataToCloud
  - plotlyServerURL config
  - The sendDataToCloud (floppy-disk) modebar button + showSendToCloud config
  - The plotly_beforeexport / plotly_afterexport events

  General-purpose export APIs (Plotly.toImage, Plotly.downloadImage, Plotly.Snapshot.*, PlotSchema.get, graphJson) are unaffected.

  Testing

  - Updated affected jasmine tests (config_test, modebar_test, snapshot_test)
  - Lint clean; modebar suite passes (103/103). Remaining failures in the local run are pre-existing WebGL/retina environment issues unrelated to this change.
  
  ## Full list of properties removed from plot schema

- `config.showLink`
- `config.linkText`
- `config.sendData`
- `config.showSources`
- `config.showEditInChartStudio`
- `<trace>.stream.*`