### PR TITLE
chore: Update branch references to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,20 +3,20 @@ Thanks for your interest in plotly.js!
 ### Translations:
 
 - Please @ mention a few other speakers of this language who can help review your translations.
-- If you've omitted any keys from [dist/translation_keys.txt](https://github.com/plotly/plotly.js/blob/master/dist/translation-keys.txt) - which means they will fall back on the US English text - just make a short comment about why in the PR description: the English text works fine in your language, or you would like someone else to help translating those, or whatever the reason.
+- If you've omitted any keys from [dist/translation_keys.txt](https://github.com/plotly/plotly.js/blob/HEAD/dist/translation-keys.txt) - which means they will fall back on the US English text - just make a short comment about why in the PR description: the English text works fine in your language, or you would like someone else to help translating those, or whatever the reason.
 - You should only update files in `lib/locales/`, not those in `dist/`
 
 ### Features, Bug fixes, and others:
 
 Before opening a pull request, developer should:
-1. make sure they are not on the `master` branch of their fork as using `master` for a pull request would make it difficult to fetch `upstream` changes.
-2. fetch latest changes from `upstream/master` into your fork i.e. `origin/master` then pull `origin/master` from you local `master`.
-3. then `git rebase master` their local dev branch off the latest `master` which should be sync with `upstream/master` at this time.
+1. make sure they are not on the `main` branch of their fork as using `main` for a pull request would make it difficult to fetch `upstream` changes.
+2. fetch latest changes from `upstream/main` into your fork i.e. `origin/main` then pull `origin/main` from you local `main`.
+3. then `git rebase main` their local dev branch off the latest `main` which should be sync with `upstream/main` at this time.
 4. make sure to **not** `git add` the `dist/` folder (the `dist/` is updated only on version bumps).
 5. make sure to commit changes to the `package-lock.json` file (if any new dependency required).
 6. provide a title and write an overview of what the PR attempts to do with a link to the issue they are trying to address.
 7. select the _Allow edits from maintainers_ option (see this [article](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for more details).
 
 After opening a pull request, developer:
- - should create a new small markdown log file using the PR number e.g. `1010_fix.md` or `1010_add.md` inside `draftlogs` folder as described in this [README](https://github.com/plotly/plotly.js/blob/master/draftlogs/README.md), commit it and push. A CI check enforces this; PRs that don't warrant a CHANGELOG entry can opt out by applying the `no-draftlog` label.
- - should **not** force push (i.e. `git push -f`) to remote branches associated with opened pull requests. Force pushes make it hard for maintainers to keep track of updates. Therefore, if required, please fetch `upstream/master` and "merge" with master instead of "rebase".
+ - should create a new small markdown log file using the PR number e.g. `1010_fix.md` or `1010_add.md` inside `draftlogs` folder as described in this [README](https://github.com/plotly/plotly.js/blob/HEAD/draftlogs/README.md), commit it and push. A CI check enforces this; PRs that don't warrant a CHANGELOG entry can opt out by applying the `no-draftlog` label.
+ - should **not** force push (i.e. `git push -f`) to remote branches associated with opened pull requests. Force pushes make it hard for maintainers to keep track of updates. Therefore, if required, please fetch `upstream/main` and "merge" with main instead of "rebase".

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thanks for your interest in plotly.js!
 ### Translations:
 
 - Please @ mention a few other speakers of this language who can help review your translations.
-- If you've omitted any keys from [dist/translation_keys.txt](https://github.com/plotly/plotly.js/blob/HEAD/dist/translation-keys.txt) - which means they will fall back on the US English text - just make a short comment about why in the PR description: the English text works fine in your language, or you would like someone else to help translating those, or whatever the reason.
+- If you've omitted any keys from [dist/translation_keys.txt](https://github.com/plotly/plotly.js/blob/main/dist/translation-keys.txt) - which means they will fall back on the US English text - just make a short comment about why in the PR description: the English text works fine in your language, or you would like someone else to help translating those, or whatever the reason.
 - You should only update files in `lib/locales/`, not those in `dist/`
 
 ### Features, Bug fixes, and others:
@@ -18,5 +18,5 @@ Before opening a pull request, developer should:
 7. select the _Allow edits from maintainers_ option (see this [article](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) for more details).
 
 After opening a pull request, developer:
- - should create a new small markdown log file using the PR number e.g. `1010_fix.md` or `1010_add.md` inside `draftlogs` folder as described in this [README](https://github.com/plotly/plotly.js/blob/HEAD/draftlogs/README.md), commit it and push. A CI check enforces this; PRs that don't warrant a CHANGELOG entry can opt out by applying the `no-draftlog` label.
+ - should create a new small markdown log file using the PR number e.g. `1010_fix.md` or `1010_add.md` inside `draftlogs` folder as described in this [README](https://github.com/plotly/plotly.js/blob/main/draftlogs/README.md), commit it and push. A CI check enforces this; PRs that don't warrant a CHANGELOG entry can opt out by applying the `no-draftlog` label.
  - should **not** force push (i.e. `git push -f`) to remote branches associated with opened pull requests. Force pushes make it hard for maintainers to keep track of updates. Therefore, if required, please fetch `upstream/main` and "merge" with main instead of "rebase".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     types:
       - opened

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -2,7 +2,7 @@ name: Publish Dist
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     types:
       - opened

--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -1,6 +1,6 @@
 name: Upload dev build from PR
 
-# See https://github.com/plotly/plotly.js/blob/master/CONTRIBUTING.md#live-links-to-dev-builds
+# See https://github.com/plotly/plotly.js/blob/HEAD/CONTRIBUTING.md#live-links-to-dev-builds
 # for documentation on the usage of this workflow.
 
 on:
@@ -226,7 +226,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
-          CONTRIBUTING_URL="https://github.com/${REPO}/blob/master/CONTRIBUTING.md#live-links-to-dev-builds"
+          CONTRIBUTING_URL="https://github.com/${REPO}/blob/HEAD/CONTRIBUTING.md#live-links-to-dev-builds"
 
           if [ "${IS_FORK}" == "true" ]; then
             STATE="success"

--- a/.github/workflows/upload-dev-build.yml
+++ b/.github/workflows/upload-dev-build.yml
@@ -1,6 +1,6 @@
 name: Upload dev build from PR
 
-# See https://github.com/plotly/plotly.js/blob/HEAD/CONTRIBUTING.md#live-links-to-dev-builds
+# See https://github.com/plotly/plotly.js/blob/main/CONTRIBUTING.md#live-links-to-dev-builds
 # for documentation on the usage of this workflow.
 
 on:
@@ -226,7 +226,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
-          CONTRIBUTING_URL="https://github.com/${REPO}/blob/HEAD/CONTRIBUTING.md#live-links-to-dev-builds"
+          CONTRIBUTING_URL="https://github.com/${REPO}/blob/main/CONTRIBUTING.md#live-links-to-dev-builds"
 
           if [ "${IS_FORK}" == "true" ]; then
             STATE="success"

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,5 @@
 # Alternative ways to require or build plotly.js
-Depending on your needs you may require/import one of [the distributed plotly.js packages](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md) or [a plotly.js/lib index file](https://github.com/plotly/plotly.js/tree/HEAD/lib) and integrate it into your application.
+Depending on your needs you may require/import one of [the distributed plotly.js packages](https://github.com/plotly/plotly.js/blob/main/dist/README.md) or [a plotly.js/lib index file](https://github.com/plotly/plotly.js/tree/main/lib) and integrate it into your application.
 
 The sections below provide additional info in respect to alternative building frameworks.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,5 @@
 # Alternative ways to require or build plotly.js
-Depending on your needs you may require/import one of [the distributed plotly.js packages](https://github.com/plotly/plotly.js/blob/master/dist/README.md) or [a plotly.js/lib index file](https://github.com/plotly/plotly.js/tree/master/lib) and integrate it into your application.
+Depending on your needs you may require/import one of [the distributed plotly.js packages](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md) or [a plotly.js/lib index file](https://github.com/plotly/plotly.js/tree/HEAD/lib) and integrate it into your application.
 
 The sections below provide additional info in respect to alternative building frameworks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 For more context information, please read through the
 [release notes](https://github.com/plotly/plotly.js/releases).
 
-To see all merged commits on the master branch that will be part of the next plotly.js release, go to:
+To see all merged commits on the default branch that will be part of the next plotly.js release, go to:
 
-<https://github.com/plotly/plotly.js/compare/vX.Y.Z...master>
+<https://github.com/plotly/plotly.js/compare/vX.Y.Z...HEAD>
 
 where X.Y.Z is the semver of most recent plotly.js release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 For more context information, please read through the
 [release notes](https://github.com/plotly/plotly.js/releases).
 
-To see all merged commits on the default branch that will be part of the next plotly.js release, go to:
+To see all merged commits on the main branch that will be part of the next plotly.js release, go to:
 
-<https://github.com/plotly/plotly.js/compare/vX.Y.Z...HEAD>
+<https://github.com/plotly/plotly.js/compare/vX.Y.Z...main>
 
 where X.Y.Z is the semver of most recent plotly.js release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ cd plotly.js
 #### Step 2: Switch to a dev branch
 
 ```bash
-# please do not use master or main for your dev branch
+# please do not use main for your dev branch
 git checkout dev-branch-name
 ```
 
@@ -138,7 +138,7 @@ comes bundled with some useful tools while developing - all bundled under the
 | `Tabs.onReload()` | By default, set to `noop` but you may set `Tabs.onReload` to any function you wish. This is useful for replotting a mock or test every time you reload the plotly.js script. |
 | `Tabs.purge()` | Destroys all plots. |
 
-View [the source](https://github.com/plotly/plotly.js/blob/master/devtools/test_dashboard/devtools.js) for more info.
+View [the source](https://github.com/plotly/plotly.js/blob/HEAD/devtools/test_dashboard/devtools.js) for more info.
 
 Three additional helpers exist that are refreshed every second:
 
@@ -205,7 +205,7 @@ previous changes. `npm run regl-codegen` will prompt you to open
 a browser window, run through the mocks for each regl-using trace
 (`parcoords`, `scattergl`, `scatterpolargl`, `splom`), and store the captured
 shader code into
-[src/generated/regl-codegen](https://github.com/plotly/plotly.js/blob/master/src/generated/regl-codegen).
+[src/generated/regl-codegen](https://github.com/plotly/plotly.js/blob/HEAD/src/generated/regl-codegen).
 The four `src/traces/{parcoords,scattergl,scatterpolargl,splom}/regl_precompiled.js`
 files are rewritten in the same pass so their imports point at the freshly
 generated shader files. Commit any changes that result — both the
@@ -241,7 +241,7 @@ npm run test-jasmine -- <suite>
 ```
 
 where the `<suite>` corresponds to the suite's file name as found in
-[`test/jasmine/tests/`](https://github.com/plotly/plotly.js/tree/master/test/jasmine/tests).
+[`test/jasmine/tests/`](https://github.com/plotly/plotly.js/tree/HEAD/test/jasmine/tests).
 
 You can also test multiple suites at a time, for example:
 
@@ -288,7 +288,7 @@ bash .github/scripts/env_image.sh
 #### Without Docker:
 Ensure you have Python 3.12+ and [`uv`](https://docs.astral.sh/uv/) installed.
 
-To install required fonts and tools, run the [setup script](https://github.com/plotly/plotly.js/blob/master/.github/scripts/env_image.sh):
+To install required fonts and tools, run the [setup script](https://github.com/plotly/plotly.js/blob/HEAD/.github/scripts/env_image.sh):
 ```sh
 bash .github/scripts/env_image.sh
 ```
@@ -386,10 +386,10 @@ If you would like a link to the dev build for your PR but don't have permission 
 
 ## Trace module design
 
-The trace modules (found in [`src/traces`](https://github.com/plotly/plotly.js/tree/master/src/traces))
+The trace modules (found in [`src/traces`](https://github.com/plotly/plotly.js/tree/HEAD/src/traces))
 are defined as plain objects with functions and constants attached to them in an index file
 (e.g. `src/traces/scatter/index.js`). The trace modules are "registered" under the `Registry` object
-(found in [`src/registry.js`](https://github.com/plotly/plotly.js/blob/master/src/registry.js)) using
+(found in [`src/registry.js`](https://github.com/plotly/plotly.js/blob/HEAD/src/registry.js)) using
 `Plotly.register` (as done in the index files in `dist/`).
 
 The trace module methods are meant to be called as part of loops during subplot-specific

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ comes bundled with some useful tools while developing - all bundled under the
 | `Tabs.onReload()` | By default, set to `noop` but you may set `Tabs.onReload` to any function you wish. This is useful for replotting a mock or test every time you reload the plotly.js script. |
 | `Tabs.purge()` | Destroys all plots. |
 
-View [the source](https://github.com/plotly/plotly.js/blob/HEAD/devtools/test_dashboard/devtools.js) for more info.
+View [the source](https://github.com/plotly/plotly.js/blob/main/devtools/test_dashboard/devtools.js) for more info.
 
 Three additional helpers exist that are refreshed every second:
 
@@ -205,7 +205,7 @@ previous changes. `npm run regl-codegen` will prompt you to open
 a browser window, run through the mocks for each regl-using trace
 (`parcoords`, `scattergl`, `scatterpolargl`, `splom`), and store the captured
 shader code into
-[src/generated/regl-codegen](https://github.com/plotly/plotly.js/blob/HEAD/src/generated/regl-codegen).
+[src/generated/regl-codegen](https://github.com/plotly/plotly.js/blob/main/src/generated/regl-codegen).
 The four `src/traces/{parcoords,scattergl,scatterpolargl,splom}/regl_precompiled.js`
 files are rewritten in the same pass so their imports point at the freshly
 generated shader files. Commit any changes that result — both the
@@ -241,7 +241,7 @@ npm run test-jasmine -- <suite>
 ```
 
 where the `<suite>` corresponds to the suite's file name as found in
-[`test/jasmine/tests/`](https://github.com/plotly/plotly.js/tree/HEAD/test/jasmine/tests).
+[`test/jasmine/tests/`](https://github.com/plotly/plotly.js/tree/main/test/jasmine/tests).
 
 You can also test multiple suites at a time, for example:
 
@@ -288,7 +288,7 @@ bash .github/scripts/env_image.sh
 #### Without Docker:
 Ensure you have Python 3.12+ and [`uv`](https://docs.astral.sh/uv/) installed.
 
-To install required fonts and tools, run the [setup script](https://github.com/plotly/plotly.js/blob/HEAD/.github/scripts/env_image.sh):
+To install required fonts and tools, run the [setup script](https://github.com/plotly/plotly.js/blob/main/.github/scripts/env_image.sh):
 ```sh
 bash .github/scripts/env_image.sh
 ```
@@ -386,10 +386,10 @@ If you would like a link to the dev build for your PR but don't have permission 
 
 ## Trace module design
 
-The trace modules (found in [`src/traces`](https://github.com/plotly/plotly.js/tree/HEAD/src/traces))
+The trace modules (found in [`src/traces`](https://github.com/plotly/plotly.js/tree/main/src/traces))
 are defined as plain objects with functions and constants attached to them in an index file
 (e.g. `src/traces/scatter/index.js`). The trace modules are "registered" under the `Registry` object
-(found in [`src/registry.js`](https://github.com/plotly/plotly.js/blob/HEAD/src/registry.js)) using
+(found in [`src/registry.js`](https://github.com/plotly/plotly.js/blob/main/src/registry.js)) using
 `Plotly.register` (as done in the index files in `dist/`).
 
 The trace module methods are meant to be called as part of loops during subplot-specific

--- a/CUSTOM_BUNDLE.md
+++ b/CUSTOM_BUNDLE.md
@@ -1,5 +1,5 @@
 # Custom bundle
-You can easily make custom bundles yourself if none of the [distributed packages](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md) meet your needs, or if you want to make a more optimized bundle file with/without specific traces.
+You can easily make custom bundles yourself if none of the [distributed packages](https://github.com/plotly/plotly.js/blob/main/dist/README.md) meet your needs, or if you want to make a more optimized bundle file with/without specific traces.
 
 Make sure you have the versions of node/npm that's recommended:
 - plotly.js before 2.5: Node 12/npm 6

--- a/CUSTOM_BUNDLE.md
+++ b/CUSTOM_BUNDLE.md
@@ -1,5 +1,5 @@
 # Custom bundle
-You can easily make custom bundles yourself if none of the [distributed packages](https://github.com/plotly/plotly.js/blob/master/dist/README.md) meet your needs, or if you want to make a more optimized bundle file with/without specific traces.
+You can easily make custom bundles yourself if none of the [distributed packages](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md) meet your needs, or if you want to make a more optimized bundle file with/without specific traces.
 
 Make sure you have the versions of node/npm that's recommended:
 - plotly.js before 2.5: Node 12/npm 6

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <a href="https://plotly.com/javascript/"><img src="https://images.plot.ly/logo/plotlyjs-logo@2x.png" height="70"></a>
 
 [![npm version](https://badge.fury.io/js/plotly.js.svg)](https://badge.fury.io/js/plotly.js)
-[![CI](https://github.com/plotly/plotly.js/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/plotly/plotly.js/actions/workflows/ci.yml)
-[![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/plotly/plotly.js/blob/master/LICENSE)
+[![CI](https://github.com/plotly/plotly.js/actions/workflows/ci.yml/badge.svg)](https://github.com/plotly/plotly.js/actions/workflows/ci.yml)
+[![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/plotly/plotly.js/blob/HEAD/LICENSE)
 
 [Plotly.js](https://plotly.com/javascript) is a standalone JavaScript data visualization library, and it also powers the Python and R modules named `plotly` in those respective ecosystems (referred to as [Plotly.py](https://plotly.com/python) and [Plotly.R](http://plotly.com/r)).
 
@@ -38,7 +38,7 @@ Plotly.js can be used to produce dozens of chart types and visualizations, inclu
 
 ---
 ## Load as a node module
-Install [a ready-to-use distributed bundle](https://github.com/plotly/plotly.js/blob/master/dist/README.md)
+Install [a ready-to-use distributed bundle](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md)
 ```sh
 npm i --save plotly.js-dist-min
 ```
@@ -121,12 +121,12 @@ You may simply load the [virtual-webgl](https://github.com/greggman/virtual-webg
 
 ## Bundles
 There are two kinds of plotly.js bundles:
-1. Complete and partial official bundles that are distributed to `npm` and the `CDN`, described in [the dist README](https://github.com/plotly/plotly.js/blob/master/dist/README.md).
-2. Custom bundles you can create yourself to optimize the size of the bundle depending on your needs. Please visit [CUSTOM_BUNDLE](https://github.com/plotly/plotly.js/blob/master/CUSTOM_BUNDLE.md) for more information.
+1. Complete and partial official bundles that are distributed to `npm` and the `CDN`, described in [the dist README](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md).
+2. Custom bundles you can create yourself to optimize the size of the bundle depending on your needs. Please visit [CUSTOM_BUNDLE](https://github.com/plotly/plotly.js/blob/HEAD/CUSTOM_BUNDLE.md) for more information.
 
 ---
 ## Alternative ways to load and build plotly.js
-If your library needs to bundle or directly load [plotly.js/lib/index.js](https://github.com/plotly/plotly.js/blob/master/lib/index.js) or parts of its modules similar to [index-basic](https://github.com/plotly/plotly.js/blob/master/lib/index-basic.js) in some other way than via an official or a custom bundle, or in case you want to tweak the default build configurations, then please visit [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/master/BUILDING.md).
+If your library needs to bundle or directly load [plotly.js/lib/index.js](https://github.com/plotly/plotly.js/blob/HEAD/lib/index.js) or parts of its modules similar to [index-basic](https://github.com/plotly/plotly.js/blob/HEAD/lib/index-basic.js) in some other way than via an official or a custom bundle, or in case you want to tweak the default build configurations, then please visit [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/HEAD/BUILDING.md).
 
 ---
 ## Documentation
@@ -139,12 +139,12 @@ For more info about contributing to Plotly documentation, please read through [c
 ---
 ## Bugs and feature requests
 
-Have a bug or a feature request? Please [open a Github issue](https://github.com/plotly/plotly.js/issues/new) keeping in mind the [issue guidelines](https://github.com/plotly/plotly.js/blob/master/.github/ISSUE_TEMPLATE.md). You may also want to read about [how changes get made to Plotly.js](https://github.com/plotly/plotly.js/blob/master/CONTRIBUTING.md).
+Have a bug or a feature request? Please [open a Github issue](https://github.com/plotly/plotly.js/issues/new) keeping in mind the [issue guidelines](https://github.com/plotly/plotly.js/blob/HEAD/.github/ISSUE_TEMPLATE.md). You may also want to read about [how changes get made to Plotly.js](https://github.com/plotly/plotly.js/blob/HEAD/CONTRIBUTING.md).
 
 ---
 ## Contributing
 
-Please read through our [contributing guidelines](https://github.com/plotly/plotly.js/blob/master/CONTRIBUTING.md). Included are directions for opening issues, using plotly.js in your project and notes on development.
+Please read through our [contributing guidelines](https://github.com/plotly/plotly.js/blob/HEAD/CONTRIBUTING.md). Included are directions for opening issues, using plotly.js in your project and notes on development.
 
 ---
 ## Notable contributors
@@ -182,7 +182,7 @@ Plotly.js is at the core of a large and dynamic ecosystem with many contributors
 
 Code and documentation copyright 2025 Plotly, Inc.
 
-Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/master/LICENSE).
+Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/HEAD/LICENSE).
 
 ### Versioning
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/plotly.js.svg)](https://badge.fury.io/js/plotly.js)
 [![CI](https://github.com/plotly/plotly.js/actions/workflows/ci.yml/badge.svg)](https://github.com/plotly/plotly.js/actions/workflows/ci.yml)
-[![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/plotly/plotly.js/blob/HEAD/LICENSE)
+[![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/plotly/plotly.js/blob/main/LICENSE)
 
 [Plotly.js](https://plotly.com/javascript) is a standalone JavaScript data visualization library, and it also powers the Python and R modules named `plotly` in those respective ecosystems (referred to as [Plotly.py](https://plotly.com/python) and [Plotly.R](http://plotly.com/r)).
 
@@ -38,7 +38,7 @@ Plotly.js can be used to produce dozens of chart types and visualizations, inclu
 
 ---
 ## Load as a node module
-Install [a ready-to-use distributed bundle](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md)
+Install [a ready-to-use distributed bundle](https://github.com/plotly/plotly.js/blob/main/dist/README.md)
 ```sh
 npm i --save plotly.js-dist-min
 ```
@@ -121,12 +121,12 @@ You may simply load the [virtual-webgl](https://github.com/greggman/virtual-webg
 
 ## Bundles
 There are two kinds of plotly.js bundles:
-1. Complete and partial official bundles that are distributed to `npm` and the `CDN`, described in [the dist README](https://github.com/plotly/plotly.js/blob/HEAD/dist/README.md).
-2. Custom bundles you can create yourself to optimize the size of the bundle depending on your needs. Please visit [CUSTOM_BUNDLE](https://github.com/plotly/plotly.js/blob/HEAD/CUSTOM_BUNDLE.md) for more information.
+1. Complete and partial official bundles that are distributed to `npm` and the `CDN`, described in [the dist README](https://github.com/plotly/plotly.js/blob/main/dist/README.md).
+2. Custom bundles you can create yourself to optimize the size of the bundle depending on your needs. Please visit [CUSTOM_BUNDLE](https://github.com/plotly/plotly.js/blob/main/CUSTOM_BUNDLE.md) for more information.
 
 ---
 ## Alternative ways to load and build plotly.js
-If your library needs to bundle or directly load [plotly.js/lib/index.js](https://github.com/plotly/plotly.js/blob/HEAD/lib/index.js) or parts of its modules similar to [index-basic](https://github.com/plotly/plotly.js/blob/HEAD/lib/index-basic.js) in some other way than via an official or a custom bundle, or in case you want to tweak the default build configurations, then please visit [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/HEAD/BUILDING.md).
+If your library needs to bundle or directly load [plotly.js/lib/index.js](https://github.com/plotly/plotly.js/blob/main/lib/index.js) or parts of its modules similar to [index-basic](https://github.com/plotly/plotly.js/blob/main/lib/index-basic.js) in some other way than via an official or a custom bundle, or in case you want to tweak the default build configurations, then please visit [`BUILDING.md`](https://github.com/plotly/plotly.js/blob/main/BUILDING.md).
 
 ---
 ## Documentation
@@ -139,12 +139,12 @@ For more info about contributing to Plotly documentation, please read through [c
 ---
 ## Bugs and feature requests
 
-Have a bug or a feature request? Please [open a Github issue](https://github.com/plotly/plotly.js/issues/new) keeping in mind the [issue guidelines](https://github.com/plotly/plotly.js/blob/HEAD/.github/ISSUE_TEMPLATE.md). You may also want to read about [how changes get made to Plotly.js](https://github.com/plotly/plotly.js/blob/HEAD/CONTRIBUTING.md).
+Have a bug or a feature request? Please [open a Github issue](https://github.com/plotly/plotly.js/issues/new) keeping in mind the [issue guidelines](https://github.com/plotly/plotly.js/blob/main/.github/ISSUE_TEMPLATE.md). You may also want to read about [how changes get made to Plotly.js](https://github.com/plotly/plotly.js/blob/main/CONTRIBUTING.md).
 
 ---
 ## Contributing
 
-Please read through our [contributing guidelines](https://github.com/plotly/plotly.js/blob/HEAD/CONTRIBUTING.md). Included are directions for opening issues, using plotly.js in your project and notes on development.
+Please read through our [contributing guidelines](https://github.com/plotly/plotly.js/blob/main/CONTRIBUTING.md). Included are directions for opening issues, using plotly.js in your project and notes on development.
 
 ---
 ## Notable contributors
@@ -182,7 +182,7 @@ Plotly.js is at the core of a large and dynamic ecosystem with many contributors
 
 Code and documentation copyright 2025 Plotly, Inc.
 
-Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/HEAD/LICENSE).
+Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/main/LICENSE).
 
 ### Versioning
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # plotly.js Security Policy
 
 The open source plotly.js library is provided "AS IS", with no security guarantees.  Please see our
-[license](https://raw.githubusercontent.com/plotly/plotly.js/master/LICENSE) for more information.
+[license](https://raw.githubusercontent.com/plotly/plotly.js/HEAD/LICENSE) for more information.
 
 In the 1.x releases of plotly.js, we attempt to protect against XSS attacks (and similar issues) resulting from
 untrusted data being graphed by plotly.js.  However, XSS or other issues may still exist.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # plotly.js Security Policy
 
 The open source plotly.js library is provided "AS IS", with no security guarantees.  Please see our
-[license](https://raw.githubusercontent.com/plotly/plotly.js/HEAD/LICENSE) for more information.
+[license](https://raw.githubusercontent.com/plotly/plotly.js/main/LICENSE) for more information.
 
 In the 1.x releases of plotly.js, we attempt to protect against XSS attacks (and similar issues) resulting from
 untrusted data being graphed by plotly.js.  However, XSS or other issues may still exist.

--- a/draftlogs/README.md
+++ b/draftlogs/README.md
@@ -1,4 +1,4 @@
-## Directory of draft logs to help prepare the upcoming [CHANGELOG](https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md)
+## Directory of draft logs to help prepare the upcoming [CHANGELOG](https://github.com/plotly/plotly.js/blob/HEAD/CHANGELOG.md)
 
 Every pull request should add at least one markdown file to this directory.
 The filename must start with the PR number, followed by one of these:

--- a/draftlogs/README.md
+++ b/draftlogs/README.md
@@ -1,4 +1,4 @@
-## Directory of draft logs to help prepare the upcoming [CHANGELOG](https://github.com/plotly/plotly.js/blob/HEAD/CHANGELOG.md)
+## Directory of draft logs to help prepare the upcoming [CHANGELOG](https://github.com/plotly/plotly.js/blob/main/CHANGELOG.md)
 
 Every pull request should add at least one markdown file to this directory.
 The filename must start with the PR number, followed by one of these:

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -17,7 +17,7 @@ var copyrightAndLicense = [
     '',
     'Code and documentation copyright ' + year + ' Plotly, Inc.',
     '',
-    'Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/master/LICENSE).',
+    'Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/HEAD/LICENSE).',
     '',
     'Docs released under the [Creative Commons license](https://github.com/plotly/documentation/blob/source/LICENSE).',
     ''

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -17,7 +17,7 @@ var copyrightAndLicense = [
     '',
     'Code and documentation copyright ' + year + ' Plotly, Inc.',
     '',
-    'Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/HEAD/LICENSE).',
+    'Code released under the [MIT license](https://github.com/plotly/plotly.js/blob/main/LICENSE).',
     '',
     'Docs released under the [Creative Commons license](https://github.com/plotly/documentation/blob/source/LICENSE).',
     ''


### PR DESCRIPTION
### Description

Update branch references from `master` to `main` in docs, scripts.

Closes #7368.

### Changes

- Update references
- Update CI
- Update scripts

### Testing

- Check that CI passes (it will have to be after the actual rename)
- Make sure the updated links still work

### Notes

- The rename needs to take place in the UI before this gets merged
- There's a chance that some CI runs won't trigger between that change and this PR getting merged