### PR TITLE
fix(sankey): transpose node.x/node.y scaling for vertical orientation

### DIFF
--- a/src/traces/sankey/render.js
+++ b/src/traces/sankey/render.js
@@ -804,13 +804,14 @@ function persistFinalNodePositions(d, gd) {
     for(var i = 0; i < d.graph.nodes.length; i++) {
         var nodeX = (d.graph.nodes[i].x0 + d.graph.nodes[i].x1) / 2;
         var nodeY = (d.graph.nodes[i].y0 + d.graph.nodes[i].y1) / 2;
-        if(d.trace.orientation === 'h') {
+        if(d.horizontal) {
             x.push(nodeX / d.figure.width);
             y.push(nodeY / d.figure.height);
         } else {
             x.push(nodeX / d.figure.height);
             y.push(nodeY / d.figure.width);
         }
+    }
     Registry.call('_guiRestyle', gd, {
         'node.x': [x],
         'node.y': [y]

--- a/src/traces/sankey/render.js
+++ b/src/traces/sankey/render.js
@@ -246,7 +246,9 @@ function sankeyModel(layout, d, traceIndex) {
     if(trace.node.x.length && trace.node.y.length) {
         for(i = 0; i < Math.min(trace.node.x.length, trace.node.y.length, graph.nodes.length); i++) {
             if(trace.node.x[i] && trace.node.y[i]) {
-                var pos = [trace.node.x[i] * width, trace.node.y[i] * height];
+                var pos = horizontal
+                    ? [trace.node.x[i] * width, trace.node.y[i] * height]
+                    : [trace.node.x[i] * height, trace.node.y[i] * width];
                 graph.nodes[i].x0 = pos[0] - nodeThickness / 2;
                 graph.nodes[i].x1 = pos[0] + nodeThickness / 2;
 
@@ -802,9 +804,13 @@ function persistFinalNodePositions(d, gd) {
     for(var i = 0; i < d.graph.nodes.length; i++) {
         var nodeX = (d.graph.nodes[i].x0 + d.graph.nodes[i].x1) / 2;
         var nodeY = (d.graph.nodes[i].y0 + d.graph.nodes[i].y1) / 2;
-        x.push(nodeX / d.figure.width);
-        y.push(nodeY / d.figure.height);
-    }
+        if(d.trace.orientation === 'h') {
+            x.push(nodeX / d.figure.width);
+            y.push(nodeY / d.figure.height);
+        } else {
+            x.push(nodeX / d.figure.height);
+            y.push(nodeY / d.figure.width);
+        }
     Registry.call('_guiRestyle', gd, {
         'node.x': [x],
         'node.y': [y]


### PR DESCRIPTION
## Problem

For vertical Sankey traces (orientation: 'v'), user-supplied `node.x` / `node.y` are normalized against the wrong extent. The d3-sankey layout space always carries the flow along its `x` axis, but for vertical orientation that space is transposed onto the screen. When the plotting area is non-square, nodes are placed outside the bounding box and the values written back after a drag can exceed the documented `[0, 1]` range.

## Root cause

In `src/traces/sankey/render.js`, `sankeyModel()`:

```js
sankey.size(horizontal ? [width, height] : [height, width]);   // (1) correctly transposed
...
var pos = [trace.node.x[i] * width, trace.node.y[i] * height]; // (2) NOT transposed
```

The user coordinates at (2) are scaled by the un-transposed extents, while the d3-sankey layout at (1) uses the transposed extents. The same asymmetry exists in the write-back path `persistFinalNodePositions()`.

## Fix

1. In `sankeyModel()`: scale `node.x` by the flow-axis extent and `node.y` by the cross-axis extent, matching the `sankey.size()` transposition
2. In `persistFinalNodePositions()`: divide by the same transposed extents on write-back

Closes #7947
