### PR TITLE
Add origin as query string to requests to plotlyServerURL

### DIFF
--- a/draftlogs/7802_change.md
+++ b/draftlogs/7802_change.md
@@ -1,2 +1,2 @@
-- Update `sendDataToCloud` modebar button to upload chart to Plotly Cloud [[#7802](https://github.com/plotly/plotly.js/pull/7802), [#7852](https://github.com/plotly/plotly.js/pull/7852)]
+- Update `sendDataToCloud` modebar button to upload chart to Plotly Cloud [[#7802](https://github.com/plotly/plotly.js/pull/7802), [#7852](https://github.com/plotly/plotly.js/pull/7852), [#7854](https://github.com/plotly/plotly.js/pull/7854)]
   - NOTE: The Plotly Cloud endpoint for receiving charts is not yet functional, so this button won't complete the upload.

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -215,10 +215,9 @@ plots.sendDataToCloud = function(gd, serverURL) {
     // the chart back to it once Cloud reports that authentication succeeded.
     // Pass the current page's origin as a query string so Cloud knows where to
     // send the CHART_AUTH_SUCCESS message back to.
-    var uploadUrl = serverURL +
-        (serverURL.indexOf('?') === -1 ? '?' : '&') +
-        'origin=' + encodeURIComponent(window.location.origin);
-    var cloudWindow = window.open(uploadUrl, '_blank');
+    var uploadUrl = new URL(serverURL);
+    uploadUrl.searchParams.set('origin', window.location.origin);
+    var cloudWindow = window.open(uploadUrl.href, '_blank');
     if(!cloudWindow) {
         console.error('Unable to open Plotly Cloud (the popup may have been blocked)');
         gd.emit('plotly_exportfail');

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -213,7 +213,12 @@ plots.sendDataToCloud = function(gd, serverURL) {
 
     // Open the Cloud login page in a new tab. We keep a reference so we can post
     // the chart back to it once Cloud reports that authentication succeeded.
-    var cloudWindow = window.open(serverURL, '_blank');
+    // Pass the current page's origin as a query string so Cloud knows where to
+    // send the CHART_AUTH_SUCCESS message back to.
+    var uploadUrl = serverURL +
+        (serverURL.indexOf('?') === -1 ? '?' : '&') +
+        'origin=' + encodeURIComponent(window.location.origin);
+    var cloudWindow = window.open(uploadUrl, '_blank');
     if(!cloudWindow) {
         console.error('Unable to open Plotly Cloud (the popup may have been blocked)');
         gd.emit('plotly_exportfail');

--- a/test/jasmine/tests/config_test.js
+++ b/test/jasmine/tests/config_test.js
@@ -585,8 +585,9 @@ describe('config argument', function() {
                 expect(confirmBtn).not.toBe(null, 'confirm button should be shown');
                 mouseEvent('click', 0, 0, {element: confirmBtn});
 
-                // Should open the provided URL's origin in a new tab
-                expect(openSpy).toHaveBeenCalledWith('https://example.plotly.com/endpoint', '_blank');
+                // Should open the provided URL's origin in a new tab,
+                // adding the current page's origin as a query parameter
+                expect(openSpy).toHaveBeenCalledWith('https://example.plotly.com/endpoint?origin=http%3A%2F%2Flocalhost%3A9876', '_blank');
             })
             .then(done, done.fail);
         });


### PR DESCRIPTION
For secure communication between tabs via postMessage (after clicking the "upload to cloud" button), we need to include the origin of the request as a query string. 