### PR TITLE
Fix bogus colorbar size rescale when restyling to the mode the colorbar already uses

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -1529,18 +1529,26 @@ function _restyle(gd, aobj, traces) {
                 // increases the margins
 
                 var gs = fullLayout._size;
-                var orient = innerContFull.orient;
-                var topOrBottom = orient === 'top' || orient === 'bottom';
+                var isHorizontal = innerContFull.orientation === 'h';
                 if (finalPart === 'thicknessmode') {
-                    var thicknorm = topOrBottom ? gs.h : gs.w;
-                    doextra(
-                        prefixDot + 'thickness',
-                        innerContFull.thickness * (newVal === 'fraction' ? 1 / thicknorm : thicknorm),
-                        i
-                    );
+                    // innerContFull.thickness is expressed in the units of
+                    // innerContFull.thicknessmode - which is not necessarily
+                    // the mode the user is switching away from, as the
+                    // default is 'pixels' (see #8012) - so only rescale
+                    // when the units actually change
+                    var thicknorm = isHorizontal ? gs.h : gs.w;
+                    if (innerContFull.thicknessmode !== newVal && innerContFull.thickness !== undefined) {
+                        doextra(
+                            prefixDot + 'thickness',
+                            innerContFull.thickness * (newVal === 'fraction' ? 1 / thicknorm : thicknorm),
+                            i
+                        );
+                    }
                 } else {
-                    var lennorm = topOrBottom ? gs.w : gs.h;
-                    doextra(prefixDot + 'len', innerContFull.len * (newVal === 'fraction' ? 1 / lennorm : lennorm), i);
+                    var lennorm = isHorizontal ? gs.w : gs.h;
+                    if (innerContFull.lenmode !== newVal && innerContFull.len !== undefined) {
+                        doextra(prefixDot + 'len', innerContFull.len * (newVal === 'fraction' ? 1 / lennorm : lennorm), i);
+                    }
                 }
             } else if (
                 ai === 'type' &&

--- a/test/jasmine/tests/colorbar_test.js
+++ b/test/jasmine/tests/colorbar_test.js
@@ -264,6 +264,88 @@ describe('Test colorbar:', function() {
             .then(done, done.fail);
         });
 
+        // https://github.com/plotly/plotly.js/issues/8012
+        // the default thicknessmode is 'pixels', so restyling an unset
+        // colorbar to 'pixels' must not rescale thickness as if the
+        // current value were a fraction
+        it('does not rescale colorbar thickness when restyling to the mode the colorbar already uses', function(done) {
+            Plotly.newPlot(gd, [{
+                type: 'heatmap',
+                z: [[1, 10], [100, 1000]],
+                colorbar: {}
+            }], {
+                height: 500,
+                width: 500,
+                margin: {l: 50, r: 50, t: 50, b: 50}
+            })
+            .then(function() {
+                expect(gd._fullData[0].colorbar.thicknessmode).toBe('pixels');
+                expect(gd._fullData[0].colorbar.thickness).toBe(30);
+
+                return Plotly.restyle(gd, {'colorbar.thicknessmode': 'pixels'});
+            })
+            .then(function() {
+                expect(gd.data[0].colorbar.thickness).toBeUndefined();
+                expect(gd._fullData[0].colorbar.thickness).toBe(30);
+            })
+            .then(done, done.fail);
+        });
+
+        it('rescales horizontal colorbar thickness against the plot height', function(done) {
+            var gsH;
+
+            Plotly.newPlot(gd, [{
+                type: 'heatmap',
+                z: [[1, 10], [100, 1000]],
+                colorbar: {orientation: 'h'}
+            }], {
+                height: 500,
+                width: 300,
+                margin: {l: 50, r: 50, t: 50, b: 50}
+            })
+            .then(function() {
+                expect(gd._fullData[0].colorbar.thickness).toBe(30);
+
+                gsH = gd._fullLayout._size.h;
+
+                return Plotly.restyle(gd, {'colorbar.thicknessmode': 'fraction'});
+            })
+            .then(function() {
+                expect(gd._fullData[0].colorbar.thickness)
+                    .toBeCloseTo(30 / gsH, 5);
+            })
+            .then(done, done.fail);
+        });
+
+        // splom marker colorbars collapse the whole grid when the
+        // bogus rescale kicks in, see the report in
+        // https://github.com/plotly/plotly.js/issues/8012
+        it('does not rescale splom marker colorbar thickness when restyling to the default pixels mode', function(done) {
+            Plotly.newPlot(gd, [{
+                type: 'splom',
+                dimensions: [
+                    {values: [1, 2, 3, 4]},
+                    {values: [2, 3, 4, 5]}
+                ],
+                marker: {color: [1, 2, 3, 4], colorbar: {}}
+            }], {
+                height: 500,
+                width: 500,
+                margin: {l: 50, r: 50, t: 50, b: 50}
+            })
+            .then(function() {
+                expect(gd._fullData[0].marker.colorbar.thicknessmode).toBe('pixels');
+                expect(gd._fullData[0].marker.colorbar.thickness).toBe(30);
+
+                return Plotly.restyle(gd, {'marker.colorbar.thicknessmode': 'pixels'});
+            })
+            .then(function() {
+                expect(gd.data[0].marker.colorbar.thickness).toBeUndefined();
+                expect(gd._fullData[0].marker.colorbar.thickness).toBe(30);
+            })
+            .then(done, done.fail);
+        });
+
         // scatter has trace.marker.{showscale, colorbar}
         it('can show and hide scatter colorbars', function(done) {
             Plotly.newPlot(gd, [{


### PR DESCRIPTION
## Problem

`Plotly.restyle(gd, {'marker.colorbar.thicknessmode': 'pixels'})` on a trace whose colorbar was created **without an explicit `thicknessmode`/`thickness`** silently writes a huge pixel value back into the user trace and collapses the layout — most dramatically for `splom`, where the whole grid squeezes into a strip (#8012, also reported from plotly.py as plotly/plotly.py#5615). Setting the exact same value at `newPlot` time renders fine.

Headless repro (jsdom + min bundle, 3.5.0), generic across trace types — not splom-specific:

```js
Plotly.newPlot(gd, [{type: 'heatmap', z: [[1, 2], [3, 4]], colorbar: {}}], {width: 750, height: 400});
Plotly.restyle(gd, {'colorbar.thicknessmode': 'pixels'});
// gd.data[0].colorbar -> {thicknessmode: 'pixels', thickness: 17700}  = 30 * gs.w
```

## Root cause

The "keep the rendered size when switching size modes" branch in `src/plot_api/plot_api.js`:

```js
var orient = innerContFull.orient;
var topOrBottom = orient === 'top' || orient === 'bottom';
if (finalPart === 'thicknessmode') {
    var thicknorm = topOrBottom ? gs.h : gs.w;
    doextra(prefixDot + 'thickness',
        innerContFull.thickness * (newVal === 'fraction' ? 1 / thicknorm : thicknorm), i);
}
```

Two defects:

1. **Wrong source units.** The branch fires as soon as `oldVal !== newVal`, and when the user never set the attribute `oldVal` is `undefined`. But `innerContFull.thickness` is expressed in the units of `innerContFull.thicknessmode` — whose **default is `'pixels'`** — so restyling an unset colorbar to `'pixels'` multiplies an already-pixel `thickness` (30) by the plot width and writes `30 * gs.w` into the user data. Restyling an unset colorbar to `'fraction'` divides in the same bogus way.
2. **Dead `orient` read.** The colorbar attribute is `orientation` (`'v'`/`'h'`), so `innerContFull.orient` is always `undefined` and `topOrBottom` is always `false`: horizontal colorbars normalize `thickness` against `gs.w` instead of `gs.h` (and `len` against `gs.h` instead of `gs.w`), disagreeing with the normalizer used at draw time (`isVertical ? gs.w : gs.h` in `src/components/colorbar/draw.js`).

## Fix

- Rescale only when the units actually change, i.e. guard with `innerContFull.thicknessmode !== newVal` (resp. `lenmode`) — the full container's mode is the authoritative statement of the units `innerContFull.thickness` is in, regardless of what the user previously set. Also skip when the value is missing instead of propagating `NaN`.
- Derive the normalizer from `innerContFull.orientation === 'h'`, matching `draw.js`.

Behavior on legitimate switches is unchanged: verified headlessly that an explicitly-set `thicknessmode: 'fraction', thickness: 0.1` restyled to `'pixels'` still converts to `0.1 * gs.w` (= 59 px at gs.w = 590), and the existing `changed size modes` test case keeps its `thickPx / 400` / `lenFrac * 400` expectations (guarded conversion still fires when the full mode differs from the new value).

## Alternatives considered

- Comparing `oldVal` instead of the full mode: `oldVal` can be `undefined`/`null` and says nothing about the units of the coerced value, so every combination needs special-casing; the full mode already encodes it.
- Dropping the rescale entirely and letting defaults re-derive the value: that would change the rendered size on legitimate mode switches, which the existing test in `colorbar_test.js` depends on.

## Tests

Three regression tests in `test/jasmine/tests/colorbar_test.js`:

- unset `colorbar` restyled to `'pixels'` keeps `thickness` at the 30 px default (root `colorbar`, and the reported `splom` `marker.colorbar` shape);
- horizontal colorbar `thickness` rescales against the plot **height** (fails on master, where `topOrBottom` is always `false`).

Closes #8012.
