### PR TITLE
feat: Add entry point types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,9 @@ jobs:
       - name: Verify generated types are in sync with schema
         run: npm run schema-typegen-diff-check
 
+      - name: Verify entry point declarations are in sync
+        run: npm run entry-point-types-check
+
   package-resolution:
     needs: install-and-cibuild
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,6 +649,21 @@ jobs:
 
           console.log('Loaded ' + modules.length + ' compiled modules and src/lib/index.js');
 
+      - name: Type-check type imports from the entry points
+        working-directory: ${{ runner.temp }}/consumer
+        run: |
+          cat > entry-point-types.ts <<'EOF'
+          import type * as Root from 'plotly.js';
+          import type { Config, Data, Layout } from 'plotly.js/lib/core';
+          import type * as calendars from 'plotly.js/lib/calendars';
+          import type * as indexBasic from 'plotly.js/lib/index-basic';
+          import type * as scatter from 'plotly.js/lib/scatter';
+          import type * as de from 'plotly.js/lib/locales/de';
+          EOF
+          "$GITHUB_WORKSPACE"/node_modules/.bin/tsc entry-point-types.ts \
+            --noEmit --strict --skipLibCheck \
+            --target es2022 --module esnext --moduleResolution bundler
+
   # ============================================================
   # Standalone jobs (no dependencies on install-and-cibuild)
   # ============================================================

--- a/draftlogs/8009_fix.md
+++ b/draftlogs/8009_fix.md
@@ -1,0 +1,1 @@
+- Add TypeScript declarations for the modular `lib/` entry points [[#8009](https://github.com/plotly/plotly.js/pull/8009)]

--- a/package.json
+++ b/package.json
@@ -5,6 +5,19 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "lib/index.d.ts": [
+        "./lib/index.d.ts"
+      ],
+      "lib/index": [
+        "./lib/index.d.ts"
+      ],
+      "lib/*": [
+        "./src/types/generated/entry_points/*.d.ts"
+      ]
+    }
+  },
   "webpack": "./dist/plotly.js",
   "repository": {
     "type": "git",
@@ -30,14 +43,16 @@
     "extra-bundles": "node tasks/extra_bundles.mjs",
     "locales": "node tasks/locales.mjs",
     "schema": "node tasks/schema.mjs",
-    "schema-typegen-diff-check": "npm run schema && git diff --exit-code src/types/generated/ test/plot-schema.json",
+    "schema-typegen-diff-check": "npm run schema && git diff --exit-code src/types/generated/schema.d.ts test/plot-schema.json",
+    "entry-point-types": "node tasks/entry_point_types.mjs",
+    "entry-point-types-check": "node tasks/entry_point_types.mjs --check",
     "stats": "node tasks/stats.mjs",
     "find-strings": "node tasks/find_locale_strings.js",
     "preprocess": "node tasks/preprocess.js",
     "use-draftlogs": "node tasks/use_draftlogs.js",
     "empty-draftlogs": "node tasks/empty_draftlogs.js",
     "empty-dist": "node tasks/empty_dist.js",
-    "build": "npm run empty-dist && npm run preprocess && npm run find-strings && npm run bundle && npm run extra-bundles && npm run locales && npm run schema dist && npm run stats",
+    "build": "npm run empty-dist && npm run preprocess && npm run entry-point-types && npm run find-strings && npm run bundle && npm run extra-bundles && npm run locales && npm run schema dist && npm run stats",
     "regl-codegen": "node devtools/regl_codegen/server.mjs",
     "cibuild": "npm run empty-dist && npm run preprocess && node tasks/cibundle.mjs",
     "lint": "npx @biomejs/biome lint",

--- a/src/types/ARCHITECTURE.md
+++ b/src/types/ARCHITECTURE.md
@@ -27,6 +27,9 @@ How TypeScript types are organized in plotly.js.
 │                          │  │  schema.d.ts — common enums,   │
 │                          │  │  traces, layout, animation,    │
 │                          │  │  config, _internal namespace   │
+│                          │  │                                │
+│                          │  │  entry_points/ — one            │
+│                          │  │  declaration per lib/ path     │
 └──────────────────────────┘  └────────────────────────────────┘
 ```
 
@@ -119,8 +122,32 @@ src/types/
 │   └── attributes.d.ts           # AttributeMap, AttrInfo (compile-time validation)
 │
 └── generated/                    # machine-generated types
-    └── schema.d.ts               # all traces + layout + shared types (from plot-schema.json)
+    ├── schema.d.ts               # all traces + layout + shared types (from plot-schema.json)
+    └── entry_points/             # one declaration per lib/ entry point
+        ├── core.d.ts             # plotly.js/lib/core
+        ├── scatter.d.ts          # plotly.js/lib/scatter, and one per trace
+        └── locales/              # plotly.js/lib/locales/<id>, one per locale
 ```
+
+### The `generated/entry_points/` directory
+
+`lib/` holds one entry point per trace, component, bundle, and locale, so a
+consumer can import `plotly.js/lib/scatter` instead of the whole library. Each
+entry point needs its own declaration. Those declarations live here rather than
+beside the entry points so `lib/` stays readable.
+
+`typesVersions` in package.json maps `plotly.js/lib/<entry>` onto this directory.
+Two things follow from that:
+
+- The `lib/index.d.ts` key in that table is necessary. TypeScript 5 runs the
+  resolved `types` field back through the table, and without the key the `lib/*`
+  pattern captures it and breaks the plain `plotly.js` import.
+- WARNING: TypeScript ignores `typesVersions` once a package has an `exports`
+  field. Adding `exports` to package.json breaks every subpath declaration here.
+
+Run `npm run entry-point-types` to regenerate. Run
+`npm run entry-point-types-check` to fail when the committed output is stale. CI
+runs the check, so a new entry point cannot ship without its declaration.
 
 ### The `.internal.d.ts` convention
 

--- a/src/types/CONVERTING_ATTRIBUTES.md
+++ b/src/types/CONVERTING_ATTRIBUTES.md
@@ -103,7 +103,7 @@ should be added to the corresponding `Full*` interface instead.
 ```bash
 npm run typecheck                      # zero errors
 npm run schema-typegen-diff-check      # regen + check test/plot-schema.json
-                                       # and src/types/generated/ are unchanged
+                                       # and generated/schema.d.ts are unchanged
 ```
 
 The `schema-typegen-diff-check` script regenerates both the runtime schema

--- a/src/types/GENERATOR.md
+++ b/src/types/GENERATOR.md
@@ -330,9 +330,13 @@ wildcard) but their bare names are not.
 ## CI integration
 
 `npm run schema-typegen-diff-check` runs the generator and then verifies that
-both `test/plot-schema.json` and `src/types/generated/` are unchanged via
-`git diff --exit-code`. If either differs, the command fails with exit code 1
+both `test/plot-schema.json` and `src/types/generated/schema.d.ts` are unchanged
+via `git diff --exit-code`. If either differs, the command fails with exit code 1
 and outputs the diff to the console.
+
+The path names `schema.d.ts` rather than the whole `generated/` directory, so an
+uncommitted change to the entry point declarations cannot fail this check.
+`npm run entry-point-types-check` covers those.
 
 This is what makes the JS-to-TS conversion workflow safe: a correct
 conversion produces a byte-identical schema, so the check passes; an

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -7,7 +7,7 @@ This directory documents the TypeScript conversion in progress.
 | [SETUP.md](SETUP.md) | First-time contributor — toolchain overview, npm scripts |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Anyone working with types — directory layout, public/private split |
 | [CONVERTING_ATTRIBUTES.md](CONVERTING_ATTRIBUTES.md) | **Contributor doing conversion work** — step-by-step recipe |
-| [GENERATOR.md](GENERATOR.md) | Maintainer extending or debugging the type generator |
+| [GENERATOR.md](GENERATOR.md) | Maintainer extending or debugging the schema type generator |
 
 ## Status
 
@@ -16,7 +16,8 @@ This directory documents the TypeScript conversion in progress.
 - `AttributeMap` validation machinery: ✅ done
 - **Schema-based type generator**: ✅ done — all trace types + layout + shared interfaces
 - Consumer entry point (`lib/index.d.ts`, wired via `package.json#types`): ✅ done
-- CI gates (`typecheck` + `schema-typegen-diff-check`): ✅ done
+- Modular entry points (`plotly.js/lib/<entry>`, wired via `package.json#typesVersions`): ✅ done
+- CI gates (`typecheck` + `schema-typegen-diff-check` + `entry-point-types-check`): ✅ done
 - First attribute file converted (modebar): ✅ done
 - Conversion of remaining files: 🚧 in progress
 
@@ -36,11 +37,23 @@ This directory documents the TypeScript conversion in progress.
   `Datum[] | Datum[][] | TypedArray` for *every* `data_array` so 2D/3D usage
   typechecks, but the trade-off is that 1D-only fields also accept 2D arrays.
 
-The published consumer surface lives at [`lib/index.d.ts`](../../lib/index.d.ts).
+The published consumer surface has two parts. [`lib/index.d.ts`](../../lib/index.d.ts)
+declares the full library for `import ... from 'plotly.js'`. The generated
+declarations in [`generated/entry_points/`](generated/entry_points/) cover the
+modular entry points, one file each: `plotly.js/lib/core`, every trace and
+component, the partial bundles, and every locale under
+`plotly.js/lib/locales/`.
+
 This `src/types/` directory is the authoring location — internal types live
 here, public types are re-exported through `lib/index.d.ts` to consumers.
 
 ## Generated types
+
+Two tasks generate types. This section covers the schema generator. For the
+entry point declarations under
+[`generated/entry_points/`](generated/entry_points/), see
+[ARCHITECTURE.md](ARCHITECTURE.md#the-generatedentry_points-directory) and run
+`npm run entry-point-types`.
 
 The following are **auto-generated from `plot-schema.json`** by
 `tasks/generate_schema_types.mjs`:

--- a/src/types/SETUP.md
+++ b/src/types/SETUP.md
@@ -29,6 +29,10 @@ npm run typecheck-watch   # incremental rechecking on change
 
 npm run schema            # rebuild test/plot-schema.json + regenerate types under src/types/generated/
 npm run schema-typegen-diff-check      # regenerate + verify no changes to test/plot-schema.json or src/types/generated/schema.d.ts
+
+npm run entry-point-types         # regenerate the entry point declarations under src/types/generated/entry_points/
+npm run entry-point-types-check   # verify the committed entry point declarations are current
+
 npm run build             # full production build (regenerate all files under `dist/`)
 ```
 
@@ -48,14 +52,16 @@ npm start
 
 ```bash
 npm run typecheck
-npm run schema          # if attribute files changed
+npm run schema              # if attribute files changed
+npm run entry-point-types   # if you added or removed a lib/ entry point
 ```
 
-**CI** runs both checks as separate jobs (see `.github/workflows/ci.yml`):
+**CI** runs these checks (see `.github/workflows/ci.yml`):
 
 ```bash
 npm run typecheck                     # validates the type system is internally consistent
 npm run schema-typegen-diff-check     # verifies generated types match the schema
+npm run entry-point-types-check       # verifies every lib/ entry point has a current declaration
 ```
 
 ## How esbuild handles `.ts`

--- a/src/types/generated/entry_points/bar.d.ts
+++ b/src/types/generated/entry_points/bar.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/bar.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `bar` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as bar from 'plotly.js/lib/bar';
+ *
+ * Plotly.register([bar]);
+ */
+declare const bar: RegisterTraceModule & { name: 'bar' };
+
+export = bar;

--- a/src/types/generated/entry_points/barpolar.d.ts
+++ b/src/types/generated/entry_points/barpolar.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/barpolar.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `barpolar` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as barpolar from 'plotly.js/lib/barpolar';
+ *
+ * Plotly.register([barpolar]);
+ */
+declare const barpolar: RegisterTraceModule & { name: 'barpolar' };
+
+export = barpolar;

--- a/src/types/generated/entry_points/box.d.ts
+++ b/src/types/generated/entry_points/box.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/box.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `box` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as box from 'plotly.js/lib/box';
+ *
+ * Plotly.register([box]);
+ */
+declare const box: RegisterTraceModule & { name: 'box' };
+
+export = box;

--- a/src/types/generated/entry_points/calendars.d.ts
+++ b/src/types/generated/entry_points/calendars.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/calendars.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterComponentModule } from '../../core/api';
+
+/**
+ * The `calendars` component module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as calendars from 'plotly.js/lib/calendars';
+ *
+ * Plotly.register([calendars]);
+ */
+declare const calendars: RegisterComponentModule & { name: 'calendars' };
+
+export = calendars;

--- a/src/types/generated/entry_points/candlestick.d.ts
+++ b/src/types/generated/entry_points/candlestick.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/candlestick.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `candlestick` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as candlestick from 'plotly.js/lib/candlestick';
+ *
+ * Plotly.register([candlestick]);
+ */
+declare const candlestick: RegisterTraceModule & { name: 'candlestick' };
+
+export = candlestick;

--- a/src/types/generated/entry_points/carpet.d.ts
+++ b/src/types/generated/entry_points/carpet.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/carpet.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `carpet` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as carpet from 'plotly.js/lib/carpet';
+ *
+ * Plotly.register([carpet]);
+ */
+declare const carpet: RegisterTraceModule & { name: 'carpet' };
+
+export = carpet;

--- a/src/types/generated/entry_points/choropleth.d.ts
+++ b/src/types/generated/entry_points/choropleth.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/choropleth.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `choropleth` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as choropleth from 'plotly.js/lib/choropleth';
+ *
+ * Plotly.register([choropleth]);
+ */
+declare const choropleth: RegisterTraceModule & { name: 'choropleth' };
+
+export = choropleth;

--- a/src/types/generated/entry_points/choroplethmap.d.ts
+++ b/src/types/generated/entry_points/choroplethmap.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/choroplethmap.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `choroplethmap` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as choroplethmap from 'plotly.js/lib/choroplethmap';
+ *
+ * Plotly.register([choroplethmap]);
+ */
+declare const choroplethmap: RegisterTraceModule & { name: 'choroplethmap' };
+
+export = choroplethmap;

--- a/src/types/generated/entry_points/cone.d.ts
+++ b/src/types/generated/entry_points/cone.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/cone.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `cone` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as cone from 'plotly.js/lib/cone';
+ *
+ * Plotly.register([cone]);
+ */
+declare const cone: RegisterTraceModule & { name: 'cone' };
+
+export = cone;

--- a/src/types/generated/entry_points/contour.d.ts
+++ b/src/types/generated/entry_points/contour.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/contour.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `contour` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as contour from 'plotly.js/lib/contour';
+ *
+ * Plotly.register([contour]);
+ */
+declare const contour: RegisterTraceModule & { name: 'contour' };
+
+export = contour;

--- a/src/types/generated/entry_points/contourcarpet.d.ts
+++ b/src/types/generated/entry_points/contourcarpet.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/contourcarpet.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `contourcarpet` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as contourcarpet from 'plotly.js/lib/contourcarpet';
+ *
+ * Plotly.register([contourcarpet]);
+ */
+declare const contourcarpet: RegisterTraceModule & { name: 'contourcarpet' };
+
+export = contourcarpet;

--- a/src/types/generated/entry_points/core.d.ts
+++ b/src/types/generated/entry_points/core.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Generated from lib/core.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/core`.
+ *
+ * It pre-registers no trace modules. Pass the ones you need to `Plotly.register`.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/densitymap.d.ts
+++ b/src/types/generated/entry_points/densitymap.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/densitymap.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `densitymap` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as densitymap from 'plotly.js/lib/densitymap';
+ *
+ * Plotly.register([densitymap]);
+ */
+declare const densitymap: RegisterTraceModule & { name: 'densitymap' };
+
+export = densitymap;

--- a/src/types/generated/entry_points/funnel.d.ts
+++ b/src/types/generated/entry_points/funnel.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/funnel.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `funnel` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as funnel from 'plotly.js/lib/funnel';
+ *
+ * Plotly.register([funnel]);
+ */
+declare const funnel: RegisterTraceModule & { name: 'funnel' };
+
+export = funnel;

--- a/src/types/generated/entry_points/funnelarea.d.ts
+++ b/src/types/generated/entry_points/funnelarea.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/funnelarea.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `funnelarea` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as funnelarea from 'plotly.js/lib/funnelarea';
+ *
+ * Plotly.register([funnelarea]);
+ */
+declare const funnelarea: RegisterTraceModule & { name: 'funnelarea' };
+
+export = funnelarea;

--- a/src/types/generated/entry_points/heatmap.d.ts
+++ b/src/types/generated/entry_points/heatmap.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/heatmap.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `heatmap` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as heatmap from 'plotly.js/lib/heatmap';
+ *
+ * Plotly.register([heatmap]);
+ */
+declare const heatmap: RegisterTraceModule & { name: 'heatmap' };
+
+export = heatmap;

--- a/src/types/generated/entry_points/histogram.d.ts
+++ b/src/types/generated/entry_points/histogram.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/histogram.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `histogram` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as histogram from 'plotly.js/lib/histogram';
+ *
+ * Plotly.register([histogram]);
+ */
+declare const histogram: RegisterTraceModule & { name: 'histogram' };
+
+export = histogram;

--- a/src/types/generated/entry_points/histogram2d.d.ts
+++ b/src/types/generated/entry_points/histogram2d.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/histogram2d.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `histogram2d` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as histogram2d from 'plotly.js/lib/histogram2d';
+ *
+ * Plotly.register([histogram2d]);
+ */
+declare const histogram2d: RegisterTraceModule & { name: 'histogram2d' };
+
+export = histogram2d;

--- a/src/types/generated/entry_points/histogram2dcontour.d.ts
+++ b/src/types/generated/entry_points/histogram2dcontour.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/histogram2dcontour.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `histogram2dcontour` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as histogram2dcontour from 'plotly.js/lib/histogram2dcontour';
+ *
+ * Plotly.register([histogram2dcontour]);
+ */
+declare const histogram2dcontour: RegisterTraceModule & { name: 'histogram2dcontour' };
+
+export = histogram2dcontour;

--- a/src/types/generated/entry_points/icicle.d.ts
+++ b/src/types/generated/entry_points/icicle.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/icicle.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `icicle` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as icicle from 'plotly.js/lib/icicle';
+ *
+ * Plotly.register([icicle]);
+ */
+declare const icicle: RegisterTraceModule & { name: 'icicle' };
+
+export = icicle;

--- a/src/types/generated/entry_points/image.d.ts
+++ b/src/types/generated/entry_points/image.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/image.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `image` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as image from 'plotly.js/lib/image';
+ *
+ * Plotly.register([image]);
+ */
+declare const image: RegisterTraceModule & { name: 'image' };
+
+export = image;

--- a/src/types/generated/entry_points/index-basic.d.ts
+++ b/src/types/generated/entry_points/index-basic.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-basic.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-basic`.
+ *
+ * It pre-registers the 3 trace modules of the basic bundle:
+ * bar, pie, scatter.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/index-cartesian.d.ts
+++ b/src/types/generated/entry_points/index-cartesian.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-cartesian.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-cartesian`.
+ *
+ * It pre-registers the 12 trace modules of the cartesian bundle:
+ * bar, box, contour, heatmap, histogram, histogram2d, histogram2dcontour, image, pie, scatter, scatterternary, violin.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/index-finance.d.ts
+++ b/src/types/generated/entry_points/index-finance.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-finance.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-finance`.
+ *
+ * It pre-registers the 10 trace modules of the finance bundle:
+ * bar, candlestick, funnel, funnelarea, histogram, indicator, ohlc, pie, scatter, waterfall.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/index-geo.d.ts
+++ b/src/types/generated/entry_points/index-geo.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-geo.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-geo`.
+ *
+ * It pre-registers the 3 trace modules of the geo bundle:
+ * choropleth, scatter, scattergeo.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/index-gl2d.d.ts
+++ b/src/types/generated/entry_points/index-gl2d.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-gl2d.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-gl2d`.
+ *
+ * It pre-registers the 4 trace modules of the gl2d bundle:
+ * parcoords, scatter, scattergl, splom.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/index-gl3d.d.ts
+++ b/src/types/generated/entry_points/index-gl3d.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-gl3d.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-gl3d`.
+ *
+ * It pre-registers the 8 trace modules of the gl3d bundle:
+ * cone, isosurface, mesh3d, scatter, scatter3d, streamtube, surface, volume.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/index-map.d.ts
+++ b/src/types/generated/entry_points/index-map.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-map.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-map`.
+ *
+ * It pre-registers the 4 trace modules of the map bundle:
+ * choroplethmap, densitymap, scatter, scattermap.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/index-strict.d.ts
+++ b/src/types/generated/entry_points/index-strict.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/index-strict.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+/**
+ * Type surface of `plotly.js/lib/index-strict`.
+ *
+ * It pre-registers the 46 trace modules of the strict bundle:
+ * bar, barpolar, box, candlestick, carpet, choropleth, choroplethmap, cone, contour, contourcarpet, densitymap, funnel, funnelarea, heatmap, histogram, histogram2d, histogram2dcontour, icicle, image, indicator, isosurface, mesh3d, ohlc, parcats, parcoords, pie, sankey, scatter, scattergl, scatter3d, scattercarpet, scattergeo, scattermap, scatterpolar, scatterpolargl, scattersmith, scatterternary, splom, streamtube, sunburst, surface, table, treemap, violin, volume, waterfall.
+ *
+ * The type surface is the same as the full bundle, so this re-exports the
+ * main declaration. A trace that is not registered at runtime still
+ * type-checks, which matches the `@types/plotly.js` declarations that this
+ * replaces.
+ */
+
+export * from '../../../../lib/index';
+export { default } from '../../../../lib/index';

--- a/src/types/generated/entry_points/indicator.d.ts
+++ b/src/types/generated/entry_points/indicator.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/indicator.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `indicator` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as indicator from 'plotly.js/lib/indicator';
+ *
+ * Plotly.register([indicator]);
+ */
+declare const indicator: RegisterTraceModule & { name: 'indicator' };
+
+export = indicator;

--- a/src/types/generated/entry_points/isosurface.d.ts
+++ b/src/types/generated/entry_points/isosurface.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/isosurface.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `isosurface` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as isosurface from 'plotly.js/lib/isosurface';
+ *
+ * Plotly.register([isosurface]);
+ */
+declare const isosurface: RegisterTraceModule & { name: 'isosurface' };
+
+export = isosurface;

--- a/src/types/generated/entry_points/locales/af.d.ts
+++ b/src/types/generated/entry_points/locales/af.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/af.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `af` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as af from 'plotly.js/lib/locales/af';
+ *
+ * Plotly.register([af]);
+ */
+declare const af: LocaleModule & { name: 'af' };
+
+export = af;

--- a/src/types/generated/entry_points/locales/am.d.ts
+++ b/src/types/generated/entry_points/locales/am.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/am.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `am` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as am from 'plotly.js/lib/locales/am';
+ *
+ * Plotly.register([am]);
+ */
+declare const am: LocaleModule & { name: 'am' };
+
+export = am;

--- a/src/types/generated/entry_points/locales/ar-dz.d.ts
+++ b/src/types/generated/entry_points/locales/ar-dz.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ar-dz.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ar-DZ` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as arDz from 'plotly.js/lib/locales/ar-dz';
+ *
+ * Plotly.register([arDz]);
+ */
+declare const arDz: LocaleModule & { name: 'ar-DZ' };
+
+export = arDz;

--- a/src/types/generated/entry_points/locales/ar-eg.d.ts
+++ b/src/types/generated/entry_points/locales/ar-eg.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ar-eg.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ar-EG` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as arEg from 'plotly.js/lib/locales/ar-eg';
+ *
+ * Plotly.register([arEg]);
+ */
+declare const arEg: LocaleModule & { name: 'ar-EG' };
+
+export = arEg;

--- a/src/types/generated/entry_points/locales/ar.d.ts
+++ b/src/types/generated/entry_points/locales/ar.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ar.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ar` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ar from 'plotly.js/lib/locales/ar';
+ *
+ * Plotly.register([ar]);
+ */
+declare const ar: LocaleModule & { name: 'ar' };
+
+export = ar;

--- a/src/types/generated/entry_points/locales/az.d.ts
+++ b/src/types/generated/entry_points/locales/az.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/az.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `az` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as az from 'plotly.js/lib/locales/az';
+ *
+ * Plotly.register([az]);
+ */
+declare const az: LocaleModule & { name: 'az' };
+
+export = az;

--- a/src/types/generated/entry_points/locales/bg.d.ts
+++ b/src/types/generated/entry_points/locales/bg.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/bg.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `bg` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as bg from 'plotly.js/lib/locales/bg';
+ *
+ * Plotly.register([bg]);
+ */
+declare const bg: LocaleModule & { name: 'bg' };
+
+export = bg;

--- a/src/types/generated/entry_points/locales/bs.d.ts
+++ b/src/types/generated/entry_points/locales/bs.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/bs.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `bs` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as bs from 'plotly.js/lib/locales/bs';
+ *
+ * Plotly.register([bs]);
+ */
+declare const bs: LocaleModule & { name: 'bs' };
+
+export = bs;

--- a/src/types/generated/entry_points/locales/ca.d.ts
+++ b/src/types/generated/entry_points/locales/ca.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ca.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ca` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ca from 'plotly.js/lib/locales/ca';
+ *
+ * Plotly.register([ca]);
+ */
+declare const ca: LocaleModule & { name: 'ca' };
+
+export = ca;

--- a/src/types/generated/entry_points/locales/cs.d.ts
+++ b/src/types/generated/entry_points/locales/cs.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/cs.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `cs` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as cs from 'plotly.js/lib/locales/cs';
+ *
+ * Plotly.register([cs]);
+ */
+declare const cs: LocaleModule & { name: 'cs' };
+
+export = cs;

--- a/src/types/generated/entry_points/locales/cy.d.ts
+++ b/src/types/generated/entry_points/locales/cy.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/cy.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `cy` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as cy from 'plotly.js/lib/locales/cy';
+ *
+ * Plotly.register([cy]);
+ */
+declare const cy: LocaleModule & { name: 'cy' };
+
+export = cy;

--- a/src/types/generated/entry_points/locales/da.d.ts
+++ b/src/types/generated/entry_points/locales/da.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/da.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `da` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as da from 'plotly.js/lib/locales/da';
+ *
+ * Plotly.register([da]);
+ */
+declare const da: LocaleModule & { name: 'da' };
+
+export = da;

--- a/src/types/generated/entry_points/locales/de-ch.d.ts
+++ b/src/types/generated/entry_points/locales/de-ch.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/de-ch.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `de-CH` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as deCh from 'plotly.js/lib/locales/de-ch';
+ *
+ * Plotly.register([deCh]);
+ */
+declare const deCh: LocaleModule & { name: 'de-CH' };
+
+export = deCh;

--- a/src/types/generated/entry_points/locales/de.d.ts
+++ b/src/types/generated/entry_points/locales/de.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/de.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `de` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as de from 'plotly.js/lib/locales/de';
+ *
+ * Plotly.register([de]);
+ */
+declare const de: LocaleModule & { name: 'de' };
+
+export = de;

--- a/src/types/generated/entry_points/locales/el.d.ts
+++ b/src/types/generated/entry_points/locales/el.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/el.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `el` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as el from 'plotly.js/lib/locales/el';
+ *
+ * Plotly.register([el]);
+ */
+declare const el: LocaleModule & { name: 'el' };
+
+export = el;

--- a/src/types/generated/entry_points/locales/eo.d.ts
+++ b/src/types/generated/entry_points/locales/eo.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/eo.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `eo` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as eo from 'plotly.js/lib/locales/eo';
+ *
+ * Plotly.register([eo]);
+ */
+declare const eo: LocaleModule & { name: 'eo' };
+
+export = eo;

--- a/src/types/generated/entry_points/locales/es-ar.d.ts
+++ b/src/types/generated/entry_points/locales/es-ar.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/es-ar.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `es-AR` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as esAr from 'plotly.js/lib/locales/es-ar';
+ *
+ * Plotly.register([esAr]);
+ */
+declare const esAr: LocaleModule & { name: 'es-AR' };
+
+export = esAr;

--- a/src/types/generated/entry_points/locales/es-pe.d.ts
+++ b/src/types/generated/entry_points/locales/es-pe.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/es-pe.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `es-PE` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as esPe from 'plotly.js/lib/locales/es-pe';
+ *
+ * Plotly.register([esPe]);
+ */
+declare const esPe: LocaleModule & { name: 'es-PE' };
+
+export = esPe;

--- a/src/types/generated/entry_points/locales/es.d.ts
+++ b/src/types/generated/entry_points/locales/es.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/es.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `es` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as es from 'plotly.js/lib/locales/es';
+ *
+ * Plotly.register([es]);
+ */
+declare const es: LocaleModule & { name: 'es' };
+
+export = es;

--- a/src/types/generated/entry_points/locales/et.d.ts
+++ b/src/types/generated/entry_points/locales/et.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/et.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `et` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as et from 'plotly.js/lib/locales/et';
+ *
+ * Plotly.register([et]);
+ */
+declare const et: LocaleModule & { name: 'et' };
+
+export = et;

--- a/src/types/generated/entry_points/locales/eu.d.ts
+++ b/src/types/generated/entry_points/locales/eu.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/eu.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `eu` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as eu from 'plotly.js/lib/locales/eu';
+ *
+ * Plotly.register([eu]);
+ */
+declare const eu: LocaleModule & { name: 'eu' };
+
+export = eu;

--- a/src/types/generated/entry_points/locales/fa.d.ts
+++ b/src/types/generated/entry_points/locales/fa.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/fa.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `fa` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as fa from 'plotly.js/lib/locales/fa';
+ *
+ * Plotly.register([fa]);
+ */
+declare const fa: LocaleModule & { name: 'fa' };
+
+export = fa;

--- a/src/types/generated/entry_points/locales/fi.d.ts
+++ b/src/types/generated/entry_points/locales/fi.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/fi.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `fi` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as fi from 'plotly.js/lib/locales/fi';
+ *
+ * Plotly.register([fi]);
+ */
+declare const fi: LocaleModule & { name: 'fi' };
+
+export = fi;

--- a/src/types/generated/entry_points/locales/fo.d.ts
+++ b/src/types/generated/entry_points/locales/fo.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/fo.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `fo` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as fo from 'plotly.js/lib/locales/fo';
+ *
+ * Plotly.register([fo]);
+ */
+declare const fo: LocaleModule & { name: 'fo' };
+
+export = fo;

--- a/src/types/generated/entry_points/locales/fr-ch.d.ts
+++ b/src/types/generated/entry_points/locales/fr-ch.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/fr-ch.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `fr-CH` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as frCh from 'plotly.js/lib/locales/fr-ch';
+ *
+ * Plotly.register([frCh]);
+ */
+declare const frCh: LocaleModule & { name: 'fr-CH' };
+
+export = frCh;

--- a/src/types/generated/entry_points/locales/fr.d.ts
+++ b/src/types/generated/entry_points/locales/fr.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/fr.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `fr` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as fr from 'plotly.js/lib/locales/fr';
+ *
+ * Plotly.register([fr]);
+ */
+declare const fr: LocaleModule & { name: 'fr' };
+
+export = fr;

--- a/src/types/generated/entry_points/locales/gl.d.ts
+++ b/src/types/generated/entry_points/locales/gl.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/gl.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `gl` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as gl from 'plotly.js/lib/locales/gl';
+ *
+ * Plotly.register([gl]);
+ */
+declare const gl: LocaleModule & { name: 'gl' };
+
+export = gl;

--- a/src/types/generated/entry_points/locales/gu.d.ts
+++ b/src/types/generated/entry_points/locales/gu.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/gu.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `gu` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as gu from 'plotly.js/lib/locales/gu';
+ *
+ * Plotly.register([gu]);
+ */
+declare const gu: LocaleModule & { name: 'gu' };
+
+export = gu;

--- a/src/types/generated/entry_points/locales/he.d.ts
+++ b/src/types/generated/entry_points/locales/he.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/he.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `he` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as he from 'plotly.js/lib/locales/he';
+ *
+ * Plotly.register([he]);
+ */
+declare const he: LocaleModule & { name: 'he' };
+
+export = he;

--- a/src/types/generated/entry_points/locales/hi-in.d.ts
+++ b/src/types/generated/entry_points/locales/hi-in.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/hi-in.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `hi-IN` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as hiIn from 'plotly.js/lib/locales/hi-in';
+ *
+ * Plotly.register([hiIn]);
+ */
+declare const hiIn: LocaleModule & { name: 'hi-IN' };
+
+export = hiIn;

--- a/src/types/generated/entry_points/locales/hr.d.ts
+++ b/src/types/generated/entry_points/locales/hr.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/hr.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `hr` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as hr from 'plotly.js/lib/locales/hr';
+ *
+ * Plotly.register([hr]);
+ */
+declare const hr: LocaleModule & { name: 'hr' };
+
+export = hr;

--- a/src/types/generated/entry_points/locales/hu.d.ts
+++ b/src/types/generated/entry_points/locales/hu.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/hu.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `hu` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as hu from 'plotly.js/lib/locales/hu';
+ *
+ * Plotly.register([hu]);
+ */
+declare const hu: LocaleModule & { name: 'hu' };
+
+export = hu;

--- a/src/types/generated/entry_points/locales/hy.d.ts
+++ b/src/types/generated/entry_points/locales/hy.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/hy.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `hy` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as hy from 'plotly.js/lib/locales/hy';
+ *
+ * Plotly.register([hy]);
+ */
+declare const hy: LocaleModule & { name: 'hy' };
+
+export = hy;

--- a/src/types/generated/entry_points/locales/id.d.ts
+++ b/src/types/generated/entry_points/locales/id.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/id.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `id` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as id from 'plotly.js/lib/locales/id';
+ *
+ * Plotly.register([id]);
+ */
+declare const id: LocaleModule & { name: 'id' };
+
+export = id;

--- a/src/types/generated/entry_points/locales/is.d.ts
+++ b/src/types/generated/entry_points/locales/is.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/is.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `is` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as is from 'plotly.js/lib/locales/is';
+ *
+ * Plotly.register([is]);
+ */
+declare const is: LocaleModule & { name: 'is' };
+
+export = is;

--- a/src/types/generated/entry_points/locales/it.d.ts
+++ b/src/types/generated/entry_points/locales/it.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/it.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `it` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as it from 'plotly.js/lib/locales/it';
+ *
+ * Plotly.register([it]);
+ */
+declare const it: LocaleModule & { name: 'it' };
+
+export = it;

--- a/src/types/generated/entry_points/locales/ja.d.ts
+++ b/src/types/generated/entry_points/locales/ja.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ja.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ja` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ja from 'plotly.js/lib/locales/ja';
+ *
+ * Plotly.register([ja]);
+ */
+declare const ja: LocaleModule & { name: 'ja' };
+
+export = ja;

--- a/src/types/generated/entry_points/locales/ka.d.ts
+++ b/src/types/generated/entry_points/locales/ka.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ka.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ka` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ka from 'plotly.js/lib/locales/ka';
+ *
+ * Plotly.register([ka]);
+ */
+declare const ka: LocaleModule & { name: 'ka' };
+
+export = ka;

--- a/src/types/generated/entry_points/locales/km.d.ts
+++ b/src/types/generated/entry_points/locales/km.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/km.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `km` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as km from 'plotly.js/lib/locales/km';
+ *
+ * Plotly.register([km]);
+ */
+declare const km: LocaleModule & { name: 'km' };
+
+export = km;

--- a/src/types/generated/entry_points/locales/ko.d.ts
+++ b/src/types/generated/entry_points/locales/ko.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ko.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ko` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ko from 'plotly.js/lib/locales/ko';
+ *
+ * Plotly.register([ko]);
+ */
+declare const ko: LocaleModule & { name: 'ko' };
+
+export = ko;

--- a/src/types/generated/entry_points/locales/lt.d.ts
+++ b/src/types/generated/entry_points/locales/lt.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/lt.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `lt` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as lt from 'plotly.js/lib/locales/lt';
+ *
+ * Plotly.register([lt]);
+ */
+declare const lt: LocaleModule & { name: 'lt' };
+
+export = lt;

--- a/src/types/generated/entry_points/locales/lv.d.ts
+++ b/src/types/generated/entry_points/locales/lv.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/lv.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `lv` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as lv from 'plotly.js/lib/locales/lv';
+ *
+ * Plotly.register([lv]);
+ */
+declare const lv: LocaleModule & { name: 'lv' };
+
+export = lv;

--- a/src/types/generated/entry_points/locales/me-me.d.ts
+++ b/src/types/generated/entry_points/locales/me-me.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/me-me.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `me-ME` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as meMe from 'plotly.js/lib/locales/me-me';
+ *
+ * Plotly.register([meMe]);
+ */
+declare const meMe: LocaleModule & { name: 'me-ME' };
+
+export = meMe;

--- a/src/types/generated/entry_points/locales/me.d.ts
+++ b/src/types/generated/entry_points/locales/me.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/me.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `me` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as me from 'plotly.js/lib/locales/me';
+ *
+ * Plotly.register([me]);
+ */
+declare const me: LocaleModule & { name: 'me' };
+
+export = me;

--- a/src/types/generated/entry_points/locales/mk.d.ts
+++ b/src/types/generated/entry_points/locales/mk.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/mk.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `mk` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as mk from 'plotly.js/lib/locales/mk';
+ *
+ * Plotly.register([mk]);
+ */
+declare const mk: LocaleModule & { name: 'mk' };
+
+export = mk;

--- a/src/types/generated/entry_points/locales/ml.d.ts
+++ b/src/types/generated/entry_points/locales/ml.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ml.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ml` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ml from 'plotly.js/lib/locales/ml';
+ *
+ * Plotly.register([ml]);
+ */
+declare const ml: LocaleModule & { name: 'ml' };
+
+export = ml;

--- a/src/types/generated/entry_points/locales/ms.d.ts
+++ b/src/types/generated/entry_points/locales/ms.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ms.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ms` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ms from 'plotly.js/lib/locales/ms';
+ *
+ * Plotly.register([ms]);
+ */
+declare const ms: LocaleModule & { name: 'ms' };
+
+export = ms;

--- a/src/types/generated/entry_points/locales/mt.d.ts
+++ b/src/types/generated/entry_points/locales/mt.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/mt.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `mt` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as mt from 'plotly.js/lib/locales/mt';
+ *
+ * Plotly.register([mt]);
+ */
+declare const mt: LocaleModule & { name: 'mt' };
+
+export = mt;

--- a/src/types/generated/entry_points/locales/nl-be.d.ts
+++ b/src/types/generated/entry_points/locales/nl-be.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/nl-be.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `nl-BE` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as nlBe from 'plotly.js/lib/locales/nl-be';
+ *
+ * Plotly.register([nlBe]);
+ */
+declare const nlBe: LocaleModule & { name: 'nl-BE' };
+
+export = nlBe;

--- a/src/types/generated/entry_points/locales/nl.d.ts
+++ b/src/types/generated/entry_points/locales/nl.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/nl.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `nl` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as nl from 'plotly.js/lib/locales/nl';
+ *
+ * Plotly.register([nl]);
+ */
+declare const nl: LocaleModule & { name: 'nl' };
+
+export = nl;

--- a/src/types/generated/entry_points/locales/no.d.ts
+++ b/src/types/generated/entry_points/locales/no.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/no.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `no` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as no from 'plotly.js/lib/locales/no';
+ *
+ * Plotly.register([no]);
+ */
+declare const no: LocaleModule & { name: 'no' };
+
+export = no;

--- a/src/types/generated/entry_points/locales/pa.d.ts
+++ b/src/types/generated/entry_points/locales/pa.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/pa.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `pa` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as pa from 'plotly.js/lib/locales/pa';
+ *
+ * Plotly.register([pa]);
+ */
+declare const pa: LocaleModule & { name: 'pa' };
+
+export = pa;

--- a/src/types/generated/entry_points/locales/pl.d.ts
+++ b/src/types/generated/entry_points/locales/pl.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/pl.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `pl` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as pl from 'plotly.js/lib/locales/pl';
+ *
+ * Plotly.register([pl]);
+ */
+declare const pl: LocaleModule & { name: 'pl' };
+
+export = pl;

--- a/src/types/generated/entry_points/locales/pt-br.d.ts
+++ b/src/types/generated/entry_points/locales/pt-br.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/pt-br.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `pt-BR` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ptBr from 'plotly.js/lib/locales/pt-br';
+ *
+ * Plotly.register([ptBr]);
+ */
+declare const ptBr: LocaleModule & { name: 'pt-BR' };
+
+export = ptBr;

--- a/src/types/generated/entry_points/locales/pt-pt.d.ts
+++ b/src/types/generated/entry_points/locales/pt-pt.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/pt-pt.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `pt-PT` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ptPt from 'plotly.js/lib/locales/pt-pt';
+ *
+ * Plotly.register([ptPt]);
+ */
+declare const ptPt: LocaleModule & { name: 'pt-PT' };
+
+export = ptPt;

--- a/src/types/generated/entry_points/locales/rm.d.ts
+++ b/src/types/generated/entry_points/locales/rm.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/rm.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `rm` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as rm from 'plotly.js/lib/locales/rm';
+ *
+ * Plotly.register([rm]);
+ */
+declare const rm: LocaleModule & { name: 'rm' };
+
+export = rm;

--- a/src/types/generated/entry_points/locales/ro.d.ts
+++ b/src/types/generated/entry_points/locales/ro.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ro.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ro` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ro from 'plotly.js/lib/locales/ro';
+ *
+ * Plotly.register([ro]);
+ */
+declare const ro: LocaleModule & { name: 'ro' };
+
+export = ro;

--- a/src/types/generated/entry_points/locales/ru.d.ts
+++ b/src/types/generated/entry_points/locales/ru.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ru.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ru` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ru from 'plotly.js/lib/locales/ru';
+ *
+ * Plotly.register([ru]);
+ */
+declare const ru: LocaleModule & { name: 'ru' };
+
+export = ru;

--- a/src/types/generated/entry_points/locales/si.d.ts
+++ b/src/types/generated/entry_points/locales/si.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/si.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `si` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as si from 'plotly.js/lib/locales/si';
+ *
+ * Plotly.register([si]);
+ */
+declare const si: LocaleModule & { name: 'si' };
+
+export = si;

--- a/src/types/generated/entry_points/locales/sk.d.ts
+++ b/src/types/generated/entry_points/locales/sk.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/sk.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `sk` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sk from 'plotly.js/lib/locales/sk';
+ *
+ * Plotly.register([sk]);
+ */
+declare const sk: LocaleModule & { name: 'sk' };
+
+export = sk;

--- a/src/types/generated/entry_points/locales/sl.d.ts
+++ b/src/types/generated/entry_points/locales/sl.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/sl.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `sl` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sl from 'plotly.js/lib/locales/sl';
+ *
+ * Plotly.register([sl]);
+ */
+declare const sl: LocaleModule & { name: 'sl' };
+
+export = sl;

--- a/src/types/generated/entry_points/locales/sq.d.ts
+++ b/src/types/generated/entry_points/locales/sq.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/sq.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `sq` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sq from 'plotly.js/lib/locales/sq';
+ *
+ * Plotly.register([sq]);
+ */
+declare const sq: LocaleModule & { name: 'sq' };
+
+export = sq;

--- a/src/types/generated/entry_points/locales/sr-sr.d.ts
+++ b/src/types/generated/entry_points/locales/sr-sr.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/sr-sr.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `sr-SR` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as srSr from 'plotly.js/lib/locales/sr-sr';
+ *
+ * Plotly.register([srSr]);
+ */
+declare const srSr: LocaleModule & { name: 'sr-SR' };
+
+export = srSr;

--- a/src/types/generated/entry_points/locales/sr.d.ts
+++ b/src/types/generated/entry_points/locales/sr.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/sr.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `sr` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sr from 'plotly.js/lib/locales/sr';
+ *
+ * Plotly.register([sr]);
+ */
+declare const sr: LocaleModule & { name: 'sr' };
+
+export = sr;

--- a/src/types/generated/entry_points/locales/sv.d.ts
+++ b/src/types/generated/entry_points/locales/sv.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/sv.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `sv` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sv from 'plotly.js/lib/locales/sv';
+ *
+ * Plotly.register([sv]);
+ */
+declare const sv: LocaleModule & { name: 'sv' };
+
+export = sv;

--- a/src/types/generated/entry_points/locales/sw.d.ts
+++ b/src/types/generated/entry_points/locales/sw.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/sw.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `sw` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sw from 'plotly.js/lib/locales/sw';
+ *
+ * Plotly.register([sw]);
+ */
+declare const sw: LocaleModule & { name: 'sw' };
+
+export = sw;

--- a/src/types/generated/entry_points/locales/ta.d.ts
+++ b/src/types/generated/entry_points/locales/ta.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ta.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ta` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ta from 'plotly.js/lib/locales/ta';
+ *
+ * Plotly.register([ta]);
+ */
+declare const ta: LocaleModule & { name: 'ta' };
+
+export = ta;

--- a/src/types/generated/entry_points/locales/th.d.ts
+++ b/src/types/generated/entry_points/locales/th.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/th.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `th` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as th from 'plotly.js/lib/locales/th';
+ *
+ * Plotly.register([th]);
+ */
+declare const th: LocaleModule & { name: 'th' };
+
+export = th;

--- a/src/types/generated/entry_points/locales/tr.d.ts
+++ b/src/types/generated/entry_points/locales/tr.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/tr.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `tr` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as tr from 'plotly.js/lib/locales/tr';
+ *
+ * Plotly.register([tr]);
+ */
+declare const tr: LocaleModule & { name: 'tr' };
+
+export = tr;

--- a/src/types/generated/entry_points/locales/tt.d.ts
+++ b/src/types/generated/entry_points/locales/tt.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/tt.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `tt` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as tt from 'plotly.js/lib/locales/tt';
+ *
+ * Plotly.register([tt]);
+ */
+declare const tt: LocaleModule & { name: 'tt' };
+
+export = tt;

--- a/src/types/generated/entry_points/locales/uk.d.ts
+++ b/src/types/generated/entry_points/locales/uk.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/uk.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `uk` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as uk from 'plotly.js/lib/locales/uk';
+ *
+ * Plotly.register([uk]);
+ */
+declare const uk: LocaleModule & { name: 'uk' };
+
+export = uk;

--- a/src/types/generated/entry_points/locales/ur.d.ts
+++ b/src/types/generated/entry_points/locales/ur.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/ur.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `ur` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ur from 'plotly.js/lib/locales/ur';
+ *
+ * Plotly.register([ur]);
+ */
+declare const ur: LocaleModule & { name: 'ur' };
+
+export = ur;

--- a/src/types/generated/entry_points/locales/vi.d.ts
+++ b/src/types/generated/entry_points/locales/vi.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/vi.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `vi` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as vi from 'plotly.js/lib/locales/vi';
+ *
+ * Plotly.register([vi]);
+ */
+declare const vi: LocaleModule & { name: 'vi' };
+
+export = vi;

--- a/src/types/generated/entry_points/locales/zh-cn.d.ts
+++ b/src/types/generated/entry_points/locales/zh-cn.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/zh-cn.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `zh-CN` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as zhCn from 'plotly.js/lib/locales/zh-cn';
+ *
+ * Plotly.register([zhCn]);
+ */
+declare const zhCn: LocaleModule & { name: 'zh-CN' };
+
+export = zhCn;

--- a/src/types/generated/entry_points/locales/zh-hk.d.ts
+++ b/src/types/generated/entry_points/locales/zh-hk.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/zh-hk.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `zh-HK` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as zhHk from 'plotly.js/lib/locales/zh-hk';
+ *
+ * Plotly.register([zhHk]);
+ */
+declare const zhHk: LocaleModule & { name: 'zh-HK' };
+
+export = zhHk;

--- a/src/types/generated/entry_points/locales/zh-tw.d.ts
+++ b/src/types/generated/entry_points/locales/zh-tw.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/locales/zh-tw.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { LocaleModule } from '../../../core/api';
+
+/**
+ * The `zh-TW` locale module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as zhTw from 'plotly.js/lib/locales/zh-tw';
+ *
+ * Plotly.register([zhTw]);
+ */
+declare const zhTw: LocaleModule & { name: 'zh-TW' };
+
+export = zhTw;

--- a/src/types/generated/entry_points/mesh3d.d.ts
+++ b/src/types/generated/entry_points/mesh3d.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/mesh3d.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `mesh3d` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as mesh3d from 'plotly.js/lib/mesh3d';
+ *
+ * Plotly.register([mesh3d]);
+ */
+declare const mesh3d: RegisterTraceModule & { name: 'mesh3d' };
+
+export = mesh3d;

--- a/src/types/generated/entry_points/ohlc.d.ts
+++ b/src/types/generated/entry_points/ohlc.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/ohlc.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `ohlc` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as ohlc from 'plotly.js/lib/ohlc';
+ *
+ * Plotly.register([ohlc]);
+ */
+declare const ohlc: RegisterTraceModule & { name: 'ohlc' };
+
+export = ohlc;

--- a/src/types/generated/entry_points/parcats.d.ts
+++ b/src/types/generated/entry_points/parcats.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/parcats.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `parcats` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as parcats from 'plotly.js/lib/parcats';
+ *
+ * Plotly.register([parcats]);
+ */
+declare const parcats: RegisterTraceModule & { name: 'parcats' };
+
+export = parcats;

--- a/src/types/generated/entry_points/parcoords.d.ts
+++ b/src/types/generated/entry_points/parcoords.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/parcoords.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `parcoords` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as parcoords from 'plotly.js/lib/parcoords';
+ *
+ * Plotly.register([parcoords]);
+ */
+declare const parcoords: RegisterTraceModule & { name: 'parcoords' };
+
+export = parcoords;

--- a/src/types/generated/entry_points/pie.d.ts
+++ b/src/types/generated/entry_points/pie.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/pie.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `pie` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as pie from 'plotly.js/lib/pie';
+ *
+ * Plotly.register([pie]);
+ */
+declare const pie: RegisterTraceModule & { name: 'pie' };
+
+export = pie;

--- a/src/types/generated/entry_points/quiver.d.ts
+++ b/src/types/generated/entry_points/quiver.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/quiver.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `quiver` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as quiver from 'plotly.js/lib/quiver';
+ *
+ * Plotly.register([quiver]);
+ */
+declare const quiver: RegisterTraceModule & { name: 'quiver' };
+
+export = quiver;

--- a/src/types/generated/entry_points/sankey.d.ts
+++ b/src/types/generated/entry_points/sankey.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/sankey.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `sankey` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sankey from 'plotly.js/lib/sankey';
+ *
+ * Plotly.register([sankey]);
+ */
+declare const sankey: RegisterTraceModule & { name: 'sankey' };
+
+export = sankey;

--- a/src/types/generated/entry_points/scatter.d.ts
+++ b/src/types/generated/entry_points/scatter.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scatter.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scatter` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scatter from 'plotly.js/lib/scatter';
+ *
+ * Plotly.register([scatter]);
+ */
+declare const scatter: RegisterTraceModule & { name: 'scatter' };
+
+export = scatter;

--- a/src/types/generated/entry_points/scatter3d.d.ts
+++ b/src/types/generated/entry_points/scatter3d.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scatter3d.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scatter3d` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scatter3d from 'plotly.js/lib/scatter3d';
+ *
+ * Plotly.register([scatter3d]);
+ */
+declare const scatter3d: RegisterTraceModule & { name: 'scatter3d' };
+
+export = scatter3d;

--- a/src/types/generated/entry_points/scattercarpet.d.ts
+++ b/src/types/generated/entry_points/scattercarpet.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scattercarpet.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scattercarpet` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scattercarpet from 'plotly.js/lib/scattercarpet';
+ *
+ * Plotly.register([scattercarpet]);
+ */
+declare const scattercarpet: RegisterTraceModule & { name: 'scattercarpet' };
+
+export = scattercarpet;

--- a/src/types/generated/entry_points/scattergeo.d.ts
+++ b/src/types/generated/entry_points/scattergeo.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scattergeo.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scattergeo` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scattergeo from 'plotly.js/lib/scattergeo';
+ *
+ * Plotly.register([scattergeo]);
+ */
+declare const scattergeo: RegisterTraceModule & { name: 'scattergeo' };
+
+export = scattergeo;

--- a/src/types/generated/entry_points/scattergl.d.ts
+++ b/src/types/generated/entry_points/scattergl.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scattergl.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scattergl` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scattergl from 'plotly.js/lib/scattergl';
+ *
+ * Plotly.register([scattergl]);
+ */
+declare const scattergl: RegisterTraceModule & { name: 'scattergl' };
+
+export = scattergl;

--- a/src/types/generated/entry_points/scattermap.d.ts
+++ b/src/types/generated/entry_points/scattermap.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scattermap.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scattermap` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scattermap from 'plotly.js/lib/scattermap';
+ *
+ * Plotly.register([scattermap]);
+ */
+declare const scattermap: RegisterTraceModule & { name: 'scattermap' };
+
+export = scattermap;

--- a/src/types/generated/entry_points/scatterpolar.d.ts
+++ b/src/types/generated/entry_points/scatterpolar.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scatterpolar.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scatterpolar` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scatterpolar from 'plotly.js/lib/scatterpolar';
+ *
+ * Plotly.register([scatterpolar]);
+ */
+declare const scatterpolar: RegisterTraceModule & { name: 'scatterpolar' };
+
+export = scatterpolar;

--- a/src/types/generated/entry_points/scatterpolargl.d.ts
+++ b/src/types/generated/entry_points/scatterpolargl.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scatterpolargl.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scatterpolargl` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scatterpolargl from 'plotly.js/lib/scatterpolargl';
+ *
+ * Plotly.register([scatterpolargl]);
+ */
+declare const scatterpolargl: RegisterTraceModule & { name: 'scatterpolargl' };
+
+export = scatterpolargl;

--- a/src/types/generated/entry_points/scattersmith.d.ts
+++ b/src/types/generated/entry_points/scattersmith.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scattersmith.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scattersmith` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scattersmith from 'plotly.js/lib/scattersmith';
+ *
+ * Plotly.register([scattersmith]);
+ */
+declare const scattersmith: RegisterTraceModule & { name: 'scattersmith' };
+
+export = scattersmith;

--- a/src/types/generated/entry_points/scatterternary.d.ts
+++ b/src/types/generated/entry_points/scatterternary.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/scatterternary.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `scatterternary` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as scatterternary from 'plotly.js/lib/scatterternary';
+ *
+ * Plotly.register([scatterternary]);
+ */
+declare const scatterternary: RegisterTraceModule & { name: 'scatterternary' };
+
+export = scatterternary;

--- a/src/types/generated/entry_points/splom.d.ts
+++ b/src/types/generated/entry_points/splom.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/splom.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `splom` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as splom from 'plotly.js/lib/splom';
+ *
+ * Plotly.register([splom]);
+ */
+declare const splom: RegisterTraceModule & { name: 'splom' };
+
+export = splom;

--- a/src/types/generated/entry_points/streamtube.d.ts
+++ b/src/types/generated/entry_points/streamtube.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/streamtube.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `streamtube` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as streamtube from 'plotly.js/lib/streamtube';
+ *
+ * Plotly.register([streamtube]);
+ */
+declare const streamtube: RegisterTraceModule & { name: 'streamtube' };
+
+export = streamtube;

--- a/src/types/generated/entry_points/sunburst.d.ts
+++ b/src/types/generated/entry_points/sunburst.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/sunburst.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `sunburst` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as sunburst from 'plotly.js/lib/sunburst';
+ *
+ * Plotly.register([sunburst]);
+ */
+declare const sunburst: RegisterTraceModule & { name: 'sunburst' };
+
+export = sunburst;

--- a/src/types/generated/entry_points/surface.d.ts
+++ b/src/types/generated/entry_points/surface.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/surface.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `surface` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as surface from 'plotly.js/lib/surface';
+ *
+ * Plotly.register([surface]);
+ */
+declare const surface: RegisterTraceModule & { name: 'surface' };
+
+export = surface;

--- a/src/types/generated/entry_points/table.d.ts
+++ b/src/types/generated/entry_points/table.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/table.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `table` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as table from 'plotly.js/lib/table';
+ *
+ * Plotly.register([table]);
+ */
+declare const table: RegisterTraceModule & { name: 'table' };
+
+export = table;

--- a/src/types/generated/entry_points/treemap.d.ts
+++ b/src/types/generated/entry_points/treemap.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/treemap.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `treemap` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as treemap from 'plotly.js/lib/treemap';
+ *
+ * Plotly.register([treemap]);
+ */
+declare const treemap: RegisterTraceModule & { name: 'treemap' };
+
+export = treemap;

--- a/src/types/generated/entry_points/violin.d.ts
+++ b/src/types/generated/entry_points/violin.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/violin.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `violin` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as violin from 'plotly.js/lib/violin';
+ *
+ * Plotly.register([violin]);
+ */
+declare const violin: RegisterTraceModule & { name: 'violin' };
+
+export = violin;

--- a/src/types/generated/entry_points/volume.d.ts
+++ b/src/types/generated/entry_points/volume.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/volume.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `volume` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as volume from 'plotly.js/lib/volume';
+ *
+ * Plotly.register([volume]);
+ */
+declare const volume: RegisterTraceModule & { name: 'volume' };
+
+export = volume;

--- a/src/types/generated/entry_points/waterfall.d.ts
+++ b/src/types/generated/entry_points/waterfall.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Generated from lib/waterfall.js by tasks/generate_entry_point_types.mjs.
+ * Do not edit by hand — run `npm run entry-point-types` to regenerate.
+ */
+
+import type { RegisterTraceModule } from '../../core/api';
+
+/**
+ * The `waterfall` trace module, for `Plotly.register`.
+ *
+ * @example
+ * import * as Plotly from 'plotly.js/lib/core';
+ * import * as waterfall from 'plotly.js/lib/waterfall';
+ *
+ * Plotly.register([waterfall]);
+ */
+declare const waterfall: RegisterTraceModule & { name: 'waterfall' };
+
+export = waterfall;

--- a/tasks/entry_point_types.mjs
+++ b/tasks/entry_point_types.mjs
@@ -1,0 +1,28 @@
+/**
+ * Write the TypeScript declarations for the modular `lib/` entry points.
+ *
+ * Run via `npm run entry-point-types`. With `--check`, the task writes nothing and exits
+ * 1 when a committed declaration is missing, stale, or no longer generated. CI
+ * runs the check so a new entry point cannot ship without its declaration.
+ */
+
+import { findStaleEntryPointTypes, OUTPUT_DIR, writeEntryPointTypes } from './generate_entry_point_types.mjs';
+
+if (process.argv.includes('--check')) {
+    const stale = findStaleEntryPointTypes();
+
+    if (stale.length) {
+        console.error(
+            `Found ${stale.length} entry point declaration(s) out of date. Run \`npm run entry-point-types\`:`
+        );
+        for (const file of stale) console.error(`  ${OUTPUT_DIR}/${file}`);
+        process.exit(1);
+    }
+
+    console.log('OK: entry point declarations are up to date');
+} else {
+    const { written, removed } = writeEntryPointTypes();
+
+    console.log(`Generated ${written} declaration(s) → ${OUTPUT_DIR}/`);
+    for (const file of removed) console.log(`Removed stale ${OUTPUT_DIR}/${file}`);
+}

--- a/tasks/generate_entry_point_types.mjs
+++ b/tasks/generate_entry_point_types.mjs
@@ -1,0 +1,393 @@
+/**
+ * Generate TypeScript declarations for the modular `lib/` entry points.
+ *
+ * `lib/index.d.ts` is hand-written and declares the full public API. Every
+ * other entry point in `lib/` ships without a declaration, so a consumer that
+ * writes `import * as scatter from 'plotly.js/lib/scatter'` is told that no
+ * declaration file was found for the module. This task writes one declaration
+ * per entry point.
+ *
+ * Declarations are written to `OUTPUT_DIR`, not next to the entry points, and
+ * `typesVersions` in package.json maps `plotly.js/lib/<entry>` onto them.
+ *
+ * Four entry point shapes exist, and each maps to one declaration:
+ *
+ *   1. `core.js` and `index-*.js` expose the whole `Plotly` object, so their
+ *      declarations re-export the hand-written `lib/index.d.ts`.
+ *   2. `<trace>.js` re-exports `src/traces/<trace>`, a trace module descriptor
+ *      for `Plotly.register`.
+ *   3. `<component>.js` re-exports `src/components/<component>`, a component
+ *      module descriptor for `Plotly.register`.
+ *   4. `locales/<id>.js` holds a locale module descriptor inline.
+ *
+ * The task reads `lib/` instead of a hard-coded list, and throws on an entry
+ * point it cannot classify. A new trace or locale therefore gets a declaration
+ * for free, and a new entry point shape fails the build instead of passing
+ * silently.
+ *
+ * Run via `npm run entry-point-types`. Run `npm run entry-point-types-check` to fail when the
+ * committed output is missing, stale, or no longer generated.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import constants from './util/constants.js';
+import { generatedHeader, isGenerated, jsDocBlock, toFileText, tsLiteral } from './util/type_gen.mjs';
+
+/** npm command that rewrites every declaration in `OUTPUT_DIR`. */
+const COMMAND = 'npm run entry-point-types';
+
+/** Path of this task, for the generated header. */
+const TASK = 'tasks/generate_entry_point_types.mjs';
+
+/**
+ * Directory that holds the generated declarations, relative to the repo root.
+ *
+ * The declarations live here rather than beside the entry points so `lib/` stays
+ * readable. `typesVersions` in package.json maps `plotly.js/lib/<entry>` onto
+ * this directory, which is what makes the redirect work for consumers.
+ */
+export const OUTPUT_DIR = 'src/types/generated/entry_points';
+
+/** Absolute path of `OUTPUT_DIR`. */
+const pathToOutput = path.join(constants.pathToRoot, OUTPUT_DIR);
+
+/** Path of the module descriptor types, from a file in `OUTPUT_DIR`. */
+const API_TYPES_PATH = '../../core/api';
+
+/** Path of the hand-written main declaration, from a file in `OUTPUT_DIR`. */
+const MAIN_TYPES_PATH = '../../../../lib/index';
+
+/**
+ * Subdirectories of `lib/` that also hold entry points.
+ *
+ * `lib/locales/` holds one entry point per locale, each importable as
+ * `plotly.js/lib/locales/<id>`, so each needs its own declaration.
+ */
+const GENERATED_SUBDIRS = ['locales'];
+
+/**
+ * `moduleType` value → the interface that describes that descriptor.
+ *
+ * An unmapped `moduleType` throws rather than emitting a wrong type.
+ */
+const DESCRIPTOR_INTERFACES = {
+    trace: 'RegisterTraceModule',
+    component: 'RegisterComponentModule',
+    locale: 'LocaleModule'
+};
+
+// ---------------------------------------------------------------------------
+// Entry point classification
+// ---------------------------------------------------------------------------
+
+/** `module.exports = require('../src/traces/scatter');` */
+const RE_EXPORT = /^module\.exports = require\('\.\.\/(src\/[\w/-]+)'\);$/m;
+
+/** `var Plotly = require('./core');` … `module.exports = Plotly;` */
+const RE_BUNDLE = /require\('\.\/core'\)/;
+
+/**
+ * Classify one `lib/` entry point from its source.
+ *
+ * @param name - entry point name without the `.js` extension
+ * @param source - full contents of the entry point
+ * @returns `{kind: 'bundle'}`, or `{kind: 'module', target}` where `target` is
+ *     the re-exported path relative to the repository root
+ * @throws when the source matches no known shape
+ */
+function classify(name, source) {
+    if (name === 'core' || RE_BUNDLE.test(source)) return { kind: 'bundle' };
+
+    const match = source.match(RE_EXPORT);
+    if (match) return { kind: 'module', target: match[1] };
+
+    // `lib/locales/*.js` hold their descriptor inline rather than re-exporting it.
+    const inline = matchDescriptor(source);
+    if (inline) return { kind: 'inline', descriptor: inline };
+
+    throw new Error(
+        `Cannot classify lib/${name}.js. Its shape matches neither a bundle nor a module ` +
+            're-export, so teach tasks/generate_entry_point_types.mjs how to declare it.'
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Module descriptor lookup
+// ---------------------------------------------------------------------------
+
+/** `moduleType: 'trace',` */
+const RE_MODULE_TYPE = /moduleType: '(\w+)'/;
+
+/** `name: 'scatter',` */
+const RE_NAME = /\bname: '([\w-]+)'/;
+
+/**
+ * `var index = require('./base_index');` … `module.exports = index;`
+ *
+ * Four gl traces (parcoords, scattergl, scatterpolargl, splom) build their
+ * descriptor in `base_index.js` and patch one field in `index.js`, so the
+ * lookup follows this single level of indirection.
+ */
+const RE_INDIRECTION = /var (\w+) = require\('\.\/(\w+)'\);/;
+
+/**
+ * Read the `moduleType` and `name` that a module passes to `Plotly.register`.
+ *
+ * @param target - module path relative to the repository root, without `index.js`
+ * @returns the descriptor's `moduleType` and `name`
+ * @throws when neither the module nor the file it re-exports declares both fields
+ */
+function readDescriptor(target) {
+    const entry = path.join(constants.pathToRoot, target, 'index.js');
+    const source = fs.readFileSync(entry, 'utf-8');
+
+    const found = matchDescriptor(source);
+    if (found) return found;
+
+    const indirect = source.match(RE_INDIRECTION);
+    if (indirect && new RegExp(`module\\.exports = ${indirect[1]};`).test(source)) {
+        const base = path.join(constants.pathToRoot, target, `${indirect[2]}.js`);
+        const viaBase = matchDescriptor(fs.readFileSync(base, 'utf-8'));
+        if (viaBase) return viaBase;
+    }
+
+    throw new Error(`Cannot read moduleType and name from ${target}/index.js`);
+}
+
+function matchDescriptor(source) {
+    const moduleType = source.match(RE_MODULE_TYPE);
+    const name = source.match(RE_NAME);
+    if (!moduleType || !name) return null;
+    return { moduleType: moduleType[1], name: name[1] };
+}
+
+// ---------------------------------------------------------------------------
+// Declaration templates
+// ---------------------------------------------------------------------------
+
+/**
+ * Declaration for `core.js` and the `index-*.js` partial bundles.
+ *
+ * Each of these entry points exports the same `Plotly` object as `lib/index.js`
+ * and differs only in which trace modules it pre-registers. The type surface is
+ * therefore identical, and the declaration re-exports `lib/index.d.ts` verbatim.
+ *
+ * @param name - entry point name without the `.js` extension
+ */
+function bundleDeclaration(name) {
+    const bundle = name.replace(/^index-/, '');
+    const traces = constants.partialBundleTraces[bundle];
+
+    if (name !== 'core' && !traces) {
+        throw new Error(
+            `No trace list for the ${bundle} bundle. Add it to partialBundleTraces in tasks/util/constants.js.`
+        );
+    }
+
+    const registered =
+        name === 'core'
+            ? ['It pre-registers no trace modules. Pass the ones you need to `Plotly.register`.']
+            : [`It pre-registers the ${traces.length} trace modules of the ${bundle} bundle:`, `${traces.join(', ')}.`];
+
+    return toFileText([
+        generatedHeader({ source: `lib/${name}.js`, task: TASK, command: COMMAND }),
+        '',
+        ...jsDocBlock({
+            description: [
+                `Type surface of \`plotly.js/lib/${name}\`.`,
+                '',
+                ...registered,
+                '',
+                'The type surface is the same as the full bundle, so this re-exports the',
+                'main declaration. A trace that is not registered at runtime still',
+                'type-checks, which matches the `@types/plotly.js` declarations that this',
+                'replaces.'
+            ].join('\n')
+        }),
+        '',
+        `export * from '${MAIN_TYPES_PATH}';`,
+        `export { default } from '${MAIN_TYPES_PATH}';`
+    ]);
+}
+
+/**
+ * Declaration for a trace or component entry point.
+ *
+ * The declaration types the entry point as its `Plotly.register` descriptor with
+ * a literal `name`, and uses `export =` to mirror the CommonJS
+ * `module.exports = <descriptor>` shape. `export =` keeps both
+ * `import * as scatter from '...'` and `import scatter from '...'` working.
+ *
+ * Only the fields that `Plotly.register` reads are declared. A trace module
+ * carries many more (`attributes`, `supplyDefaults`, `plot`, …), but those are
+ * internal and are deliberately left off the public surface.
+ *
+ * @param entry - entry point name without the `.js` extension
+ * @param descriptor - `moduleType` and `name` read from the module
+ * @param target - module path relative to the repository root, named in the error message
+ * @param subdir - subdirectory under `lib/`, or `''` for a top-level entry point
+ */
+function moduleDeclaration(entry, descriptor, target, subdir) {
+    const iface = DESCRIPTOR_INTERFACES[descriptor.moduleType];
+    if (!iface) {
+        throw new Error(`Unknown moduleType '${descriptor.moduleType}' in ${target}. Add it to DESCRIPTOR_INTERFACES.`);
+    }
+
+    const identifier = toIdentifier(entry);
+    const apiTypesPath = subdir ? `../${API_TYPES_PATH}` : API_TYPES_PATH;
+    const specifier = subdir ? `${subdir}/${entry}` : entry;
+
+    return toFileText([
+        generatedHeader({ source: `lib/${specifier}.js`, task: TASK, command: COMMAND }),
+        '',
+        `import type { ${iface} } from '${apiTypesPath}';`,
+        '',
+        ...jsDocBlock({
+            description: [
+                `The \`${descriptor.name}\` ${descriptor.moduleType} module, for \`Plotly.register\`.`,
+                '',
+                '@example',
+                "import * as Plotly from 'plotly.js/lib/core';",
+                `import * as ${identifier} from 'plotly.js/lib/${specifier}';`,
+                '',
+                `Plotly.register([${identifier}]);`
+            ].join('\n')
+        }),
+        `declare const ${identifier}: ${iface} & { name: ${tsLiteral(descriptor.name)} };`,
+        '',
+        `export = ${identifier};`
+    ]);
+}
+
+/** Convert an entry point name to a valid TypeScript identifier. */
+function toIdentifier(name) {
+    const identifier = name.replace(/-(\w)/g, (_, c) => c.toUpperCase());
+    return /^\d/.test(identifier) ? `_${identifier}` : identifier;
+}
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the declaration text for every generated declaration.
+ *
+ * Reads `lib/` and `src/`, and writes nothing. Callers either write the result
+ * to disk or compare it against the committed files.
+ *
+ * @returns path under `OUTPUT_DIR` → declaration text, for every entry point
+ *     except `lib/index.js`, whose declaration is hand-written
+ * @throws when an entry point cannot be classified, or when a module does not
+ *     declare both `moduleType` and `name`
+ */
+export function buildEntryPointTypes() {
+    const declarations = new Map();
+
+    for (const subdir of ['', ...GENERATED_SUBDIRS]) {
+        const dir = path.join(constants.pathToLib, subdir);
+
+        const entries = fs
+            .readdirSync(dir)
+            .filter((file) => file.endsWith('.js'))
+            .map((file) => path.basename(file, '.js'))
+            .filter((name) => !(subdir === '' && name === 'index'))
+            .sort();
+
+        for (const entry of entries) {
+            const source = fs.readFileSync(path.join(dir, `${entry}.js`), 'utf-8');
+            const classified = classify(entry, source);
+
+            let text;
+            if (classified.kind === 'bundle') {
+                text = bundleDeclaration(entry);
+            } else if (classified.kind === 'inline') {
+                text = moduleDeclaration(entry, classified.descriptor, `lib/${subdir}/${entry}.js`, subdir);
+            } else {
+                text = moduleDeclaration(entry, readDescriptor(classified.target), classified.target, subdir);
+            }
+
+            declarations.set(subdir ? `${subdir}/${entry}.d.ts` : `${entry}.d.ts`, text);
+        }
+    }
+
+    return declarations;
+}
+
+/**
+ * List every committed `.d.ts` under `OUTPUT_DIR`.
+ *
+ * @returns paths relative to `OUTPUT_DIR`, using forward slashes
+ */
+function listCommittedDeclarations() {
+    const files = [];
+
+    for (const subdir of ['', ...GENERATED_SUBDIRS]) {
+        const dir = path.join(pathToOutput, subdir);
+        if (!fs.existsSync(dir)) continue;
+
+        for (const file of fs.readdirSync(dir)) {
+            if (!file.endsWith('.d.ts')) continue;
+            files.push(subdir ? `${subdir}/${file}` : file);
+        }
+    }
+
+    return files;
+}
+
+/**
+ * Write every generated declaration into `OUTPUT_DIR`, and delete stale ones.
+ *
+ * A declaration that carries the generated banner but no longer has a matching
+ * entry point in `lib/` is removed, so deleting a trace does not leave a
+ * declaration for a module that no longer exists.
+ *
+ * @returns counts of the files written and removed
+ */
+export function writeEntryPointTypes() {
+    const declarations = buildEntryPointTypes();
+
+    for (const subdir of ['', ...GENERATED_SUBDIRS]) {
+        fs.mkdirSync(path.join(pathToOutput, subdir), { recursive: true });
+    }
+
+    for (const [file, text] of declarations) {
+        fs.writeFileSync(path.join(pathToOutput, file), text);
+    }
+
+    const removed = [];
+    for (const file of listCommittedDeclarations()) {
+        if (declarations.has(file)) continue;
+
+        const full = path.join(pathToOutput, file);
+        if (!isGenerated(fs.readFileSync(full, 'utf-8'))) continue;
+
+        fs.unlinkSync(full);
+        removed.push(file);
+    }
+
+    return { written: declarations.size, removed };
+}
+
+/**
+ * Compare the committed declarations against freshly generated text.
+ *
+ * @returns names of the files that are missing, stale, or no longer generated
+ */
+export function findStaleEntryPointTypes() {
+    const declarations = buildEntryPointTypes();
+    const stale = [];
+
+    for (const [file, text] of declarations) {
+        const full = path.join(pathToOutput, file);
+        if (!fs.existsSync(full) || fs.readFileSync(full, 'utf-8') !== text) stale.push(file);
+    }
+
+    for (const file of listCommittedDeclarations()) {
+        if (declarations.has(file)) continue;
+        if (isGenerated(fs.readFileSync(path.join(pathToOutput, file), 'utf-8'))) stale.push(file);
+    }
+
+    return stale.sort();
+}

--- a/tasks/generate_schema_types.mjs
+++ b/tasks/generate_schema_types.mjs
@@ -15,6 +15,8 @@
 
 import * as fs from 'fs';
 
+import { generatedHeader, jsDocBlock, toFileText, tsLiteral } from './util/type_gen.mjs';
+
 // ---------------------------------------------------------------------------
 // Meta keys to skip (not user-facing attributes)
 // ---------------------------------------------------------------------------
@@ -186,13 +188,7 @@ const LAYOUT_ARRAY_NAMES = new Map([
 // valType → TS type
 // ---------------------------------------------------------------------------
 
-function serializeValue(v) {
-    if (typeof v === 'string') {
-        const escaped = v.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-        return `'${escaped}'`;
-    }
-    return String(v); // numbers, booleans
-}
+const serializeValue = tsLiteral;
 
 /**
  * Try to match a values array to a known common type.
@@ -305,27 +301,7 @@ function formatJSDoc(attr, indent) {
         }
     }
 
-    if (!description && tags.length === 0) return [];
-
-    // Single-line — preserve original compact format when there's only a description
-    if (description && tags.length === 0) {
-        const text = description.replace(/\*\//g, '*\\/');
-        return [`${indent}/** ${text} */`];
-    }
-
-    // Multi-line block
-    const out = [`${indent}/**`];
-    if (description) {
-        const text = description.replace(/\*\//g, '*\\/');
-        for (const line of text.split('\n')) {
-            out.push(`${indent} * ${line}`);
-        }
-    }
-    for (const tag of tags) {
-        out.push(`${indent} * ${tag}`);
-    }
-    out.push(`${indent} */`);
-    return out;
+    return jsDocBlock({ description, tags, indent });
 }
 
 /**
@@ -1075,10 +1051,11 @@ export function generateSchemaTypes(schema, outputPath) {
 
     // ----- Phase 4: Build output -----
     const chunks = [
-        '/**',
-        ' * Generated from plot-schema.json by tasks/generate_schema_types.mjs.',
-        ' * Do not edit by hand — run `npm run schema` to regenerate.',
-        ' */',
+        generatedHeader({
+            source: 'plot-schema.json',
+            task: 'tasks/generate_schema_types.mjs',
+            command: 'npm run schema'
+        }),
         '',
         "import type { Color, ColorScale, Datum, MarkerSymbol, TypedArray } from '../lib/common';",
         ''
@@ -1265,7 +1242,7 @@ export function generateSchemaTypes(schema, outputPath) {
         }
     }
 
-    fs.writeFileSync(outputPath, chunks.join('\n'));
+    fs.writeFileSync(outputPath, toFileText(chunks));
 
     const sharedCount = sharedList.length;
     const layoutCount = subplotGroups.size + arrayItems.size + 1; // +1 for Layout itself

--- a/tasks/util/type_gen.mjs
+++ b/tasks/util/type_gen.mjs
@@ -1,0 +1,132 @@
+/**
+ * Shared helpers for the TypeScript declaration generators.
+ */
+
+// ---------------------------------------------------------------------------
+// Generated file headers
+// ---------------------------------------------------------------------------
+
+/**
+ * Opening text of every generated header.
+ *
+ * `generatedHeader` writes this text and `isGenerated` looks for it, so the two
+ * cannot drift apart. A task that deletes its own stale output depends on that:
+ * if the recognizer stopped matching the emitter, cleanup would quietly skip
+ * every file instead of failing.
+ */
+const HEADER_OPENING = '/**\n * Generated from ';
+
+/**
+ * Build the header block for a generated file.
+ *
+ * The caller adds the blank line that separates the header from the body.
+ *
+ * @param source - what the file is generated from, as a path or file name
+ * @param task - path of the task that writes the file, from the repository root
+ * @param command - npm command that regenerates the file
+ * @returns the header block, without a trailing newline
+ */
+export function generatedHeader({ source, task, command }) {
+    return [
+        `${HEADER_OPENING}${source} by ${task}.`,
+        // NOTE: the em dash matches the header that `schema.d.ts` already
+        // carries. Changing it rewrites that file for no behavioral gain.
+        ` * Do not edit by hand — run \`${command}\` to regenerate.`,
+        ' */'
+    ].join('\n');
+}
+
+/**
+ * Report whether a file was written by one of the type generators.
+ *
+ * Use this before deleting a file that a generator no longer produces, so a
+ * hand-written file in the same directory is never removed.
+ *
+ * @param text - the file's contents
+ * @returns true when the file carries a generated header
+ */
+export function isGenerated(text) {
+    return text.startsWith(HEADER_OPENING);
+}
+
+// ---------------------------------------------------------------------------
+// File text
+// ---------------------------------------------------------------------------
+
+/**
+ * Join generated lines into a file body.
+ *
+ * The result ends in exactly one newline, whatever the caller's array ends with.
+ * `npm run test-syntax` asserts that every file in the repository ends in a
+ * newline, and a generator that emits two would fail the repository's own
+ * formatting rules.
+ *
+ * @param lines - the generated lines, without line endings
+ * @returns the file body
+ */
+export function toFileText(lines) {
+    return `${lines.join('\n').replace(/\n+$/, '')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript literals
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a JavaScript value as a TypeScript literal.
+ *
+ * Strings are single-quoted, with backslashes and single quotes escaped.
+ * Numbers and booleans are rendered as themselves.
+ *
+ * @param value - the value to render
+ * @returns the literal, ready to paste into generated source
+ */
+export function tsLiteral(value) {
+    if (typeof value === 'string') {
+        const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+        return `'${escaped}'`;
+    }
+    return String(value);
+}
+
+// ---------------------------------------------------------------------------
+// JSDoc
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a JSDoc comment block.
+ *
+ * A description and no tags collapse to a single line. Anything longer becomes a
+ * multi-line block. A description with no tags and no text produces no lines at
+ * all, so a caller can pass whatever it has without testing for emptiness first.
+ *
+ * Any `*​/` inside the text is escaped, so a description cannot close the comment
+ * early and corrupt the file.
+ *
+ * @param description - free text, which may contain newlines
+ * @param tags - extra lines placed after the description, such as `@default 3`
+ * @param indent - string prefixed to every emitted line
+ * @returns the block's lines, without line endings
+ */
+export function jsDocBlock({ description, tags = [], indent = '' }) {
+    if (!description && tags.length === 0) return [];
+
+    const escape = (text) => text.replace(/\*\//g, '*\\/');
+
+    if (description && tags.length === 0 && !description.includes('\n')) {
+        return [`${indent}/** ${escape(description)} */`];
+    }
+
+    const out = [`${indent}/**`];
+
+    if (description) {
+        for (const line of escape(description).split('\n')) {
+            out.push(line === '' ? `${indent} *` : `${indent} * ${line}`);
+        }
+    }
+
+    for (const tag of tags) out.push(`${indent} * ${tag}`);
+
+    out.push(`${indent} */`);
+    return out;
+}


### PR DESCRIPTION
### Description

Add TypeScript types for entry points in `lib/`.

Closes #8004.

### Changes

- Add entry point types and generator scripts
- Update CI
- Update TS docs

### Testing

Check that CI is passing.

### Notes

- There are a number of alternate entry points for plotly.js in `lib/`
- This PR adds types for these in addition to the main entry point `lib/index.js`
- I opted to locate these in the generated types folder rather than along with the entry point files to keep things tidy
- Type resoultion happens via the `typesVersions` object in `package.json`
- The types are generated rather than hand written. This might not be necessary given that the entry points don't change very often, but it makes it automated so we don't have to think about it.