### PR TITLE
Fix adjustFormat dropping d3-format specs that start with a sign flag

### DIFF
--- a/draftlogs/7900_fix.md
+++ b/draftlogs/7900_fix.md
@@ -1,1 +1,1 @@
-- Fix `hovertemplate`/`texttemplate`/`tickformat`/`hoverformat` improperly handling d3-format specs that start with a sign flag such as `+.2f` [[#7900](https://github.com/plotly/plotly.js/pull/7900)]
+- Fix `hovertemplate`/`texttemplate`/`tickformat`/`hoverformat` improperly handling d3-format specs that start with a sign flag such as `+.2f` [[#7900](https://github.com/plotly/plotly.js/pull/7900)], with thanks to @TemRevil for the contribution!

--- a/draftlogs/7900_fix.md
+++ b/draftlogs/7900_fix.md
@@ -1,1 +1,1 @@
-- Fix `hovertemplate`/`texttemplate`/`tickformat`/`hoverformat` silently ignoring d3-format specs that start with a sign flag such as `+.2f` [[#7900](https://github.com/plotly/plotly.js/pull/7900)]
+- Fix `hovertemplate`/`texttemplate`/`tickformat`/`hoverformat` improperly handling d3-format specs that start with a sign flag such as `+.2f` [[#7900](https://github.com/plotly/plotly.js/pull/7900)]

--- a/draftlogs/7900_fix.md
+++ b/draftlogs/7900_fix.md
@@ -1,0 +1,1 @@
+- Fix `hovertemplate`/`texttemplate`/`tickformat`/`hoverformat` silently ignoring d3-format specs that start with a sign flag such as `+.2f` [[#7900](https://github.com/plotly/plotly.js/pull/7900)]

--- a/draftlogs/_fix.md
+++ b/draftlogs/_fix.md
@@ -1,0 +1,1 @@
+- Fix `hovertemplate`/`texttemplate`/`tickformat`/`hoverformat` silently ignoring d3-format specs that start with a sign flag such as `+.2f` [[#](https://github.com/plotly/plotly.js/pull/)]

--- a/draftlogs/_fix.md
+++ b/draftlogs/_fix.md
@@ -1,1 +1,0 @@
-- Fix `hovertemplate`/`texttemplate`/`tickformat`/`hoverformat` silently ignoring d3-format specs that start with a sign flag such as `+.2f` [[#](https://github.com/plotly/plotly.js/pull/)]

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -23,7 +23,7 @@ lib.adjustFormat = function adjustFormat(formatStr) {
     // that prefix before deciding whether to trim, and reattach it: prepending
     // the tilde to the whole string (e.g. "~+.2f") is an invalid spec that
     // d3Format rejects, so "+.2f" used to be silently dropped.
-    var prefix = (formatStr.match(/^[+\-( ]/) || [''])[0];
+    var prefix = (formatStr.match(/^[+\-( ]?/) || [''])[0];
     var rest = formatStr.slice(prefix.length);
 
     // try adding tilde to trim trailing zeros; leave symbol-led specs ($, #)

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -19,15 +19,16 @@ lib.adjustFormat = function adjustFormat(formatStr) {
     if (/^\d%/.test(formatStr)) return '~%';
     if (/^\ds/.test(formatStr)) return '~s';
 
-    // A d3-format spec may begin with a sign flag (+, -, (, space) and/or a
-    // symbol ($, #). Look past that prefix before deciding whether to trim, and
-    // reattach it: prepending the tilde to the whole string (e.g. "~+.2f") is an
-    // invalid spec that d3Format rejects, so "+.2f" used to be silently dropped.
-    var prefix = (formatStr.match(/^[+\-( ]?[$#]?/) || [''])[0];
+    // A d3-format spec may begin with a sign flag (+, -, (, space). Look past
+    // that prefix before deciding whether to trim, and reattach it: prepending
+    // the tilde to the whole string (e.g. "~+.2f") is an invalid spec that
+    // d3Format rejects, so "+.2f" used to be silently dropped.
+    var prefix = (formatStr.match(/^[+\-( ]/) || [''])[0];
     var rest = formatStr.slice(prefix.length);
 
-    // try adding tilde to trim trailing zeros
-    if (!/^[~,.0$]/.test(rest) && /[&fps]/.test(rest)) return prefix + '~' + rest;
+    // try adding tilde to trim trailing zeros; leave symbol-led specs ($, #)
+    // untrimmed, since the symbol isn't part of the prefix we stripped above
+    if (!/^[~,.0$#]/.test(rest) && /[&fps]/.test(rest)) return prefix + '~' + rest;
 
     return formatStr;
 };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -19,8 +19,15 @@ lib.adjustFormat = function adjustFormat(formatStr) {
     if (/^\d%/.test(formatStr)) return '~%';
     if (/^\ds/.test(formatStr)) return '~s';
 
-    // try adding tilde to the start of format in order to trim
-    if (!/^[~,.0$]/.test(formatStr) && /[&fps]/.test(formatStr)) return '~' + formatStr;
+    // A d3-format spec may begin with a sign flag (+, -, (, space) and/or a
+    // symbol ($, #). Look past that prefix before deciding whether to trim, and
+    // reattach it: prepending the tilde to the whole string (e.g. "~+.2f") is an
+    // invalid spec that d3Format rejects, so "+.2f" used to be silently dropped.
+    var prefix = (formatStr.match(/^[+\-( ]?[$#]?/) || [''])[0];
+    var rest = formatStr.slice(prefix.length);
+
+    // try adding tilde to trim trailing zeros
+    if (!/^[~,.0$]/.test(rest) && /[&fps]/.test(rest)) return prefix + '~' + rest;
 
     return formatStr;
 };

--- a/test/jasmine/tests/lib_number_format_test.js
+++ b/test/jasmine/tests/lib_number_format_test.js
@@ -53,6 +53,12 @@ describe('number format', function() {
         { format: '0f', number: float, exp: '12345.678901'},
         { format: '1f', number: float, exp: '12345.678901'},
 
+        // sign flag with an explicit precision must not be dropped (was silently
+        // ignored because adjustFormat produced the invalid spec "~+.2f")
+        { format: '+.2f', number: float, exp: '+12345.68'},
+        { format: '+.0f', number: float, exp: '+12346'},
+        { format: '-.4f', number: float, exp: '12345.6789'},
+
         // space-filled and default sign
         { format: '-13', number: float, exp: '-12345.678901'},
         { format: '-14', number: float, exp: ' -12345.678901'},

--- a/test/jasmine/tests/lib_number_format_test.js
+++ b/test/jasmine/tests/lib_number_format_test.js
@@ -59,6 +59,11 @@ describe('number format', function() {
         { format: '+.0f', number: float, exp: '+12346'},
         { format: '-.4f', number: float, exp: '12345.6789'},
 
+        // symbol-led specs ($, #) are left untrimmed
+        { format: '$f', number: 1.5, exp: '$1.500000'},
+        { format: '#f', number: 1.5, exp: '1.500000'},
+        { format: '$s', number: 1500, exp: '$1.50000k'},
+
         // space-filled and default sign
         { format: '-13', number: float, exp: '-12345.678901'},
         { format: '-14', number: float, exp: ' -12345.678901'},


### PR DESCRIPTION
Fixes #7897

A d3-format specifier that begins with a sign flag (`+`, `-`, `(`, or a space) was silently ignored in `hovertemplate`, `texttemplate`, `tickformat`, and `hoverformat`, showing the raw unformatted number instead. For example `%{y:+.2f}` rendered `12.3456789` rather than `+12.35`.

**Cause:** `Lib.adjustFormat` prepends a trim tilde to the start of the whole string, so `+.2f` became `~+.2f` — an invalid spec (the `~` flag must sit just before the type). `d3.format` threw, `Lib.numberFormat` caught it and fell back to `Lib.noFormat`.

**Fix:** skip past an optional leading sign flag and symbol (`$`, `#`) before the trim heuristic, then reattach that prefix, so the tilde is only inserted in a valid position. Formats without such a prefix are unchanged.

Verified against `d3-format` v1 directly: `+.2f` → `+12345.68`, `+.0f` → `+12346`, `-.4f` → `12345.6789`, while `.2f`, `s`, `0.3s`, `+13`, `-13`, `($15`, `#0X`, `.2%` produce identical output to before. Added matching cases in `test/jasmine/tests/lib_number_format_test.js`.