### PR TITLE
Fix multicategory axis second-level category ordering

### DIFF
--- a/draftlogs/7931_fix.md
+++ b/draftlogs/7931_fix.md
@@ -1,0 +1,1 @@
+ - Fix `multicategory` axes ordering second-level categories by a single global order instead of the data order within each first-level category [[#7931](https://github.com/plotly/plotly.js/pull/7931)]

--- a/src/plots/cartesian/set_convert.js
+++ b/src/plots/cartesian/set_convert.js
@@ -371,10 +371,15 @@ module.exports = function setConvert(ax, fullLayout) {
                 }
             }
 
-            // [ [cnt, {$cat: index}], for 1,2 ]
-            var seen = [[0, {}], [0, {}]];
-            // [ [arrayIn[0][i], arrayIn[1][i]], for i .. N ]
-            var list = [];
+            // first-level categories in first-appearance order
+            var parents = [];
+            // {$parentCat: {seen: {$childCat: 1}, children: [$childCat, ..]}}
+            // second-level categories are tracked *per parent*, so that each
+            // parent keeps the child order found in its own data rather than
+            // sharing one global order across all parents.
+            // prototype-less objects so that e.g. a category named 'toString'
+            // does not resolve through Object.prototype
+            var childrenOf = Object.create(null);
 
             for(i = 0; i < traceIndices.length; i++) {
                 var trace = fullData[traceIndices[i]];
@@ -389,13 +394,15 @@ module.exports = function setConvert(ax, fullLayout) {
                             var v1 = arrayIn[1][j];
 
                             if(isValidCategory(v0) && isValidCategory(v1)) {
-                                list.push([v0, v1]);
-
-                                if(!(v0 in seen[0][1])) {
-                                    seen[0][1][v0] = seen[0][0]++;
+                                if(!(v0 in childrenOf)) {
+                                    childrenOf[v0] = {seen: Object.create(null), children: []};
+                                    parents.push(v0);
                                 }
-                                if(!(v1 in seen[1][1])) {
-                                    seen[1][1][v1] = seen[1][0]++;
+
+                                var kids = childrenOf[v0];
+                                if(!(v1 in kids.seen)) {
+                                    kids.seen[v1] = 1;
+                                    kids.children.push(v1);
                                 }
                             }
                         }
@@ -403,17 +410,11 @@ module.exports = function setConvert(ax, fullLayout) {
                 }
             }
 
-            list.sort(function(a, b) {
-                var ind0 = seen[0][1];
-                var d = ind0[a[0]] - ind0[b[0]];
-                if(d) return d;
-
-                var ind1 = seen[1][1];
-                return ind1[a[1]] - ind1[b[1]];
-            });
-
-            for(i = 0; i < list.length; i++) {
-                setCategoryIndex(list[i]);
+            for(i = 0; i < parents.length; i++) {
+                var children = childrenOf[parents[i]].children;
+                for(j = 0; j < children.length; j++) {
+                    setCategoryIndex([parents[i], children[j]]);
+                }
             }
         };
     }

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -4354,6 +4354,27 @@ describe('Test axes', function() {
                 expect(ax._categoriesMap).toEqual({'1,a': 0, '1,b': 1, '2,a': 2, '2,b': 3});
             });
 
+            it('should order second-level categories per parent, not globally', function() {
+                var out = _makeCalcdata({
+                    x: [['1', '1', '2', '2'], ['b', 'a', 'a', 'b']]
+                }, 'x', 'multicategory');
+
+                // '2' keeps its own 'a' then 'b' order, even though 'b' is
+                // the first second-level category seen overall (under '1')
+                expect(out).toEqual([0, 1, 2, 3]);
+                expect(ax._categories).toEqual([['1', 'b'], ['1', 'a'], ['2', 'a'], ['2', 'b']]);
+                expect(ax._categoriesMap).toEqual({'1,b': 0, '1,a': 1, '2,a': 2, '2,b': 3});
+            });
+
+            it('should not let second-level categories inherit the prototype chain', function() {
+                var out = _makeCalcdata({
+                    x: [['1', '1'], ['toString', 'a']]
+                }, 'x', 'multicategory');
+
+                expect(out).toEqual([0, 1]);
+                expect(ax._categories).toEqual([['1', 'toString'], ['1', 'a']]);
+            });
+
             it('case invalid in x[0]', function() {
                 var out = _makeCalcdata({
                     x: [['1', '2', null, '2'], ['a', 'a', 'b', 'b']]


### PR DESCRIPTION
_Written with Claude Code_

Split out of #7929 (the fix half; the `categoryorder`/`categoryarray` feature follows separately) after review discussion there concluded the two changes should be weighed independently.

## Overview

On a `multicategory` axis the second-level categories share one global ordering, keyed on where each label first appears *anywhere* in the data. Every first-level category therefore renders the same child sequence, regardless of its own data order.

Minimal case — data order is `P1/b, P1/a, P2/a, P2/b`:

```js
Plotly.newPlot('graph', [{
  type: 'bar',
  x: [['P1','P1','P2','P2'], ['b','a','a','b']],
  y: [1, 2, 3, 4]
}]);
```

| | order |
|---|---|
| expected | `P1/b  P1/a  P2/a  P2/b` |
| before | `P1/b  P1/a  P2/b  P2/a` |

`P2` is flipped: `b` was seen first under `P1`, so `b` precedes `a` under every parent. Real-world shape: months under years supplied in strict chronological order starting mid-year render every year in the first year's month order. Reported downstream at plotly/dash-ai-analyst#171.

## The fix

`setupMultiCategory` in `set_convert.js` now tracks second-level categories *per parent*: parents are collected in first-appearance order, each parent's children in the order that parent's own data supplies them, and the pairs are emitted directly. Since `setCategoryIndex` already dedups, this removes the flat row list and the sort from the previous implementation rather than adding a second level of index maps to it — net simpler and O(n).

The category lookups are also prototype-less now, so a category literally named `toString` no longer resolves through `Object.prototype` (previously it never received an index, producing NaN comparisons in the sort).

## Tests

Two new `Axes.makeCalcdata` specs: per-parent ordering and the `toString` prototype case.

## Baselines — needs a maintainer

Three committed baselines encode the bug and need regenerating (per #7929's regression sweep of all 1067 non-gl3d/map/geo mocks, these are the only three multicategory orderings that change):

| mock | before | after |
|---|---|---|
| `multicategory2` | `2018/q1 2018/q3 2018/q2` | `2018/q1 2018/q2 2018/q3` |
| `multicategory-y` | `2018/q1 2018/q3 2018/q2` | `2018/q1 2018/q2 2018/q3` |
| `multicategory-sorting` | `4/1 4/2 … 6/1 6/2` | `4/2 4/1 … 6/2 6/1` |

`multicategory2` supplies `2018 q1, q2, q3` and the committed baseline shows `q1, q3, q2`. Sandbox-generated baselines don't match CI's font rendering (a control regeneration of an untouched baseline differed by ~11k pixels), so:

```
npm run baseline -- multicategory2 multicategory-y multicategory-sorting
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuN1reWCtHE6WFsNZjdGCD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuN1reWCtHE6WFsNZjdGCD)_