### PR TITLE
Fix degenerate MultiPolygon centroids

### DIFF
--- a/draftlogs/7921_fix.md
+++ b/draftlogs/7921_fix.md
@@ -1,1 +1,1 @@
-- Prevent degenerate MultiPolygon features from aborting choropleth rendering [[#7921](https://github.com/plotly/plotly.js/pull/7921)]
+- Prevent MultiPolygon features with no positive-area polygon from aborting choropleth rendering [[#7921](https://github.com/plotly/plotly.js/pull/7921)], with thanks to @swjturay for the contribution!

--- a/draftlogs/7921_fix.md
+++ b/draftlogs/7921_fix.md
@@ -1,0 +1,1 @@
+- Prevent degenerate MultiPolygon features from aborting choropleth rendering [[#7921](https://github.com/plotly/plotly.js/pull/7921)]

--- a/src/lib/geo_location_utils.js
+++ b/src/lib/geo_location_utils.js
@@ -331,6 +331,9 @@ function findCentroid(feature) {
         poly = geometry;
     }
 
+    // Degenerate MultiPolygons may not contain a positive-area polygon.
+    if (!poly) return [NaN, NaN];
+
     return turfCentroid(poly).geometry.coordinates;
 }
 

--- a/src/lib/geo_location_utils.js
+++ b/src/lib/geo_location_utils.js
@@ -242,11 +242,18 @@ function extractTraceFeature(calcTrace) {
                     properties: {}
                 };
 
-                // Compute centroid, add it to the properties
-                if (fOut.geometry.coordinates.length > 0) {
-                    fOut.properties.ct = findCentroid(fOut);
-                } else {
-                    fOut.properties.ct = [NaN, NaN];
+                fOut.properties.ct = findCentroid(fOut);
+
+                if (isNaN(fOut.properties.ct[0])) {
+                    loggers.log(
+                        [
+                            'Location',
+                            cdi.loc,
+                            'has no polygon with positive area.',
+                            'Its centroid could not be computed,',
+                            'so hover and selection will not work for it.'
+                        ].join(' ')
+                    );
                 }
 
                 // Mutate in in/out features into calcdata
@@ -331,8 +338,10 @@ function findCentroid(feature) {
         poly = geometry;
     }
 
-    // Degenerate MultiPolygons may not contain a positive-area polygon.
-    if (!poly) return [NaN, NaN];
+    // Guard against MultiPolygons that don't contain a positive-area polygon
+    // (collapsed rings measure zero, malformed ring ordering measures negative)
+    // and when either geometry type has rings holding no points at all.
+    if (!poly || !poly.coordinates.some((ring) => ring.length > 0)) return [NaN, NaN];
 
     return turfCentroid(poly).geometry.coordinates;
 }

--- a/test/jasmine/tests/lib_geo_location_utils_test.js
+++ b/test/jasmine/tests/lib_geo_location_utils_test.js
@@ -1,4 +1,67 @@
-const { getFitboundsLonRange, unwrapLonRange, doesCrossAntiMeridian } = require('../../../src/lib/geo_location_utils');
+const {
+    extractTraceFeature,
+    getFitboundsLonRange,
+    unwrapLonRange,
+    doesCrossAntiMeridian
+} = require('../../../src/lib/geo_location_utils');
+
+describe('Test geo_location_utils.extractTraceFeature', () => {
+    it('keeps degenerate MultiPolygons without affecting valid features', () => {
+        const trace = {
+            _length: 2,
+            geojson: {
+                type: 'FeatureCollection',
+                features: [
+                    {
+                        type: 'Feature',
+                        id: 'degenerate',
+                        geometry: {
+                            type: 'MultiPolygon',
+                            coordinates: [
+                                [
+                                    [
+                                        [0, 0],
+                                        [1, 1],
+                                        [0, 0],
+                                        [0, 0]
+                                    ]
+                                ]
+                            ]
+                        }
+                    },
+                    {
+                        type: 'Feature',
+                        id: 'valid',
+                        geometry: {
+                            type: 'Polygon',
+                            coordinates: [
+                                [
+                                    [0, 0],
+                                    [0, 1],
+                                    [1, 1],
+                                    [1, 0],
+                                    [0, 0]
+                                ]
+                            ]
+                        }
+                    }
+                ]
+            }
+        };
+        const calcTrace = [
+            { loc: 'degenerate', trace },
+            { loc: 'valid', trace }
+        ];
+
+        const features = extractTraceFeature(calcTrace);
+
+        expect(features.length).toBe(2);
+        expect(features[0].id).toBe('degenerate');
+        expect(features[0].properties.ct.every(Number.isNaN)).toBe(true);
+        expect(features[1].id).toBe('valid');
+        expect(features[1].properties.ct.every(Number.isFinite)).toBe(true);
+    });
+});
 
 describe('Test geo_location_utils.getFitboundsLonRange', () => {
     it('returns the compact crossing range when point data straddles the antimeridian', () => {

--- a/test/jasmine/tests/lib_geo_location_utils_test.js
+++ b/test/jasmine/tests/lib_geo_location_utils_test.js
@@ -4,9 +4,19 @@ const {
     unwrapLonRange,
     doesCrossAntiMeridian
 } = require('../../../src/lib/geo_location_utils');
+const loggers = require('../../../src/lib/loggers');
+
+function extractSingleFeature(geometry) {
+    const trace = {
+        _length: 1,
+        geojson: { type: 'Feature', id: 'Omicron Persei 8', geometry }
+    };
+
+    return extractTraceFeature([{ loc: 'Omicron Persei 8', trace }])[0];
+}
 
 describe('Test geo_location_utils.extractTraceFeature', () => {
-    it('keeps degenerate MultiPolygons without affecting valid features', () => {
+    it('keeps MultiPolygons with no positive-area polygon without affecting valid features', () => {
         const trace = {
             _length: 2,
             geojson: {
@@ -14,7 +24,7 @@ describe('Test geo_location_utils.extractTraceFeature', () => {
                 features: [
                     {
                         type: 'Feature',
-                        id: 'degenerate',
+                        id: 'zero-area',
                         geometry: {
                             type: 'MultiPolygon',
                             coordinates: [
@@ -49,17 +59,70 @@ describe('Test geo_location_utils.extractTraceFeature', () => {
             }
         };
         const calcTrace = [
-            { loc: 'degenerate', trace },
+            { loc: 'zero-area', trace },
             { loc: 'valid', trace }
         ];
 
         const features = extractTraceFeature(calcTrace);
 
         expect(features.length).toBe(2);
-        expect(features[0].id).toBe('degenerate');
+        expect(features[0].id).toBe('zero-area');
         expect(features[0].properties.ct.every(Number.isNaN)).toBe(true);
         expect(features[1].id).toBe('valid');
         expect(features[1].properties.ct.every(Number.isFinite)).toBe(true);
+    });
+
+    it('keeps Polygons and MultiPolygons whose rings hold no points', () => {
+        const polygon = extractSingleFeature({ type: 'Polygon', coordinates: [[]] });
+        const multiPolygon = extractSingleFeature({ type: 'MultiPolygon', coordinates: [[[]]] });
+
+        expect(polygon.properties.ct.every(Number.isNaN)).toBe(true);
+        expect(multiPolygon.properties.ct.every(Number.isNaN)).toBe(true);
+    });
+
+    it('logs the locations whose centroid could not be computed', () => {
+        spyOn(loggers, 'log');
+
+        extractSingleFeature({
+            type: 'MultiPolygon',
+            coordinates: [
+                [
+                    [
+                        [0, 0],
+                        [1, 1],
+                        [0, 0],
+                        [0, 0]
+                    ]
+                ]
+            ]
+        });
+
+        expect(loggers.log).toHaveBeenCalledWith(
+            [
+                'Location Omicron Persei 8 has no polygon with positive area.',
+                'Its centroid could not be computed,',
+                'so hover and selection will not work for it.'
+            ].join(' ')
+        );
+    });
+
+    it('does not log for features with a computable centroid', () => {
+        spyOn(loggers, 'log');
+
+        extractSingleFeature({
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [0, 0],
+                    [0, 1],
+                    [1, 1],
+                    [1, 0],
+                    [0, 0]
+                ]
+            ]
+        });
+
+        expect(loggers.log).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
## Overview

Fixes #7874.

Prevent a zero-area `MultiPolygon` feature from aborting choropleth rendering. When centroid selection cannot find a positive-area sub-polygon, the feature now receives the existing `[NaN, NaN]` centroid sentinel. Its geometry remains available for rendering, while valid sibling features continue through extraction.

## Root cause and user impact

The `MultiPolygon` centroid path initialized `maxArea` to zero and only selected sub-polygons whose area was strictly greater. If every sub-polygon had zero area, the selected polygon remained undefined and was passed to Turf's centroid helper, causing an uncaught `TypeError` that stopped the entire plot.

The guard is limited to that no-positive-area case. Centroid calculation for valid `Polygon` and `MultiPolygon` features is unchanged.

## Validation

- Added a regression test using the issue's two-distinct-vertex degenerate ring alongside a valid polygon.
- Verified the regression test failed before the source change with `Cannot read properties of undefined (reading 'type')`.
- `npm run test-jasmine -- lib_geo_location_utils choropleth --nowatch --report-spec` — 37/37 passed (Chromium-based Edge via `CHROME_BIN`).
- `npm run test-syntax`
- `npm run lint`
- `git diff --check`
