### PR TITLE
Return actual data values (rather than calcdata values) for `xvals` / `yvals` in `hoveranywhere` and `clickanywhere` events

### DIFF
--- a/draftlogs/7964_change.md
+++ b/draftlogs/7964_change.md
@@ -1,1 +1,1 @@
-- Return actual data values (rather than calcdata values) for `xvals` / `yvals` in `hoveranywhere` and `clickanywhere` events [[#7964](https://github.com/plotly/plotly.js/pull/7964)]
+- **Breaking**: Return actual data values (rather than calcdata values) for `xvals` / `yvals` in `hoveranywhere` and `clickanywhere` events. Date and category axes will now return strings rather than numeric values. Linear and log axis values remain unchanged. [[#7964](https://github.com/plotly/plotly.js/pull/7964)]

--- a/draftlogs/7964_change.md
+++ b/draftlogs/7964_change.md
@@ -1,0 +1,1 @@
+- Return actual data values (rather than calcdata values) for `xvals` / `yvals` in `hoveranywhere` and `clickanywhere` events [[#7964](https://github.com/plotly/plotly.js/pull/7964)]

--- a/src/components/fx/click.js
+++ b/src/components/fx/click.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Registry = require('../../registry');
+var helpers = require('./helpers');
 var hover = require('./hover').hover;
 
 module.exports = function click(gd, evt, subplot) {
@@ -21,8 +22,8 @@ module.exports = function click(gd, evt, subplot) {
         // get coordinate values from latest hover call, if available
         clickData.xaxes ??= gd._hoverXAxes;
         clickData.yaxes ??= gd._hoverYAxes;
-        clickData.xvals ??= gd._hoverXVals;
-        clickData.yvals ??= gd._hoverYVals;
+        clickData.xvals ??= gd._hoverXVals && helpers.c2dApply(gd._hoverXAxes, gd._hoverXVals);
+        clickData.yvals ??= gd._hoverYVals && helpers.c2dApply(gd._hoverYAxes, gd._hoverYVals);
 
         gd.emit('plotly_click', clickData);
     }

--- a/src/components/fx/helpers.js
+++ b/src/components/fx/helpers.js
@@ -44,6 +44,39 @@ exports.p2c = function (axArray, v) {
     return out;
 };
 
+/*
+ * Given an array of calcdata values and an array of axes corresponding to each value,
+ * convert the calcdata values to data values by calling the `c2d` method of each axis.
+ *
+ * This function is intended to be used in constructing hover and click events,
+ * for converting x/y values from calc space to data space. axArray and valArray are arrays
+ * rather than single values because in the case of stacked subplots, there may be multiple axes
+ * (and therefore multiple data values) corresponding to a single hover or click event.
+ *
+ * For linear and log axes, this conversion has no effect beyond validating the inputs.
+ * However, for some axes types, the converted values may be of a different type than the
+ * inputs:
+ *  - For category axes, `c2d` converts calcdata values (numeric) into category labels (strings)
+ *  - For date axes, `c2d` converts calcdata values (numeric values in ms) into date strings
+ *
+ * For axes which don't define `c2d` (e.g. geo, map), the inputs are passed through untouched.
+ *
+ * @param {Array} axArray : axes corresponding to each value in valArray
+ * @param {Array} valArray : calcdata values
+ * @return {Array} : data values, computed by calling `ax.c2d` (if defined) on each input value
+ */
+exports.c2dApply = function (axArray, valArray) {
+    if(axArray.length !== valArray.length) {
+        Lib.warn('c2dApply: axArray and valArray must be the same length');
+    }
+    var out = new Array(valArray.length);
+    for (var i = 0; i < valArray.length; i++) {
+        var ax = axArray && axArray[i];
+        out[i] = ax && ax.c2d ? ax.c2d(valArray[i]) : valArray[i];
+    }
+    return out;
+};
+
 exports.getDistanceFunction = function (mode, dx, dy, dxy) {
     if (mode === 'closest') return dxy || exports.quadrature(dx, dy);
     return mode.charAt(0) === 'x' ? dx : dy;

--- a/src/components/fx/hover.js
+++ b/src/components/fx/hover.js
@@ -976,8 +976,8 @@ function _hover(gd, evt, subplot, noHoverEvent, eventTarget) {
             points: points,
             xaxes: xaArray,
             yaxes: yaArray,
-            xvals: xvalArray,
-            yvals: yvalArray
+            xvals: helpers.c2dApply(xaArray, xvalArray),
+            yvals: helpers.c2dApply(yaArray, yvalArray)
         });
     }
 }

--- a/test/jasmine/tests/hover_click_anywhere_test.js
+++ b/test/jasmine/tests/hover_click_anywhere_test.js
@@ -6,16 +6,19 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var click = require('../assets/click');
 
-function makePlot(gd, layoutExtras = {}, configExtras) {
+function makePlot(gd, layoutExtras = {}, traceExtras = {}, configExtras) {
     return Plotly.newPlot(
         gd,
         [
-            {
-                x: [1, 2, 3],
-                y: [1, 3, 2],
-                type: 'scatter',
-                mode: 'markers'
-            }
+            Lib.extendFlat(
+                {
+                    x: [1, 2, 3],
+                    y: [1, 3, 2],
+                    type: 'scatter',
+                    mode: 'markers'
+                },
+                traceExtras
+            )
         ],
         Lib.extendFlat(
             {
@@ -30,6 +33,20 @@ function makePlot(gd, layoutExtras = {}, configExtras) {
         ),
         configExtras
     );
+}
+
+// local midnight, as in https://github.com/plotly/plotly.js/issues/7816
+var dayStart = new Date(2026, 4, 31);
+var dayNoon = new Date(2026, 4, 31, 12);
+var dayEnd = new Date(2026, 5, 1);
+
+// the 300px-wide plot area spans exactly one day, so 0px is local midnight
+// and 150px is local noon, in any timezone
+function makeDatePlot(gd, layoutExtras) {
+    return makePlot(gd, Lib.extendFlat({ xaxis: { type: 'date', range: [dayStart, dayEnd] } }, layoutExtras), {
+        x: [dayStart, dayNoon],
+        y: [1, 3]
+    });
 }
 
 describe('hoveranywhere', () => {
@@ -205,6 +222,7 @@ describe('hoveranywhere', () => {
                     }
                 ]
             },
+            {},
             { edits: { shapePosition: true } }
         )
             .then(() => {
@@ -228,6 +246,55 @@ describe('hoveranywhere', () => {
                 expect(hoverData.points).toEqual([]);
                 expect(hoverData.xvals[0]).toBeCloseTo(7.5, 1);
                 expect(hoverData.yvals[0]).toBeCloseTo(7.5, 1);
+            })
+            .then(done, done.fail);
+    });
+
+    it('reports date axis positions as date strings', (done) => {
+        var hoverData;
+
+        makeDatePlot(gd, { hoveranywhere: true })
+            .then(() => {
+                gd.on('plotly_hover', (d) => (hoverData = d));
+
+                _hover(0, 60);
+                expect(hoverData.points).toEqual([]);
+                expect(hoverData.xvals[0]).toBe('2026-05-31');
+                expect(hoverData.yvals[0]).toBeCloseTo(10 - 60 / 30, 2);
+
+                _hover(150, 60);
+                expect(hoverData.xvals[0]).toBe('2026-05-31 12:00');
+
+                // the point at (dayStart, 1) reports that same value
+                _hover(0, gd._fullLayout.yaxis.c2p(1));
+                expect(hoverData.points[0].x).toBe('2026-05-31');
+                expect(hoverData.xvals[0]).toBe('2026-05-31');
+            })
+            .then(done, done.fail);
+    });
+
+    it('reports category names and log axis data values', (done) => {
+        var hoverData;
+
+        makePlot(
+            gd,
+            { xaxis: { type: 'category' }, yaxis: { type: 'log', range: [1, 3] }, hoveranywhere: true },
+            { x: ['a', 'b', 'c'], y: [10, 20, 30] }
+        )
+            .then(() => {
+                gd.on('plotly_hover', (d) => (hoverData = d));
+
+                var xa = gd._fullLayout.xaxis;
+
+                // empty space above the middle category, halfway up 10 -> 1000
+                _hover(xa.c2p(1), 150);
+                expect(hoverData.points).toEqual([]);
+                expect(hoverData.xvals[0]).toBe('b');
+                expect(hoverData.yvals[0]).toBeCloseTo(100, 6);
+
+                _hover(xa.c2p(1), gd._fullLayout.yaxis.c2p(20));
+                expect(hoverData.points[0].x).toBe('b');
+                expect(hoverData.xvals[0]).toBe('b');
             })
             .then(done, done.fail);
     });
@@ -342,6 +409,7 @@ describe('clickanywhere', () => {
                     }
                 ]
             },
+            {},
             { edits: { shapePosition: true } }
         )
             .then(() => {
@@ -364,6 +432,23 @@ describe('clickanywhere', () => {
                 expect(clickData.points).toEqual([]);
                 expect(clickData.xvals[0]).toBeCloseTo(7.5, 1);
                 expect(clickData.yvals[0]).toBeCloseTo(7.5, 1);
+            })
+            .then(done, done.fail);
+    });
+    it('reports date axis positions as date strings', (done) => {
+        var clickData;
+
+        makeDatePlot(gd, { clickanywhere: true })
+            .then(() => {
+                gd.on('plotly_click', (d) => (clickData = d));
+
+                var bb = gd.getBoundingClientRect();
+                var s = gd._fullLayout._size;
+                click(bb.left + s.l, bb.top + s.t + 60);
+
+                expect(clickData.points).toEqual([]);
+                expect(clickData.xvals[0]).toBe('2026-05-31');
+                expect(clickData.yvals[0]).toBeCloseTo(10 - 60 / 30, 2);
             })
             .then(done, done.fail);
     });

--- a/test/jasmine/tests/hover_click_anywhere_test.js
+++ b/test/jasmine/tests/hover_click_anywhere_test.js
@@ -6,7 +6,7 @@ var createGraphDiv = require('../assets/create_graph_div');
 var destroyGraphDiv = require('../assets/destroy_graph_div');
 var click = require('../assets/click');
 
-function makePlot(gd, layoutExtras = {}, traceExtras = {}, configExtras) {
+function makePlot(gd, traceExtras = {}, layoutExtras = {}, configExtras) {
     return Plotly.newPlot(
         gd,
         [
@@ -42,11 +42,12 @@ var dayEnd = new Date(2026, 5, 1);
 
 // the 300px-wide plot area spans exactly one day, so 0px is local midnight
 // and 150px is local noon, in any timezone
-function makeDatePlot(gd, layoutExtras) {
-    return makePlot(gd, Lib.extendFlat({ xaxis: { type: 'date', range: [dayStart, dayEnd] } }, layoutExtras), {
-        x: [dayStart, dayNoon],
-        y: [1, 3]
-    });
+function makeDatePlot(gd, traceExtras, layoutExtras) {
+    return makePlot(
+        gd,
+        Lib.extendFlat({ x: [dayStart, dayNoon], y: [1, 3] }, traceExtras),
+        Lib.extendFlat({ xaxis: { type: 'date', range: [dayStart, dayEnd] } }, layoutExtras)
+    );
 }
 
 describe('hoveranywhere', () => {
@@ -75,7 +76,7 @@ describe('hoveranywhere', () => {
     it('emits plotly_hover with coordinate data on empty space', (done) => {
         var hoverData;
 
-        makePlot(gd, { hoveranywhere: true })
+        makePlot(gd, {}, { hoveranywhere: true })
             .then(() => {
                 gd.on('plotly_hover', (d) => (hoverData = d));
 
@@ -111,7 +112,7 @@ describe('hoveranywhere', () => {
     it('still returns normal point data on traces', (done) => {
         var hoverData;
 
-        makePlot(gd, { hoveranywhere: true })
+        makePlot(gd, {}, { hoveranywhere: true })
             .then(() => {
                 gd.on('plotly_hover', (d) => (hoverData = d));
 
@@ -149,7 +150,7 @@ describe('hoveranywhere', () => {
     it('respects hovermode:false', (done) => {
         var hoverData;
 
-        makePlot(gd, { hoveranywhere: true, hovermode: false })
+        makePlot(gd, {}, { hoveranywhere: true, hovermode: false })
             .then(() => {
                 gd.on('plotly_hover', (d) => (hoverData = d));
                 _hover(250, 50);
@@ -161,7 +162,7 @@ describe('hoveranywhere', () => {
     it('emits plotly_hover over an editable shape', (done) => {
         let hoverData;
 
-        makePlot(gd, {
+        makePlot(gd, {}, {
             hoveranywhere: true,
             shapes: [
                 {
@@ -209,6 +210,7 @@ describe('hoveranywhere', () => {
 
         makePlot(
             gd,
+            {},
             {
                 hoveranywhere: true,
                 shapes: [
@@ -222,7 +224,6 @@ describe('hoveranywhere', () => {
                     }
                 ]
             },
-            {},
             { edits: { shapePosition: true } }
         )
             .then(() => {
@@ -253,7 +254,7 @@ describe('hoveranywhere', () => {
     it('reports date axis positions as date strings', (done) => {
         var hoverData;
 
-        makeDatePlot(gd, { hoveranywhere: true })
+        makeDatePlot(gd, {}, { hoveranywhere: true })
             .then(() => {
                 gd.on('plotly_hover', (d) => (hoverData = d));
 
@@ -278,8 +279,8 @@ describe('hoveranywhere', () => {
 
         makePlot(
             gd,
-            { xaxis: { type: 'category' }, yaxis: { type: 'log', range: [1, 3] }, hoveranywhere: true },
-            { x: ['a', 'b', 'c'], y: [10, 20, 30] }
+            { x: ['a', 'b', 'c'], y: [10, 20, 30] },
+            { xaxis: { type: 'category' }, yaxis: { type: 'log', range: [1, 3] }, hoveranywhere: true }
         )
             .then(() => {
                 gd.on('plotly_hover', (d) => (hoverData = d));
@@ -311,7 +312,7 @@ describe('clickanywhere', () => {
     it('emits plotly_click with empty points on empty space', (done) => {
         var clickData;
 
-        makePlot(gd, { clickanywhere: true })
+        makePlot(gd, {}, { clickanywhere: true })
             .then(() => {
                 gd.on('plotly_click', (d) => (clickData = d));
 
@@ -352,7 +353,7 @@ describe('clickanywhere', () => {
     it('emits plotly_click over an editable shape', (done) => {
         let clickData;
 
-        makePlot(gd, {
+        makePlot(gd, {}, {
             clickanywhere: true,
             shapes: [
                 {
@@ -396,6 +397,7 @@ describe('clickanywhere', () => {
 
         makePlot(
             gd,
+            {},
             {
                 clickanywhere: true,
                 shapes: [
@@ -409,7 +411,6 @@ describe('clickanywhere', () => {
                     }
                 ]
             },
-            {},
             { edits: { shapePosition: true } }
         )
             .then(() => {
@@ -438,7 +439,7 @@ describe('clickanywhere', () => {
     it('reports date axis positions as date strings', (done) => {
         var clickData;
 
-        makeDatePlot(gd, { clickanywhere: true })
+        makeDatePlot(gd, {}, { clickanywhere: true })
             .then(() => {
                 gd.on('plotly_click', (d) => (clickData = d));
 


### PR DESCRIPTION
Closes #7816

Modify hoverdata and clickdata such that the `xvals` / `yvals` properties always contain data values (in the same form as the input data, i.e. may be strings in some cases) rather than `calcdata` values (which are always numeric).

Result:
- For ordinary numeric axes (e.g. `linear` and `log`) this change has (essentially) no effect.
  - _Technically there is some validation that happens during `c2d`, but it's basically just checking that the values are numeric, and returning `undefined` if not_
- For date axes, `xvals` / `yvals` now contain date strings rather than numbers representing milliseconds. (This addresses the bug reported in #7816)
- For category axes, `xvals` / `yvals` now contain strings corresponding to category names rather than numeric values.

The attribute descriptions for `hoveranywhere` / `clickanywhere` refer to `xvals` and `yvals` being "in data space", so I believe this was always the intended behavior.

## Steps for testing

- Check out this branch
- Create the following HTML file in the repo root. This HTML page creates a plotly.js plot where the x-axis is a date axis and the y-axis is a category axis:

<details>

```html
<!doctype html>
<meta charset="utf-8">
<title>hoveranywhere / clickanywhere coordinates</title>
<script src="dist/plotly.js"></script>
<p>Open the console, then hover and click anywhere in the plot.</p>
<div id="gd" style="width:700px;height:400px"></div>
<script>
    var gd = document.getElementById('gd');

    // local midnight -> next local midnight, as in issue #7816
    var dayStart = new Date(2026, 4, 31);
    var dayEnd = new Date(2026, 5, 1);

    Plotly.newPlot(gd, [{
        x: [new Date(2026, 4, 31, 6), new Date(2026, 4, 31, 18)],
        y: ['b', 'c'],
        mode: 'markers',
        marker: {size: 12}
    }], {
        xaxis: {type: 'date', range: [dayStart, dayEnd]},
        yaxis: {type: 'category', categoryorder: 'array', categoryarray: ['a', 'b', 'c', 'd']},
        hoveranywhere: true,
        clickanywhere: true,
        margin: {t: 20}
    });

    function log(name) {
        return function(d) {
            console.log(name, {
                xvals: d.xvals[0],
                yvals: d.yvals[0],
                'points[0].x': d.points[0] && d.points[0].x,
                'points[0].y': d.points[0] && d.points[0].y
            });
        };
    }

    gd.on('plotly_hover', log('hover'));
    gd.on('plotly_click', log('click'));
</script>
```

</details>

- Run `npm ci && npm run build`
- Open the HTML file in the browser, hover anywhere in the plot, and look at the console output. Note that `xvals` contains date strings and `yvals` contains a string matching a category (correct behavior)
- Check out `v4.0` and run `npm ci && npm run build`
- Refresh the browser and note that `xvals` and `yvals` are now both numeric (incorrect behavior)