### PR TITLE
fix(heatmap): add eventData handler for proper click event data

### DIFF
--- a/draftlogs/7920_fix.md
+++ b/draftlogs/7920_fix.md
@@ -1,0 +1,1 @@
+ - Add `eventData` handler to `heatmap` trace to properly format 2D `pointNumber` and `z` values on click [[#7920](https://github.com/plotly/plotly.js/pull/7920)]

--- a/src/traces/heatmap/event_data.js
+++ b/src/traces/heatmap/event_data.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = function eventData(out, pt) {
+    if ('index' in pt) {
+        out.pointNumber = pt.index;
+        out.pointIndex = pt.index;
+    }
+
+    if ('xVal' in pt) out.x = pt.xVal;
+    else if ('x' in pt) out.x = pt.x;
+    else if ('xLabelVal' in pt) out.x = pt.xLabelVal;
+
+    if ('yVal' in pt) out.y = pt.yVal;
+    else if ('y' in pt) out.y = pt.y;
+    else if ('yLabelVal' in pt) out.y = pt.yLabelVal;
+
+    if (pt.xa) out.xaxis = pt.xa;
+    if (pt.ya) out.yaxis = pt.ya;
+
+    if ('zLabelVal' in pt) {
+        out.z = pt.zLabelVal;
+    } else if ('z' in pt) {
+        out.z = pt.z;
+    }
+
+    return out;
+};

--- a/src/traces/heatmap/index.js
+++ b/src/traces/heatmap/index.js
@@ -8,6 +8,7 @@ module.exports = {
     colorbar: require('./colorbar'),
     style: require('./style'),
     hoverPoints: require('./hover'),
+    eventData: require('./event_data'),
 
     moduleType: 'trace',
     name: 'heatmap',

--- a/test/jasmine/tests/heatmap_test.js
+++ b/test/jasmine/tests/heatmap_test.js
@@ -1114,4 +1114,48 @@ describe('heatmap hover', function() {
             expect(pt).toEqual(undefined);
         });
     });
+
+    describe('heatmap event data', function() {
+        var gd;
+
+        beforeEach(function() {
+            gd = createGraphDiv();
+        });
+
+        afterEach(destroyGraphDiv);
+
+        it('should include 2D pointNumber and z value in plotly_click payload', function(done) {
+            var mockData = [{
+                type: 'heatmap',
+                z: [[1, 2], [3, 4]],
+                x: ['A', 'B'],
+                y: ['Row1', 'Row2']
+            }];
+
+            Plotly.newPlot(gd, mockData).then(function() {
+                var clickData = null;
+
+                gd.on('plotly_click', function(data) {
+                    clickData = data;
+                });
+
+                var mockClick = require('../assets/click');
+                var bBox = gd.getBoundingClientRect();
+
+                mockClick(bBox.left + 100, bBox.top + 300);
+
+                expect(clickData).not.toBeNull();
+                expect(clickData.points.length).toBe(1);
+
+                var pt = clickData.points[0];
+
+                expect(Array.isArray(pt.pointNumber)).toBe(true, 'pointNumber should be an array');
+                expect(pt.pointNumber).toEqual([0, 0], 'should point to the first row and col');
+                expect(pt.z).toBe(1, 'should extract the correct z value');
+
+                done();
+            }).catch(done.fail);
+        });
+    });
 });
+


### PR DESCRIPTION
## Description
When interacting with heatmaps, the standard `plotly_click` event previously lacked properly formatted 2D matrix indices and explicit `z` values. This made it difficult for downstream wrappers (such as Streamlit or Marimo) to identify the exact clicked cell natively.

### Architecture Note: `plotly_click` vs `plotly_heatmapclick`
While introducing a trace-specific event like `plotly_heatmapclick` (similar to `plotly_treemapclick` or `plotly_sunburstclick`) was originally discussed in #7685, doing so for heatmaps is an anti-pattern. Heatmaps are Cartesian trace types that reside on standard 2D Cartesian subplots. Introducing trace-specific click events on Cartesian subplots breaks consistency across Cartesian traces. The correct architectural approach is to rely on the standard `plotly_click` event and delegate trace-specific payload formatting to a dedicated `eventData` handler.

### Summary of Changes
This PR introduces the missing `eventData` handler for the heatmap trace:
- `pointNumber` and `pointIndex` are properly exposed as a 2D array `[row, col]`.
- `z` values are explicitly attached to the event payload.

This PR completes and supersedes #7686 (which was stalled). Unlike #7686, this implementation cleanly exposes the 2D `pointNumber: [row, col]` matrix indices and `z` values via `eventData` without modifying `hover.js` (avoiding category axis regressions), and includes complete Jasmine unit tests.

Closes #7685.

## Testing
- Added regression tests in `test/jasmine/tests/heatmap_test.js` to verify that standard `plotly_click` events emit 2D `pointNumber` and `z` values.
- Ran Jasmine test suite (`npm run test-jasmine -- test/jasmine/tests/heatmap_test.js`) with 51/51 specs passing successfully.
