### PR TITLE
Remove `*src` attributes

### DIFF
--- a/draftlogs/7623_change.md
+++ b/draftlogs/7623_change.md
@@ -1,1 +1,0 @@
-- Remove all `*src` attributes, as well as `layout.hidesources` attribute, from the schema. Change signature of `plots.graphJson()` function to remove `mode` argument [[#7623](https://github.com/plotly/plotly.js/pull/7623)]

--- a/draftlogs/7623_change.md
+++ b/draftlogs/7623_change.md
@@ -1,0 +1,1 @@
+- Remove all `*src` attributes, as well as `layout.hidesources` attribute, from the schema. Change signature of `plots.graphJson()` function to remove `mode` argument [[#7623](https://github.com/plotly/plotly.js/pull/7623)]

--- a/draftlogs/7812_remove.md
+++ b/draftlogs/7812_remove.md
@@ -1,0 +1,1 @@
+- Remove config attributes `showLink`, `linkText`, `sendData`, `showSources`, and `showEditInChartStudio`, as well as trace attribute `stream`, since all of these were associated with Chart Studio and are no longer needed [[#7812](https://github.com/plotly/plotly.js/pull/7812)]

--- a/draftlogs/7829_change.md
+++ b/draftlogs/7829_change.md
@@ -1,0 +1,1 @@
+- Change signature of `plots.graphJson()` function to remove `mode` argument [[#7829](https://github.com/plotly/plotly.js/pull/7829)]

--- a/draftlogs/7829_remove.md
+++ b/draftlogs/7829_remove.md
@@ -1,0 +1,1 @@
+- Remove all `*src` attributes, as well as `layout.hidesources` attribute, from the schema [[#7829](https://github.com/plotly/plotly.js/pull/7829)]

--- a/src/plot_api/helpers.js
+++ b/src/plot_api/helpers.js
@@ -354,7 +354,7 @@ function emptyContainer(outer, innerStr) {
 // swap all the data and data attributes associated with x and y
 exports.swapXYData = function (trace) {
     var i;
-    Lib.swapAttrs(trace, ['?', '?0', 'd?', '?bins', 'nbins?', 'autobin?', '?src', 'error_?']);
+    Lib.swapAttrs(trace, ['?', '?0', 'd?', '?bins', 'nbins?', 'autobin?', 'error_?']);
     if (Array.isArray(trace.z) && Array.isArray(trace.z[0])) {
         if (trace.transpose) delete trace.transpose;
         else trace.transpose = true;

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1564,9 +1564,9 @@ function _restyle(gd, aobj, traces) {
                     labelsTo = 'y';
                     valuesTo = 'x';
                 }
-                Lib.swapAttrs(cont, ['?', '?src'], 'labels', labelsTo);
+                Lib.swapAttrs(cont, ['?'], 'labels', labelsTo);
                 Lib.swapAttrs(cont, ['d?', '?0'], 'label', labelsTo);
-                Lib.swapAttrs(cont, ['?', '?src'], 'values', valuesTo);
+                Lib.swapAttrs(cont, ['?'], 'values', valuesTo);
 
                 if (oldVal === 'pie' || oldVal === 'funnelarea') {
                     nestedProperty(cont, 'marker.color').set(nestedProperty(cont, 'marker.colors').get());

--- a/src/plot_api/plot_schema.js
+++ b/src/plot_api/plot_schema.js
@@ -539,29 +539,16 @@ function getFramesAttributes() {
 }
 
 function formatAttributes(attrs) {
-    mergeValTypeAndRole(attrs);
+    setRole(attrs);
     formatArrayContainers(attrs);
     stringify(attrs);
 
     return attrs;
 }
 
-function mergeValTypeAndRole(attrs) {
-    function makeSrcAttr(attrName) {
-        return {
-            valType: 'string',
-            description: 'Sets the source reference on Chart Studio Cloud for `' + attrName + '`.',
-            editType: 'none'
-        };
-    }
-
+function setRole(attrs) {
     function callback(attr, attrName, attrs) {
-        if(exports.isValObject(attr)) {
-            if(attr.arrayOk === true || attr.valType === 'data_array') {
-                // all 'arrayOk' and 'data_array' attrs have a corresponding 'src' attr
-                attrs[attrName + 'src'] = makeSrcAttr(attrName);
-            }
-        } else if(isPlainObject(attr)) {
+        if(!exports.isValObject(attr) && isPlainObject(attr)) {
             // all attrs container objects get role 'object'
             attr.role = 'object';
         }

--- a/src/plot_api/to_image.js
+++ b/src/plot_api/to_image.js
@@ -170,7 +170,7 @@ function toImage(gd, opts) {
             }
 
             if(format === 'full-json') {
-                var json = plots.graphJson(clonedGd, false, 'keepdata', 'object', true, true);
+                var json = plots.graphJson(clonedGd, false, 'object', true, true);
                 json.version = version;
                 json = JSON.stringify(json);
                 cleanup();

--- a/src/plots/layout_attributes.js
+++ b/src/plots/layout_attributes.js
@@ -318,17 +318,6 @@ module.exports = {
             'other locales may alter this default.'
         ].join(' ')
     },
-    hidesources: {
-        valType: 'boolean',
-        dflt: false,
-        editType: 'plot',
-        description: [
-            'Determines whether or not a text link citing the data source is',
-            'placed at the bottom-right cored of the figure.',
-            'Has only an effect only on graphs that have been generated via',
-            'forked graphs from the Chart Studio Cloud (at https://chart-studio.plotly.com or on-premise).'
-        ].join(' ')
-    },
     showlegend: {
         // handled in legend.supplyLayoutDefaults
         // but included here because it's not in the legend object

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -139,7 +139,7 @@ plots.sendDataToCloud = function(gd) {
             name: 'data'
         });
 
-    hiddenformInput.node().value = plots.graphJson(gd, false);
+    hiddenformInput.node().value = plots.graphJson(gd);
     hiddenform.node().submit();
     hiddenformDiv.remove();
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1318,7 +1318,6 @@ plots.supplyLayoutGlobalDefaults = function(layoutIn, layoutOut, formatObj) {
     coerce('paper_bgcolor');
 
     coerce('separators', formatObj.decimal + formatObj.thousands);
-    coerce('hidesources');
 
     coerce('colorway');
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -139,7 +139,7 @@ plots.sendDataToCloud = function(gd) {
             name: 'data'
         });
 
-    hiddenformInput.node().value = plots.graphJson(gd, false, 'keepdata');
+    hiddenformInput.node().value = plots.graphJson(gd, false);
     hiddenform.node().submit();
     hiddenformDiv.remove();
 
@@ -1964,7 +1964,7 @@ plots.didMarginChange = function(margin0, margin1) {
 /**
  * JSONify the graph data and layout
  *
- * This function needs to recurse because some src can be inside
+ * This function needs to recurse because some objects can be inside
  * sub-objects.
  *
  * It also strips out functions and private (starts with _) elements.
@@ -1973,18 +1973,12 @@ plots.didMarginChange = function(margin0, margin1) {
  *
  * @param gd The graphDiv
  * @param {Boolean} dataonly If true, don't return layout.
- * @param {'keepref'|'keepdata'|'keepall'} [mode='keepref'] Filter what's kept
- *      keepref: remove data for which there's a src present
- *          eg if there's xsrc present (and xsrc is well-formed,
- *          ie has : and some chars before it), strip out x
- *      keepdata: remove all src tags, don't remove the data itself
- *      keepall: keep data and src
  * @param {String} output If you specify 'object', the result will not be stringified
  * @param {Boolean} useDefaults If truthy, use _fullLayout and _fullData
  * @param {Boolean} includeConfig If truthy, include _context
  * @returns {Object|String}
  */
-plots.graphJson = function(gd, dataonly, mode, output, useDefaults, includeConfig) {
+plots.graphJson = function(gd, dataonly, output, useDefaults, includeConfig) {
     // if the defaults aren't supplied yet, we need to do that...
     if((useDefaults && dataonly && !gd._fullData) ||
             (useDefaults && !dataonly && !gd._fullLayout)) {
@@ -2001,7 +1995,6 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults, includeConfi
         }
         if(Lib.isPlainObject(d)) {
             var o = {};
-            var src;
             Object.keys(d).sort().forEach(function(v) {
                 // remove private elements and functions
                 // _ is for private, [ is a mistake ie [object Object]
@@ -2011,21 +2004,6 @@ plots.graphJson = function(gd, dataonly, mode, output, useDefaults, includeConfi
                 if(typeof d[v] === 'function') {
                     if(keepFunction) o[v] = '_function';
                     return;
-                }
-
-                // look for src/data matches and remove the appropriate one
-                if(mode === 'keepdata') {
-                    // keepdata: remove all ...src tags
-                    if(v.slice(-3) === 'src') {
-                        return;
-                    }
-                } else if(mode !== 'keepall') {
-                    // keepref: remove sourced data but only
-                    // if the source tag is well-formed
-                    src = d[v + 'src'];
-                    if(typeof src === 'string' && src.indexOf(':') > 0) {
-                        return;
-                    }
                 }
 
                 // OK, we're including this... recurse into it

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1971,13 +1971,13 @@ plots.didMarginChange = function(margin0, margin1) {
  * get saved.
  *
  * @param gd The graphDiv
- * @param {Boolean} dataonly If true, don't return layout.
- * @param {String} output If you specify 'object', the result will not be stringified
- * @param {Boolean} useDefaults If truthy, use _fullLayout and _fullData
- * @param {Boolean} includeConfig If truthy, include _context
+ * @param {Boolean} [dataonly=false] If true, don't return layout.
+ * @param {String} [output='json'] If set to 'object', return result as a JS Object, otherwise return as a JSON string
+ * @param {Boolean} [useDefaults=false] If truthy, use _fullLayout and _fullData (after supplyDefaults step)
+ * @param {Boolean} [includeConfig=false] If truthy, include _context
  * @returns {Object|String}
  */
-plots.graphJson = function(gd, dataonly, output, useDefaults, includeConfig) {
+plots.graphJson = function(gd, dataonly = false, output = 'json', useDefaults = false, includeConfig = false) {
     // if the defaults aren't supplied yet, we need to do that...
     if((useDefaults && dataonly && !gd._fullData) ||
             (useDefaults && !dataonly && !gd._fullLayout)) {

--- a/src/snapshot/cloneplot.js
+++ b/src/snapshot/cloneplot.js
@@ -26,7 +26,6 @@ function cloneLayoutOverride(tileClass) {
         case 'thumbnail':
             override = {
                 title: {text: ''},
-                hidesources: true,
                 showlegend: false,
                 borderwidth: 0,
                 bordercolor: '',

--- a/src/types/generated/schema.d.ts
+++ b/src/types/generated/schema.d.ts
@@ -16254,7 +16254,6 @@ export interface Layout {
         yside?: 'left' | 'left plot' | 'right plot' | 'right';
     };
     height?: number;
-    hidesources?: boolean;
     hoveranywhere?: boolean;
     hoverdistance?: number;
     hoverlabel?: {

--- a/tasks/generate_schema_types.mjs
+++ b/tasks/generate_schema_types.mjs
@@ -456,16 +456,6 @@ function valTypeToTS(attr, attrPath) {
 // ---------------------------------------------------------------------------
 
 /**
- * Returns true if key looks like an auto-generated *src attribute.
- * These are created for Chart Studio Cloud and shouldn't appear in types.
- */
-function isSrcAttr(key, siblings) {
-    if (!key.endsWith('src')) return false;
-    const base = key.slice(0, -3);
-    return base in siblings;
-}
-
-/**
  * Detect a linked-to-array container in the serialized schema.
  *
  * In the source, these are marked with `_isLinkedToArray`, but that flag
@@ -508,7 +498,6 @@ function containerFingerprint(attrs) {
     for (const key of Object.keys(attrs).sort()) {
         if (META_KEYS.has(key)) continue;
         const val = attrs[key];
-        if (isSrcAttr(key, attrs)) continue;
         if (val == null) continue;
 
         if (typeof val === 'string') {
@@ -546,7 +535,6 @@ function collectFingerprints(attrs, collector) {
     for (const key of Object.keys(attrs).sort()) {
         if (META_KEYS.has(key)) continue;
         const val = attrs[key];
-        if (isSrcAttr(key, attrs)) continue;
         if (val == null || typeof val !== 'object' || val.valType) continue;
 
         let containerAttrs;
@@ -586,7 +574,6 @@ function countProperties(attrs) {
     let count = 0;
     for (const key of Object.keys(attrs)) {
         if (META_KEYS.has(key)) continue;
-        if (isSrcAttr(key, attrs)) continue;
         const val = attrs[key];
         if (val == null) continue;
         if (typeof val === 'string' || typeof val !== 'object') {
@@ -759,9 +746,6 @@ function attrsToProperties(attrs, indent, pathPrefix, sharedTypes, fieldOverride
 
         const val = attrs[key];
 
-        // Skip src attributes
-        if (isSrcAttr(key, attrs)) continue;
-
         // Skip null/undefined
         if (val == null) continue;
 
@@ -928,7 +912,6 @@ function generateLayoutProperties(layoutAttrs, sharedTypes, subplotGroups, array
     for (const key of Object.keys(layoutAttrs).sort()) {
         if (META_KEYS.has(key)) continue;
         const val = layoutAttrs[key];
-        if (isSrcAttr(key, layoutAttrs)) continue;
         if (val == null) continue;
 
         // String literal

--- a/test/image/mocks/0.json
+++ b/test/image/mocks/0.json
@@ -1217,7 +1217,6 @@
     "barmode": "stack",
     "bargap": 0.2,
     "bargroupgap": 0,
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/1.json
+++ b/test/image/mocks/1.json
@@ -609,7 +609,6 @@
     "hovermode": "x",
     "dragmode": "zoom",
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/10.json
+++ b/test/image/mocks/10.json
@@ -256,7 +256,6 @@
     "plot_bgcolor": "rgb(255, 255, 255)",
     "hovermode": "x",
     "dragmode": "zoom",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/11.json
+++ b/test/image/mocks/11.json
@@ -232,7 +232,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/12.json
+++ b/test/image/mocks/12.json
@@ -505,7 +505,6 @@
     "bargroupgap": 0,
     "boxmode": "overlay",
     "separators": ".,",
-    "hidesources": false,
     "selections": [
       {
         "x0": 150,

--- a/test/image/mocks/13.json
+++ b/test/image/mocks/13.json
@@ -328,7 +328,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/14.json
+++ b/test/image/mocks/14.json
@@ -335,7 +335,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/15.json
+++ b/test/image/mocks/15.json
@@ -270,7 +270,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/17.json
+++ b/test/image/mocks/17.json
@@ -632,7 +632,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/18.json
+++ b/test/image/mocks/18.json
@@ -1235,7 +1235,6 @@
     "bargroupgap": 0,
     "boxmode": "overlay",
     "separators": ".,",
-    "hidesources": false,
     "yaxis2": {
       "title": {
         "text": "sepal width",

--- a/test/image/mocks/19.json
+++ b/test/image/mocks/19.json
@@ -153,7 +153,6 @@
     "bargroupgap": 0,
     "boxmode": "overlay",
     "separators": ".,",
-    "hidesources": false,
     "yaxis2": {
       "title": {
         "text": "Click to enter Y2 axis title"

--- a/test/image/mocks/21.json
+++ b/test/image/mocks/21.json
@@ -485,7 +485,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/22.json
+++ b/test/image/mocks/22.json
@@ -288,7 +288,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/23.json
+++ b/test/image/mocks/23.json
@@ -144,7 +144,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/24.json
+++ b/test/image/mocks/24.json
@@ -183,7 +183,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/25.json
+++ b/test/image/mocks/25.json
@@ -178,7 +178,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/26.json
+++ b/test/image/mocks/26.json
@@ -21207,7 +21207,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/27.json
+++ b/test/image/mocks/27.json
@@ -347,7 +347,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".",
-    "hidesources": false
+    "separators": "."
   }
 }

--- a/test/image/mocks/28.json
+++ b/test/image/mocks/28.json
@@ -1002,7 +1002,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".",
-    "hidesources": false
+    "separators": "."
   }
 }

--- a/test/image/mocks/29.json
+++ b/test/image/mocks/29.json
@@ -2284,7 +2284,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/30.json
+++ b/test/image/mocks/30.json
@@ -198,7 +198,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/31.json
+++ b/test/image/mocks/31.json
@@ -381,7 +381,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/32.json
+++ b/test/image/mocks/32.json
@@ -828,7 +828,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/4.json
+++ b/test/image/mocks/4.json
@@ -128,7 +128,6 @@
     "plot_bgcolor": "#fff",
     "hovermode": "x",
     "dragmode": "zoom",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/5.json
+++ b/test/image/mocks/5.json
@@ -184,7 +184,6 @@
     "plot_bgcolor": "#fff",
     "hovermode": "x",
     "dragmode": "zoom",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/contour_match_edges.json
+++ b/test/image/mocks/contour_match_edges.json
@@ -1926,7 +1926,6 @@
       "exponentformat": "B"
     },
     "bargroupgap": 0,
-    "hidesources": false,
     "showlegend": false,
     "separators": ".,",
     "barmode": "group",

--- a/test/image/mocks/fonts.json
+++ b/test/image/mocks/fonts.json
@@ -431,7 +431,6 @@
       "anchor": "x",
       "exponentformat": "B"
     },
-    "hidesources": false,
     "boxgroupgap": 0.3,
     "margin": {
       "b": 80,

--- a/test/image/mocks/funnel_11.json
+++ b/test/image/mocks/funnel_11.json
@@ -120,7 +120,6 @@
     "funnelmode": "group",
     "funnelgap": 0.2,
     "funnelgroupgap": 0,
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/gl2d_10.json
+++ b/test/image/mocks/gl2d_10.json
@@ -145,7 +145,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/gl2d_12.json
+++ b/test/image/mocks/gl2d_12.json
@@ -502,7 +502,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/gl2d_14.json
+++ b/test/image/mocks/gl2d_14.json
@@ -146,7 +146,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/gl2d_17.json
+++ b/test/image/mocks/gl2d_17.json
@@ -588,7 +588,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/gl2d_fonts.json
+++ b/test/image/mocks/gl2d_fonts.json
@@ -427,7 +427,6 @@
     "bargroupgap": 0,
     "boxmode": "overlay",
     "boxgap": 0.3,
-    "boxgroupgap": 0.3,
-    "hidesources": false
+    "boxgroupgap": 0.3
   }
 }

--- a/test/image/mocks/gl2d_scatter-subplot-panel.json
+++ b/test/image/mocks/gl2d_scatter-subplot-panel.json
@@ -3,8 +3,6 @@
     {
       "uid": "ab6939",
       "yaxis": "y",
-      "ysrc": "jackp:17616:013c39",
-      "xsrc": "jackp:17616:7ad609",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -153,8 +151,6 @@
     {
       "uid": "f17ffc",
       "yaxis": "y",
-      "ysrc": "jackp:17616:ee32d5",
-      "xsrc": "jackp:17616:0d67c1",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -335,8 +331,6 @@
     {
       "uid": "dace31",
       "yaxis": "y",
-      "ysrc": "jackp:17616:3908ce",
-      "xsrc": "jackp:17616:45a03c",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -469,8 +463,6 @@
     {
       "uid": "c6e1cb",
       "yaxis": "y",
-      "ysrc": "jackp:17616:1e013b",
-      "xsrc": "jackp:17616:4b5447",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -581,8 +573,6 @@
     {
       "uid": "c62c21",
       "yaxis": "y",
-      "ysrc": "jackp:17616:479c89",
-      "xsrc": "jackp:17616:548eee",
       "marker": {
         "color": "rgb(148, 103, 189)",
         "line": {
@@ -605,8 +595,6 @@
     {
       "uid": "08893d",
       "yaxis": "y2",
-      "ysrc": "jackp:17616:36d993",
-      "xsrc": "jackp:17616:6d7fe8",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -745,8 +733,6 @@
     {
       "uid": "fa9571",
       "yaxis": "y2",
-      "ysrc": "jackp:17616:89729a",
-      "xsrc": "jackp:17616:512573",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -895,8 +881,6 @@
     {
       "uid": "7677a5",
       "yaxis": "y2",
-      "ysrc": "jackp:17616:567114",
-      "xsrc": "jackp:17616:2bf765",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -1017,8 +1001,6 @@
     {
       "uid": "59b4c9",
       "yaxis": "y2",
-      "ysrc": "jackp:17616:42cadc",
-      "xsrc": "jackp:17616:1ea406",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -1125,8 +1107,6 @@
     {
       "uid": "524443",
       "yaxis": "y2",
-      "ysrc": "jackp:17616:b896d3",
-      "xsrc": "jackp:17616:0f5f52",
       "marker": {
         "color": "rgb(148, 103, 189)",
         "line": {
@@ -1150,8 +1130,6 @@
     {
       "uid": "0481fb",
       "yaxis": "y3",
-      "ysrc": "jackp:17616:474ec3",
-      "xsrc": "jackp:17616:36d4e6",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -1276,8 +1254,6 @@
     {
       "uid": "ea480c",
       "yaxis": "y3",
-      "ysrc": "jackp:17616:d4eb68",
-      "xsrc": "jackp:17616:856c9d",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -1412,8 +1388,6 @@
     {
       "uid": "b16b7f",
       "yaxis": "y3",
-      "ysrc": "jackp:17616:6e5c39",
-      "xsrc": "jackp:17616:f6b328",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -1533,8 +1507,6 @@
     {
       "uid": "c6d9fa",
       "yaxis": "y3",
-      "ysrc": "jackp:17616:b8c075",
-      "xsrc": "jackp:17616:e7d470",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -1649,8 +1621,6 @@
     {
       "uid": "c631a8",
       "yaxis": "y3",
-      "ysrc": "jackp:17616:63bc1a",
-      "xsrc": "jackp:17616:106531",
       "marker": {
         "color": "rgb(148, 103, 189)",
         "line": {
@@ -1677,8 +1647,6 @@
     {
       "uid": "b906f7",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:292289",
-      "xsrc": "jackp:17616:878a2c",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -1817,8 +1785,6 @@
     {
       "uid": "d2a84e",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:c068e9",
-      "xsrc": "jackp:17616:0d9a13",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -1977,8 +1943,6 @@
     {
       "uid": "732989",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:262a53",
-      "xsrc": "jackp:17616:30666d",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -2101,8 +2065,6 @@
     {
       "uid": "6a8130",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:cecf5b",
-      "xsrc": "jackp:17616:8d8322",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -2150,8 +2112,6 @@
       "showlegend": false,
       "uid": "29557f",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:1f8d2e",
-      "xsrc": "jackp:17616:1dd020",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -2169,8 +2129,6 @@
       "showlegend": false,
       "uid": "3e367a",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:1f8d2e",
-      "xsrc": "jackp:17616:1dd020",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -2188,8 +2146,6 @@
       "showlegend": false,
       "uid": "337db2",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:1f8d2e",
-      "xsrc": "jackp:17616:1dd020",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -2207,8 +2163,6 @@
       "showlegend": false,
       "uid": "daacfd",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:1f8d2e",
-      "xsrc": "jackp:17616:1dd020",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -2226,8 +2180,6 @@
       "showlegend": false,
       "uid": "ec7e38",
       "yaxis": "y4",
-      "ysrc": "jackp:17616:1f8d2e",
-      "xsrc": "jackp:17616:1dd020",
       "marker": {
         "color": "rgb(148, 103, 189)",
         "line": {
@@ -2244,8 +2196,6 @@
     {
       "uid": "4c0c61",
       "yaxis": "y5",
-      "ysrc": "jackp:17616:e2020b",
-      "xsrc": "jackp:17616:097e51",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -2382,8 +2332,6 @@
     {
       "uid": "0224d9",
       "yaxis": "y5",
-      "ysrc": "jackp:17616:7a9127",
-      "xsrc": "jackp:17616:0baf91",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -2542,8 +2490,6 @@
     {
       "uid": "631b1f",
       "yaxis": "y5",
-      "ysrc": "jackp:17616:8e2b9c",
-      "xsrc": "jackp:17616:87a56a",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -2674,8 +2620,6 @@
     {
       "uid": "92020c",
       "yaxis": "y5",
-      "ysrc": "jackp:17616:d23bb6",
-      "xsrc": "jackp:17616:b1d52c",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -2788,8 +2732,6 @@
     {
       "uid": "537fed",
       "yaxis": "y5",
-      "ysrc": "jackp:17616:3c7520",
-      "xsrc": "jackp:17616:b91412",
       "marker": {
         "color": "rgb(148, 103, 189)",
         "line": {
@@ -2818,8 +2760,6 @@
     {
       "uid": "f44104",
       "yaxis": "y6",
-      "ysrc": "jackp:17616:3c2a0b",
-      "xsrc": "jackp:17616:19613b",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -2958,8 +2898,6 @@
     {
       "uid": "8fb1ff",
       "yaxis": "y6",
-      "ysrc": "jackp:17616:aca112",
-      "xsrc": "jackp:17616:1f9da8",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -3124,8 +3062,6 @@
     {
       "uid": "e676c7",
       "yaxis": "y6",
-      "ysrc": "jackp:17616:24335b",
-      "xsrc": "jackp:17616:2f0d1f",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -3258,8 +3194,6 @@
     {
       "uid": "0df67e",
       "yaxis": "y6",
-      "ysrc": "jackp:17616:ab87d8",
-      "xsrc": "jackp:17616:5cf5f8",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -3376,8 +3310,6 @@
     {
       "uid": "182eac",
       "yaxis": "y6",
-      "ysrc": "jackp:17616:601f7d",
-      "xsrc": "jackp:17616:12eb26",
       "marker": {
         "color": "rgb(148, 103, 189)",
         "line": {
@@ -3404,8 +3336,6 @@
     {
       "uid": "376ffd",
       "yaxis": "y7",
-      "ysrc": "jackp:17616:375858",
-      "xsrc": "jackp:17616:725e8e",
       "marker": {
         "color": "rgb(31, 119, 180)",
         "line": {
@@ -3516,8 +3446,6 @@
     {
       "uid": "5d7bed",
       "yaxis": "y7",
-      "ysrc": "jackp:17616:a2b0f6",
-      "xsrc": "jackp:17616:9cbb59",
       "marker": {
         "color": "rgb(255, 127, 14)",
         "line": {
@@ -3630,8 +3558,6 @@
     {
       "uid": "1b9a1f",
       "yaxis": "y7",
-      "ysrc": "jackp:17616:93c145",
-      "xsrc": "jackp:17616:4bf754",
       "marker": {
         "color": "rgb(44, 160, 44)",
         "line": {
@@ -3742,8 +3668,6 @@
     {
       "uid": "26c716",
       "yaxis": "y7",
-      "ysrc": "jackp:17616:ec6fcf",
-      "xsrc": "jackp:17616:6fd863",
       "marker": {
         "color": "rgb(214, 39, 40)",
         "line": {
@@ -3850,8 +3774,6 @@
     {
       "uid": "db52b5",
       "yaxis": "y7",
-      "ysrc": "jackp:17616:e406b3",
-      "xsrc": "jackp:17616:1f1b53",
       "marker": {
         "color": "rgb(148, 103, 189)",
         "line": {

--- a/test/image/mocks/gl3d_opacity-surface.json
+++ b/test/image/mocks/gl3d_opacity-surface.json
@@ -1528,7 +1528,6 @@
     }
   ],
   "layout": {
-    "hidesources": false,
     "autosize": true,
     "font": {
       "color": "#444",

--- a/test/image/mocks/legend_horizontal.json
+++ b/test/image/mocks/legend_horizontal.json
@@ -137,7 +137,6 @@
     "bargap": 0.2,
     "bargroupgap": 0,
     "boxmode": "overlay",
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/image/mocks/text_export.json
+++ b/test/image/mocks/text_export.json
@@ -1670,7 +1670,6 @@
       "size": 12
     },
     "height": 630,
-    "hidesources": false,
     "hovermode": "x",
     "legend": {
       "x": 0.5392124763053593,

--- a/test/image/mocks/titles-avoid-labels.json
+++ b/test/image/mocks/titles-avoid-labels.json
@@ -140,7 +140,6 @@
     "dragmode": "zoom",
     "hovermode": "x",
     "separators": ".,",
-    "hidesources": false,
     "showlegend": false
   }
 }

--- a/test/image/mocks/waterfall_11.json
+++ b/test/image/mocks/waterfall_11.json
@@ -133,7 +133,6 @@
     "waterfallmode": "group",
     "waterfallgap": 0.2,
     "waterfallgroupgap": 0.1,
-    "separators": ".,",
-    "hidesources": false
+    "separators": ".,"
   }
 }

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -578,7 +578,7 @@ describe('Test Plots', function() {
             };
 
             Plotly.newPlot(gd, mock).then(function() {
-                var str = Plots.graphJson(gd, false);
+                var str = Plots.graphJson(gd);
                 var obj = JSON.parse(str);
 
                 expect(obj.data).toEqual(mock.data);
@@ -612,7 +612,7 @@ describe('Test Plots', function() {
             };
 
             Plotly.newPlot(gd, [trace]).then(function() {
-                var str = Plots.graphJson(gd, false);
+                var str = Plots.graphJson(gd);
                 var obj = JSON.parse(str);
 
                 expect(obj.data[0].x).toEqual([1, 2, 3]);

--- a/test/jasmine/tests/plots_test.js
+++ b/test/jasmine/tests/plots_test.js
@@ -578,7 +578,7 @@ describe('Test Plots', function() {
             };
 
             Plotly.newPlot(gd, mock).then(function() {
-                var str = Plots.graphJson(gd, false, 'keepdata');
+                var str = Plots.graphJson(gd, false);
                 var obj = JSON.parse(str);
 
                 expect(obj.data).toEqual(mock.data);
@@ -612,7 +612,7 @@ describe('Test Plots', function() {
             };
 
             Plotly.newPlot(gd, [trace]).then(function() {
-                var str = Plots.graphJson(gd, false, 'keepdata');
+                var str = Plots.graphJson(gd, false);
                 var obj = JSON.parse(str);
 
                 expect(obj.data[0].x).toEqual([1, 2, 3]);

--- a/test/jasmine/tests/snapshot_test.js
+++ b/test/jasmine/tests/snapshot_test.js
@@ -100,7 +100,6 @@ describe('Plotly.Snapshot', function() {
 
             var THUMBNAIL_DEFAULT_LAYOUT = {
                 title: {text: ''},
-                hidesources: true,
                 showlegend: false,
                 hovermode: false,
                 dragmode: false,
@@ -112,7 +111,6 @@ describe('Plotly.Snapshot', function() {
             };
 
             var thumbTile = Plotly.Snapshot.clone(dummyGraphObj, thumbnailOptions);
-            expect(thumbTile.layout.hidesources).toEqual(THUMBNAIL_DEFAULT_LAYOUT.hidesources);
             expect(thumbTile.layout.showlegend).toEqual(THUMBNAIL_DEFAULT_LAYOUT.showlegend);
             expect(thumbTile.layout.borderwidth).toEqual(THUMBNAIL_DEFAULT_LAYOUT.borderwidth);
             expect(thumbTile.layout.annotations).toEqual(THUMBNAIL_DEFAULT_LAYOUT.annotations);


### PR DESCRIPTION
Addresses #7623

Schema attributes ending in `src` existed only to work with Chart Studio features, so they are no longer necessary

This PR:
- Removes all `*src` attributes and associated logic
- Removes `layout.hideSources` attribute which was also only needed for Chart Studio
- Updates tests accordingly (including deleting these removed attributes from image mocks)
- Updates typegen script
- Regenerates `plot-schema.json` and generated types