### PR TITLE
fix: Include type defs in appropriate partial bundles

### DIFF
--- a/draftlogs/8001_fix.md
+++ b/draftlogs/8001_fix.md
@@ -1,0 +1,1 @@
+- Include type defs in appropriate partial bundles [[#8001](https://github.com/plotly/plotly.js/pull/8001)]

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -8,9 +8,9 @@ var common = require('./util/common');
 var constants = require('./util/constants');
 var pkg = require('../package.json');
 var rc = pkg.version.split('-')[1];
-var tag = rc ? (' --tag ' + rc.split('.')[0]) : '';
+var tag = rc ? ' --tag ' + rc.split('.')[0] : '';
 
-var year = (new Date()).getFullYear();
+var year = new Date().getFullYear();
 
 var copyrightAndLicense = [
     '## Copyright and license',
@@ -27,7 +27,7 @@ var partialBundlePaths = constants.partialBundleNames.map(constants.makePartialB
 
 // sync "partial bundle" packages
 partialBundlePaths
-    .map(function(d) {
+    .map(function (d) {
         return {
             name: 'plotly.js-' + d.name + '-dist',
             index: d.index,
@@ -37,19 +37,21 @@ partialBundlePaths
             traceList: constants.partialBundleTraces[d.name]
         };
     })
-    .concat([{
-        name: 'plotly.js-dist',
-        index: path.join(constants.pathToLib, 'index.js'),
-        main: 'plotly.js',
-        dist: constants.pathToPlotlyDist,
-        desc: 'Ready-to-use plotly.js distributed bundle.',
-        traceList: constants.allTraces
-    }])
+    .concat([
+        {
+            name: 'plotly.js-dist',
+            index: path.join(constants.pathToLib, 'index.js'),
+            main: 'plotly.js',
+            dist: constants.pathToPlotlyDist,
+            desc: 'Ready-to-use plotly.js distributed bundle.',
+            traceList: constants.allTraces
+        }
+    ])
     .forEach(syncPartialBundlePkg);
 
 // sync "minified partial bundle" packages
 partialBundlePaths
-    .map(function(d) {
+    .map(function (d) {
         return {
             name: 'plotly.js-' + d.name + '-dist-min',
             index: d.index,
@@ -59,14 +61,16 @@ partialBundlePaths
             traceList: constants.partialBundleTraces[d.name]
         };
     })
-    .concat([{
-        name: 'plotly.js-dist-min',
-        index: path.join(constants.pathToLib, 'index.js'),
-        main: 'plotly.min.js',
-        dist: constants.pathToPlotlyDistMin,
-        desc: 'Ready-to-use minified plotly.js distributed bundle.',
-        traceList: constants.allTraces
-    }])
+    .concat([
+        {
+            name: 'plotly.js-dist-min',
+            index: path.join(constants.pathToLib, 'index.js'),
+            main: 'plotly.min.js',
+            dist: constants.pathToPlotlyDistMin,
+            desc: 'Ready-to-use minified plotly.js distributed bundle.',
+            traceList: constants.allTraces
+        }
+    ])
     .forEach(syncPartialBundlePkg);
 
 // sync "locales" package
@@ -74,7 +78,7 @@ syncLocalesPkg({
     name: 'plotly.js-locales',
     dir: path.join(constants.pathToLib, 'locales'),
     main: 'index.js',
-    desc: 'Ready-to-use plotly.js locales',
+    desc: 'Ready-to-use plotly.js locales'
 });
 
 function syncPartialBundlePkg(d) {
@@ -93,20 +97,11 @@ function syncPartialBundlePkg(d) {
             bugs: pkg.bugs,
             author: pkg.author,
             keywords: pkg.keywords,
-            files: [
-                'LICENSE',
-                'README.md',
-                d.main
-            ]
+            files: ['LICENSE', 'README.md', d.main]
         };
 
-        fs.writeFile(
-            path.join(pkgPath, 'package.json'),
-            JSON.stringify(cnt, null, 2) + '\n',
-            cb
-        );
+        fs.writeFile(path.join(pkgPath, 'package.json'), JSON.stringify(cnt, null, 2) + '\n', cb);
     }
-
 
     function writeREADME(cb) {
         var cnt = [
@@ -127,21 +122,19 @@ function syncPartialBundlePkg(d) {
             '',
             '```js',
             '// ES6 module',
-            'import Plotly from \'' + d.name + '\'',
+            "import Plotly from '" + d.name + "'",
             '',
             '// CommonJS',
-            'var Plotly = require(\'' + d.name + '\')',
+            "var Plotly = require('" + d.name + "')",
             '```',
             '',
             copyrightAndLicense,
-            'Please visit [complete list of dependencies](https://www.npmjs.com/package/plotly.js/v/' + pkg.version + '?activeTab=dependencies).'
+            'Please visit [complete list of dependencies](https://www.npmjs.com/package/plotly.js/v/' +
+                pkg.version +
+                '?activeTab=dependencies).'
         ];
 
-        fs.writeFile(
-            path.join(pkgPath, 'README.md'),
-            cnt.join('\n'),
-            cb
-        );
+        fs.writeFile(path.join(pkgPath, 'README.md'), cnt.join('\n'), cb);
     }
 
     function copyMain(cb) {
@@ -152,15 +145,8 @@ function syncPartialBundlePkg(d) {
 
     var publishToNPM = _publishToNPM(d, pkgPath);
 
-    runSeries([
-        initDirectory,
-        writePackageJSON,
-        writeREADME,
-        copyMain,
-        copyLicense,
-        publishToNPM
-    ], function(err) {
-        if(err) throw err;
+    runSeries([initDirectory, writePackageJSON, writeREADME, copyMain, copyLicense, publishToNPM], function (err) {
+        if (err) throw err;
     });
 }
 
@@ -172,12 +158,14 @@ function syncLocalesPkg(d) {
     var localeFiles;
     function listLocalFiles(cb) {
         var localeGlob = path.join(constants.pathToLib, 'locales', '*.js');
-        glob(localeGlob).then(function(_localeFiles) {
-            localeFiles = _localeFiles;
-            cb();
-        }).catch(function(err) {
-            cb(null);
-        });
+        glob(localeGlob)
+            .then(function (_localeFiles) {
+                localeFiles = _localeFiles;
+                cb();
+            })
+            .catch(function (err) {
+                cb(null);
+            });
     }
 
     function writePackageJSON(cb) {
@@ -191,18 +179,14 @@ function syncLocalesPkg(d) {
             bugs: pkg.bugs,
             author: pkg.author,
             keywords: pkg.keywords,
-            files: [
-                'LICENSE',
-                'README.md',
-                d.main
-            ].concat(localeFiles.map(function(f) { return path.basename(f); }))
+            files: ['LICENSE', 'README.md', d.main].concat(
+                localeFiles.map(function (f) {
+                    return path.basename(f);
+                })
+            )
         };
 
-        fs.writeFile(
-            path.join(pkgPath, 'package.json'),
-            JSON.stringify(cnt, null, 2) + '\n',
-            cb
-        );
+        fs.writeFile(path.join(pkgPath, 'package.json'), JSON.stringify(cnt, null, 2) + '\n', cb);
     }
 
     function writeREADME(cb) {
@@ -224,72 +208,70 @@ function syncLocalesPkg(d) {
             '',
             '```js',
             '// ES6 module',
-            'import Plotly from \'plotly.js\'',
-            'import locale from \'' + d.name + '/fr' + '\'',
+            "import Plotly from 'plotly.js'",
+            "import locale from '" + d.name + '/fr' + "'",
             '',
             '// CommonJS',
-            'var Plotly = require(\'plotly.js\')',
-            'var locale = require(\'' + d.name + '/fr\')',
+            "var Plotly = require('plotly.js')",
+            "var locale = require('" + d.name + "/fr')",
             '',
             '// then',
             'Plotly.register(locale)',
-            'Plotly.setPlotConfig({locale: \'fr\'})',
+            "Plotly.setPlotConfig({locale: 'fr'})",
             '```',
             '',
             copyrightAndLicense
         ];
 
-        fs.writeFile(
-            path.join(pkgPath, 'README.md'),
-            cnt.join('\n'),
-            cb
-        );
+        fs.writeFile(path.join(pkgPath, 'README.md'), cnt.join('\n'), cb);
     }
 
     function writeMain(cb) {
         var cnt = [constants.licenseDist, ''];
-        localeFiles.forEach(function(f) {
+        localeFiles.forEach(function (f) {
             var n = path.basename(f, '.js');
-            cnt.push('exports[\'' + n + '\'] = require(\'./' + n + '.js\')');
+            cnt.push("exports['" + n + "'] = require('./" + n + ".js')");
         });
         cnt.push('');
 
-        fs.writeFile(
-            path.join(pkgPath, d.main),
-            cnt.join('\n'),
-            cb
-        );
+        fs.writeFile(path.join(pkgPath, d.main), cnt.join('\n'), cb);
     }
 
     function copyLocaleFiles(cb) {
-        runSeries(localeFiles.map(function(f) {
-            return function(cb) {
-                fs.copy(f, path.join(pkgPath, path.basename(f)), cb);
-            };
-        }), cb);
+        runSeries(
+            localeFiles.map(function (f) {
+                return function (cb) {
+                    fs.copy(f, path.join(pkgPath, path.basename(f)), cb);
+                };
+            }),
+            cb
+        );
     }
 
     var copyLicense = _copyLicense(d, pkgPath);
 
     var publishToNPM = _publishToNPM(d, pkgPath);
 
-    runSeries([
-        initDirectory,
-        listLocalFiles,
-        writePackageJSON,
-        writeREADME,
-        writeMain,
-        copyLocaleFiles,
-        copyLicense,
-        publishToNPM
-    ], function(err) {
-        if(err) throw err;
-    });
+    runSeries(
+        [
+            initDirectory,
+            listLocalFiles,
+            writePackageJSON,
+            writeREADME,
+            writeMain,
+            copyLocaleFiles,
+            copyLicense,
+            publishToNPM
+        ],
+        function (err) {
+            if (err) throw err;
+        }
+    );
 }
 
 function _initDirectory(d, pkgPath) {
-    return function(cb) {
-        if(common.doesDirExist(pkgPath)) {
+    return function (cb) {
+        if (common.doesDirExist(pkgPath)) {
             cb();
         } else {
             fs.mkdir(pkgPath, cb);
@@ -298,22 +280,18 @@ function _initDirectory(d, pkgPath) {
 }
 
 function _copyLicense(d, pkgPath) {
-    return function(cb) {
-        fs.copy(
-            path.join(constants.pathToRoot, 'LICENSE'),
-            path.join(pkgPath, 'LICENSE'),
-            cb
-        );
+    return function (cb) {
+        fs.copy(path.join(constants.pathToRoot, 'LICENSE'), path.join(pkgPath, 'LICENSE'), cb);
     };
 }
 
 function _publishToNPM(d, pkgPath) {
-    return function(cb) {
-        if(process.env.DRYRUN) {
+    return function (cb) {
+        if (process.env.DRYRUN) {
             console.log('dry run, did not publish ' + d.name);
             cb();
             return;
         }
-        exec('npm publish' + tag, {cwd: pkgPath}, cb).stdout.pipe(process.stdout);
+        exec('npm publish' + tag, { cwd: pkgPath }, cb).stdout.pipe(process.stdout);
     };
 }

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -23,6 +23,10 @@ var copyrightAndLicense = [
     ''
 ].join('\n');
 
+// Type info for the packages that carry types (only the two full bundles for now)
+const TYPES_MAIN = 'lib/index.d.ts';
+const TYPES_FILES = [TYPES_MAIN, 'src/types'];
+
 var partialBundlePaths = constants.partialBundleNames.map(constants.makePartialBundleOpts);
 
 // sync "partial bundle" packages
@@ -44,7 +48,8 @@ partialBundlePaths
             main: 'plotly.js',
             dist: constants.pathToPlotlyDist,
             desc: 'Ready-to-use plotly.js distributed bundle.',
-            traceList: constants.allTraces
+            traceList: constants.allTraces,
+            includeTypes: true
         }
     ])
     .forEach(syncPartialBundlePkg);
@@ -68,7 +73,8 @@ partialBundlePaths
             main: 'plotly.min.js',
             dist: constants.pathToPlotlyDistMin,
             desc: 'Ready-to-use minified plotly.js distributed bundle.',
-            traceList: constants.allTraces
+            traceList: constants.allTraces,
+            includeTypes: true
         }
     ])
     .forEach(syncPartialBundlePkg);
@@ -99,6 +105,10 @@ function syncPartialBundlePkg(d) {
             keywords: pkg.keywords,
             files: ['LICENSE', 'README.md', d.main]
         };
+        if (d.includeTypes) {
+            cnt.types = TYPES_MAIN;
+            cnt.files.push(...TYPES_FILES);
+        }
 
         fs.writeFile(path.join(pkgPath, 'package.json'), JSON.stringify(cnt, null, 2) + '\n', cb);
     }
@@ -128,6 +138,24 @@ function syncPartialBundlePkg(d) {
             "var Plotly = require('" + d.name + "')",
             '```',
             '',
+            ...(d.includeTypes
+                ? [
+                      '## TypeScript',
+                      '',
+                      'This package includes its own TypeScript declarations.',
+                      '',
+                      '```ts',
+                      "import Plotly from '" + d.name + "'",
+                      "import type { Data, Layout } from '" + d.name + "'",
+                      '',
+                      "const data: Data[] = [{ type: 'scatter', x: [1, 2, 3], y: [4, 5, 6] }]",
+                      "const layout: Partial<Layout> = { title: { text: 'Demo' } }",
+                      '',
+                      'await Plotly.newPlot(div, data, layout)',
+                      '```',
+                      ''
+                  ]
+                : []),
             copyrightAndLicense,
             'Please visit [complete list of dependencies](https://www.npmjs.com/package/plotly.js/v/' +
                 pkg.version +
@@ -141,11 +169,36 @@ function syncPartialBundlePkg(d) {
         fs.copy(d.dist, path.join(pkgPath, d.main), cb);
     }
 
+    function copyTypes(cb) {
+        if (!d.includeTypes) {
+            cb();
+            return;
+        }
+
+        // Only include type related files in copy
+        const isDeclaration = (src) => fs.statSync(src).isDirectory() || src.endsWith('.d.ts');
+
+        // Match the type file structure from the full library
+        runSeries(
+            [
+                (cb) => fs.copy(path.join(constants.pathToLib, 'index.d.ts'), path.join(pkgPath, TYPES_MAIN), cb),
+                (cb) =>
+                    fs.copy(
+                        path.join(constants.pathToSrc, 'types'),
+                        path.join(pkgPath, 'src', 'types'),
+                        { filter: isDeclaration },
+                        cb
+                    )
+            ],
+            cb
+        );
+    }
+
     var copyLicense = _copyLicense(d, pkgPath);
 
     var publishToNPM = _publishToNPM(d, pkgPath);
 
-    runSeries([initDirectory, writePackageJSON, writeREADME, copyMain, copyLicense, publishToNPM], function (err) {
+    runSeries([initDirectory, writePackageJSON, writeREADME, copyMain, copyTypes, copyLicense, publishToNPM], (err) => {
         if (err) throw err;
     });
 }

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -23,7 +23,7 @@ var copyrightAndLicense = [
     ''
 ].join('\n');
 
-// Type info for the packages that carry types (only the two full bundles for now)
+// Type info for the packages that carry types (plotly.js-dist and plotly.js-dist-min)
 const TYPES_MAIN = 'lib/index.d.ts';
 const TYPES_FILES = [TYPES_MAIN, 'src/types'];
 

--- a/tasks/sync_packages.js
+++ b/tasks/sync_packages.js
@@ -342,7 +342,7 @@ function _publishToNPM(d, pkgPath) {
     return function (cb) {
         if (process.env.DRYRUN) {
             console.log('dry run, did not publish ' + d.name);
-            cb();
+            exec('npm publish --dry-run' + tag, { cwd: pkgPath }, cb).stderr.pipe(process.stderr);
             return;
         }
         exec('npm publish' + tag, { cwd: pkgPath }, cb).stdout.pipe(process.stdout);


### PR DESCRIPTION
### Description

Include the type definitions in the `plotly.js-dist`, `plotly.js-dist-min` partial bundles.

Closes #7996.

### Changes

- Add types during packaging
- Linting/formatting

### Testing

- Be on this branch
- Run `DRYRUN=1 node tasks/sync_packages.js`
- Note that the type files are include in the correct packages

### Notes

- Ideally, a user would be able to use this package in a browser, but that's not possible right now due to Node specific dependencies
- ~~I'm going to open another issue to track that~~ An issue already exists: #6014 
- This PR should land after #8000