### PR TITLE
Fix multicategory axis ordering and support categoryorder / categoryarray

### DIFF
--- a/draftlogs/7929_fix.md
+++ b/draftlogs/7929_fix.md
@@ -1,0 +1,1 @@
+ - Fix `multicategory` axes ordering second-level categories by a single global order instead of the data order within each first-level category, and honour `categoryorder`/`categoryarray` on those axes [[#7929](https://github.com/plotly/plotly.js/pull/7929)]

--- a/src/plots/cartesian/category_order_defaults.js
+++ b/src/plots/cartesian/category_order_defaults.js
@@ -1,38 +1,104 @@
 'use strict';
 
+var isArrayOrTypedArray = require('../../lib/array').isArrayOrTypedArray;
 var isTypedArraySpec = require('../../lib/array').isTypedArraySpec;
 
-function findCategories(ax, opts) {
+// 'total ascending', 'median descending', ... - ordering by aggregated value,
+// which `sortAxisCategoriesByValue` only implements for 'category' axes.
+// Mirrors `sortAxisCategoriesByValueRegex` in plots.js
+var VALUE_ORDER_RE = /(total|sum|min|max|mean|geometric mean|median) (ascending|descending)/;
+
+function isValidCategory(v) {
+    return v !== null && v !== undefined;
+}
+
+// a multicategory entry is a [parent, child] pair
+function isValidPair(v) {
+    return Array.isArray(v) && v.length === 2 &&
+        isValidCategory(v[0]) && isValidCategory(v[1]);
+}
+
+function compareAsString(a, b) {
+    a = String(a);
+    b = String(b);
+    return a < b ? -1 : (a > b ? 1 : 0);
+}
+
+function comparePairs(a, b) {
+    return compareAsString(a[0], b[0]) || compareAsString(a[1], b[1]);
+}
+
+function getAxData(ax, opts) {
     var dataAttr = opts.dataAttr || ax._id.charAt(0);
-    var lookup = {};
-    var axData;
-    var i, j;
 
     if(opts.axData) {
         // non-x/y case
-        axData = opts.axData;
-    } else {
-        // x/y case
-        axData = [];
-        for(i = 0; i < opts.data.length; i++) {
-            var trace = opts.data[i];
-            if(trace[dataAttr + 'axis'] === ax._id) {
-                axData.push(trace);
-            }
+        return opts.axData;
+    }
+
+    // x/y case
+    var axData = [];
+    for(var i = 0; i < opts.data.length; i++) {
+        var trace = opts.data[i];
+        if(trace[dataAttr + 'axis'] === ax._id) {
+            axData.push(trace);
         }
     }
+    return axData;
+}
+
+function findCategories(ax, opts) {
+    var dataAttr = opts.dataAttr || ax._id.charAt(0);
+    var axData = getAxData(ax, opts);
+    var lookup = {};
+    var i, j;
 
     for(i = 0; i < axData.length; i++) {
         var vals = axData[i][dataAttr];
         for(j = 0; j < vals.length; j++) {
             var v = vals[j];
-            if(v !== null && v !== undefined) {
+            if(isValidCategory(v)) {
                 lookup[v] = 1;
             }
         }
     }
 
     return Object.keys(lookup);
+}
+
+// multicategory variant: returns the unique [parent, child] pairs found in the
+// data, which is what `_categories` holds for these axes
+function findCategoryPairs(ax, opts) {
+    var dataAttr = opts.dataAttr || ax._id.charAt(0);
+    var axData = getAxData(ax, opts);
+    var lookup = Object.create(null);
+    var list = [];
+    var i, j;
+
+    for(i = 0; i < axData.length; i++) {
+        var arrayIn = axData[i][dataAttr];
+        if(!isArrayOrTypedArray(arrayIn) ||
+            !isArrayOrTypedArray(arrayIn[0]) ||
+            !isArrayOrTypedArray(arrayIn[1])
+        ) continue;
+
+        var len = Math.min(arrayIn[0].length, arrayIn[1].length);
+
+        for(j = 0; j < len; j++) {
+            var v0 = arrayIn[0][j];
+            var v1 = arrayIn[1][j];
+
+            if(isValidCategory(v0) && isValidCategory(v1)) {
+                var key = v0 + ',' + v1;
+                if(!(key in lookup)) {
+                    lookup[key] = 1;
+                    list.push([v0, v1]);
+                }
+            }
+        }
+    }
+
+    return list;
 }
 
 /**
@@ -48,11 +114,17 @@ function findCategories(ax, opts) {
  *   - dataAttr {string} : attribute name corresponding to coordinate array
  */
 module.exports = function handleCategoryOrderDefaults(containerIn, containerOut, coerce, opts) {
-    if(containerOut.type !== 'category') return;
+    var isMultiCategory = containerOut.type === 'multicategory';
+    if(containerOut.type !== 'category' && !isMultiCategory) return;
 
     var arrayIn = containerIn.categoryarray;
     var isValidArray = (Array.isArray(arrayIn) && arrayIn.length > 0) ||
         isTypedArraySpec(arrayIn);
+
+    // on multicategory axes every entry must be a [parent, child] pair
+    if(isMultiCategory && isValidArray) {
+        isValidArray = Array.isArray(arrayIn) && arrayIn.some(isValidPair);
+    }
 
     // override default 'categoryorder' value when non-empty array is supplied
     var orderDefault;
@@ -60,6 +132,12 @@ module.exports = function handleCategoryOrderDefaults(containerIn, containerOut,
 
     var order = coerce('categoryorder', orderDefault);
     var array;
+
+    // ordering by aggregated value is not implemented for multicategory axes -
+    // it would also interleave children across parents, breaking the grouping
+    if(isMultiCategory && VALUE_ORDER_RE.test(order)) {
+        order = containerOut.categoryorder = 'trace';
+    }
 
     // coerce 'categoryarray' only in array order case
     if(order === 'array') {
@@ -75,9 +153,15 @@ module.exports = function handleCategoryOrderDefaults(containerIn, containerOut,
     if(order === 'trace') {
         containerOut._initialCategories = [];
     } else if(order === 'array') {
-        containerOut._initialCategories = array.slice();
+        array = array.slice();
+        // drop malformed entries so they can't land in `_categories`
+        if(isMultiCategory) array = array.filter(isValidPair);
+        containerOut._initialCategories = array;
     } else {
-        array = findCategories(containerOut, opts).sort();
+        array = isMultiCategory ?
+            findCategoryPairs(containerOut, opts).sort(comparePairs) :
+            findCategories(containerOut, opts).sort();
+
         if(order === 'category ascending') {
             containerOut._initialCategories = array;
         } else if(order === 'category descending') {

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -1265,7 +1265,10 @@ module.exports = {
             'the *trace* mode. The unspecified categories will follow the categories in `categoryarray`.',
             'Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the',
             'numerical order of the values.',
-            'Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.'
+            'Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.',
+            'On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data',
+            'within each first-level category, and ordering by aggregated value is not supported',
+            '- those values fall back on *trace*.'
         ].join(' ')
     },
     categoryarray: {
@@ -1274,7 +1277,9 @@ module.exports = {
         description: [
             'Sets the order in which categories on this axis appear.',
             'Only has an effect if `categoryorder` is set to *array*.',
-            'Used with `categoryorder`.'
+            'Used with `categoryorder`.',
+            'On *multicategory* axes each entry is a [first-level, second-level] pair,',
+            'e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.'
         ].join(' ')
     },
     uirevision: {

--- a/src/plots/cartesian/set_convert.js
+++ b/src/plots/cartesian/set_convert.js
@@ -371,8 +371,12 @@ module.exports = function setConvert(ax, fullLayout) {
                 }
             }
 
-            // [ [cnt, {$cat: index}], for 1,2 ]
-            var seen = [[0, {}], [0, {}]];
+            // [cnt, {$cat: index}] for the first (parent) level
+            var seen0 = [0, Object.create(null)];
+            // {$parentCat: [cnt, {$cat: index}]} for the second (child) level,
+            // tracked *per parent* so that each parent keeps the child order
+            // found in its own data rather than sharing one global order
+            var seen1 = Object.create(null);
             // [ [arrayIn[0][i], arrayIn[1][i]], for i .. N ]
             var list = [];
 
@@ -391,11 +395,14 @@ module.exports = function setConvert(ax, fullLayout) {
                             if(isValidCategory(v0) && isValidCategory(v1)) {
                                 list.push([v0, v1]);
 
-                                if(!(v0 in seen[0][1])) {
-                                    seen[0][1][v0] = seen[0][0]++;
+                                if(!(v0 in seen0[1])) {
+                                    seen0[1][v0] = seen0[0]++;
+                                    seen1[v0] = [0, Object.create(null)];
                                 }
-                                if(!(v1 in seen[1][1])) {
-                                    seen[1][1][v1] = seen[1][0]++;
+
+                                var seenUnder = seen1[v0];
+                                if(!(v1 in seenUnder[1])) {
+                                    seenUnder[1][v1] = seenUnder[0]++;
                                 }
                             }
                         }
@@ -404,12 +411,12 @@ module.exports = function setConvert(ax, fullLayout) {
             }
 
             list.sort(function(a, b) {
-                var ind0 = seen[0][1];
+                var ind0 = seen0[1];
                 var d = ind0[a[0]] - ind0[b[0]];
                 if(d) return d;
 
-                var ind1 = seen[1][1];
-                return ind1[a[1]] - ind1[b[1]];
+                // same parent, so the two rows share a child-index map
+                return seen1[a[0]][1][a[1]] - seen1[b[0]][1][b[1]];
             });
 
             for(i = 0; i < list.length; i++) {

--- a/test/image/mocks/multicategory-categoryorder.json
+++ b/test/image/mocks/multicategory-categoryorder.json
@@ -1,0 +1,84 @@
+{
+  "data": [
+    {
+      "type": "bar",
+      "x": [
+        ["2023", "2023", "2024", "2024", "2024", "2024"],
+        ["Q4", "Q3", "Q2", "Q1", "Q4", "Q3"]
+      ],
+      "y": [4, 3, 2, 1, 4, 3],
+      "marker": { "color": "#636efa" }
+    },
+
+    {
+      "type": "bar",
+      "x": [
+        ["2023", "2023", "2024", "2024", "2024", "2024"],
+        ["Q4", "Q3", "Q2", "Q1", "Q4", "Q3"]
+      ],
+      "y": [4, 3, 2, 1, 4, 3],
+      "marker": { "color": "#ef553b" },
+      "xaxis": "x2",
+      "yaxis": "y2"
+    },
+
+    {
+      "type": "bar",
+      "x": [
+        ["2023", "2023", "2024", "2024", "2024", "2024"],
+        ["Q4", "Q3", "Q2", "Q1", "Q4", "Q3"]
+      ],
+      "y": [4, 3, 2, 1, 4, 3],
+      "marker": { "color": "#00cc96" },
+      "xaxis": "x3",
+      "yaxis": "y3"
+    },
+
+    {
+      "type": "bar",
+      "x": [
+        ["2023", "2023", "2024", "2024", "2024", "2024"],
+        ["Q4", "Q3", "Q2", "Q1", "Q4", "Q3"]
+      ],
+      "y": [4, 3, 2, 1, 4, 3],
+      "marker": { "color": "#ab63fa" },
+      "xaxis": "x4",
+      "yaxis": "y4"
+    }
+  ],
+  "layout": {
+    "title": { "text": "multicategory categoryorder" },
+    "grid": {
+      "rows": 2,
+      "columns": 2,
+      "pattern": "independent",
+      "xgap": 0.15,
+      "ygap": 0.4
+    },
+    "xaxis": { "title": { "text": "trace (default)" } },
+    "xaxis2": {
+      "title": { "text": "array" },
+      "categoryorder": "array",
+      "categoryarray": [
+        ["2024", "Q1"],
+        ["2024", "Q2"],
+        ["2024", "Q3"],
+        ["2024", "Q4"],
+        ["2023", "Q3"],
+        ["2023", "Q4"]
+      ]
+    },
+    "xaxis3": {
+      "title": { "text": "category ascending" },
+      "categoryorder": "category ascending"
+    },
+    "xaxis4": {
+      "title": { "text": "category descending" },
+      "categoryorder": "category descending"
+    },
+    "width": 700,
+    "height": 500,
+    "margin": { "l": 40, "b": 60, "t": 40, "r": 20 },
+    "showlegend": false
+  }
+}

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -2386,6 +2386,120 @@ describe('Test axes', function() {
                 .then(done, done.fail);
             });
         });
+
+        describe('on multicategory axes', function() {
+            // '2023' contributes 'b' first, so under the previous behaviour
+            // '2024' rendered as b, a - one global second-level order was
+            // shared by every first-level category
+            var trace = {
+                type: 'bar',
+                x: [
+                    ['2023', '2023', '2024', '2024'],
+                    ['b', 'c', 'a', 'b']
+                ],
+                y: [1, 2, 3, 4]
+            };
+
+            function _plot(xaxis) {
+                return Plotly.newPlot(gd, [Lib.extendDeep({}, trace)], xaxis ? {xaxis: xaxis} : {});
+            }
+
+            function _categories() {
+                return gd._fullLayout.xaxis._categories;
+            }
+
+            it('should follow the data order within each first-level category', function(done) {
+                _plot()
+                .then(function() {
+                    expect(gd._fullLayout.xaxis.categoryorder).toBe('trace');
+                    expect(_categories()).toEqual([
+                        ['2023', 'b'], ['2023', 'c'], ['2024', 'a'], ['2024', 'b']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+
+            it('should honour categoryorder "array" with [parent, child] pairs', function(done) {
+                _plot({
+                    categoryorder: 'array',
+                    categoryarray: [['2024', 'b'], ['2024', 'a'], ['2023', 'c'], ['2023', 'b']]
+                })
+                .then(function() {
+                    expect(gd._fullLayout.xaxis.categoryorder).toBe('array');
+                    expect(_categories()).toEqual([
+                        ['2024', 'b'], ['2024', 'a'], ['2023', 'c'], ['2023', 'b']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+
+            it('should switch categoryorder to "array" when only categoryarray is supplied', function(done) {
+                _plot({categoryarray: [['2024', 'b'], ['2024', 'a']]})
+                .then(function() {
+                    expect(gd._fullLayout.xaxis.categoryorder).toBe('array');
+                    // categories missing from categoryarray follow in trace order
+                    expect(_categories()).toEqual([
+                        ['2024', 'b'], ['2024', 'a'], ['2023', 'b'], ['2023', 'c']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+
+            it('should revert categoryorder to "trace" when categoryarray holds no valid pair', function(done) {
+                _plot({categoryorder: 'array', categoryarray: ['a', 'b']})
+                .then(function() {
+                    expect(gd._fullLayout.xaxis.categoryorder).toBe('trace');
+                    expect(_categories()).toEqual([
+                        ['2023', 'b'], ['2023', 'c'], ['2024', 'a'], ['2024', 'b']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+
+            it('should drop malformed categoryarray entries', function(done) {
+                _plot({
+                    categoryorder: 'array',
+                    categoryarray: ['2024', ['2024', 'b'], null, ['2023', 'c', 'extra']]
+                })
+                .then(function() {
+                    expect(_categories()).toEqual([
+                        ['2024', 'b'], ['2023', 'b'], ['2023', 'c'], ['2024', 'a']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+
+            it('should honour categoryorder "category ascending"', function(done) {
+                _plot({categoryorder: 'category ascending'})
+                .then(function() {
+                    expect(_categories()).toEqual([
+                        ['2023', 'b'], ['2023', 'c'], ['2024', 'a'], ['2024', 'b']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+
+            it('should honour categoryorder "category descending"', function(done) {
+                _plot({categoryorder: 'category descending'})
+                .then(function() {
+                    expect(_categories()).toEqual([
+                        ['2024', 'b'], ['2024', 'a'], ['2023', 'c'], ['2023', 'b']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+
+            it('should revert value-based categoryorder to "trace"', function(done) {
+                _plot({categoryorder: 'total descending'})
+                .then(function() {
+                    expect(gd._fullLayout.xaxis.categoryorder).toBe('trace');
+                    expect(_categories()).toEqual([
+                        ['2023', 'b'], ['2023', 'c'], ['2024', 'a'], ['2024', 'b']
+                    ]);
+                })
+                .then(done, done.fail);
+            });
+        });
     });
 
     describe('bar category autorange', function() {
@@ -4352,6 +4466,27 @@ describe('Test axes', function() {
                 expect(out).toEqual([0, 2, 1, 3]);
                 expect(ax._categories).toEqual([['1', 'a'], ['1', 'b'], ['2', 'a'], ['2', 'b']]);
                 expect(ax._categoriesMap).toEqual({'1,a': 0, '1,b': 1, '2,a': 2, '2,b': 3});
+            });
+
+            it('should order second-level categories per parent, not globally', function() {
+                var out = _makeCalcdata({
+                    x: [['1', '1', '2', '2'], ['b', 'a', 'a', 'b']]
+                }, 'x', 'multicategory');
+
+                // '2' keeps its own 'a' then 'b' order, even though 'b' is
+                // the first second-level category seen overall (under '1')
+                expect(out).toEqual([0, 1, 2, 3]);
+                expect(ax._categories).toEqual([['1', 'b'], ['1', 'a'], ['2', 'a'], ['2', 'b']]);
+                expect(ax._categoriesMap).toEqual({'1,b': 0, '1,a': 1, '2,a': 2, '2,b': 3});
+            });
+
+            it('should not let second-level categories inherit the prototype chain', function() {
+                var out = _makeCalcdata({
+                    x: [['1', '1'], ['toString', 'a']]
+                }, 'x', 'multicategory');
+
+                expect(out).toEqual([0, 1]);
+                expect(ax._categories).toEqual([['1', 'toString'], ['1', 'a']]);
             });
 
             it('case invalid in x[0]', function() {

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -5117,7 +5117,7 @@
             ]
           },
           "categoryarray": {
-            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`. On *multicategory* axes each entry is a [first-level, second-level] pair, e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.",
             "editType": "calc",
             "valType": "data_array"
           },
@@ -5127,7 +5127,7 @@
             "valType": "string"
           },
           "categoryorder": {
-            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.",
+            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values. On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data within each first-level category, and ordering by aggregated value is not supported - those values fall back on *trace*.",
             "dflt": "trace",
             "editType": "calc",
             "valType": "enumerated",
@@ -5820,7 +5820,7 @@
             ]
           },
           "categoryarray": {
-            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`. On *multicategory* axes each entry is a [first-level, second-level] pair, e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.",
             "editType": "calc",
             "valType": "data_array"
           },
@@ -5830,7 +5830,7 @@
             "valType": "string"
           },
           "categoryorder": {
-            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.",
+            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values. On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data within each first-level category, and ordering by aggregated value is not supported - those values fall back on *trace*.",
             "dflt": "trace",
             "editType": "calc",
             "valType": "enumerated",
@@ -7249,7 +7249,7 @@
             ]
           },
           "categoryarray": {
-            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`. On *multicategory* axes each entry is a [first-level, second-level] pair, e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.",
             "editType": "plot",
             "valType": "data_array"
           },
@@ -7259,7 +7259,7 @@
             "valType": "string"
           },
           "categoryorder": {
-            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.",
+            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values. On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data within each first-level category, and ordering by aggregated value is not supported - those values fall back on *trace*.",
             "dflt": "trace",
             "editType": "plot",
             "valType": "enumerated",
@@ -7989,7 +7989,7 @@
             ]
           },
           "categoryarray": {
-            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`. On *multicategory* axes each entry is a [first-level, second-level] pair, e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.",
             "editType": "plot",
             "valType": "data_array"
           },
@@ -7999,7 +7999,7 @@
             "valType": "string"
           },
           "categoryorder": {
-            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.",
+            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values. On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data within each first-level category, and ordering by aggregated value is not supported - those values fall back on *trace*.",
             "dflt": "trace",
             "editType": "plot",
             "valType": "enumerated",
@@ -8729,7 +8729,7 @@
             ]
           },
           "categoryarray": {
-            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+            "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`. On *multicategory* axes each entry is a [first-level, second-level] pair, e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.",
             "editType": "plot",
             "valType": "data_array"
           },
@@ -8739,7 +8739,7 @@
             "valType": "string"
           },
           "categoryorder": {
-            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.",
+            "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values. On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data within each first-level category, and ordering by aggregated value is not supported - those values fall back on *trace*.",
             "dflt": "trace",
             "editType": "plot",
             "valType": "enumerated",
@@ -13675,7 +13675,7 @@
           ]
         },
         "categoryarray": {
-          "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+          "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`. On *multicategory* axes each entry is a [first-level, second-level] pair, e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.",
           "editType": "calc",
           "valType": "data_array"
         },
@@ -13685,7 +13685,7 @@
           "valType": "string"
         },
         "categoryorder": {
-          "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.",
+          "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values. On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data within each first-level category, and ordering by aggregated value is not supported - those values fall back on *trace*.",
           "dflt": "trace",
           "editType": "calc",
           "valType": "enumerated",
@@ -15271,7 +15271,7 @@
           ]
         },
         "categoryarray": {
-          "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+          "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`. On *multicategory* axes each entry is a [first-level, second-level] pair, e.g. `[[*2023*, *Q4*], [*2024*, *Q1*]]`; entries that are not such a pair are ignored.",
           "editType": "calc",
           "valType": "data_array"
         },
@@ -15281,7 +15281,7 @@
           "valType": "string"
         },
         "categoryorder": {
-          "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values.",
+          "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`. Set `categoryorder` to *total ascending* or *total descending* if order should be determined by the numerical order of the values. Similarly, the order can be determined by the min, max, sum, mean, geometric mean or median of all the values. On *multicategory* axes, *trace* orders the second-level categories by the order they appear in the data within each first-level category, and ordering by aggregated value is not supported - those values fall back on *trace*.",
           "dflt": "trace",
           "editType": "calc",
           "valType": "enumerated",


### PR DESCRIPTION
_Written with Claude Code_

Draft — the three baselines noted below still need regenerating, see [Baselines](#baselines).

## The problem

On a `multicategory` axis the second-level categories share **one global ordering**, keyed on where each label first appears *anywhere* in the data. Every first-level category therefore renders the same child sequence, regardless of its own data order.

Minimal case — data order is `P1/b, P1/a, P2/a, P2/b`:

```js
Plotly.newPlot('graph', [{
  type: 'bar',
  x: [['P1','P1','P2','P2'], ['b','a','a','b']],
  y: [1, 2, 3, 4]
}]);
```

| | order |
|---|---|
| expected | `P1/b  P1/a  P2/a  P2/b` |
| before | `P1/b  P1/a  P2/b  P2/a` |

`P2` is flipped: `b` was seen first under `P1`, so `b` precedes `a` under every parent.

Real-world shape — months under years, rows supplied in strict chronological order (2023 Jul–Dec, 2024 Jan–Dec, 2025 Jan–Jun). 2023 contributes Jul–Dec first, which pins `Jul…Dec` ahead of `Jan…Jun` for *every* year:

```
before   2023 -> Jul Aug Sep Oct Nov Dec
         2024 -> Jul Aug Sep Oct Nov Dec Jan Feb Mar Apr May Jun   <- supplied Jan..Dec
         2025 -> Jan Feb Mar Apr May Jun

after    2023 -> Jul Aug Sep Oct Nov Dec
         2024 -> Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
         2025 -> Jan Feb Mar Apr May Jun
```

2023 and 2025 looked correct before only because each happens to be a contiguous slice of that one global ordering.

Separately, `categoryorder` and `categoryarray` were **never coerced** on multicategory axes — `handleCategoryOrderDefaults` returned early for any non-`category` type — so setting them was a silent no-op with no way to work around the ordering above.

Reported downstream at plotly/dash-ai-analyst#171.

## The fix

**`set_convert.js` — `setupMultiCategory`.** Track the child first-appearance index *per parent* instead of globally, and sort by `(parent rank, child rank within that parent)`. The lookup objects are now prototype-less, so a category named `toString` no longer resolves through `Object.prototype`.

**`category_order_defaults.js`.** Let multicategory axes through, and handle the pair shape:

- `trace` (default) — per-parent data order, as above
- `array` — `categoryarray` entries are `[first-level, second-level]` pairs. Malformed entries are dropped; an array holding no valid pair falls back to `trace`. Categories absent from `categoryarray` follow in trace order, matching how `category` axes already behave
- `category ascending` / `category descending` — sort the pairs by label
- ordering by aggregated value (`total ascending`, …) is **not** implemented for these axes — `sortAxisCategoriesByValue` skips non-`category` axes, and interleaving children across parents would break the grouping brackets anyway. Rather than accept it and silently do nothing, it now falls back to `trace`

No new attributes; `categoryarray` is already `data_array`. Descriptions updated for both, with `test/plot-schema.json` regenerated.

## Tests

**Visual** — new mock `test/image/mocks/multicategory-categoryorder.json`, four panels over identical data so each ordering is distinguishable. Data is supplied as 2023 → Q4, Q3 and 2024 → Q2, Q1, Q4, Q3, so trace order is deliberately not alphabetical and all four panels differ:

```
trace (default)      2023/Q4 2023/Q3 2024/Q2 2024/Q1 2024/Q4 2024/Q3
array                2024/Q1 2024/Q2 2024/Q3 2024/Q4 2023/Q3 2023/Q4
category ascending   2023/Q3 2023/Q4 2024/Q1 2024/Q2 2024/Q3 2024/Q4
category descending  2024/Q4 2024/Q3 2024/Q2 2024/Q1 2023/Q4 2023/Q3
```

I verified this renders correctly in Chromium against a bundle built from this branch — year brackets intact, each panel distinct — but I can't attach screenshots through the API, so the baseline PNG will be the first rendering committed here.

**Unit** — 10 new specs in `test/jasmine/tests/axes_test.js`: per-parent ordering, prototype-name safety, and each `categoryorder` mode including both fallbacks.

`npm run test-jasmine -- axes` goes from 398 to 408 passing. The 2 `insiderange` failures in my sandbox are font-metric tolerances that fail identically on unmodified `master`.

## Regression sweep

Rendered all 1067 non-gl3d/map/geo mocks under `master` and this branch and diffed each multicategory axis's resolved `_categories`. **1064 identical, 3 changed** — all three corrections:

| mock | before | after |
|---|---|---|
| `multicategory2` | `2018/q1 2018/q3 2018/q2` | `2018/q1 2018/q2 2018/q3` |
| `multicategory-y` | `2018/q1 2018/q3 2018/q2` | `2018/q1 2018/q2 2018/q3` |
| `multicategory-sorting` | `4/1 4/2 … 6/1 6/2` | `4/2 4/1 … 6/2 6/1` |

`multicategory2` is the clearest: the mock supplies `2018 q1, q2, q3` and the committed baseline shows `q1, q3, q2` — the existing baseline encodes the bug.

`multicategory-sorting` subplot 2 draws `4/2` from the first trace before `4/1` from the second, so per-parent order is `4/2, 4/1`.

<a name="baselines"></a>
## Baselines — needs a maintainer

Four baselines need generating: the three above, plus the new mock. I did not commit them. My sandbox's kaleido rendering does not match CI's — regenerating the untouched `multicategory` baseline as a control produced 10910 differing pixels (max channel delta 205), i.e. font rendering differs, so any baseline I generated would be wrong in a way unrelated to this change.

```
npm run baseline -- multicategory2 multicategory-y multicategory-sorting multicategory-categoryorder
```

Happy to push them if a maintainer would rather paste the generated PNGs, or to split the three baseline updates into their own commit.

## Notes for review

- `findCategoryPairs` duplicates a little of `setupMultiCategory`'s traversal. It runs at defaults time, before calc, where `trace._length` isn't available yet — hence `Math.min` on the two row lengths rather than `Lib.minRowLength`. Happy to factor it out if you'd prefer.
- `VALUE_ORDER_RE` mirrors `sortAxisCategoriesByValueRegex` in `plots.js`. I kept them as separate literals to avoid a require cycle and left a comment on each; exporting one from a shared module would also work.
- The `_initialCategories` seeding in `clearCalc` already handled array-valued categories — `setCategoryIndex` stringifies pairs to `"parent,child"` for `_categoriesMap` and pushes the array onto `_categories`. That mechanism needed no change; multicategory simply never reached it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAGQnaXsViqVPvak39Y4qo