### PR TITLE
ci: Require PR number in file name, link for draftlogs

### DIFF
--- a/.github/workflows/check-draftlog.yml
+++ b/.github/workflows/check-draftlog.yml
@@ -53,12 +53,12 @@ jobs:
             exit 1
           fi
 
-          INVALID_NAMES=$(echo "$ADDED" | grep -vE '^draftlogs/[0-9]+_(fix|add|remove|change|deprecate)\.md$' || true)
+          INVALID_NAMES=$(echo "$ADDED" | grep -vE "^draftlogs/${PR_NUMBER}_(fix|add|remove|change|deprecate)\.md$" || true)
           if [ -n "$INVALID_NAMES" ]; then
             echo "::error::Invalid draftlog filename(s):"
             echo "$INVALID_NAMES" | sed 's/^/  - /'
             echo ""
-            echo "Expected pattern: draftlogs/<number>_(fix|add|remove|change|deprecate).md"
+            echo "Expected pattern: draftlogs/${PR_NUMBER}_(fix|add|remove|change|deprecate).md"
             echo "See draftlogs/README.md for details."
             exit 1
           fi
@@ -67,17 +67,17 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             content=$(gh api -H 'Accept: application/vnd.github.raw' "/repos/$REPO/contents/$f?ref=$HEAD_SHA")
-            if ! echo "$content" | grep -qE '\[\[#[0-9]+\]\(https://github\.com/plotly/plotly\.js/pull/[0-9]+\)\]'; then
+            if ! echo "$content" | grep -qE "\[\[#${PR_NUMBER}\]\(https://github\.com/plotly/plotly\.js/(pull|issues)/${PR_NUMBER}\)\]"; then
               MISSING_LINK="$MISSING_LINK$f"$'\n'
             fi
           done <<< "$ADDED"
 
           if [ -n "$MISSING_LINK" ]; then
-            echo "::error::Draftlog entry(ies) missing a PR link:"
+            echo "::error::Draftlog entry(ies) missing a link to this PR (#${PR_NUMBER}):"
             printf '%s' "$MISSING_LINK" | sed 's/^/  - /'
             echo ""
             echo "Each entry must include a link in the form:"
-            echo "  [[#1234](https://github.com/plotly/plotly.js/pull/1234)]"
+            echo "  [[#${PR_NUMBER}](https://github.com/plotly/plotly.js/pull/${PR_NUMBER})]"
             echo "See draftlogs/README.md for an example."
             exit 1
           fi

--- a/draftlogs/README.md
+++ b/draftlogs/README.md
@@ -1,7 +1,7 @@
 ## Directory of draft logs to help prepare the upcoming [CHANGELOG](https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md)
 
 Every pull request should add at least one markdown file to this directory.
-The filename must start with a number, preferably the PR number, followed by one of these:
+The filename must start with the PR number, followed by one of these:
 1. `_fix.md` to propose a bug fix
 2. `_add.md` to propose new features
 3. `_remove.md` to propose a feature removal
@@ -21,9 +21,11 @@ which would render
 
 > Please start your single-line or multiple lined message with a verb.
 
-Each entry must include a link back to the PR in the form shown above:
+Each entry must include a link back to its own PR in the form shown above:
 `[[#1234](https://github.com/plotly/plotly.js/pull/1234)]` (a link to
 `/issues/1234` is also accepted, since GitHub redirects between the two).
+The number in the filename, the `#1234` label, and the URL must all be the
+same PR number.
 
 ### Skipping the draftlog
 


### PR DESCRIPTION
### Description

Require PR number in draftlog file name, link.

### Changes

- Update workflow
- Update draftlog README

### Testing

- Create a PR
- Add a draftlog file that has the wrong number in the file name
- Note the error
- Update that file to use the correct number, but use the incorrect number in the link
- Note the error
- Fix it all and note that the check passes