### PR TITLE
Harden reselect against empty/undefined calcdata entries

### DIFF
--- a/src/components/selections/select.js
+++ b/src/components/selections/select.js
@@ -790,6 +790,8 @@ function determineSearchTraces(gd, xAxes, yAxes, subplot) {
 
     for(i = 0; i < gd.calcdata.length; i++) {
         cd = gd.calcdata[i];
+        // guard against a transient empty/undefined calcdata entry (see epmtySplomSelectionBatch)
+        if(!cd || !cd[0]) continue;
         trace = cd[0].trace;
 
         if(trace.visible !== true || !trace._module || !trace._module.selectPoints) continue;
@@ -1286,6 +1288,10 @@ function epmtySplomSelectionBatch(gd) {
     if(!cd) return;
 
     for(var i = 0; i < cd.length; i++) {
+        // calcdata can transiently hold an empty/undefined entry (e.g. during
+        // react/relayout diffing); reselect runs on every redraw, so skip
+        // instead of throwing. See supplyDefaultsUpdateCalc for the same guard.
+        if(!cd[i] || !cd[i][0]) continue;
         var cd0 = cd[i][0];
         var trace = cd0.trace;
         var splomScenes = gd._fullLayout._splomScenes;

--- a/test/jasmine/tests/select_test.js
+++ b/test/jasmine/tests/select_test.js
@@ -3,6 +3,7 @@ var d3SelectAll = require('../../strict-d3').selectAll;
 
 var Plotly = require('../../../lib/index');
 var Lib = require('../../../src/lib');
+var Registry = require('../../../src/registry');
 var click = require('../assets/click');
 var doubleClick = require('../assets/double_click');
 var DBLCLICKDELAY = require('../../../src/plot_api/plot_config').dfltConfig.doubleClickDelay;
@@ -3595,6 +3596,35 @@ describe('Test that selection styles propagate to range-slider plot:', function(
         .then(function() { return doubleClick(200, 200); })
         .then(function() {
             _assert('after double-click reset', [1, 1]);
+        })
+        .then(done, done.fail);
+    });
+});
+
+describe('Test reselect with malformed calcdata:', function() {
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    // reselect runs unconditionally at the end of every redraw sequence
+    // (newPlot / react / relayout / resize) and dereferences gd.calcdata[i][0].
+    // calcdata can transiently hold an empty or undefined entry, which used to
+    // throw "Cannot read properties of undefined (reading '0')" and kill the
+    // chart even when no selection exists.
+    it('should not throw on an empty or undefined calcdata entry', function(done) {
+        var reselect = Registry.getComponentMethod('selections', 'reselect');
+
+        Plotly.newPlot(gd, [{y: [1, 2, 3]}, {y: [2, 3, 4]}])
+        .then(function() {
+            gd.calcdata[1] = undefined;
+            expect(function() { reselect(gd); }).not.toThrow();
+
+            gd.calcdata[0] = [];
+            expect(function() { reselect(gd); }).not.toThrow();
         })
         .then(done, done.fail);
     });


### PR DESCRIPTION
Skip empty/undefined calcdata entries in `epmtySplomSelectionBatch` and `determineSearchTraces` instead of dereferencing them.

### What happens

`reselect` runs unconditionally at the end of every redraw sequence (`newPlot` / `react` / `relayout` / resize). Its helper  `epmtySplomSelectionBatch` iterates `gd.calcdata` and dereferences `cd[i][0]` with no guard:

```js
  for (var i = 0; i < cd.length; i++) {
      var cd0 = cd[i][0];   // throws if cd[i] is undefined
      var trace = cd0.trace;
```

  When gd.calcdata contains an empty ([]) or undefined entry, this throws
  and the redraw promise rejects:

```
  TypeError: Cannot read properties of undefined (reading '0')
      at epmtySplomSelectionBatch (src/components/selections/select.js)
      at reselect             (src/components/selections/select.js)
      at Plots.reselect       (src/plots/plots.js)
      at Lib.syncOrAsync      (src/lib/index.js)
      at relayout             (src/plot_api/plot_api.js)
```
