### PR TITLE
Defer automargin during scroll-wheel zoom

### DIFF
--- a/draftlogs/7815_fix.md
+++ b/draftlogs/7815_fix.md
@@ -1,0 +1,1 @@
+- Defer automargin during scroll-wheel zoom, to prevent erratic jittering while zooming [[#7815](https://github.com/plotly/plotly.js/pull/7815)], with thanks to @keilogic for the contribution!

--- a/src/plots/cartesian/dragbox.js
+++ b/src/plots/cartesian/dragbox.js
@@ -487,6 +487,10 @@ function makeDragBox(gd, plotinfo, x, y, w, h, ns, ew) {
             return;
         }
 
+        // Keep automargin from changing plot size while wheel zoom is still
+        // debouncing. The final dragTail relayout will release this guard.
+        gd._fullLayout._replotting = true;
+
         var zoom = Math.exp(-Math.min(Math.max(wheelDelta, -20), 20) / 200);
         var gbb = mainplot.draglayer.select('.nsewdrag').node().getBoundingClientRect();
         var xfrac = (e.clientX - gbb.left) / gbb.width;

--- a/test/jasmine/tests/cartesian_interact_test.js
+++ b/test/jasmine/tests/cartesian_interact_test.js
@@ -4,6 +4,7 @@ var d3SelectAll = require('../../strict-d3').selectAll;
 var Plotly = require('../../../lib/index');
 var Lib = require('../../../src/lib');
 var Axes = require('../../../src/plots/cartesian/axes');
+var Plots = require('../../../src/plots/plots');
 var Drawing = require('../../../src/components/drawing');
 var constants = require('../../../src/plots/cartesian/constants');
 
@@ -687,6 +688,36 @@ describe('axis zoom/pan and main plot zoom', function() {
         .then(function() {
             expect(events.length).toEqual(nsteps);
             expect(relayoutCallback).toHaveBeenCalledTimes(1);
+        })
+        .then(done, done.fail);
+    });
+
+    it('should defer automargin while zooming via mouse wheel', function(done) {
+        var doAutoMarginSpy;
+        var data = [{y: [0, 12]}];
+        var layout = {
+            width: 500,
+            height: 400,
+            yaxis: {automargin: true}
+        };
+
+        Plotly.newPlot(gd, data, layout, {scrollZoom: true})
+        .then(function() {
+            doAutoMarginSpy = spyOn(Plots, 'doAutoMargin').and.callThrough();
+
+            var dragger = getDragger('xy', 'nsew');
+            var coords = getNodeCoords(dragger, 'se');
+
+            mouseEvent('scroll', coords.x, coords.y, {deltaY: 100, element: dragger});
+
+            expect(gd._fullLayout._replotting).toBe(true);
+            expect(doAutoMarginSpy).not.toHaveBeenCalled();
+
+            return delay(constants.REDRAWDELAY + 10)();
+        })
+        .then(function() {
+            expect(gd._fullLayout._replotting).toBe(false);
+            expect(doAutoMarginSpy).toHaveBeenCalled();
         })
         .then(done, done.fail);
     });


### PR DESCRIPTION
## Summary

- defer cartesian axis automargin while scroll-wheel zoom is still debouncing
- reuse the existing `_replotting` guard that pan drag already uses, then let `dragTail()` release it before the final relayout
- add a Jasmine regression that verifies `Plots.doAutoMargin` is not called during the wheel event and is called after the debounced relayout

## Why

In #6235, scroll zoom can jitter when tick-label width changes and automargin resizes the plot while the wheel interaction is still in progress. Deferring automargin until the final debounced relayout keeps the plot box stable during the scroll interaction.

Fixes #6235.
Fixes #7494.

## Validation

- `npx @biomejs/biome lint src/plots/cartesian/dragbox.js test/jasmine/tests/cartesian_interact_test.js`
- `npm run test-jasmine -- cartesian_interact --nowatch --report-spec`
  - The new `should defer automargin while zooming via mouse wheel` regression passed.
  - This Windows/Chrome 148 run still reports one unrelated existing tolerance failure in `should compute correct multicategory tick label span during drag` (`436.3244` vs expected `430 ± 5.5`).

## Bounty note

If the $100 PayPal/Venmo offer in #6235 still applies after this is accepted/merged, PayPal is available at https://www.paypal.com/paypalme/aogkft.