### PR TITLE
fix(geo): preserve D3 projection default rotation when user does not set rotation

### DIFF
--- a/src/plots/geo/geo.js
+++ b/src/plots/geo/geo.js
@@ -303,9 +303,22 @@ proto.updateProjection = function(geoCalcData, fullLayout) {
 
     // set 'pre-fit' projection
     projection
-        .center([center.lon - rotation.lon, center.lat - rotation.lat])
-        .rotate([-rotation.lon, -rotation.lat, rotation.roll])
-        .parallels(projLayout.parallels);
+        .center([center.lon - rotation.lon, center.lat - rotation.lat]);
+
+    // Only override the projection's built-in rotation when the user
+    // explicitly set it (or when fitbounds derived one). Otherwise
+    // preserve the D3 projection's default rotation so that projections
+    // with a non-identity default (e.g. peirce quincuncial, wiechel)
+    // render in their canonical orientation.
+    if (fullLayout._input && fullLayout._input[this.id] &&
+        fullLayout._input[this.id].projection &&
+        fullLayout._input[this.id].projection.rotation) {
+        projection.rotate([-rotation.lon, -rotation.lat, rotation.roll]);
+    } else if (geoLayout.fitbounds) {
+        projection.rotate([-rotation.lon, -rotation.lat, rotation.roll]);
+    }
+
+    projection.parallels(projLayout.parallels);
 
     // fit projection 'scale' and 'translate' to set lon/lat ranges
     var rangeBox = makeRangeBox(lonaxisRange, lataxisRange);


### PR DESCRIPTION
Fixes #7949

## Problem
Geo.updateProjection unconditionally calls projection.rotate() which overwrites the D3 projection's built-in default rotation. Six projections in plotly.js carry a non-identity default rotation (e.g. peirce quincuncial [-90, -90, 45], wiechel [0, -90, 45]), and the unconditional override causes these to render in the wrong orientation.

## Fix
Only call projection.rotate() when the user explicitly set rotation values in the layout input, or when fitbounds has derived a rotation from the data. Otherwise preserve the D3 projection's default rotation so that maps render in their canonical orientation.

## Testing
- Projections with non-identity defaults (peirce quincuncial, wiechel, etc.) now render in their canonical orientation when no rotation is specified
- When the user explicitly sets projection.rotation, the supplied values are applied correctly
- fitbounds mode continues to work as before (rotation is derived from data bounds)