### PR TITLE
Fix "Unrecognized GUI edit" warning

### DIFF
--- a/draftlogs/7836_fix.md
+++ b/draftlogs/7836_fix.md
@@ -1,0 +1,1 @@
+- Fix "unrecognized GUI edit: selections[0]..." warnings emitted after making a box or lasso selection and then calling `Plotly.react()` [[#7836](https://github.com/plotly/plotly.js/issues/7836)]

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -2338,6 +2338,7 @@ var layoutUIControlPatterns = [
 
     { pattern: /^legend\.(x|y)$/, attr: 'editrevision' },
     { pattern: /^(shapes|annotations)/, attr: 'editrevision' },
+    { pattern: /^selections/, attr: 'selectionrevision' },
     { pattern: /^title\.text$/, attr: 'editrevision' }
 ];
 

--- a/test/jasmine/tests/plot_api_react_test.js
+++ b/test/jasmine/tests/plot_api_react_test.js
@@ -1544,6 +1544,47 @@ describe('Plotly.react and uirevision attributes', function() {
         _run(fig, editSelection, checkNoSelection, checkSelection).then(done, done.fail);
     });
 
+    it('preserves layout selections using selectionrevision without logging unrecognized GUI edits', function(done) {
+        // Regression test for https://github.com/plotly/plotly.js/issues/7809
+        // Check that a box selection is correctly recognized by selectionrevision
+        // following a call to Plotly.react(), rather than notifying with an
+        // "unrecognized GUI edit: selections[0]..." error
+        function fig(mainRev, selectionRev) {
+            return {
+                data: [{y: [1, 3, 1]}, {y: [2, 1, 3]}],
+                layout: {
+                    uirevision: mainRev,
+                    selectionrevision: selectionRev,
+                    dragmode: 'select',
+                    width: 400,
+                    height: 400,
+                    margin: {l: 100, t: 100, r: 100, b: 100}
+                }
+            };
+        }
+
+        function editSelection() {
+            return drag({node: document.querySelector('.nsewdrag'), dpos: [148, 100], pos0: [150, 102]});
+        }
+
+        function checkNoSelection() {
+            expect((gd.layout.selections || []).length).toBe(0, 'layout.selections cleared');
+        }
+        function checkSelection() {
+            expect((gd.layout.selections || []).length).toBe(1, 'layout.selections preserved');
+        }
+
+        var warnings = [];
+        spyOn(Lib, 'warn').and.callFake(function(msg) { warnings.push(msg); });
+
+        _run(fig, editSelection, checkNoSelection, checkSelection).then(function() {
+            var guiEditWarnings = warnings.filter(function(msg) {
+                return String(msg).indexOf('unrecognized GUI edit') !== -1;
+            });
+            expect(guiEditWarnings).toEqual([], 'no unrecognized GUI edit warnings');
+        }).then(done, done.fail);
+    });
+
     it('preserves polar view changes using polar.uirevision', function(done) {
         // polar you can control either at the subplot or the axis level
         function fig(mainRev, polarRev) {


### PR DESCRIPTION
Closes #7809

Fix "Unrecognized GUI edit" warning by adding a missing `selections` layout UI pattern and mapping it to `selectionrevision`.

Also add a regression test for the issue.

### Steps for testing

1. Go to [@lana-k's codepen](https://codepen.io/skochitove/pen/WboZaPv?editors=1111)
2. Click "Settings" in the upper-right corner
3. Under "Add External Scripts/Pens", replace the Plotly 3.5.1 CDN link with [the link to the dev build for this PR](https://plotly.github.io/plotly.js-dev-builds/upload/pr-7836/latest/plotly.min.js)
4. Click "Close"
5. Click "Run" in the upper-right corner
6. Follow the reproduction steps in #7809. The "Unrecognized GUI edit" notifications should NOT show up.