### PR TITLE
ci: Move label check before checkout, use GH API for file check

### DIFF
--- a/.github/workflows/check-draftlog.yml
+++ b/.github/workflows/check-draftlog.yml
@@ -10,29 +10,37 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   check-draftlog:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Check for a new draftlog entry
+      - name: Check for no-draftlog label
+        id: label-check
         env:
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if echo "$PR_LABELS" | grep -q '"no-draftlog"'; then
+            echo "Skipping draftlog check: 'no-draftlog' label is set."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for a new draftlog entry
+        if: steps.label-check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          if echo "$PR_LABELS" | grep -q '"no-draftlog"'; then
-            echo "Skipping draftlog check: 'no-draftlog' label is set."
-            exit 0
-          fi
-
-          ADDED=$(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- 'draftlogs/*.md' | grep -v '^draftlogs/README\.md$' || true)
+          ADDED=$(gh api --paginate "/repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[] | select(.status=="added") | .filename' \
+            | grep '^draftlogs/' | grep -v '^draftlogs/README\.md$' || true)
 
           if [ -z "$ADDED" ]; then
             echo "::error::No new draftlog entry was added under draftlogs/."
@@ -58,7 +66,8 @@ jobs:
           MISSING_LINK=""
           while IFS= read -r f; do
             [ -z "$f" ] && continue
-            if ! grep -qE '\[\[#[0-9]+\]\(https://github\.com/plotly/plotly\.js/pull/[0-9]+\)\]' "$f"; then
+            content=$(gh api -H 'Accept: application/vnd.github.raw' "/repos/$REPO/contents/$f?ref=$HEAD_SHA")
+            if ! echo "$content" | grep -qE '\[\[#[0-9]+\]\(https://github\.com/plotly/plotly\.js/pull/[0-9]+\)\]'; then
               MISSING_LINK="$MISSING_LINK$f"$'\n'
             fi
           done <<< "$ADDED"


### PR DESCRIPTION
### Description

Update the check draftlog CI workflow to check the labels first, then use the GH API to look for log files.

### Notes

This should be a lot faster than checking out the whole history of the repo.