### PR TITLE
Change default doubleClickDelay to 500ms (from 300ms)

### DIFF
--- a/draftlogs/8014_change.md
+++ b/draftlogs/8014_change.md
@@ -1,0 +1,1 @@
+- Increase default double-click delay threshold to 500ms (from 300) [[#8014](https://github.com/plotly/plotly.js/pull/8014)]

--- a/src/plot_api/plot_config.js
+++ b/src/plot_api/plot_config.js
@@ -181,7 +181,7 @@ var configAttributes = {
     },
     doubleClickDelay: {
         valType: 'number',
-        dflt: 300,
+        dflt: 500,
         min: 0,
         description: [
             'Sets the delay for registering a double-click in ms.',

--- a/src/types/generated/schema.d.ts
+++ b/src/types/generated/schema.d.ts
@@ -16573,7 +16573,7 @@ export interface ConfigBase {
     doubleClick?: false | 'reset' | 'autosize' | 'reset+autosize';
     /**
      * Sets the delay for registering a double-click in ms. This is the time interval (in ms) between first mousedown and 2nd mouseup to constitute a double-click. This setting propagates to all on-subplot double clicks (except for geo and map) and on-legend double clicks.
-     * @default 300
+     * @default 500
      * Minimum: 0
      */
     doubleClickDelay?: number;

--- a/test/jasmine/tests/dragelement_test.js
+++ b/test/jasmine/tests/dragelement_test.js
@@ -20,7 +20,7 @@ describe('dragElement', function() {
             _hoverlayer: d3Select(this.hoverlayer)
         };
         this.gd._context = {
-            doubleClickDelay: 300
+            doubleClickDelay: 500
         };
         this.element.innerHTML = 'drag element';
 

--- a/test/plot-schema.json
+++ b/test/plot-schema.json
@@ -142,7 +142,7 @@
     },
     "doubleClickDelay": {
       "description": "Sets the delay for registering a double-click in ms. This is the time interval (in ms) between first mousedown and 2nd mouseup to constitute a double-click. This setting propagates to all on-subplot double clicks (except for geo and map) and on-legend double clicks.",
-      "dflt": 300,
+      "dflt": 500,
       "min": 0,
       "valType": "number"
     },


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.js/issues/8013 (see also original discussion in https://github.com/plotly/plotly.js/issues/6538)

Increase Plotly's default double-click delay to 500ms, to align with the most common OS defaults.

### Steps for testing

1. Run the devtools dashboard and open any mock with a legend, for example `legend_horizontal`
2. Experiment with how fast you need to double-click a legend item in order to hide all other traces. If you double-click too slow, your clicks will be interpreted as single clicks and the clicked item will simply hide and then show again quickly
3. Do the same experimentation on `main`. Notice that the double-click speed threshold is noticeably slower on this branch compared to `main`.