### PR TITLE
fix: Add missing country code

### DIFF
--- a/src/lib/custom_country_codes.ts
+++ b/src/lib/custom_country_codes.ts
@@ -36,6 +36,13 @@ export const COUNTRIES_X: ReadonlyArray<CountryRecord> = [
         aliases: []
     },
     {
+        iso3: 'XIT',
+        iso2: '',
+        m49: '',
+        name: 'Ilemi Triangle',
+        aliases: []
+    },
+    {
         iso3: 'XJK',
         iso2: '',
         m49: '',


### PR DESCRIPTION
### Description

Add missing 'XIT' country code to custom codes list.

Closes #7938.

### Notes

- This code is included in the default topojson, so it should be included here as well