### PR TITLE
Fix: legend sizing for MathJax names

### DIFF
--- a/draftlogs/7927_fix.md
+++ b/draftlogs/7927_fix.md
@@ -1,0 +1,1 @@
+- Fix legend sizing for traces with MathJax names [[#7920](https://github.com/plotly/plotly.js/pull/7920)]

--- a/draftlogs/7927_fix.md
+++ b/draftlogs/7927_fix.md
@@ -1,1 +1,1 @@
-- Fix legend sizing for traces with MathJax names [[#7920](https://github.com/plotly/plotly.js/pull/7920)]
+- Fix legend sizing for traces with MathJax names [[#7927](https://github.com/plotly/plotly.js/pull/7927)]

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -772,7 +772,19 @@ function computeTextDimensions(g, gd, legendObj, aTitle) {
     var height, width;
 
     if(mathjaxNode) {
-        var mathjaxBB = Drawing.bBox(mathjaxNode);
+        var mathjaxBB;
+        var mjInnerSvg = mathjaxNode.querySelector && mathjaxNode.querySelector('svg');
+        var mjViewBox = mjInnerSvg && mjInnerSvg.getAttribute('viewBox');
+        if(mjViewBox) {
+            var vbParts = mjViewBox.split(/\s+/).map(Number);
+            var emPx = parseFloat(window.getComputedStyle(mathjaxNode).fontSize) || font.size;
+            mathjaxBB = {
+                width: (vbParts[2] / 1000) * emPx,
+                height: (vbParts[3] / 1000) * emPx
+            };
+        } else {
+            mathjaxBB = Drawing.bBox(mathjaxNode);
+        }
 
         height = mathjaxBB.height;
         width = mathjaxBB.width;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -778,10 +778,11 @@ function computeTextDimensions(g, gd, legendObj, aTitle) {
         if(mjViewBox) {
             var vbParts = mjViewBox.split(/\s+/).map(Number);
             var emPx = parseFloat(window.getComputedStyle(mathjaxNode).fontSize) || font.size;
-            mathjaxBB = {
-                width: (vbParts[2] / 1000) * emPx,
-                height: (vbParts[3] / 1000) * emPx
-            };
+            var vbWidth = (vbParts[2] / 1000) * emPx;
+            var vbHeight = (vbParts[3] / 1000) * emPx;
+            mathjaxBB = (isFinite(vbWidth) && isFinite(vbHeight))
+                ? {width: vbWidth, height: vbHeight}
+                : Drawing.bBox(mathjaxNode);
         } else {
             mathjaxBB = Drawing.bBox(mathjaxNode);
         }


### PR DESCRIPTION
### Bug fix:

When a trace's `name` contains LaTeX/MathJax (e.g. `$\alpha_{1c} = 352$`), the legend sometimes renders too small to fit the math  cutting it off completely. This mostlyshows up in Firefox, but the underlying bug isn't Firefox-specific.
This PR tries to resolve this bug

Fixes #559


