### PR TITLE
chore: Update map fitbounds attribute to be enum

### DIFF
--- a/draftlogs/7884_fix.md
+++ b/draftlogs/7884_fix.md
@@ -1,1 +1,1 @@
- - Fix `scattermap`, `densitymap` traces not showing all points by dynamically computing `center`, `zoom` values [[#7884](https://github.com/plotly/plotly.js/pull/7884)], with thanks to @palmerusaf and @DhruvGarg111 for the contributions!
+ - Fix `scattermap`, `densitymap` traces not showing all points by dynamically computing `center`, `zoom` values [[#7884](https://github.com/plotly/plotly.js/pull/7884), [#7913](https://github.com/plotly/plotly.js/pull/7913)], with thanks to @palmerusaf and @DhruvGarg111 for the contributions!

--- a/src/plots/map/layout_attributes.js
+++ b/src/plots/map/layout_attributes.js
@@ -81,12 +81,13 @@ var attrs = (module.exports = overrideAll(
         },
 
         fitbounds: {
-            valType: 'boolean',
-            dflt: true,
+            valType: 'enumerated',
+            values: [false, 'locations'],
+            dflt: 'locations',
             description: [
-                'Determines whether the map view auto-fits to the data.',
-                'For *true* (default), `center` and `zoom` are computed from the provided lon/lat coordinates,',
-                'For *false*, `center` and `zoom` are computed from the schema defaults or user-supplied values.',
+                "Determines if this subplot's view settings are auto-computed to fit trace data.",
+                'If *locations* (default), the view is auto-fit to the lon/lat coordinates of the visible trace data.',
+                'If *false*, the view settings are used as-is; set this to opt out of auto-fitting.',
                 'If `fitbounds` is enabled but a user provides `center` or `zoom`, auto-fit will be skipped.'
             ].join(' ')
         },

--- a/src/types/generated/schema.d.ts
+++ b/src/types/generated/schema.d.ts
@@ -12637,10 +12637,10 @@ export interface MapLayout {
     };
     domain?: Domain;
     /**
-     * Determines whether the map view auto-fits to the data. For *true* (default), `center` and `zoom` are computed from the provided lon/lat coordinates, For *false*, `center` and `zoom` are computed from the schema defaults or user-supplied values. If `fitbounds` is enabled but a user provides `center` or `zoom`, auto-fit will be skipped.
-     * @default true
+     * Determines if this subplot's view settings are auto-computed to fit trace data. If *locations* (default), the view is auto-fit to the lon/lat coordinates of the visible trace data. If *false*, the view settings are used as-is; set this to opt out of auto-fitting. If `fitbounds` is enabled but a user provides `center` or `zoom`, auto-fit will be skipped.
+     * @default 'locations'
      */
-    fitbounds?: boolean;
+    fitbounds?: false | 'locations';
     layers?: Array<{
         /** Determines if the layer will be inserted before the layer with the specified ID. If omitted or set to '', the layer will be inserted above every existing layer. */
         below?: string;

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -3807,10 +3807,14 @@
         },
         "editType": "plot",
         "fitbounds": {
-          "description": "Determines whether the map view auto-fits to the data. For *true* (default), `center` and `zoom` are computed from the provided lon/lat coordinates, For *false*, `center` and `zoom` are computed from the schema defaults or user-supplied values. If `fitbounds` is enabled but a user provides `center` or `zoom`, auto-fit will be skipped.",
-          "dflt": true,
+          "description": "Determines if this subplot's view settings are auto-computed to fit trace data. If *locations* (default), the view is auto-fit to the lon/lat coordinates of the visible trace data. If *false*, the view settings are used as-is; set this to opt out of auto-fitting. If `fitbounds` is enabled but a user provides `center` or `zoom`, auto-fit will be skipped.",
+          "dflt": "locations",
           "editType": "plot",
-          "valType": "boolean"
+          "valType": "enumerated",
+          "values": [
+            false,
+            "locations"
+          ]
         },
         "layers": {
           "items": {


### PR DESCRIPTION
### Description

Update the map trace `fitbounds` attribute to be an enum instead of boolean.

Closes #7912.

### Changes

- Update attribute
- Update schema and types

### Testing

Check that CI is passing.

### Notes

- This change is to help set us up in the future to allow for auto-fitting the choroplethmap trace
- This is a follow up to #7884 