### PR TITLE
CI: Fix wrong GitHub property name in `upload-dev-build` workflow

### DIFF
--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REPO: ${{ github.repository }}
-          SHA: ${{ github.event.workflow_run.sha }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           PR_NUM: ${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number }}
         run: |


### PR DESCRIPTION
The `workflow_run` trigger scenario for the workflow was failing due to accessing the wrong property name to get the SHA (`.sha` rather than the correct `.head_sha`).

This updated workflow can't be triggered by `workflow_run` until after this PR is merged, but I've verified in a separate repo that `github.event.workflow_run.head_sha` is the correct property name and returns the expected value.