### PR TITLE
Add legend.itemheight to set the height of the legend fill swatch

### DIFF
--- a/draftlogs/7925_add.md
+++ b/draftlogs/7925_add.md
@@ -1,0 +1,1 @@
+- Add `layout.legend.itemheight` to set the height of the legend fill swatch, so more of a trace `fillpattern` is visible in the legend [[#7925](https://github.com/plotly/plotly.js/pull/7925)]

--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -141,6 +141,17 @@ module.exports = {
         editType: 'legend',
         description: 'Sets the width (in px) of the legend item symbols (the part other than the title.text).',
     },
+    itemheight: {
+        valType: 'number',
+        min: 6,
+        dflt: 6,
+        editType: 'legend',
+        description: [
+            'Sets the height (in px) of the legend item fill swatch.',
+            'Increasing it reveals more of a trace *fill* or *fillpattern* in the legend,',
+            'and grows the legend item to fit.',
+        ].join(' '),
+    },
     itemclick: {
         valType: 'enumerated',
         values: ['toggle', 'toggleothers', false],

--- a/src/components/legend/defaults.js
+++ b/src/components/legend/defaults.js
@@ -219,6 +219,7 @@ function groupDefaults(legendId, layoutIn, layoutOut, fullData, legendCount) {
     coerce('indentation');
     coerce('itemsizing');
     coerce('itemwidth');
+    coerce('itemheight');
 
     coerce('itemclick');
     coerce('itemdoubleclick');

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -826,7 +826,7 @@ function computeTextDimensions(g, gd, legendObj, aTitle) {
         legendObj._titleHeight = height;
     } else { // legend item
         legendItem.lineHeight = lineHeight;
-        legendItem.height = Math.max(height, 16) + 3;
+        legendItem.height = Math.max(height, 16, legendObj.itemheight + 10) + 3;
         legendItem.width = width;
     }
 }

--- a/src/components/legend/style.js
+++ b/src/components/legend/style.js
@@ -26,6 +26,7 @@ module.exports = function style(s, gd, legend) {
     if (!legend) legend = fullLayout.legend;
     var constantItemSizing = legend.itemsizing === 'constant';
     var itemWidth = legend.itemwidth;
+    var itemHeight = legend.itemheight;
     var centerPos = (itemWidth + constants.itemGap * 2) / 2;
     var centerTransform = strTranslate(centerPos, 0);
 
@@ -139,7 +140,7 @@ module.exports = function style(s, gd, legend) {
             .data(showFill || showGradientFill ? [d] : []);
         fill.enter().append('path').classed('js-fill', true);
         fill.exit().remove();
-        fill.attr('d', pathStart + 'h' + itemWidth + 'v6h-' + itemWidth + 'z').call(fillStyle);
+        fill.attr('d', pathStart + 'h' + itemWidth + 'v' + itemHeight + 'h-' + itemWidth + 'z').call(fillStyle);
 
         if (showLine || showGradientLine) {
             var lw = boundLineWidth(undefined, trace.line, MAX_LINE_WIDTH, CST_LINE_WIDTH);

--- a/test/jasmine/tests/legend_test.js
+++ b/test/jasmine/tests/legend_test.js
@@ -83,6 +83,21 @@ describe('legend defaults', function () {
         expect(layoutOut.showlegend).toBe(false);
     });
 
+    it('defaults itemheight to 6 and clamps values below the minimum', function () {
+        fullData = allShown([{ type: 'scatter' }, { type: 'scatter' }]);
+
+        supplyLayoutDefaults({}, layoutOut, fullData);
+        expect(layoutOut.legend.itemheight).toBe(6);
+
+        layoutOut = { font: Plots.layoutAttributes.font, bg_color: Plots.layoutAttributes.bg_color };
+        supplyLayoutDefaults({ showlegend: true, legend: { itemheight: 1 } }, layoutOut, fullData);
+        expect(layoutOut.legend.itemheight).toBe(6);
+
+        layoutOut = { font: Plots.layoutAttributes.font, bg_color: Plots.layoutAttributes.bg_color };
+        supplyLayoutDefaults({ showlegend: true, legend: { itemheight: 24 } }, layoutOut, fullData);
+        expect(layoutOut.legend.itemheight).toBe(24);
+    });
+
     it('shows with one visible pie', function () {
         fullData = allShown([{ type: 'pie' }]);
 
@@ -3497,5 +3512,136 @@ describe('legend title click', function() {
                 expect(titleToggle.style.cursor).not.toBe('pointer');
             }
         }).then(done, done.fail);
+    });
+});
+describe('legend itemheight:', function() {
+    'use strict';
+
+    var gd;
+
+    beforeEach(function() {
+        gd = createGraphDiv();
+    });
+
+    afterEach(destroyGraphDiv);
+
+    function fillPathD() {
+        return d3Select(gd).select('g.legendfill').select('path').attr('d');
+    }
+
+    function linePathD() {
+        return d3Select(gd).select('g.legendlines').select('path').attr('d');
+    }
+
+    // The toggle rect is sized to the computed row height, see setRect in draw.js
+    function rowHeights() {
+        var heights = [];
+        d3Select(gd).selectAll('rect.legendtoggle').each(function() {
+            heights.push(+this.getAttribute('height'));
+        });
+        return heights;
+    }
+
+    var filled = [
+        { x: [1, 2], y: [1, 2], fill: 'tozeroy', name: 'a' },
+        { x: [1, 2], y: [2, 3], fill: 'tozeroy', name: 'b' }
+    ];
+
+    it('reproduces the historical 6px swatch at the default', function(done) {
+        Plotly.newPlot(gd, filled, { showlegend: true })
+            .then(function() {
+                expect(gd._fullLayout.legend.itemheight).toBe(6);
+                expect(fillPathD()).toBe('M5,0h30v6h-30z');
+            })
+            .then(done, done.fail);
+    });
+
+    it('grows the fill swatch to the requested height', function(done) {
+        Plotly.newPlot(gd, filled, { showlegend: true, legend: { itemheight: 24 } })
+            .then(function() {
+                expect(fillPathD()).toBe('M5,0h30v24h-30z');
+            })
+            .then(done, done.fail);
+    });
+
+    it('grows the swatch downwards, leaving the line on top of the fill', function(done) {
+        var dfltLine;
+
+        Plotly.newPlot(gd, filled, { showlegend: true })
+            .then(function() {
+                dfltLine = linePathD();
+                return Plotly.relayout(gd, 'legend.itemheight', 30);
+            })
+            .then(function() {
+                // the line marks the top edge of the fill, exactly as in the plot itself
+                expect(linePathD()).toBe(dfltLine);
+                expect(fillPathD()).toBe('M5,0h30v30h-30z');
+            })
+            .then(done, done.fail);
+    });
+
+    it('does not move the swatch of a trace without fill', function(done) {
+        var unfilled = [
+            { x: [1, 2], y: [1, 2], name: 'a' },
+            { x: [1, 2], y: [2, 3], name: 'b' }
+        ];
+        var dfltLine;
+
+        Plotly.newPlot(gd, unfilled, { showlegend: true })
+            .then(function() {
+                dfltLine = linePathD();
+                return Plotly.relayout(gd, 'legend.itemheight', 40);
+            })
+            .then(function() {
+                expect(linePathD()).toBe(dfltLine);
+            })
+            .then(done, done.fail);
+    });
+
+    it('grows each legend row so taller swatches do not overlap', function(done) {
+        var dflt;
+
+        Plotly.newPlot(gd, filled, { showlegend: true })
+            .then(function() {
+                dflt = rowHeights();
+                expect(dflt.length).toBe(2);
+                return Plotly.relayout(gd, 'legend.itemheight', 40);
+            })
+            .then(function() {
+                var grown = rowHeights();
+                expect(grown.length).toBe(dflt.length);
+                grown.forEach(function(h, i) {
+                    expect(h).toBeGreaterThan(dflt[i]);
+                    // Math.max(textHeight, 16, itemheight + 10) + 3
+                    expect(h).toBe(53);
+                });
+            })
+            .then(done, done.fail);
+    });
+
+    it('leaves row heights untouched at the default', function(done) {
+        var dflt;
+
+        Plotly.newPlot(gd, filled, { showlegend: true })
+            .then(function() {
+                dflt = rowHeights();
+                return Plotly.relayout(gd, 'legend.itemheight', 6);
+            })
+            .then(function() {
+                expect(rowHeights()).toEqual(dflt);
+            })
+            .then(done, done.fail);
+    });
+
+    it('applies to unified hover labels without error', function(done) {
+        Plotly.newPlot(gd, filled, {
+            showlegend: true,
+            hovermode: 'x unified',
+            legend: { itemheight: 18 }
+        })
+            .then(function() {
+                expect(gd._fullLayout.legend.itemheight).toBe(18);
+            })
+            .then(done, done.fail);
     });
 });

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -3464,6 +3464,13 @@
             false
           ]
         },
+        "itemheight": {
+          "description": "Sets the height (in px) of the legend item fill swatch. Increasing it reveals more of a trace *fill* or *fillpattern* in the legend, and grows the legend item to fit.",
+          "dflt": 6,
+          "editType": "legend",
+          "min": 6,
+          "valType": "number"
+        },
         "itemsizing": {
           "description": "Determines if the legend items symbols scale with their corresponding *trace* attributes or remain *constant* independent of the symbol size on the graph.",
           "dflt": "trace",


### PR DESCRIPTION
Closes #7924

Adds `layout.legend.itemheight`, the vertical counterpart to the existing `itemwidth`, so a taller legend swatch can reveal more of a trace's `fillpattern`.

### The two parts

The fill swatch height was hardcoded in `src/components/legend/style.js`:

```js
fill.attr('d', pathStart + 'h' + itemWidth + 'v6h-' + itemWidth + 'z')
```

That `v6` is the 6 pixels mentioned in the issue. Making it configurable on its own is not enough, though: legend row height is computed in `draw.js` as `Math.max(height, 16) + 3`, so anything taller than about 13px would have overlapped its neighbours. That is most likely the "my vertical alignment is off" in the original report. This PR changes both:

- `attributes.js` / `defaults.js`: new `itemheight`, `min: 6`, `dflt: 6`, `editType: 'legend'`. `min === dflt` mirrors `itemwidth` exactly (`min: 30, dflt: 30`).
- `style.js`: `v6` becomes `v<itemheight>`.
- `draw.js`: row height becomes `Math.max(height, 16, legendObj.itemheight + 10) + 3`, so items grow to fit the swatch.

At the default the rendering is unchanged. Since `6 + 10 === 16`, the new term cannot win at `itemheight: 6`, and the swatch path is still `v6`. I kept the literal `16` as an independent floor rather than replacing it with `itemheight + 10`, because those two being equal at the default is a choice of constant on my part, not something I can show about why `16` was originally picked.

The swatch grows downwards, leaving `pathStart` alone. That keeps the trace line sitting on the top edge of the fill, which is how a filled area actually renders in the plot, and it matches the mock in the issue. It also means a trace with no fill is completely unaffected, since `pathStart` is what positions the line.

Unified hover labels need no separate handling: `hover.js` builds its `mockLegend` through `legendSupplyDefaults`, so the new attribute is coerced there too.

### Before / after

Three `fillpattern` traces, default versus `legend.itemheight: 24`. The `/`, `x` and `.` patterns are hard to tell apart at 6px and legible at 24px.

| Before | After |
| --- | --- |
| <img width="580" height="390" alt="image" src="https://github.com/user-attachments/assets/d323d63e-4aad-47ed-9f6f-5e12e821f304" /> | <img width="580" height="390" alt="image" src="https://github.com/user-attachments/assets/127997ea-4810-42d7-b9ee-8bb665021e63" /> |

### Testing

`npm run test-jasmine -- legend --nowatch` gives 132 passing, of which 8 are new. `hover_label` is 221 passing. `npm run lint`, `npm run test-syntax` and `npm run test-mock` are all clean. `test/plot-schema.json` regenerated with `npm run schema`; `dist/` deliberately untouched.

New tests:

| Test | Purpose |
|---|---|
| `reproduces the historical 6px swatch at the default` | pins `M5,0h30v6h-30z` so the default cannot drift |
| `grows the fill swatch to the requested height` | the feature |
| `grows the swatch downwards, leaving the line on top of the fill` | pins the growth direction |
| `does not move the swatch of a trace without fill` | guards unfilled traces |
| `grows each legend row so taller swatches do not overlap` | the `draw.js` half |
| `leaves row heights untouched at the default` | no regression for existing charts |
| `applies to unified hover labels without error` | the `mockLegend` path |
| `defaults itemheight to 6 and clamps values below the minimum` | coercion |

I verified the tests actually bind to the change rather than passing regardless. Reverting only the `style.js` line fails exactly the two swatch-growth tests and nothing else; reverting only the `draw.js` line fails exactly the row-growth test. The default-behaviour guards pass either way by design, which is what stops the feature from degenerating into "move the swatch".

### Three things worth a maintainer's call

1. **Scope.** `itemheight` currently drives only the fill swatch. Bar and marker swatches have their own fixed geometry (`styleBars` draws `M6,6H-6V-6H6Z`, a 12x12 square). Should `itemheight` drive those too, or stay fill-only as the issue requests?
2. **`min: 6`.** Chosen to match today's height and to mirror `itemwidth`'s `min === dflt`. Happy to lower it if you would rather allow thinner swatches.
3. **Label alignment.** Because the swatch grows downwards, the label sits nearer the top of a tall swatch rather than centred on it. `legend.valign` already offers some control here and the default is untouched, so I left text positioning alone rather than adding a second alignment mechanism. Say the word if you would prefer the label centred on the swatch.

No image mock is included yet. The `itemwidth` precedent is `test/image/mocks/legend_itemwidth_dashline.json`, so I am happy to add one, but since baselines are generated on `ubuntu-latest` I would rather take the baseline from CI than commit a macOS render. Let me know and I will add it.
