### PR TITLE
Fix rangeslider "fixed" rangemode using placeholder range of autoranged counter axis

### DIFF
--- a/draftlogs/7967_fix.md
+++ b/draftlogs/7967_fix.md
@@ -1,0 +1,1 @@
+- Fix range slider drawing spurious grey bands on initial render when `rangeslider.yaxis.rangemode` is `"fixed"` and the counter axis is autoranged [[#7967](https://github.com/plotly/plotly.js/pull/7967)]

--- a/src/components/rangeslider/defaults.js
+++ b/src/components/rangeslider/defaults.js
@@ -67,6 +67,10 @@ module.exports = function handleDefaults(layoutIn, layoutOut, axName) {
             var rangeMode = coerceRange('rangemode', rangemodeDflt);
             if(rangeMode !== 'match') {
                 coerceRange('range', yAxOut.range.slice());
+
+                if(rangeMode === 'fixed' && !rangemodeDflt && yAxOut.autorange) {
+                    rangeContainerOut._rangeDfltFromAutorangedAx = true;
+                }
             }
         }
     }

--- a/src/plots/cartesian/autorange.js
+++ b/src/plots/cartesian/autorange.js
@@ -400,6 +400,7 @@ function doAutoRange(gd, ax, presetRange) {
         if(axeRangeOpts) {
             if(axeRangeOpts.rangemode === 'auto' || axeRangeOpts._rangeDfltFromAutorangedAx) {
                 axeRangeOpts.range = getAutoRange(gd, ax);
+                delete axeRangeOpts._rangeDfltFromAutorangedAx;
             }
         }
         anchorAx._input.rangeslider[ax._name] = Lib.extendFlat({}, axeRangeOpts);

--- a/src/plots/cartesian/autorange.js
+++ b/src/plots/cartesian/autorange.js
@@ -398,7 +398,7 @@ function doAutoRange(gd, ax, presetRange) {
     if(anchorAx && anchorAx.rangeslider) {
         var axeRangeOpts = anchorAx.rangeslider[ax._name];
         if(axeRangeOpts) {
-            if(axeRangeOpts.rangemode === 'auto') {
+            if(axeRangeOpts.rangemode === 'auto' || axeRangeOpts._rangeDfltFromAutorangedAx) {
                 axeRangeOpts.range = getAutoRange(gd, ax);
             }
         }

--- a/test/jasmine/tests/range_slider_test.js
+++ b/test/jasmine/tests/range_slider_test.js
@@ -1127,6 +1127,30 @@ describe('rangesliders in general', function() {
         .then(done, done.fail);
     });
 
+    it('should not leave "fixed" rangemode on the placeholder range of an autoranged counter axis', function(done) {
+        Plotly.newPlot(gd, [{
+            // use a heatmap because it doesn't add any padding
+            x0: 0, dx: 1,
+            y0: 1, dy: 1,
+            z: [[1, 2, 3], [2, 3, 4], [3, 4, 5]],
+            type: 'heatmap'
+        }], {
+            xaxis: {
+                rangeslider: {visible: true, yaxis: {rangemode: 'fixed'}}
+            }
+        })
+        .then(function() {
+            expect(gd._fullLayout.yaxis.range).toBeCloseToArray([0.5, 3.5], 3);
+            expect(gd._fullLayout.xaxis.rangeslider.yaxis.range).toBeCloseToArray([0.5, 3.5], 3);
+            return Plotly.restyle(gd, {dy: 4});
+        })
+        .then(function() {
+            expect(gd._fullLayout.yaxis.range).toBeCloseToArray([-1, 11], 3);
+            expect(gd._fullLayout.xaxis.rangeslider.yaxis.range).toBeCloseToArray([0.5, 3.5], 3);
+        })
+        .then(done, done.fail);
+    });
+
     it('should be able to turn on rangeslider x/y autorange implicitly by deleting x range', function(done) {
         // this does not apply to y ranges, because the default there is 'match'
         Plotly.newPlot(gd, [{


### PR DESCRIPTION
Fixes plotly/plotly.py#5614

## Problem

With `rangeslider.yaxis.rangemode: "fixed"` and no explicit range, the slider renders two grey bands on initial load; toggling rangemode away and back clears them. The bands are the opp-axis masks, which shade the slider outside the fixed y-range — visible only when that range disagrees with the data.

<img width="1914" height="900" alt="image" src="https://github.com/user-attachments/assets/f6ff2a6c-9707-448c-a4e4-27c4c808757f" />


## Cause

`rangeslider/defaults.js` defaults the fixed range off `yAxOut.range`. When the counter axis autoranges, that is still the `DFLTRANGEY` `[-1, 4]` placeholder at supplyDefaults time. Unlike `rangemode: 'auto'`, nothing revisits it afterwards.
Toggling works only because it forces a second supplyDefaults, by which point the axis holds its computed range.


## Fix

Flag a `fixed` range defaulted off a not-yet-autoranged axis, and let `doAutoRange` fill it in via the path `'auto'` already uses. The flag is deleted once consumed, so `fixed` resolves once and then stays put, and the internal key is not copied out to `layout`.

No schema change; `auto`, `match`, explicit ranges and non-autoranged axes are unaffected.