### PR TITLE
test: Increase delay in flaky test

### DIFF
--- a/test/jasmine/tests/transition_test.js
+++ b/test/jasmine/tests/transition_test.js
@@ -650,7 +650,7 @@ describe('Plotly.react transitions:', function() {
             layout.xaxis.range = [-1, 1];
             return Plotly.react(gd, data, layout);
         })
-        .then(delay(100))
+        .then(delay(300))
         .then(function() {
             assertSpies('both trace and layout transitions', [
                 [Plots, 'transitionFromReact', 1],


### PR DESCRIPTION
### Description

Increase delay in flaky transition test.

### Testing

Check CI runs.

### Notes

- This test has been failing a lot recently, possibly due to the delay not being long enough:
  - https://github.com/plotly/plotly.js/actions/runs/27976159123/job/82794485828
  - https://github.com/plotly/plotly.js/actions/runs/27776341980/job/82189525470
  - https://github.com/plotly/plotly.js/actions/runs/27729654120/job/82033716999
  - https://github.com/plotly/plotly.js/actions/runs/27703098895/job/81944566710