### PR TITLE
fix: Handle NaN values in sortAxisCategoriesByValue conditional check

### DIFF
--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -3193,8 +3193,7 @@ function sortAxisCategoriesByValue(axList, gd) {
                         if(catIndex === undefined) catIndex = cdi[axLetter];
 
                         // Skip points whose position is not a valid category
-                        // (e.g. a null/NaN coordinate maps to BADNUM)
-                        if (catIndex == null || catIndex < 0) continue;
+                        if (isNaN(catIndex) || catIndex < 0) continue;
 
                         value = cdi.s;
                         if(value === undefined) value = cdi.v;


### PR DESCRIPTION
### Description

Update conditional check for `sortAxisCategoriesByValue` to handle `NaN` values.

### Changes

- Update conditional check

### Testing

- Run `npm run test-jasmine calcdata` locally
- Check CI

### Notes

- This check was added in #7855, but I broke it in the last commit