### PR TITLE
chore: Add issue template for chore tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -2,7 +2,7 @@
 name: Chore
 about: Track maintenance work for plotly.js (dependency bumps, build/CI, internal refactors, docs)
 title: "[CHORE]: "
-labels: chore
+labels: "chore,plotly-internal"
 
 ---
 <!-- 

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,33 @@
+---
+name: Chore
+about: Track maintenance work for plotly.js (dependency bumps, build/CI, internal refactors, docs)
+title: "[CHORE]: "
+labels: chore
+
+---
+<!-- 
+Instructions (remove this section before submitting issue)
+
+Thanks for your interest in plotly.js!
+
+- Use this template for maintenance work that does not change end-user behavior: dependency updates, build pipeline changes, CI/CD adjustments, internal refactors, lint/format/typing cleanup, or documentation updates.
+- For user-facing bugs use the **Bug report** template, and for new functionality use the **Feature request** template.
+- Before opening a new chore, please search for existing and closed issues to avoid duplicates.
+- Comments should add content to the discussion. Approbation comments such as *+1* will be deleted by the maintainers — use [GitHub reactions](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments) instead.
+-->
+
+### Description
+
+<!-- Add a clear description of the update that should be made. -->
+
+### Why should this change be made?
+
+<!-- Provide an argument for why this update should be made. Please consider creating a PR and making the update yourself. Help is always appreciated. -->
+
+### Scope
+
+<!-- Provide specifics on the changes that need to be made. -->
+
+### Notes
+
+<!-- Add info here that doesn't fit in the other sections. -->


### PR DESCRIPTION
### Description

Add an issue template for chore tasks, like updating dependencies, refactoring code, etc.

### Changes

- Add new chore template

### Testing

After merging this PR:

- Create a new issue
- Choose the chore template
- Verify that the template looks correct