### PR TITLE
Fix near-zero linear tick labels

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -90,6 +90,18 @@ function expandRange(range) {
     ];
 }
 
+function cleanLinearTickValue(ax, x, dtick) {
+    if(ax.type !== 'linear' || !isNumeric(dtick)) return x;
+
+    var tolerance = Math.abs(dtick) * 1e-10;
+    var r2l = ax.r2l || Number;
+    var tick0 = r2l(ax.tick0);
+
+    if(Math.abs(x - tick0) < tolerance) return tick0;
+    if(Math.abs(x) < tolerance) return 0;
+    return x;
+}
+
 /*
  * find the list of possible axes to reference with an xref or yref attribute
  * and coerce it to that list
@@ -1104,6 +1116,8 @@ axes.calcTicks = function calcTicks(ax, opts) {
                     if(mockAx.maskBreaks(x) === BADNUM && moveOutsideBreak(x, mockAx) >= maxRange) break;
                 }
             }
+
+            x = cleanLinearTickValue(mockAx, x, dtick);
 
             // prevent infinite loops - no more than one tick per pixel,
             // and make sure each value is different from the previous

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -3440,6 +3440,21 @@ describe('Test axes', function() {
             });
         }
 
+        it('snaps ticks close to tick0 before formatting', function() {
+            var textOut = mockCalc({
+                type: 'linear',
+                tickmode: 'linear',
+                tickformat: '~r',
+                tick0: 0,
+                dtick: 0.2,
+                range: [-0.6, 0.6]
+            });
+
+            expect(textOut).toEqual([
+                '−0.6', '−0.4', '−0.2', '0', '0.2', '0.4', '0.6'
+            ]);
+        });
+
         it('reverts to "power" for SI/B exponentformat beyond the prefix range (linear case)', function() {
             var textOut = mockCalc({
                 type: 'linear',


### PR DESCRIPTION
## Summary
- Snap linear tick values that land extremely close to `tick0` or zero before formatting.
- Add a regression for `tickformat: "~r"` so the zero tick renders as `0` instead of a floating-point artifact.

Fixes #7765.

## Testing
- `git diff --check`
- `npx @biomejs/biome lint src/plots/cartesian/axes.js test/jasmine/tests/axes_test.js`
- `npm run test-jasmine -- axes --nowatch --report-spec` (the new regression passes; this local run still has the existing untagged `insiderange react to new data` failure at `test/jasmine/tests/axes_test.js:8233`)
