### PR TITLE
build: Add alias for regl in esbuild config

### DIFF
--- a/esbuild-config.js
+++ b/esbuild-config.js
@@ -14,6 +14,8 @@ const esbuildConfig = {
     sourcemap: false,
     plugins: [InlineCSSPlugin(), glsl({ minify: true }), environmentPlugin({ NODE_DEBUG: false })],
     alias: {
+        // Force users of regl (gl-text) to use the plotly flavor to deduplicate code
+        regl: '@plotly/regl',
         stream: 'stream-browserify'
     },
     define: {


### PR DESCRIPTION
### Description

Add alias for `regl` in `esbuild` config to deduplicate some code.

### Changes

- Update config

### Testing

Check the CI run.

### Notes

- This will save about 300KB on the built library size