### PR TITLE
Fix stale modebar hover colors after style updates

### DIFF
--- a/draftlogs/8024_fix.md
+++ b/draftlogs/8024_fix.md
@@ -1,0 +1,1 @@
+- Fix modebar hover colors not updating after `color` or `activecolor` changes [[#8024](https://github.com/plotly/plotly.js/pull/8024)]

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -109,22 +109,29 @@ function setStyleOnHover(selector, activeSelector, childSelector, activeStyle, i
         element = document;
     }
     element.querySelectorAll(selector).forEach(function(el) {
+        el._hoverStyle = {
+            activeStyleParts: activeStyleParts,
+            inactiveStyleParts: inactiveStyleParts
+        };
+
         if(!el.getAttribute(eventAddedAttrName)) {
             // Emulate ":hover" CSS style using JS event handlers to set the
             // style in a strict CSP-compliant manner.
             el.addEventListener('mouseenter', function() {
+                var hoverStyle = this._hoverStyle;
                 var childEl = this.querySelector(childSelector);
                 if(childEl) {
-                    childEl.style[activeStyleParts[0]] = activeStyleParts[1];
+                    childEl.style[hoverStyle.activeStyleParts[0]] = hoverStyle.activeStyleParts[1];
                 }
             });
             el.addEventListener('mouseleave', function() {
+                var hoverStyle = this._hoverStyle;
                 var childEl = this.querySelector(childSelector);
                 if(childEl) {
                     if(activeSelector && this.matches(activeSelector)) {
-                        childEl.style[activeStyleParts[0]] = activeStyleParts[1];
+                        childEl.style[hoverStyle.activeStyleParts[0]] = hoverStyle.activeStyleParts[1];
                     } else {
-                        childEl.style[inactiveStyleParts[0]] = inactiveStyleParts[1];
+                        childEl.style[hoverStyle.inactiveStyleParts[0]] = hoverStyle.inactiveStyleParts[1];
                     }
                 }
             });


### PR DESCRIPTION
Closes #8023

This PR fixes modebar hover colors retaining the initial `color` and `activecolor` values after they are updated, for example when switching between light and dark themes.

`setStyleOnHover()` attaches the `mouseenter` and `mouseleave` listeners only once. As a result, both listeners therefore kept the `activeStyleParts` and `inactiveStyleParts` values from the initial call.

https://github.com/plotly/plotly.js/blob/c5ad3565415d5aa17c22594a33a241fe27f57035/src/lib/dom.js#L104-L134