### PR TITLE
fix: Update country-iso-search to v0.1.2

### DIFF
--- a/draftlogs/7994_fix.md
+++ b/draftlogs/7994_fix.md
@@ -1,0 +1,1 @@
+- Update country-iso-search to v0.1.2 to fix issue with UTF-8 characters being decoded incorrectly [[#7994](https://github.com/plotly/plotly.js/pull/7994)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@turf/centroid": "^7.3.5",
         "@turf/meta": "^7.3.5",
         "base64-arraybuffer": "^1.0.2",
-        "country-iso-search": "^0.1.1",
+        "country-iso-search": "^0.1.2",
         "culori": "^4.0.2",
         "d3-force": "^1.2.1",
         "d3-format": "^1.4.5",
@@ -2649,9 +2649,9 @@
       }
     },
     "node_modules/country-iso-search": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/country-iso-search/-/country-iso-search-0.1.1.tgz",
-      "integrity": "sha512-JJxdoVmgZW3F4DdQ4Jq3NuVfqsk6XoHq8PE8QXNIv1BVwAKyJum2dahC7hsW+v60xwH7pm7g8BwCJ05aUabApg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/country-iso-search/-/country-iso-search-0.1.2.tgz",
+      "integrity": "sha512-7VMhhWPSNg/ivAUwp3BvxEGDycCfqiTggaV+hAW+N5+F+jzbEuY5HqvSMnGeP9CxKXBWO0fydbUgLUHmKj89vA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@turf/centroid": "^7.3.5",
     "@turf/meta": "^7.3.5",
     "base64-arraybuffer": "^1.0.2",
-    "country-iso-search": "^0.1.1",
+    "country-iso-search": "^0.1.2",
     "culori": "^4.0.2",
     "d3-force": "^1.2.1",
     "d3-format": "^1.4.5",


### PR DESCRIPTION
### Description

Update [country-iso-search](https://github.com/plotly/country-iso-search) to v0.1.2.

Closes #7993.

### Changes

- Update dependency

### Testing

- Be on main
- Run `npm ci`
- Save the following html into the root project folder and open it in a Chromium based browser:
	```html
	<!doctype html>
	<script src="build/plotly.js"></script>
	<div id="gd"></div>
	<script>
	Plotly.newPlot("gd", /* JSON object */ {
	    "data": [{ "y": [1, 2, 3] }],
	    "layout": { "width": 600, "height": 400}
	})
	</script>
	```
- Note the error in the devtools console
- Switch to this branch
- Run `npm ci`
- Reload the html file
- Note that no error occurs and the plot renders

### Notes

- [country-iso-search](https://github.com/plotly/country-iso-search) runs a sanitize function that previously looked for literal Unicode characters in regex patterns
- This caused errors for pages loading plotly.js without specifying that UTF-8 encoding should be used
- The literal characters were changed to escaped ASCII characters to address the issue