### PR TITLE
Reset forced minimum tick spacing on every calc pass

### DIFF
--- a/draftlogs/7950_fix.md
+++ b/draftlogs/7950_fix.md
@@ -1,0 +1,1 @@
+ - Fix box, violin, candlestick and ohlc traces losing their forced minimum tick spacing when a graph div is updated in place with `Plotly.react` or `Plotly.restyle` [[#7950](https://github.com/plotly/plotly.js/pull/7950)]

--- a/src/plots/cartesian/set_convert.js
+++ b/src/plots/cartesian/set_convert.js
@@ -58,7 +58,7 @@ function isValidCategory(v) {
  * Creates/updates these conversion functions, and a few more utilities
  * like cleanRange, and makeCalcdata
  *
- * also clears ._minDtick, ._forceTick0
+ * also creates ax.clearCalc, which clears ._minDtick, ._forceTick0
  */
 module.exports = function setConvert(ax, fullLayout) {
     fullLayout = fullLayout || {};
@@ -952,6 +952,12 @@ module.exports = function setConvert(ax, fullLayout) {
 
     // should skip if not category nor multicategory
     ax.clearCalc = function() {
+        // for bar charts and box plots: reset forced minimum tick spacing.
+        // this has to happen here rather than in setConvert, as the values
+        // are relinked onto the new fullLayout after supplyDefaults runs
+        delete ax._minDtick;
+        delete ax._forceTick0;
+
         var group = ax._matchGroup;
         if(group) {
             var categories = null;
@@ -1024,8 +1030,4 @@ module.exports = function setConvert(ax, fullLayout) {
     // even though it won't be needed by this axis
     ax._separators = fullLayout.separators;
     ax._numFormat = locale ? locale.numberFormat : numberFormat;
-
-    // and for bar charts and box plots: reset forced minimum tick spacing
-    delete ax._minDtick;
-    delete ax._forceTick0;
 };

--- a/test/jasmine/tests/axes_test.js
+++ b/test/jasmine/tests/axes_test.js
@@ -8303,6 +8303,45 @@ describe('more react tests', function() {
             expect(gd._fullLayout.xaxis.range).toBeCloseToArray([-0.173, 2]);
         }).then(done, done.fail);
     });
+
+    it('should not carry over the forced minimum tick spacing of the previous figure', function(done) {
+        var layout = {width: 700, height: 400};
+
+        var scatterFig = {
+            data: [{y: [1, 2, 3]}],
+            layout: layout
+        };
+
+        // one box per integer position - each box forces a tick of its own
+        var boxFig = {
+            data: [{
+                type: 'box',
+                x: [1, 1, 2, 2, 3, 3],
+                y: [1, 2, 3, 4, 5, 6]
+            }],
+            layout: layout
+        };
+
+        function getXLabels() {
+            return gd._fullLayout.xaxis._vals.map(function(d) { return d.text; });
+        }
+
+        Plotly.newPlot(gd, boxFig)
+        .then(function() {
+            expect(getXLabels()).toEqual(['1', '2', '3']);
+
+            // scatter cancels the forcing for its own figure only
+            return Plotly.newPlot(gd, scatterFig);
+        })
+        .then(function() {
+            return Plotly.react(gd, boxFig);
+        })
+        .then(function() {
+            expect(gd._fullLayout.xaxis._minDtick).toBe(1);
+            expect(getXLabels()).toEqual(['1', '2', '3']);
+        })
+        .then(done, done.fail);
+    });
 });
 
 describe('category preservation tests on gd passed to Plotly.react()', function() {

--- a/test/jasmine/tests/plot_api_test.js
+++ b/test/jasmine/tests/plot_api_test.js
@@ -1649,7 +1649,8 @@ describe('Test plot api', function () {
                     return Plotly.restyle(gd, { x0: 12.3 });
                 })
                 .then(function () {
-                    checkTicks('x', ['12', '12.5'], 'switched to numeric');
+                    // a single box forces one tick at its own position
+                    checkTicks('x', ['12.3'], 'switched to numeric');
                     expect(gd._fullLayout.xaxis.type).toBe('linear');
                 })
                 .then(done, done.fail);


### PR DESCRIPTION
Closes #7968 

### The bug

`Plotly.react` can draw an axis with different ticks than `Plotly.newPlot` of the exact same figure. Same for `restyle`, `addTraces` and friends — anything that updates a graph div in place.

```js
var boxFig = {
    data: [{type: 'box', x: [1, 1, 2, 2, 3, 3], y: [1, 2, 3, 4, 5, 6]}],
    layout: {width: 700, height: 400}
};
var scatterFig = {data: [{y: [1, 2, 3]}], layout: {width: 700, height: 400}};

// x ticks: 1, 2, 3
Plotly.newPlot(gd, boxFig);

// x ticks: 0.5, 1, 1.5, 2, 2.5, 3, 3.5
Plotly.newPlot(gd, scatterFig).then(function() { return Plotly.react(gd, boxFig); });
```

Box, violin, candlestick and ohlc traces ask the position axis for a minimum tick spacing, so that each box gets a tick of its own instead of ticks at meaningless in-between positions. In the second case that forcing is silently lost.

It is most obvious on a date axis. Five daily candles at `width: 1000`, reached by reacting from a line chart over the same dates:

```
newPlot:  Jan 1 | Jan 2 | Jan 3 | Jan 4 | Jan 5
react:    12:00 Dec 31, 2023 | 00:00 Jan 1, 2024 | 12:00 | 00:00 Jan 2, 2024 | 12:00 | ...
```

Every second tick falls in the gap between two candles, and the axis now starts on the day before the data.

### Cause

`Axes.minDtick` keeps its state in `ax._minDtick` / `ax._forceTick0` and distinguishes three cases: `undefined` (nothing forced yet — adopt this trace's spacing), a positive number (a forcing is in effect), and `0` (forcing cancelled, e.g. by non-grouped bars or by scatter/heatmap, and sticky so a later trace can't reinstate it).

The reset back to `undefined` between passes was at the bottom of `setConvert`, but it has never had any effect on a real axis: `setConvert` runs while `supplyDefaults` builds the **new** `_fullLayout`, where those keys don't exist yet, and `relinkPrivateKeys` then copies the old values back onto it. So whichever figure the graph div held first decides the forcing forever after. `Plotly.newPlot` isn't affected because it starts from an empty `_fullLayout`.

`doCalcdata` already handles the identical relink staleness for shared color axes ("clear relinked cmin/cmax values in shared axes to start aggregation from scratch"). This moves the reset into `ax.clearCalc()` — the axis' own per-calc-pass reset, which `doCalcdata` runs for every axis, and always before any `crossTraceCalc`.

### One existing expectation changed

`plot_api_test.js` → *"updates box position and axis type when it falls back to name"* asserted that a single box restyled to `x0: 12.3` ends up with ticks `['12', '12.5']`. That was the stale value. `Plotly.newPlot` of that same figure produces a single tick at `12.3`, on master as well as here, so the change makes `restyle` agree with `newPlot`:

| | master | this PR |
|---|---|---|
| `newPlot` box `x0: 12.3` | `12.3` | `12.3` |
| `restyle` to `x0: 12.3` | `12`, `12.5` | `12.3` |
| `react` to `x0: 12.3` | `12`, `12.5` | `12.3` |

### Testing

- New regression test in `axes_test.js` → *"should not carry over the forced minimum tick spacing of the previous figure"*. It fails on master (`Expected 0 to be 1`) and passes here.
- `npm run test-jasmine -- --nowatch`: 7000 specs, and the failure set is identical to master's on this machine (a batch of font-metric, WebGL, drag/touch and `@flaky` tests fail either way; the two extra failures in my run pass when their suites are run alone).
- `npm run lint` and `npm run test-syntax` are clean.
- I don't have the docker setup for `test-image` / `test-export`. Those baselines shouldn't be able to move: they're all single `newPlot` calls, which never have a previous `_fullLayout` to relink from.
