### PR TITLE
docs: Add template hints to attribute descriptions

### DIFF
--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -240,7 +240,7 @@ exports.valObjectMeta = {
     flaglist: {
         description: [
             'A string representing a combination of flags',
-            '(order does not matter here).',
+            '(flag order does not affect the output).',
             'Combine any of the available `flags` with *+*.',
             "(e.g. ('lines+markers')).",
             'Values in `extras` cannot be combined.'

--- a/src/lib/coerce.js
+++ b/src/lib/coerce.js
@@ -47,37 +47,30 @@ exports.valObjectMeta = {
         ].join(' '),
         requiredOpts: [],
         otherOpts: ['dflt'],
-        coerceFunction: function(v, propOut, dflt) {
-            propOut.set(
-                isArrayOrTypedArray(v) ? v :
-                isTypedArraySpec(v) ? decodeTypedArraySpec(v) :
-                dflt
-            );
+        coerceFunction: function (v, propOut, dflt) {
+            propOut.set(isArrayOrTypedArray(v) ? v : isTypedArraySpec(v) ? decodeTypedArraySpec(v) : dflt);
         }
     },
     enumerated: {
-        description: [
-            'Enumerated value type. The available values are listed',
-            'in `values`.'
-        ].join(' '),
+        description: ['Enumerated value type. The available values are listed', 'in `values`.'].join(' '),
         requiredOpts: ['values'],
         otherOpts: ['dflt', 'coerceNumber', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt, opts) {
-            if(opts.coerceNumber) v = +v;
-            if(opts.values.indexOf(v) === -1) propOut.set(dflt);
+        coerceFunction: function (v, propOut, dflt, opts) {
+            if (opts.coerceNumber) v = +v;
+            if (opts.values.indexOf(v) === -1) propOut.set(dflt);
             else propOut.set(v);
         },
-        validateFunction: function(v, opts) {
-            if(opts.coerceNumber) v = +v;
+        validateFunction: function (v, opts) {
+            if (opts.coerceNumber) v = +v;
 
             var values = opts.values;
-            for(var i = 0; i < values.length; i++) {
+            for (var i = 0; i < values.length; i++) {
                 var k = String(values[i]);
 
-                if((k.charAt(0) === '/' && k.charAt(k.length - 1) === '/')) {
+                if (k.charAt(0) === '/' && k.charAt(k.length - 1) === '/') {
                     var regex = new RegExp(k.slice(1, -1));
-                    if(regex.test(v)) return true;
-                } else if(v === values[i]) return true;
+                    if (regex.test(v)) return true;
+                } else if (v === values[i]) return true;
             }
             return false;
         }
@@ -86,8 +79,8 @@ exports.valObjectMeta = {
         description: 'A boolean (true/false) value.',
         requiredOpts: [],
         otherOpts: ['dflt', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt, opts) {
-            const isBoolean = value => value === true || value === false;
+        coerceFunction: function (v, propOut, dflt, opts) {
+            const isBoolean = (value) => value === true || value === false;
             if (isBoolean(v) || (opts.arrayOk && Array.isArray(v) && v.length > 0 && v.every(isBoolean))) {
                 propOut.set(v);
             } else {
@@ -104,12 +97,10 @@ exports.valObjectMeta = {
         ].join(' '),
         requiredOpts: [],
         otherOpts: ['dflt', 'min', 'max', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt, opts) {
-            if(isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
+        coerceFunction: function (v, propOut, dflt, opts) {
+            if (isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
 
-            if(!isNumeric(v) ||
-                    (opts.min !== undefined && v < opts.min) ||
-                    (opts.max !== undefined && v > opts.max)) {
+            if (!isNumeric(v) || (opts.min !== undefined && v < opts.min) || (opts.max !== undefined && v > opts.max)) {
                 propOut.set(dflt);
             } else propOut.set(+v);
         }
@@ -122,17 +113,20 @@ exports.valObjectMeta = {
         ].join(' '),
         requiredOpts: [],
         otherOpts: ['dflt', 'min', 'max', 'arrayOk', 'extras'],
-        coerceFunction: function(v, propOut, dflt, opts) {
-            if((opts.extras || []).indexOf(v) !== -1) {
+        coerceFunction: function (v, propOut, dflt, opts) {
+            if ((opts.extras || []).indexOf(v) !== -1) {
                 propOut.set(v);
                 return;
             }
 
-            if(isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
+            if (isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
 
-            if(v % 1 || !isNumeric(v) ||
-                    (opts.min !== undefined && v < opts.min) ||
-                    (opts.max !== undefined && v > opts.max)) {
+            if (
+                v % 1 ||
+                !isNumeric(v) ||
+                (opts.min !== undefined && v < opts.min) ||
+                (opts.max !== undefined && v > opts.max)
+            ) {
                 propOut.set(dflt);
             } else propOut.set(+v);
         }
@@ -146,13 +140,13 @@ exports.valObjectMeta = {
         requiredOpts: [],
         // TODO 'values shouldn't be in there (edge case: 'dash' in Scatter)
         otherOpts: ['dflt', 'noBlank', 'strict', 'arrayOk', 'values'],
-        coerceFunction: function(v, propOut, dflt, opts) {
-            if(typeof v !== 'string') {
-                var okToCoerce = (typeof v === 'number');
+        coerceFunction: function (v, propOut, dflt, opts) {
+            if (typeof v !== 'string') {
+                var okToCoerce = typeof v === 'number';
 
-                if(opts.strict === true || !okToCoerce) propOut.set(dflt);
+                if (opts.strict === true || !okToCoerce) propOut.set(dflt);
                 else propOut.set(String(v));
-            } else if(opts.noBlank && !v) propOut.set(dflt);
+            } else if (opts.noBlank && !v) propOut.set(dflt);
             else propOut.set(v);
         }
     },
@@ -170,30 +164,29 @@ exports.valObjectMeta = {
         ].join(' '),
         requiredOpts: [],
         otherOpts: ['dflt', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt) {
-            if(isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
+        coerceFunction: function (v, propOut, dflt) {
+            if (isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
 
-            if(Color.isValid(v)) propOut.set(v);
+            if (Color.isValid(v)) propOut.set(v);
             else propOut.set(dflt);
         }
     },
     colorlist: {
-        description: [
-            'A list of colors.',
-            'Must be an {array} containing valid colors.',
-        ].join(' '),
+        description: ['A list of colors.', 'Must be an {array} containing valid colors.'].join(' '),
         requiredOpts: [],
         otherOpts: ['dflt'],
-        coerceFunction: function(v, propOut, dflt) {
-            if(!Array.isArray(v) || !v.length) propOut.set(dflt);
-            else if(v.every(color => Color.isValid(color))) propOut.set(v);
+        coerceFunction: function (v, propOut, dflt) {
+            if (!Array.isArray(v) || !v.length) propOut.set(dflt);
+            else if (v.every((color) => Color.isValid(color))) propOut.set(v);
             else propOut.set(dflt);
         }
     },
     colorscale: {
         description: [
             'A Plotly colorscale either picked by a name:',
-            '(any of', Object.keys(colorscales.scales).join(', '), ')',
+            '(any of',
+            Object.keys(colorscales.scales).join(', '),
+            ')',
             'customized as an {array} of 2-element {arrays} where',
             'the first element is the normalized color level value',
             '(starting at *0* and ending at *1*),',
@@ -201,47 +194,45 @@ exports.valObjectMeta = {
         ].join(' '),
         requiredOpts: [],
         otherOpts: ['dflt'],
-        coerceFunction: function(v, propOut, dflt) {
+        coerceFunction: function (v, propOut, dflt) {
             propOut.set(colorscales.get(v, dflt));
         }
     },
     angle: {
-        description: [
-            'A number (in degree) between -180 and 180.'
-        ].join(' '),
+        description: ['A number (in degree) between -180 and 180.'].join(' '),
         requiredOpts: [],
         otherOpts: ['dflt', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt) {
-            if(isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
+        coerceFunction: function (v, propOut, dflt) {
+            if (isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
 
-            if(v === 'auto') propOut.set('auto');
-            else if(!isNumeric(v)) propOut.set(dflt);
+            if (v === 'auto') propOut.set('auto');
+            else if (!isNumeric(v)) propOut.set(dflt);
             else propOut.set(modHalf(+v, 360));
         }
     },
     subplotid: {
         description: [
             'An id string of a subplot type (given by dflt), optionally',
-            'followed by an integer >1. e.g. if dflt=\'geo\', we can have',
-            '\'geo\', \'geo2\', \'geo3\', ...'
+            "followed by an integer >1. e.g. if dflt='geo', we can have",
+            "'geo', 'geo2', 'geo3', ..."
         ].join(' '),
         requiredOpts: ['dflt'],
         otherOpts: ['regex', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt, opts) {
+        coerceFunction: function (v, propOut, dflt, opts) {
             var regex = opts.regex || counterRegex(dflt);
-            const isSubplotId = value => typeof value === 'string' && regex.test(value);
+            const isSubplotId = (value) => typeof value === 'string' && regex.test(value);
             if (isSubplotId(v) || (opts.arrayOk && isArrayOrTypedArray(v) && v.length > 0 && v.every(isSubplotId))) {
                 propOut.set(v);
             } else {
                 propOut.set(dflt);
             }
         },
-        validateFunction: function(v, opts) {
+        validateFunction: function (v, opts) {
             var dflt = opts.dflt;
 
-            if(v === dflt) return true;
-            if(typeof v !== 'string') return false;
-            if(counterRegex(dflt).test(v)) return true;
+            if (v === dflt) return true;
+            if (typeof v !== 'string') return false;
+            if (counterRegex(dflt).test(v)) return true;
 
             return false;
         }
@@ -251,29 +242,29 @@ exports.valObjectMeta = {
             'A string representing a combination of flags',
             '(order does not matter here).',
             'Combine any of the available `flags` with *+*.',
-            '(e.g. (\'lines+markers\')).',
+            "(e.g. ('lines+markers')).",
             'Values in `extras` cannot be combined.'
         ].join(' '),
         requiredOpts: ['flags'],
         otherOpts: ['dflt', 'extras', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt, opts) {
-            if((opts.extras || []).indexOf(v) !== -1) {
+        coerceFunction: function (v, propOut, dflt, opts) {
+            if ((opts.extras || []).indexOf(v) !== -1) {
                 propOut.set(v);
                 return;
             }
-            if(typeof v !== 'string') {
+            if (typeof v !== 'string') {
                 propOut.set(dflt);
                 return;
             }
             var vParts = v.split('+');
             var i = 0;
-            while(i < vParts.length) {
+            while (i < vParts.length) {
                 var vi = vParts[i];
-                if(opts.flags.indexOf(vi) === -1 || vParts.indexOf(vi) < i) {
+                if (opts.flags.indexOf(vi) === -1 || vParts.indexOf(vi) < i) {
                     vParts.splice(i, 1);
                 } else i++;
             }
-            if(!vParts.length) propOut.set(dflt);
+            if (!vParts.length) propOut.set(dflt);
             else propOut.set(vParts.join('+'));
         }
     },
@@ -281,21 +272,16 @@ exports.valObjectMeta = {
         description: 'Any type.',
         requiredOpts: [],
         otherOpts: ['dflt', 'values', 'arrayOk'],
-        coerceFunction: function(v, propOut, dflt) {
-            if(v === undefined) {
+        coerceFunction: function (v, propOut, dflt) {
+            if (v === undefined) {
                 propOut.set(dflt);
             } else {
-                propOut.set(
-                    isTypedArraySpec(v) ? decodeTypedArraySpec(v) :
-                    v
-                );
+                propOut.set(isTypedArraySpec(v) ? decodeTypedArraySpec(v) : v);
             }
         }
     },
     info_array: {
-        description: [
-            'An {array} of plot information.'
-        ].join(' '),
+        description: ['An {array} of plot information.'].join(' '),
         requiredOpts: ['items'],
         // set `dimensions=2` for a 2D array or '1-2' for either
         // `items` may be a single object instead of an array, in which case
@@ -303,87 +289,92 @@ exports.valObjectMeta = {
         // if `dimensions='1-2'` and items is a 1D array, then the value can
         // either be a matching 1D array or an array of such matching 1D arrays
         otherOpts: ['dflt', 'freeLength', 'dimensions'],
-        coerceFunction: function(v, propOut, dflt, opts) {
+        coerceFunction: function (v, propOut, dflt, opts) {
             // simplified coerce function just for array items
             function coercePart(v, opts, dflt) {
                 var out;
-                var propPart = {set: function(v) { out = v; }};
+                var propPart = {
+                    set: function (v) {
+                        out = v;
+                    }
+                };
 
-                if(dflt === undefined) dflt = opts.dflt;
+                if (dflt === undefined) dflt = opts.dflt;
 
                 exports.valObjectMeta[opts.valType].coerceFunction(v, propPart, dflt, opts);
 
                 return out;
             }
 
-            if(isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
+            if (isTypedArraySpec(v)) v = decodeTypedArraySpec(v);
 
-            if(!isArrayOrTypedArray(v)) {
+            if (!isArrayOrTypedArray(v)) {
                 propOut.set(dflt);
                 return;
             }
 
-            var twoD = opts.dimensions === 2 || (opts.dimensions === '1-2' && Array.isArray(v) && isArrayOrTypedArray(v[0]));
+            var twoD =
+                opts.dimensions === 2 || (opts.dimensions === '1-2' && Array.isArray(v) && isArrayOrTypedArray(v[0]));
 
             var items = opts.items;
             var vOut = [];
             var arrayItems = Array.isArray(items);
             var arrayItems2D = arrayItems && twoD && isArrayOrTypedArray(items[0]);
             var innerItemsOnly = twoD && arrayItems && !arrayItems2D;
-            var len = (arrayItems && !innerItemsOnly) ? items.length : v.length;
+            var len = arrayItems && !innerItemsOnly ? items.length : v.length;
 
             var i, j, row, item, len2, vNew;
 
             dflt = Array.isArray(dflt) ? dflt : [];
 
-            if(twoD) {
-                for(i = 0; i < len; i++) {
+            if (twoD) {
+                for (i = 0; i < len; i++) {
                     vOut[i] = [];
                     row = isArrayOrTypedArray(v[i]) ? v[i] : [];
-                    if(innerItemsOnly) len2 = items.length;
-                    else if(arrayItems) len2 = items[i].length;
+                    if (innerItemsOnly) len2 = items.length;
+                    else if (arrayItems) len2 = items[i].length;
                     else len2 = row.length;
 
-                    for(j = 0; j < len2; j++) {
-                        if(innerItemsOnly) item = items[j];
-                        else if(arrayItems) item = items[i][j];
+                    for (j = 0; j < len2; j++) {
+                        if (innerItemsOnly) item = items[j];
+                        else if (arrayItems) item = items[i][j];
                         else item = items;
 
                         vNew = coercePart(row[j], item, (dflt[i] || [])[j]);
-                        if(vNew !== undefined) vOut[i][j] = vNew;
+                        if (vNew !== undefined) vOut[i][j] = vNew;
                     }
                 }
             } else {
-                for(i = 0; i < len; i++) {
+                for (i = 0; i < len; i++) {
                     vNew = coercePart(v[i], arrayItems ? items[i] : items, dflt[i]);
-                    if(vNew !== undefined) vOut[i] = vNew;
+                    if (vNew !== undefined) vOut[i] = vNew;
                 }
             }
 
             propOut.set(vOut);
         },
-        validateFunction: function(v, opts) {
-            if(!isArrayOrTypedArray(v)) return false;
+        validateFunction: function (v, opts) {
+            if (!isArrayOrTypedArray(v)) return false;
 
             var items = opts.items;
             var arrayItems = Array.isArray(items);
             var twoD = opts.dimensions === 2;
 
             // when free length is off, input and declared lengths must match
-            if(!opts.freeLength && v.length !== items.length) return false;
+            if (!opts.freeLength && v.length !== items.length) return false;
 
             // valid when all input items are valid
-            for(var i = 0; i < v.length; i++) {
-                if(twoD) {
-                    if(!isArrayOrTypedArray(v[i]) || (!opts.freeLength && v[i].length !== items[i].length)) {
+            for (var i = 0; i < v.length; i++) {
+                if (twoD) {
+                    if (!isArrayOrTypedArray(v[i]) || (!opts.freeLength && v[i].length !== items[i].length)) {
                         return false;
                     }
-                    for(var j = 0; j < v[i].length; j++) {
-                        if(!validate(v[i][j], arrayItems ? items[i][j] : items)) {
+                    for (var j = 0; j < v[i].length; j++) {
+                        if (!validate(v[i][j], arrayItems ? items[i][j] : items)) {
                             return false;
                         }
                     }
-                } else if(!validate(v[i], arrayItems ? items[i] : items)) return false;
+                } else if (!validate(v[i], arrayItems ? items[i] : items)) return false;
             }
 
             return true;
@@ -403,23 +394,23 @@ exports.valObjectMeta = {
  *      if dflt is provided as an argument to lib.coerce it takes precedence
  *      as a convenience, returns the value it finally set
  */
-exports.coerce = function(containerIn, containerOut, attributes, attribute, dflt) {
+exports.coerce = function (containerIn, containerOut, attributes, attribute, dflt) {
     var opts = nestedProperty(attributes, attribute).get();
     var propIn = nestedProperty(containerIn, attribute);
     var propOut = nestedProperty(containerOut, attribute);
     var v = propIn.get();
 
     var template = containerOut._template;
-    if(v === undefined && template) {
+    if (v === undefined && template) {
         v = nestedProperty(template, attribute).get();
         // already used the template value, so short-circuit the second check
         template = 0;
     }
 
-    if(dflt === undefined) dflt = opts.dflt;
+    if (dflt === undefined) dflt = opts.dflt;
 
-    if(opts.arrayOk) {
-        if(isArrayOrTypedArray(v)) {
+    if (opts.arrayOk) {
+        if (isArrayOrTypedArray(v)) {
             /**
              * arrayOk: value MAY be an array, then we do no value checking
              * at this point, because it can be more complicated than the
@@ -430,7 +421,7 @@ exports.coerce = function(containerIn, containerOut, attributes, attribute, dflt
             propOut.set(v);
             return v;
         } else {
-            if(isTypedArraySpec(v)) {
+            if (isTypedArraySpec(v)) {
                 v = decodeTypedArraySpec(v);
                 propOut.set(v);
                 return v;
@@ -444,7 +435,7 @@ exports.coerce = function(containerIn, containerOut, attributes, attribute, dflt
     var out = propOut.get();
     // in case v was provided but invalid, try the template again so it still
     // overrides the regular default
-    if(template && out === dflt && !validate(v, opts)) {
+    if (template && out === dflt && !validate(v, opts)) {
         v = nestedProperty(template, attribute).get();
         coerceFunction(v, propOut, dflt, opts);
         out = propOut.get();
@@ -459,12 +450,12 @@ exports.coerce = function(containerIn, containerOut, attributes, attribute, dflt
  * returns attribute default if user input is not valid or
  * returns false if there is no user input.
  */
-exports.coerce2 = function(containerIn, containerOut, attributes, attribute, dflt) {
+exports.coerce2 = function (containerIn, containerOut, attributes, attribute, dflt) {
     var propIn = nestedProperty(containerIn, attribute);
     var propOut = exports.coerce(containerIn, containerOut, attributes, attribute, dflt);
     var valIn = propIn.get();
 
-    return (valIn !== undefined && valIn !== null) ? propOut : false;
+    return valIn !== undefined && valIn !== null ? propOut : false;
 };
 
 /*
@@ -472,8 +463,8 @@ exports.coerce2 = function(containerIn, containerOut, attributes, attribute, dfl
  *
  * 'coerce' is a lib.coerce wrapper with implied first three arguments
  */
-exports.coerceFont = function(coerce, attr, dfltObj, opts) {
-    if(!opts) opts = {};
+exports.coerceFont = function (coerce, attr, dfltObj, opts) {
+    if (!opts) opts = {};
     dfltObj = extendFlat({}, dfltObj);
     dfltObj = extendFlat(dfltObj, opts.overrideDflt || {});
 
@@ -482,15 +473,15 @@ exports.coerceFont = function(coerce, attr, dfltObj, opts) {
         size: coerce(attr + '.size', dfltObj.size),
         color: coerce(attr + '.color', dfltObj.color),
         weight: coerce(attr + '.weight', dfltObj.weight),
-        style: coerce(attr + '.style', dfltObj.style),
+        style: coerce(attr + '.style', dfltObj.style)
     };
 
-    if(!opts.noFontVariant) out.variant = coerce(attr + '.variant', dfltObj.variant);
-    if(!opts.noFontLineposition) out.lineposition = coerce(attr + '.lineposition', dfltObj.lineposition);
-    if(!opts.noFontTextcase) out.textcase = coerce(attr + '.textcase', dfltObj.textcase);
-    if(!opts.noFontShadow) {
+    if (!opts.noFontVariant) out.variant = coerce(attr + '.variant', dfltObj.variant);
+    if (!opts.noFontLineposition) out.lineposition = coerce(attr + '.lineposition', dfltObj.lineposition);
+    if (!opts.noFontTextcase) out.textcase = coerce(attr + '.textcase', dfltObj.textcase);
+    if (!opts.noFontShadow) {
         var dfltShadow = dfltObj.shadow;
-        if(dfltShadow === 'none' && opts.autoShadowDflt) {
+        if (dfltShadow === 'none' && opts.autoShadowDflt) {
             dfltShadow = 'auto';
         }
         out.shadow = coerce(attr + '.shadow', dfltShadow);
@@ -502,36 +493,27 @@ exports.coerceFont = function(coerce, attr, dfltObj, opts) {
 /*
  * Shortcut to coerce the pattern attributes
  */
-exports.coercePattern = function(coerce, attr, markerColor, hasMarkerColorscale) {
+exports.coercePattern = function (coerce, attr, markerColor, hasMarkerColorscale) {
     var shape = coerce(attr + '.shape');
     var path;
-    if(!shape) {
+    if (!shape) {
         path = coerce(attr + '.path');
     }
-    if(shape || path) {
-        if(shape) {
+    if (shape || path) {
+        if (shape) {
             coerce(attr + '.solidity');
         }
         coerce(attr + '.size');
         var fillmode = coerce(attr + '.fillmode');
         var isOverlay = fillmode === 'overlay';
 
-        if(!hasMarkerColorscale) {
-            var bgcolor = coerce(attr + '.bgcolor', isOverlay ?
-                markerColor :
-                undefined
-            );
+        if (!hasMarkerColorscale) {
+            var bgcolor = coerce(attr + '.bgcolor', isOverlay ? markerColor : undefined);
 
-            coerce(attr + '.fgcolor', isOverlay ?
-                Color.contrast(bgcolor) :
-                markerColor
-            );
+            coerce(attr + '.fgcolor', isOverlay ? Color.contrast(bgcolor) : markerColor);
         }
 
-        coerce(attr + '.fgopacity', isOverlay ?
-            0.5 :
-            1
-        );
+        coerce(attr + '.fgopacity', isOverlay ? 0.5 : 1);
     }
 };
 
@@ -543,17 +525,15 @@ exports.coercePattern = function(coerce, attr, markerColor, hasMarkerColorscale)
  * @param {object} layoutOut : full layout object (require _dataLength ref)
  * @return {any} : the coerced value
  */
-exports.coerceHoverinfo = function(traceIn, traceOut, layoutOut) {
+exports.coerceHoverinfo = function (traceIn, traceOut, layoutOut) {
     var moduleAttrs = traceOut._module.attributes;
     var attrs = moduleAttrs.hoverinfo ? moduleAttrs : baseTraceAttrs;
 
     var valObj = attrs.hoverinfo;
     var dflt;
 
-    if(layoutOut._dataLength === 1) {
-        var flags = valObj.dflt === 'all' ?
-            valObj.flags.slice() :
-            valObj.dflt.split('+');
+    if (layoutOut._dataLength === 1) {
+        var flags = valObj.dflt === 'all' ? valObj.flags.slice() : valObj.dflt.split('+');
 
         flags.splice(flags.indexOf('name'), 1);
         dflt = flags.join('+');
@@ -573,12 +553,12 @@ exports.coerceHoverinfo = function(traceIn, traceOut, layoutOut) {
  * @param {object} traceOut : fullData item
  * @param {function} coerce : lib.coerce wrapper with implied first three arguments
  */
-exports.coerceSelectionMarkerOpacity = function(traceOut, coerce) {
-    if(!traceOut.marker) return;
+exports.coerceSelectionMarkerOpacity = function (traceOut, coerce) {
+    if (!traceOut.marker) return;
 
     var mo = traceOut.marker.opacity;
     // you can still have a `marker` container with no markers if there's text
-    if(mo === undefined) return;
+    if (mo === undefined) return;
 
     var smoDflt;
     var usmoDflt;
@@ -588,7 +568,7 @@ exports.coerceSelectionMarkerOpacity = function(traceOut, coerce) {
     //
     // Only give [un]selected.marker.opacity a default value if you don't
     // set any other [un]selected attributes.
-    if(!isArrayOrTypedArray(mo) && !traceOut.selected && !traceOut.unselected) {
+    if (!isArrayOrTypedArray(mo) && !traceOut.selected && !traceOut.unselected) {
         smoDflt = mo;
         usmoDflt = DESELECTDIM * mo;
     }
@@ -600,15 +580,19 @@ exports.coerceSelectionMarkerOpacity = function(traceOut, coerce) {
 function validate(value, opts) {
     var valObjectDef = exports.valObjectMeta[opts.valType];
 
-    if(opts.arrayOk && isArrayOrTypedArray(value)) return true;
+    if (opts.arrayOk && isArrayOrTypedArray(value)) return true;
 
-    if(valObjectDef.validateFunction) {
+    if (valObjectDef.validateFunction) {
         return valObjectDef.validateFunction(value, opts);
     }
 
     var failed = {};
     var out = failed;
-    var propMock = { set: function(v) { out = v; } };
+    var propMock = {
+        set: function (v) {
+            out = v;
+        }
+    };
 
     // 'failed' just something mutable that won't be === anything else
 

--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -6,7 +6,7 @@ var fxAttrs = require('../components/fx/attributes');
 module.exports = {
     type: {
         valType: 'enumerated',
-        values: [],     // listed dynamically
+        values: [], // listed dynamically
         dflt: 'scatter',
         editType: 'calc+clearAxisTypes',
         _noTemplating: true // we handle this at a higher level
@@ -27,10 +27,9 @@ module.exports = {
         valType: 'boolean',
         dflt: true,
         editType: 'style',
-        description: [
-            'Determines whether or not an item corresponding to this',
-            'trace is shown in the legend.'
-        ].join(' ')
+        description: ['Determines whether or not an item corresponding to this', 'trace is shown in the legend.'].join(
+            ' '
+        )
     },
     legend: {
         valType: 'subplotid',
@@ -59,17 +58,13 @@ module.exports = {
             valType: 'string',
             dflt: '',
             editType: 'style',
-            description: [
-                'Sets the title of the legend group.'
-            ].join(' ')
+            description: ['Sets the title of the legend group.'].join(' ')
         },
         font: fontAttrs({
             editType: 'style',
-            description: [
-                'Sets this legend group\'s title font.'
-            ].join(' '),
+            description: ["Sets this legend group's title font."].join(' ')
         }),
-        editType: 'style',
+        editType: 'style'
     },
     legendrank: {
         valType: 'number',
@@ -90,7 +85,7 @@ module.exports = {
         valType: 'number',
         min: 0,
         editType: 'style',
-        description: 'Sets the width (in px or fraction) of the legend for this trace.',
+        description: 'Sets the width (in px or fraction) of the legend for this trace.'
     },
     opacity: {
         valType: 'number',
@@ -103,10 +98,7 @@ module.exports = {
     name: {
         valType: 'string',
         editType: 'style',
-        description: [
-            'Sets the trace name.',
-            'The trace name appears as the legend item and on hover.'
-        ].join(' ')
+        description: ['Sets the trace name.', 'The trace name appears as the legend item and on hover.'].join(' ')
     },
     uid: {
         valType: 'string',

--- a/src/plots/attributes.js
+++ b/src/plots/attributes.js
@@ -174,7 +174,7 @@ module.exports = {
         dflt: 'all',
         editType: 'none',
         description: [
-            'Determines which trace information appear on hover.',
+            'Determines what trace information appears on hover.',
             'If `none` or `skip` are set, no information is displayed upon hovering.',
             'But, if `none` is set, click and hover events are still fired.'
         ].join(' ')

--- a/src/traces/funnel/attributes.js
+++ b/src/traces/funnel/attributes.js
@@ -41,9 +41,12 @@ module.exports = {
         editType: 'plot',
         arrayOk: false,
         description: [
-            'Determines which trace information appear on the graph.',
+            'Determines what trace information appears on the graph.',
             'In the case of having multiple funnels, percentages & totals',
-            'are computed separately (per trace).'
+            'are computed separately (per trace).',
+            'Flags are rendered in a fixed order; use `texttemplate` if you',
+            'need explicit control over the rendered string, including the',
+            'order of fields and surrounding text.'
         ].join(' ')
     },
     // TODO: incorporate `label` and `value` in the eventData

--- a/src/traces/funnelarea/attributes.js
+++ b/src/traces/funnelarea/attributes.js
@@ -50,7 +50,13 @@ module.exports = {
     texttemplatefallback: templatefallbackAttrs({ editType: 'plot' }),
 
     hoverinfo: extendFlat({}, baseAttrs.hoverinfo, {
-        flags: ['label', 'text', 'value', 'percent', 'name']
+        flags: ['label', 'text', 'value', 'percent', 'name'],
+        description: [
+            'Determines what trace information appears on hover.',
+            'Flags are rendered in a fixed order; use `hovertemplate` if you',
+            'need explicit control over the rendered string, including the',
+            'order of fields and surrounding text.'
+        ].join(' ')
     }),
 
     hovertemplate: hovertemplateAttrs({}, { keys: ['label', 'color', 'value', 'text', 'percent'] }),

--- a/src/traces/pie/attributes.js
+++ b/src/traces/pie/attributes.js
@@ -133,10 +133,21 @@ module.exports = {
         flags: ['label', 'text', 'value', 'percent'],
         extras: ['none'],
         editType: 'calc',
-        description: ['Determines which trace information appear on the graph.'].join(' ')
+        description: [
+            'Determines what trace information appears on the graph.',
+            'Flags are rendered in a fixed order; use `texttemplate` if you',
+            'need explicit control over the rendered string, including the',
+            'order of fields and surrounding text.'
+        ].join(' ')
     },
     hoverinfo: extendFlat({}, baseAttrs.hoverinfo, {
-        flags: ['label', 'text', 'value', 'percent', 'name']
+        flags: ['label', 'text', 'value', 'percent', 'name'],
+        description: [
+            'Determines what trace information appears on hover.',
+            'Flags are rendered in a fixed order; use `hovertemplate` if you',
+            'need explicit control over the rendered string, including the',
+            'order of fields and surrounding text.'
+        ].join(' ')
     }),
     hovertemplate: hovertemplateAttrs({}, { keys: ['label', 'color', 'value', 'percent', 'text'] }),
     hovertemplatefallback: templatefallbackAttrs(),

--- a/src/traces/sankey/attributes.js
+++ b/src/traces/sankey/attributes.js
@@ -19,7 +19,7 @@ var attrs = (module.exports = overrideAll(
             flags: [],
             arrayOk: false,
             description: [
-                'Determines which trace information appear on hover.',
+                'Determines what trace information appears on hover.',
                 'If `none` or `skip` are set, no information is displayed upon hovering.',
                 'But, if `none` is set, click and hover events are still fired.',
                 'Note that this attribute is superseded by `node.hoverinfo` and `node.hoverinfo`',
@@ -150,7 +150,7 @@ var attrs = (module.exports = overrideAll(
                 values: ['all', 'none', 'skip'],
                 dflt: 'all',
                 description: [
-                    'Determines which trace information appear when hovering nodes.',
+                    'Determines what trace information appears when hovering nodes.',
                     'If `none` or `skip` are set, no information is displayed upon hovering.',
                     'But, if `none` is set, click and hover events are still fired.'
                 ].join(' ')
@@ -242,7 +242,7 @@ var attrs = (module.exports = overrideAll(
                 values: ['all', 'none', 'skip'],
                 dflt: 'all',
                 description: [
-                    'Determines which trace information appear when hovering links.',
+                    'Determines what trace information appears when hovering links.',
                     'If `none` or `skip` are set, no information is displayed upon hovering.',
                     'But, if `none` is set, click and hover events are still fired.'
                 ].join(' ')

--- a/src/traces/sunburst/attributes.js
+++ b/src/traces/sunburst/attributes.js
@@ -138,7 +138,12 @@ module.exports = {
         flags: ['label', 'text', 'value', 'current path', 'percent root', 'percent entry', 'percent parent'],
         extras: ['none'],
         editType: 'plot',
-        description: ['Determines which trace information appear on the graph.'].join(' ')
+        description: [
+            'Determines what trace information appears on the graph.',
+            'Flags are rendered in a fixed order; use `texttemplate` if you',
+            'need explicit control over the rendered string, including the',
+            'order of fields and surrounding text.'
+        ].join(' ')
     },
 
     // TODO: incorporate `label` and `value` in the eventData
@@ -148,7 +153,13 @@ module.exports = {
     hovertext: pieAttrs.hovertext,
     hoverinfo: extendFlat({}, baseAttrs.hoverinfo, {
         flags: ['label', 'text', 'value', 'name', 'current path', 'percent root', 'percent entry', 'percent parent'],
-        dflt: 'label+text+value+name'
+        dflt: 'label+text+value+name',
+        description: [
+            'Determines what trace information appears on hover.',
+            'Flags are rendered in a fixed order; use `hovertemplate` if you',
+            'need explicit control over the rendered string, including the',
+            'order of fields and surrounding text.'
+        ].join(' ')
     }),
     hovertemplate: hovertemplateAttrs({}, { keys: constants.eventDataKeys }),
     hovertemplatefallback: templatefallbackAttrs(),

--- a/src/traces/waterfall/attributes.js
+++ b/src/traces/waterfall/attributes.js
@@ -89,9 +89,12 @@ module.exports = {
         editType: 'plot',
         arrayOk: false,
         description: [
-            'Determines which trace information appear on the graph.',
+            'Determines what trace information appears on the graph.',
             'In the case of having multiple waterfalls, totals',
-            'are computed separately (per trace).'
+            'are computed separately (per trace).',
+            'Flags are rendered in a fixed order; use `texttemplate` if you',
+            'need explicit control over the rendered string, including the',
+            'order of fields and surrounding text.'
         ].join(' ')
     },
     // TODO: incorporate `label` and `value` in the eventData

--- a/src/types/generated/schema.d.ts
+++ b/src/types/generated/schema.d.ts
@@ -811,7 +811,7 @@ export interface BarData {
     };
     error_y?: _internal.ErrorY;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -1074,7 +1074,7 @@ export interface BarpolarData {
     /** Sets the theta coordinate step. By default, the `dtheta` step equals the subplot's period divided by the length of the `r` coordinates. */
     dtheta?: number;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'r' | 'theta' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('r' | 'theta' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -1263,7 +1263,7 @@ export interface BoxData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -1560,7 +1560,7 @@ export interface CandlestickData {
     /** Sets the high values. */
     high?: Datum[] | Datum[][] | TypedArray;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -2311,7 +2311,7 @@ export interface ChoroplethData {
     /** Sets optional GeoJSON data associated with this trace. If not given, the features on the base map are used. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type *FeatureCollection* or *Feature* with geometries of type *Polygon* or *MultiPolygon*. */
     geojson?: any;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'location' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('location' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -2459,7 +2459,7 @@ export interface ChoroplethmapData {
     /** Sets the GeoJSON data associated with this trace. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type *FeatureCollection* or *Feature* with geometries of type *Polygon* or *MultiPolygon*. */
     geojson?: any;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'location' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('location' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -2620,7 +2620,7 @@ export interface ConeData {
     /** Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements */
     customdata?: Datum[] | Datum[][] | TypedArray;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'x+y+z+norm+text+name'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'u' | 'v' | 'w' | 'norm' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'u' | 'v' | 'w' | 'norm' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -2846,7 +2846,7 @@ export interface ContourData {
     /** Sets the fill color if `contours.type` is *constraint*. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -3331,7 +3331,7 @@ export interface DensitymapData {
     /** Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements */
     customdata?: Datum[] | Datum[][] | TypedArray;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'lon' | 'lat' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('lon' | 'lat' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -3491,7 +3491,7 @@ export interface FunnelData {
      */
     dy?: number;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'name' | 'x' | 'y' | 'text' | 'percent initial' | 'percent previous' | 'percent total' | 'all' | 'none' | 'skip' | (string & {}) | ('name' | 'x' | 'y' | 'text' | 'percent initial' | 'percent previous' | 'percent total' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -3617,7 +3617,7 @@ export interface FunnelData {
     textangle?: number | 'auto';
     /** Sets the font used for `text`. */
     textfont?: FontArray;
-    /** Determines which trace information appear on the graph. In the case of having multiple funnels, percentages & totals are computed separately (per trace). */
+    /** Determines what trace information appears on the graph. In the case of having multiple funnels, percentages & totals are computed separately (per trace). Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text. */
     textinfo?: 'label' | 'text' | 'percent initial' | 'percent previous' | 'percent total' | 'value' | 'none' | (string & {});
     /**
      * Specifies the location of the `text`. *inside* positions `text` inside, next to the bar end (rotated and scaled if needed). *outside* positions `text` outside, next to the bar end (scaled if needed), unless there is another bar stacked on this one, then the text gets pushed inside. *auto* tries to position `text` inside the bar, but if the bar is too small and no bar is stacked on this one the text is moved outside. If *none*, no text appears.
@@ -3727,7 +3727,7 @@ export interface FunnelareaData {
     dlabel?: number;
     domain?: Domain;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.
      * @default 'all'
      */
     hoverinfo?: 'label' | 'text' | 'value' | 'percent' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('label' | 'text' | 'value' | 'percent' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -3798,7 +3798,7 @@ export interface FunnelareaData {
     text?: Datum[] | Datum[][] | TypedArray;
     /** Sets the font used for `textinfo`. */
     textfont?: FontArray;
-    /** Determines which trace information appear on the graph. */
+    /** Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text. */
     textinfo?: 'label' | 'text' | 'value' | 'percent' | 'none' | (string & {});
     /**
      * Specifies the location of the `textinfo`.
@@ -3868,7 +3868,7 @@ export interface HeatmapData {
      */
     dy?: number;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -4182,7 +4182,7 @@ export interface HistogramData {
     /** Specifies the type of normalization used for this histogram trace. If **, the span of each bar corresponds to the number of occurrences (i.e. the number of data points lying inside the bins). If *percent* / *probability*, the span of each bar corresponds to the percentage / fraction of occurrences with respect to the total number of sample points (here, the sum of all bin HEIGHTS equals 100% / 1). If *density*, the span of each bar corresponds to the number of occurrences in a bin divided by the size of the bin interval (here, the sum of all bin AREAS equals the total number of sample points). If *probability density*, the area of each bar corresponds to the probability that an event will fall into the corresponding bin (here, the sum of all bin AREAS equals 1). */
     histnorm?: '' | 'percent' | 'probability' | 'density' | 'probability density';
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -4449,7 +4449,7 @@ export interface Histogram2dData {
     /** Specifies the type of normalization used for this histogram trace. If **, the span of each bar corresponds to the number of occurrences (i.e. the number of data points lying inside the bins). If *percent* / *probability*, the span of each bar corresponds to the percentage / fraction of occurrences with respect to the total number of sample points (here, the sum of all bin HEIGHTS equals 100% / 1). If *density*, the span of each bar corresponds to the number of occurrences in a bin divided by the size of the bin interval (here, the sum of all bin AREAS equals the total number of sample points). If *probability density*, the area of each bar corresponds to the probability that an event will fall into the corresponding bin (here, the sum of all bin AREAS equals 1). */
     histnorm?: '' | 'percent' | 'probability' | 'density' | 'probability density';
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -4719,7 +4719,7 @@ export interface Histogram2dcontourData {
     /** Specifies the type of normalization used for this histogram trace. If **, the span of each bar corresponds to the number of occurrences (i.e. the number of data points lying inside the bins). If *percent* / *probability*, the span of each bar corresponds to the percentage / fraction of occurrences with respect to the total number of sample points (here, the sum of all bin HEIGHTS equals 100% / 1). If *density*, the span of each bar corresponds to the number of occurrences in a bin divided by the size of the bin interval (here, the sum of all bin AREAS equals the total number of sample points). If *probability density*, the area of each bar corresponds to the probability that an event will fall into the corresponding bin (here, the sum of all bin AREAS equals 1). */
     histnorm?: '' | 'percent' | 'probability' | 'density' | 'probability density';
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -4924,7 +4924,7 @@ export interface IcicleData {
     customdata?: Datum[] | Datum[][] | TypedArray;
     domain?: Domain;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.
      * @default 'label+text+value+name'
      */
     hoverinfo?: 'label' | 'text' | 'value' | 'name' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'all' | 'none' | 'skip' | (string & {}) | ('label' | 'text' | 'value' | 'name' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -5069,7 +5069,7 @@ export interface IcicleData {
     text?: Datum[] | Datum[][] | TypedArray;
     /** Sets the font used for `textinfo`. */
     textfont?: FontArray;
-    /** Determines which trace information appear on the graph. */
+    /** Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text. */
     textinfo?: 'label' | 'text' | 'value' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'none' | (string & {});
     /**
      * Sets the positions of the `text` elements.
@@ -5128,7 +5128,7 @@ export interface ImageData {
      */
     dy?: number;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'x+y+z+text+name'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'color' | 'name' | 'text' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'color' | 'name' | 'text' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -5612,7 +5612,7 @@ export interface IsosurfaceData {
      */
     flatshading?: boolean;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -5895,7 +5895,7 @@ export interface Mesh3dData {
      */
     flatshading?: boolean;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -6064,7 +6064,7 @@ export interface OhlcData {
     /** Sets the high values. */
     high?: Datum[] | Datum[][] | TypedArray;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -6282,7 +6282,7 @@ export interface ParcatsData {
     }>;
     domain?: Domain;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'count' | 'probability' | 'all' | 'none' | 'skip' | (string & {});
@@ -6555,7 +6555,7 @@ export interface PieData {
      */
     hole?: number;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.
      * @default 'all'
      */
     hoverinfo?: 'label' | 'text' | 'value' | 'percent' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('label' | 'text' | 'value' | 'percent' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -6649,7 +6649,7 @@ export interface PieData {
     text?: Datum[] | Datum[][] | TypedArray;
     /** Sets the font used for `textinfo`. */
     textfont?: FontArray;
-    /** Determines which trace information appear on the graph. */
+    /** Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text. */
     textinfo?: 'label' | 'text' | 'value' | 'percent' | 'none' | (string & {});
     /**
      * Specifies the location of the `textinfo`.
@@ -6695,7 +6695,7 @@ export interface SankeyData {
     customdata?: Datum[] | Datum[][] | TypedArray;
     domain?: Domain;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired. Note that this attribute is superseded by `node.hoverinfo` and `node.hoverinfo` for nodes and links respectively.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired. Note that this attribute is superseded by `node.hoverinfo` and `node.hoverinfo` for nodes and links respectively.
      * @default 'all'
      */
     hoverinfo?: 'all' | 'none' | 'skip' | (string & {});
@@ -6757,7 +6757,7 @@ export interface SankeyData {
         /** Sets the `link` hover color. It can be a single value, or an array for specifying hover colors for each `link`. If `link.hovercolor` is omitted, then by default, links will become slightly more opaque when hovered over. */
         hovercolor?: Color | Color[];
         /**
-         * Determines which trace information appear when hovering links. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+         * Determines what trace information appears when hovering links. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
          * @default 'all'
          */
         hoverinfo?: 'all' | 'none' | 'skip';
@@ -6813,7 +6813,7 @@ export interface SankeyData {
          */
         groups?: number[];
         /**
-         * Determines which trace information appear when hovering nodes. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+         * Determines what trace information appears when hovering nodes. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
          * @default 'all'
          */
         hoverinfo?: 'all' | 'none' | 'skip';
@@ -6979,7 +6979,7 @@ export interface ScatterData {
     /** Only relevant when `stackgroup` is used, and only the first `groupnorm` found in the `stackgroup` will be used - including if `visible` is *legendonly* but not if it is `false`. Sets the normalization for the sum of this `stackgroup`. With *fraction*, the value of each trace at each location is divided by the sum of all trace values at that location. *percent* is the same but multiplied by 100 to show percentages. If there are multiple subplots, or multiple `stackgroup`s on one subplot, each will be normalized within its own set. */
     groupnorm?: '' | 'fraction' | 'percent';
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -7318,7 +7318,7 @@ export interface Scatter3dData {
     };
     error_z?: _internal.ErrorY;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -7718,7 +7718,7 @@ export interface ScattercarpetData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'a' | 'b' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('a' | 'b' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -7914,7 +7914,7 @@ export interface ScattergeoData {
     /** Sets optional GeoJSON data associated with this trace. If not given, the features on the base map are used when `locations` is set. It can be set as a valid GeoJSON object or as a URL string. Note that we only accept GeoJSONs of type *FeatureCollection* or *Feature* with geometries of type *Polygon* or *MultiPolygon*. */
     geojson?: any;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'lon' | 'lat' | 'location' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('lon' | 'lat' | 'location' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -8235,7 +8235,7 @@ export interface ScatterglData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -8504,7 +8504,7 @@ export interface ScattermapData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'lon' | 'lat' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('lon' | 'lat' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -8744,7 +8744,7 @@ export interface ScatterpolarData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'r' | 'theta' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('r' | 'theta' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -8941,7 +8941,7 @@ export interface ScatterpolarglData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'r' | 'theta' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('r' | 'theta' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -9140,7 +9140,7 @@ export interface ScattersmithData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'real' | 'imag' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('real' | 'imag' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -9326,7 +9326,7 @@ export interface ScatterternaryData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'a' | 'b' | 'c' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('a' | 'b' | 'c' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -9525,7 +9525,7 @@ export interface SplomData {
         visible?: boolean;
     }>;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -9675,7 +9675,7 @@ export interface StreamtubeData {
     /** Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements */
     customdata?: Datum[] | Datum[][] | TypedArray;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'x+y+z+norm+text+name'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'u' | 'v' | 'w' | 'norm' | 'divergence' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'u' | 'v' | 'w' | 'norm' | 'divergence' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -9833,7 +9833,7 @@ export interface SunburstData {
     customdata?: Datum[] | Datum[][] | TypedArray;
     domain?: Domain;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.
      * @default 'label+text+value+name'
      */
     hoverinfo?: 'label' | 'text' | 'value' | 'name' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'all' | 'none' | 'skip' | (string & {}) | ('label' | 'text' | 'value' | 'name' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -9964,7 +9964,7 @@ export interface SunburstData {
     text?: Datum[] | Datum[][] | TypedArray;
     /** Sets the font used for `textinfo`. */
     textfont?: FontArray;
-    /** Determines which trace information appear on the graph. */
+    /** Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text. */
     textinfo?: 'label' | 'text' | 'value' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'none' | (string & {});
     /** Template string used for rendering the information text that appears on points. Note that this will override `textinfo`. Variables are inserted using %{variable}, for example "y: %{y}". Numbers are formatted using d3-format's syntax %{variable:d3-format}, for example "Price: %{y:$.2f}". https://github.com/d3/d3-format/tree/v1.4.5#d3-format for details on the formatting syntax. Dates are formatted using d3-time-format's syntax %{variable|d3-time-format}, for example "Day: %{2019-01-01|%A}". https://github.com/d3/d3-time-format/tree/v2.2.3#locale_format for details on the date formatting syntax. Variables that can't be found will be replaced with the specifier. For example, a template of "data: %{x}, %{y}" will result in a value of "data: 1, %{y}" if x is 1 and y is missing. Variables with an undefined value will be replaced with the fallback value. All attributes that can be specified per-point (the ones that are `arrayOk: true`) are available. Finally, the template string has access to variables `currentPath`, `root`, `entry`, `percentRoot`, `percentEntry`, `percentParent`, `label` and `value`. */
     texttemplate?: string | string[];
@@ -10228,7 +10228,7 @@ export interface SurfaceData {
      */
     hidesurface?: boolean;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -10456,7 +10456,7 @@ export interface TableData {
         values?: Datum[] | Datum[][] | TypedArray;
     };
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -10510,7 +10510,7 @@ export interface TreemapData {
     customdata?: Datum[] | Datum[][] | TypedArray;
     domain?: Domain;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.
      * @default 'label+text+value+name'
      */
     hoverinfo?: 'label' | 'text' | 'value' | 'name' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'all' | 'none' | 'skip' | (string & {}) | ('label' | 'text' | 'value' | 'name' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -10678,7 +10678,7 @@ export interface TreemapData {
     text?: Datum[] | Datum[][] | TypedArray;
     /** Sets the font used for `textinfo`. */
     textfont?: FontArray;
-    /** Determines which trace information appear on the graph. */
+    /** Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text. */
     textinfo?: 'label' | 'text' | 'value' | 'current path' | 'percent root' | 'percent entry' | 'percent parent' | 'none' | (string & {});
     /**
      * Sets the positions of the `text` elements.
@@ -10756,7 +10756,7 @@ export interface ViolinData {
     /** Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available. */
     fillcolor?: Color;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -11096,7 +11096,7 @@ export interface VolumeData {
      */
     flatshading?: boolean;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}) | ('x' | 'y' | 'z' | 'text' | 'name' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -11375,7 +11375,7 @@ export interface WaterfallData {
      */
     dy?: number;
     /**
-     * Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
+     * Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.
      * @default 'all'
      */
     hoverinfo?: 'name' | 'x' | 'y' | 'text' | 'initial' | 'delta' | 'final' | 'all' | 'none' | 'skip' | (string & {}) | ('name' | 'x' | 'y' | 'text' | 'initial' | 'delta' | 'final' | 'all' | 'none' | 'skip' | (string & {}))[];
@@ -11462,7 +11462,7 @@ export interface WaterfallData {
     textangle?: number | 'auto';
     /** Sets the font used for `text`. */
     textfont?: FontArray;
-    /** Determines which trace information appear on the graph. In the case of having multiple waterfalls, totals are computed separately (per trace). */
+    /** Determines what trace information appears on the graph. In the case of having multiple waterfalls, totals are computed separately (per trace). Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text. */
     textinfo?: 'label' | 'text' | 'initial' | 'delta' | 'final' | 'none' | (string & {});
     /**
      * Specifies the location of the `text`. *inside* positions `text` inside, next to the bar end (rotated and scaled if needed). *outside* positions `text` outside, next to the bar end (scaled if needed), unless there is another bar stacked on this one, then the text gets pushed inside. *auto* tries to position `text` inside the bar, but if the bar is too small and no bar is stacked on this one the text is moved outside. If *none*, no text appears.

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -467,7 +467,7 @@
         ]
       },
       "flaglist": {
-        "description": "A string representing a combination of flags (order does not matter here). Combine any of the available `flags` with *+*. (e.g. ('lines+markers')). Values in `extras` cannot be combined.",
+        "description": "A string representing a combination of flags (flag order does not affect the output). Combine any of the available `flags` with *+*. (e.g. ('lines+markers')). Values in `extras` cannot be combined.",
         "otherOpts": [
           "dflt",
           "extras",
@@ -15965,7 +15965,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -17835,7 +17835,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -19230,7 +19230,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -20600,7 +20600,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -23436,7 +23436,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -24576,7 +24576,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -25740,7 +25740,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "x+y+z+norm+text+name",
           "editType": "calc",
           "extras": [
@@ -27159,7 +27159,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -29789,7 +29789,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -30325,7 +30325,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -31766,7 +31766,7 @@
         },
         "textinfo": {
           "arrayOk": false,
-          "description": "Determines which trace information appear on the graph. In the case of having multiple funnels, percentages & totals are computed separately (per trace).",
+          "description": "Determines what trace information appears on the graph. In the case of having multiple funnels, percentages & totals are computed separately (per trace). Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "editType": "plot",
           "extras": [
             "none"
@@ -32070,7 +32070,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -32721,7 +32721,7 @@
           }
         },
         "textinfo": {
-          "description": "Determines which trace information appear on the graph.",
+          "description": "Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "editType": "calc",
           "extras": [
             "none"
@@ -33586,7 +33586,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -34611,7 +34611,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -37073,7 +37073,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -38643,7 +38643,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -39455,7 +39455,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "dflt": "label+text+value+name",
           "editType": "none",
           "extras": [
@@ -41029,7 +41029,7 @@
           }
         },
         "textinfo": {
-          "description": "Determines which trace information appear on the graph.",
+          "description": "Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "editType": "plot",
           "extras": [
             "none"
@@ -41188,7 +41188,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "x+y+z+text+name",
           "editType": "none",
           "extras": [
@@ -43551,7 +43551,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -44936,7 +44936,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -45606,7 +45606,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -46294,7 +46294,7 @@
         },
         "hoverinfo": {
           "arrayOk": false,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "plot",
           "extras": [
@@ -48843,7 +48843,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -49628,7 +49628,7 @@
           }
         },
         "textinfo": {
-          "description": "Determines which trace information appear on the graph.",
+          "description": "Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "editType": "calc",
           "extras": [
             "none"
@@ -49931,7 +49931,7 @@
         },
         "hoverinfo": {
           "arrayOk": false,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired. Note that this attribute is superseded by `node.hoverinfo` and `node.hoverinfo` for nodes and links respectively.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired. Note that this attribute is superseded by `node.hoverinfo` and `node.hoverinfo` for nodes and links respectively.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -50287,7 +50287,7 @@
             "valType": "color"
           },
           "hoverinfo": {
-            "description": "Determines which trace information appear when hovering links. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+            "description": "Determines what trace information appears when hovering links. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
             "dflt": "all",
             "editType": "calc",
             "valType": "enumerated",
@@ -50549,7 +50549,7 @@
             "valType": "info_array"
           },
           "hoverinfo": {
-            "description": "Determines which trace information appear when hovering nodes. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+            "description": "Determines what trace information appears when hovering nodes. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
             "dflt": "all",
             "editType": "calc",
             "valType": "enumerated",
@@ -51255,7 +51255,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -53748,7 +53748,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -55984,7 +55984,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -58062,7 +58062,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -60269,7 +60269,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -62378,7 +62378,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -63710,7 +63710,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -65805,7 +65805,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -67754,7 +67754,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -69832,7 +69832,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -71932,7 +71932,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -74363,7 +74363,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "x+y+z+norm+text+name",
           "editType": "calc",
           "extras": [
@@ -75034,7 +75034,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "dflt": "label+text+value+name",
           "editType": "none",
           "extras": [
@@ -76489,7 +76489,7 @@
           }
         },
         "textinfo": {
-          "description": "Determines which trace information appear on the graph.",
+          "description": "Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "editType": "plot",
           "extras": [
             "none"
@@ -77517,7 +77517,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -78525,7 +78525,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -78940,7 +78940,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. Flags are rendered in a fixed order; use `hovertemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "dflt": "label+text+value+name",
           "editType": "none",
           "extras": [
@@ -80548,7 +80548,7 @@
           }
         },
         "textinfo": {
-          "description": "Determines which trace information appear on the graph.",
+          "description": "Determines what trace information appears on the graph. Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "editType": "plot",
           "extras": [
             "none"
@@ -80749,7 +80749,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -82737,7 +82737,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "calc",
           "extras": [
@@ -83544,7 +83544,7 @@
         },
         "hoverinfo": {
           "arrayOk": true,
-          "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+          "description": "Determines what trace information appears on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
           "dflt": "all",
           "editType": "none",
           "extras": [
@@ -84261,7 +84261,7 @@
         },
         "textinfo": {
           "arrayOk": false,
-          "description": "Determines which trace information appear on the graph. In the case of having multiple waterfalls, totals are computed separately (per trace).",
+          "description": "Determines what trace information appears on the graph. In the case of having multiple waterfalls, totals are computed separately (per trace). Flags are rendered in a fixed order; use `texttemplate` if you need explicit control over the rendered string, including the order of fields and surrounding text.",
           "editType": "plot",
           "extras": [
             "none"


### PR DESCRIPTION
### Description

Update `textinfo`, `hoverinfo` attribute descriptions to point users toward `texttemplate`, `hovertemplate` attributes for custom order of info.

### Changes

- Update descriptions
- Fix some grammar mistakes
- Update schema and types

### Testing

Make sure that the language is clear and that CI is passing.

### Notes

- This change was prompted by investigating #7751 (and the PR to fix it in #7752)
- Since a solution already exists to acheive what the user was asking for in the issue, it was closed as already completed. However, it seems like promoting `texttemplate` and `hovertemplate` would help communicate that.