### PR TITLE
Add JSON download modebar button

### DIFF
--- a/draftlogs/7990_add.md
+++ b/draftlogs/7990_add.md
@@ -1,1 +1,1 @@
-- Add an opt-in modebar button for downloading Plotly figures as JSON [[#7990](https://github.com/plotly/plotly.js/pull/7990)]
+- Add an opt-in modebar button for downloading Plotly figures as JSON [[#7990](https://github.com/plotly/plotly.js/pull/7990)], with thanks to @gokul-debugger for the contribution!

--- a/draftlogs/7990_add.md
+++ b/draftlogs/7990_add.md
@@ -1,0 +1,1 @@
+- Add an opt-in modebar button for downloading Plotly figures as JSON [[#7990](https://github.com/plotly/plotly.js/pull/7990)]

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -69,6 +69,19 @@ modeBarButtons.toImage = {
     }
 };
 
+modeBarButtons.downloadJson = {
+    name: 'downloadJson',
+    title: function (gd) {
+        return _(gd, 'Download plot as JSON');
+    },
+    icon: Icons.disk,
+    click: function (gd) {
+        Registry.call('downloadImage', gd, {format: 'full-json'}).catch(function () {
+            Lib.notifier(_(gd, 'Sorry, there was a problem downloading your JSON file!'), 'long', gd);
+        });
+    }
+};
+
 modeBarButtons.sendChartToCloud = {
     name: 'sendChartToCloud',
     title: function (gd) {

--- a/src/components/modebar/buttons.js
+++ b/src/components/modebar/buttons.js
@@ -76,9 +76,13 @@ modeBarButtons.downloadJson = {
     },
     icon: Icons.disk,
     click: function (gd) {
-        Registry.call('downloadImage', gd, {format: 'full-json'}).catch(function () {
-            Lib.notifier(_(gd, 'Sorry, there was a problem downloading your JSON file!'), 'long', gd);
-        });
+        Registry.call('downloadImage', gd, {format: 'full-json'})
+            .then(function(filename) {
+                Lib.notifier(_(gd, 'JSON download succeeded') + ' - ' + filename, 'long', gd);
+            })
+            .catch(function() {
+                Lib.notifier(_(gd, 'Sorry, there was a problem downloading your JSON file!'), 'long', gd);
+            });
     }
 };
 

--- a/src/components/modebar/constants.js
+++ b/src/components/modebar/constants.js
@@ -18,7 +18,7 @@ var backButtons = [
     'hovercompare',
     'togglehover',
     'togglespikelines'
-].concat(DRAW_MODES);
+].concat(DRAW_MODES, ['downloadJson']);
 
 var foreButtons = [];
 var addToForeButtons = function(b) {

--- a/src/components/modebar/manage.js
+++ b/src/components/modebar/manage.js
@@ -246,6 +246,8 @@ function getButtonGroups(gd) {
                     enableHover('hoverClosestGeo');
                     enableHover('hoverClosest3d');
                     enableHover('hoverClosestPie');
+                } else if(b === 'downloadjson') {
+                    newList.push(modeBarButtons.downloadJson);
                 }
             } else newList.push(b);
         }

--- a/src/components/modebar/manage.js
+++ b/src/components/modebar/manage.js
@@ -142,10 +142,7 @@ function getButtonGroups(gd) {
         groups.push(out);
     }
 
-    // buttons common to all plot types
-    var commonGroup = ['toImage'];
-    if(context.showSendToCloud) commonGroup.push('sendChartToCloud');
-    addGroup(commonGroup);
+    var addDownloadJson = false;
 
     var zoomGroup = [];
     var hoverGroup = [];
@@ -247,12 +244,18 @@ function getButtonGroups(gd) {
                     enableHover('hoverClosest3d');
                     enableHover('hoverClosestPie');
                 } else if(b === 'downloadjson') {
-                    newList.push(modeBarButtons.downloadJson);
+                    addDownloadJson = true;
                 }
             } else newList.push(b);
         }
         buttonsToAdd = newList;
     }
+
+    // buttons common to all plot types
+    var commonGroup = ['toImage'];
+    if(addDownloadJson) commonGroup.push('downloadJson');
+    if(context.showSendToCloud) commonGroup.push('sendChartToCloud');
+    addGroup(commonGroup);
 
     addGroup(dragModeGroup);
     addGroup(zoomGroup.concat(resetGroup));

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -262,7 +262,8 @@ var configAttributes = {
             'To enable predefined modebar buttons e.g. shape drawing, hover and spikelines,',
             'simply provide their string name(s). This could include:',
             '*v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*,',
-            '*drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect* and *eraseshape*.',
+            '*drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect*, *eraseshape*',
+            'and *downloadJson*.',
             'Please note that these predefined buttons will only be shown if they are compatible',
             'with all trace types used in a graph.'
         ].join(' ')

--- a/src/types/core/layout.d.ts
+++ b/src/types/core/layout.d.ts
@@ -93,8 +93,8 @@ export type ModeBarDefaultButtons =
     | 'drawcircle'
     | 'drawrect'
     | 'eraseshape'
-    | 'downloadJson'
     // Other
+    | 'downloadJson'
     | 'toImage'
     | 'sendChartToCloud'
     | 'resetViews'

--- a/src/types/core/layout.d.ts
+++ b/src/types/core/layout.d.ts
@@ -44,9 +44,10 @@ export type AxisName = XAxisName | YAxisName;
  * - `config.modeBarButtons` — the button's registry key, resolved against
  *   Plotly's button table; an unknown key throws.
  * - `config.modeBarButtonsToAdd` — as a *string*, only the shape-drawing
- *   buttons (`drawline` … `eraseshape`) and the category aliases at the end of
- *   this union. Any other button has to be added as a `ModeBarButton` object;
- *   passing its name as a string does not resolve to the built-in button.
+ *   buttons (`drawline` … `eraseshape`), `downloadJson`, and the category
+ *   aliases at the end of this union. Any other button has to be added as a
+ *   `ModeBarButton` object; passing its name as a string does not resolve to
+ *   the built-in button.
  */
 export type ModeBarDefaultButtons =
     // Cartesian
@@ -92,6 +93,7 @@ export type ModeBarDefaultButtons =
     | 'drawcircle'
     | 'drawrect'
     | 'eraseshape'
+    | 'downloadJson'
     // Other
     | 'toImage'
     | 'sendChartToCloud'
@@ -169,4 +171,3 @@ export interface Template {
     /** Template layout defaults. */
     layout?: Partial<Layout> | undefined;
 }
-

--- a/src/types/generated/schema.d.ts
+++ b/src/types/generated/schema.d.ts
@@ -16166,7 +16166,7 @@ export interface Layout {
     modebar?: {
         /** Sets the color of the active or hovered on icons in the modebar. */
         activecolor?: Color;
-        /** Determines which predefined modebar buttons to add. Please note that these buttons will only be shown if they are compatible with all trace types used in a graph. Similar to `config.modeBarButtonsToAdd` option. This may include *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect*, *eraseshape*. */
+        /** Determines which predefined modebar buttons to add. Please note that these buttons will only be shown if they are compatible with all trace types used in a graph. Similar to `config.modeBarButtonsToAdd` option. This may include *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect*, *eraseshape*, *downloadJson*. */
         add?: string | string[];
         /** Sets the background color of the modebar. */
         bgcolor?: Color;
@@ -16621,7 +16621,7 @@ export interface ConfigBase {
      */
     modeBarButtons?: any;
     /**
-     * Add mode bar button using config objects See ./components/modebar/buttons.js for list of arguments. To enable predefined modebar buttons e.g. shape drawing, hover and spikelines, simply provide their string name(s). This could include: *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect* and *eraseshape*. Please note that these predefined buttons will only be shown if they are compatible with all trace types used in a graph.
+     * Add mode bar button using config objects See ./components/modebar/buttons.js for list of arguments. To enable predefined modebar buttons e.g. shape drawing, hover and spikelines, simply provide their string name(s). This could include: *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect*, *eraseshape* and *downloadJson*. Please note that these predefined buttons will only be shown if they are compatible with all trace types used in a graph.
      * @default []
      */
     modeBarButtonsToAdd?: any;

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -4,6 +4,7 @@ var createModeBar = require('../../../src/components/modebar/modebar');
 var manageModeBar = require('../../../src/components/modebar/manage');
 
 var Plotly = require('../../../lib/index');
+var Lib = require('../../../src/lib');
 var Plots = require('../../../src/plots/plots');
 var Registry = require('../../../src/registry');
 var createGraphDiv = require('../assets/create_graph_div');
@@ -1049,6 +1050,60 @@ describe('ModeBar', function() {
                     selectButton(gd._fullLayout._modeBar, 'toImage').click();
                     expect(Registry.call)
                         .toHaveBeenCalledWith('downloadImage', gd, {format: 'png', width: null, height: null});
+                })
+                .then(done, done.fail);
+            });
+        });
+
+        describe('downloadJson handler', function() {
+            beforeEach(function() {
+                spyOn(Registry, 'call').and.returnValue(Promise.resolve());
+                gd = createGraphDiv();
+            });
+
+            it('requests a full JSON download when added through config', function(done) {
+                Plotly.newPlot(gd, {data: [], layout: {}, config: {
+                    modeBarButtonsToAdd: ['downloadJson']
+                }})
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'downloadJson').click();
+                    expect(Registry.call)
+                        .toHaveBeenCalledWith('downloadImage', gd, {format: 'full-json'});
+                })
+                .then(done, done.fail);
+            });
+
+            it('requests a full JSON download when added through layout', function(done) {
+                Plotly.newPlot(gd, {data: [], layout: {
+                    modebar: {add: ['downloadJson']}
+                }})
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'downloadJson').click();
+                    expect(Registry.call)
+                        .toHaveBeenCalledWith('downloadImage', gd, {format: 'full-json'});
+                })
+                .then(done, done.fail);
+            });
+
+            it('reports download failures', function(done) {
+                spyOn(Lib, 'notifier');
+                Registry.call.and.callFake(function() {
+                    return Promise.reject();
+                });
+
+                Plotly.newPlot(gd, {data: [], layout: {}, config: {
+                    modeBarButtonsToAdd: ['downloadJson']
+                }})
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'downloadJson').click();
+                    return Promise.resolve();
+                })
+                .then(function() {
+                    expect(Lib.notifier).toHaveBeenCalledWith(
+                        'Sorry, there was a problem downloading your JSON file!',
+                        'long',
+                        gd
+                    );
                 })
                 .then(done, done.fail);
             });

--- a/test/jasmine/tests/modebar_test.js
+++ b/test/jasmine/tests/modebar_test.js
@@ -869,6 +869,17 @@ describe('ModeBar', function() {
                 .toEqual(initialButtonCount + 1);
         });
 
+        it('groups downloadJson with toImage when added by name', function() {
+            var gd = setupGraphInfo();
+            gd._context.modeBarButtonsToAdd = ['downloadJson'];
+
+            manageModeBar(gd);
+
+            expect(gd._fullLayout._modeBar.buttons[0].map(function(button) {
+                return button.name;
+            })).toEqual(['toImage', 'downloadJson']);
+        });
+
         it('sets up buttons with modeBarButtonsToAdd and modeBarButtonToRemove', function() {
             var gd = setupGraphInfo();
             gd._context.modeBarButtonsToRemove = [
@@ -1081,6 +1092,27 @@ describe('ModeBar', function() {
                     selectButton(gd._fullLayout._modeBar, 'downloadJson').click();
                     expect(Registry.call)
                         .toHaveBeenCalledWith('downloadImage', gd, {format: 'full-json'});
+                })
+                .then(done, done.fail);
+            });
+
+            it('reports successful downloads with the filename', function(done) {
+                spyOn(Lib, 'notifier');
+                Registry.call.and.returnValue(Promise.resolve('plot.json'));
+
+                Plotly.newPlot(gd, {data: [], layout: {}, config: {
+                    modeBarButtonsToAdd: ['downloadJson']
+                }})
+                .then(function() {
+                    selectButton(gd._fullLayout._modeBar, 'downloadJson').click();
+                    return Promise.resolve();
+                })
+                .then(function() {
+                    expect(Lib.notifier).toHaveBeenCalledWith(
+                        'JSON download succeeded - plot.json',
+                        'long',
+                        gd
+                    );
                 })
                 .then(done, done.fail);
             });

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -244,7 +244,7 @@
       "valType": "any"
     },
     "modeBarButtonsToAdd": {
-      "description": "Add mode bar button using config objects See ./components/modebar/buttons.js for list of arguments. To enable predefined modebar buttons e.g. shape drawing, hover and spikelines, simply provide their string name(s). This could include: *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect* and *eraseshape*. Please note that these predefined buttons will only be shown if they are compatible with all trace types used in a graph.",
+      "description": "Add mode bar button using config objects See ./components/modebar/buttons.js for list of arguments. To enable predefined modebar buttons e.g. shape drawing, hover and spikelines, simply provide their string name(s). This could include: *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect*, *eraseshape* and *downloadJson*. Please note that these predefined buttons will only be shown if they are compatible with all trace types used in a graph.",
       "dflt": [],
       "valType": "any"
     },
@@ -4167,7 +4167,7 @@
         },
         "add": {
           "arrayOk": true,
-          "description": "Determines which predefined modebar buttons to add. Please note that these buttons will only be shown if they are compatible with all trace types used in a graph. Similar to `config.modeBarButtonsToAdd` option. This may include *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect*, *eraseshape*.",
+          "description": "Determines which predefined modebar buttons to add. Please note that these buttons will only be shown if they are compatible with all trace types used in a graph. Similar to `config.modeBarButtonsToAdd` option. This may include *v1hovermode*, *hoverclosest*, *hovercompare*, *togglehover*, *togglespikelines*, *drawline*, *drawopenpath*, *drawclosedpath*, *drawcircle*, *drawrect*, *eraseshape*, *downloadJson*.",
           "dflt": "",
           "editType": "modebar",
           "valType": "string"


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `downloadJson` modebar button for exporting the current Plotly figure as JSON.

The button can be enabled through:

```js
config: {
    modeBarButtonsToAdd: ['downloadJson']
}
```

or through `layout.modebar.add`.

It uses Plotly's existing `full-json` export pipeline, preserving the established serialization behavior for figure data, layout, config, typed arrays, and version metadata. Download failures are reported through the existing Plotly notifier.

This replaces #7963, which GitHub closed after its base branch was deleted.

Closes #7917

## Testing

- `npm run test-jasmine -- modebar --nowatch` (103 tests passed)
- `npm run lint`
- `npm run typecheck`
- `npm run test-syntax`
- `npm run schema-typegen-diff-check`
- `git diff --check`