### PR TITLE
Fix crash when ordering categories by value with null coordinates

### DIFF
--- a/draftlogs/7855_fix.md
+++ b/draftlogs/7855_fix.md
@@ -1,0 +1,1 @@
+- Fix crash when ordering categories by value (e.g. `sum descending`) with `null` coordinates [[#7855](https://github.com/plotly/plotly.js/pull/7855)]

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -3188,6 +3188,10 @@ function sortAxisCategoriesByValue(axList, gd) {
                         catIndex = cdi.p;
                         if(catIndex === undefined) catIndex = cdi[axLetter];
 
+                        // Skip points whose position is not a valid category
+                        // (e.g. a null/NaN coordinate maps to BADNUM)
+                        if(!(catIndex + 1)) continue;
+
                         value = cdi.s;
                         if(value === undefined) value = cdi.v;
                         if(value === undefined) value = isX ? cdi.y : cdi.x;

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -3190,7 +3190,7 @@ function sortAxisCategoriesByValue(axList, gd) {
 
                         // Skip points whose position is not a valid category
                         // (e.g. a null/NaN coordinate maps to BADNUM)
-                        if(!(catIndex + 1)) continue;
+                        if (catIndex == null || catIndex < 0) continue;
 
                         value = cdi.s;
                         if(value === undefined) value = cdi.v;

--- a/test/jasmine/tests/calcdata_test.js
+++ b/test/jasmine/tests/calcdata_test.js
@@ -1215,6 +1215,21 @@ describe('calculated data and points', function() {
                 })
                 .then(done, done.fail);
             });
+
+            it('does not throw when a category coordinate is null and ordering by value', function(done) {
+                Plotly.newPlot(gd, [{
+                    type: 'bar',
+                    x: ['a', null, 'b'],
+                    y: [3, 5, 7]
+                }], {
+                    xaxis: {type: 'category', categoryorder: 'sum descending'}
+                })
+                .then(function() {
+                    // the null point is dropped, remaining categories are ordered by value
+                    expect(gd._fullLayout.xaxis._categories).toEqual(['b', 'a']);
+                })
+                .then(done, done.fail);
+            });
         });
     });
 


### PR DESCRIPTION
Fixes #7840.

When `categoryorder` is set to a value-based order (e.g. `sum descending`, `total ascending`), `sortAxisCategoriesByValue` collects per-category values by indexing `categoriesValue[catIndex]`. A data point with a `null`/`NaN` category coordinate maps to `BADNUM`, so `catIndex` is `undefined` and `categoriesValue[catIndex][1]` throws `TypeError: Cannot read properties of undefined (reading '1')`, leaving the chart blank.

This skips points whose position is not a valid category, using the same `catIndex + 1` guard already applied in the 2dMap branch above. Such points carry no category to order anyway. Added a regression test for a bar chart with a `null` x and `sum descending`.
